### PR TITLE
Pulsar VDIF timestamp bug fix

### DIFF
--- a/lib/processes/pulsarPostProcess.cpp
+++ b/lib/processes/pulsarPostProcess.cpp
@@ -80,8 +80,8 @@ void pulsarPostProcess::fill_headers(unsigned char * out_buf,
         //Increment time for the next frame
         time_now->tv_nsec +=_timesamples_per_pulsar_packet*2560;
         if (time_now->tv_nsec > 999999999) {
+            time_now->tv_sec += (uint)(time_now->tv_nsec / 1000000000.);
             time_now->tv_nsec = time_now->tv_nsec % 1000000000;
-            time_now->tv_sec += (uint)(time_now->tv_nsec / 1000000000);
         }
     } //end packet
 }
@@ -177,8 +177,8 @@ void pulsarPostProcess::main_thread() {
             first_seq_number  = first_seq_number+seq_number_offset; //so that we start at an fpga_seq_no that is divisible by the packet nsamp
             time_now.tv_nsec +=seq_number_offset*2560;
             if (time_now.tv_nsec > 999999999) {
+                time_now.tv_sec += (uint)(time_now.tv_nsec / 1000000000.);
                 time_now.tv_nsec = time_now.tv_nsec % 1000000000;
-                time_now.tv_sec += (uint)(time_now.tv_nsec / 1000000000);
             }
             
             // Fill the first output buffer headers


### PR DESCRIPTION
We had previously added a fix to make sure the pulsar VDIF packet starts on a fpga_seq_number that is divisible by 625. That is proved to be working. But we forgot to also update the `time_now` parameter. So I added line 178-182 in `pulsarPostProcess.cpp`.

This is a minor change but would help the pulsar downstream process because both fpga seq no. and time are being used to fold the pulsar data. I suggest putting it in as a hot fix and implement it asap (instead of waiting till the next run).