### PR TITLE
Fix floating point issue in config update

### DIFF
--- a/lib/hsa/hsaBeamformKernel.cpp
+++ b/lib/hsa/hsaBeamformKernel.cpp
@@ -109,7 +109,7 @@ void hsaBeamformKernel::update_EW_beam_callback(connectionInstance& conn, json& 
     }
     _ew_spacing_c[ew_id] = json_request["ew_beam"];
     update_EW_beam=true;
-    config.update_value(unique_name, "ew_spacing/" + std::to_string(ew_id), _ew_spacing_c[ew_id]);
+    config.update_value(unique_name, "ew_spacing/" + std::to_string(ew_id), json_request["ew_beam"]);
     conn.send_empty_reply(HTTP_RESPONSE::OK);
 
 }
@@ -124,7 +124,7 @@ void hsaBeamformKernel::update_NS_beam_callback(connectionInstance& conn, json& 
     freq_ref = (LIGHT_SPEED*(128) / (sin(_northmost_beam *PI/180.) * FEED_SEP *256))/1.e6;
     update_NS_beam=true;
 
-    config.update_value(unique_name, "northmost_beam", _northmost_beam);
+    config.update_value(unique_name, "northmost_beam", json_request["northmost_beam"]);
     conn.send_empty_reply(HTTP_RESPONSE::OK);
     config.update_value(unique_name, "gain_dir", _gain_dir);
 }

--- a/lib/hsa/hsaPulsarUpdatePhase.cpp
+++ b/lib/hsa/hsaPulsarUpdatePhase.cpp
@@ -142,9 +142,9 @@ void hsaPulsarUpdatePhase::calculate_phase(struct psrCoord psr_coord, timespec t
             for (int j=0;j<256;j++) { //loop 256 feeds
                 float dist_y = j*_feed_sep_NS;
                 float dist_x = i*_feed_sep_EW;
-                projection_angle = 90*D2R - atan2(dist_y, dist_x); 
+                projection_angle = 90*D2R - atan2(dist_y, dist_x);
                 offset_distance  = sqrt( pow(dist_y,2) + pow(dist_x,2) ) ;
-                effective_angle  = projection_angle - az; 
+                effective_angle  = projection_angle - az;
                 float delay_real = cos(TAU*cos(effective_angle)*cos(alt)*offset_distance*FREQ*one_over_c);
                 float delay_imag = -sin(TAU*cos(effective_angle)*cos(-alt)*offset_distance*FREQ*one_over_c);
                 for (int p=0;p<2;p++){ //loop 2 pol
@@ -278,8 +278,8 @@ void hsaPulsarUpdatePhase::pulsar_grab_callback(connectionInstance& conn, json& 
         psr_coord.dec[beam] = json_request["dec"];
 	psr_coord.scaling[beam] = json_request["scaling"];
         conn.send_empty_reply(HTTP_RESPONSE::OK);
-	config.update_value(unique_name, "source_ra/" + std::to_string(beam), psr_coord.ra[beam]);
-	config.update_value(unique_name, "source_dec/" + std::to_string(beam), psr_coord.dec[beam]);
-	config.update_value(unique_name, "psr_scaling/" + std::to_string(beam), psr_coord.scaling[beam]);
+	config.update_value(unique_name, "source_ra/" + std::to_string(beam), json_request["ra"]);
+	config.update_value(unique_name, "source_dec/" + std::to_string(beam), json_request["dec"]);
+	config.update_value(unique_name, "psr_scaling/" + std::to_string(beam), json_request["scaling"]);
     }
 }


### PR DESCRIPTION
Avoids the double -> float -> double casting when updating the config from FRB/Pulsar endpoints.