### PR TITLE
Add python unit tests to CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,9 +3,17 @@ pipeline {
   stages {
     stage('Build') {
       parallel {
-        stage('Build CHIME kotekan') {
+        stage('Build kotekan without hardware specific options') {
           steps {
             sh '''cd build/
+                  cmake -DCMAKE_BUILD_TYPE=Debug -DUSE_HDF5=ON -DHIGHFIVE_PATH=/opt/HighFive -DOPENBLAS_PATH=/opt/OpenBLAS/build/ -DUSE_LAPACK=ON ..
+                  make'''
+          }
+        }
+        stage('Build CHIME kotekan') {
+          steps {
+            sh '''mkdir build_chime
+                  cd build_chime/
                   cmake -DRTE_SDK=/opt/dpdk-stable-16.11.4/ -DRTE_TARGET=x86_64-native-linuxapp-gcc -DUSE_DPDK=ON -DUSE_HSA=ON -DCMAKE_BUILD_TYPE=Debug -DUSE_HDF5=ON -DHIGHFIVE_PATH=/opt/HighFive -DOPENBLAS_PATH=/opt/OpenBLAS/build/ -DUSE_LAPACK=ON ..
                   make'''
           }


### PR DESCRIPTION
Does not work yet, because it uses the CHIME build which tries to lock huge pages as a result of DPDK being included.  The new DPDK changes will fix this by not locking huge pages unless DPDK is included in the config.  So I'm just going to leave this here until that's merged into master. 