### PR TITLE
Baseband manager readout race (closes #111)

### DIFF
--- a/lib/core/basebandRequestManager.hpp
+++ b/lib/core/basebandRequestManager.hpp
@@ -144,11 +144,14 @@ private:
         /// Queue of unprocessed baseband requests for this frequency
         std::deque<basebandRequest> request_queue;
 
+        /// Status of the baseband dump currently in progress
+        std::shared_ptr<basebandDumpStatus> current_status = nullptr;
+
         /// Lock to update the current basebandDumpStatus object
-        std::shared_ptr<std::mutex> current_lock;
+        std::shared_ptr<std::mutex> current_lock = std::make_shared<std::mutex>();
 
         /// Queue of completed baseband requests for this frequency
-        std::vector<std::shared_ptr<basebandDumpStatus>> processing;
+        std::vector<basebandDumpStatus> processing;
     };
 
     /**

--- a/lib/processes/basebandReadout.cpp
+++ b/lib/processes/basebandReadout.cpp
@@ -217,7 +217,7 @@ void basebandReadout::write_thread(std::shared_ptr<std::mutex> status_lock) {
             auto data = std::get<0>(dump_tup);
 
             try {
-                write_dump(data, dump_status, status_lock);
+                write_dump(data, dump_status, status_lock.get());
             } catch (HighFive::FileException& e) {
                 INFO("Writing Baseband dump file failed with hdf5 error.");
                 std::lock_guard<std::mutex> lock(*status_lock);
@@ -397,7 +397,7 @@ void basebandReadout::unlock_range(int start_frame, int end_frame) {
 
 void basebandReadout::write_dump(basebandDumpData data,
                                  std::shared_ptr<basebandDumpStatus> dump_status,
-                                 std::shared_ptr<std::mutex> status_lock) {
+                                 std::mutex* status_lock) {
 
     // TODO Create parent directories.
     std::string filename = _base_dir + dump_status->request.file_name;

--- a/lib/processes/basebandReadout.hpp
+++ b/lib/processes/basebandReadout.hpp
@@ -131,7 +131,7 @@ private:
     void write_thread(std::shared_ptr<std::mutex> status_lock);
     void write_dump(basebandDumpData data,
                     std::shared_ptr<basebandDumpStatus> dump_status,
-                    std::shared_ptr<std::mutex> status_lock);
+                    std::mutex* status_lock);
     int add_replace_frame(int frame_id);
     void lock_range(int start_frame, int end_frame);
     void unlock_range(int start_frame, int end_frame);


### PR DESCRIPTION
This further refactors the data structures for keeping track of baseband dumps, and adds synchronization on dump status updates between the basebandRequestManager and basebandReadout::write_thread that was previously missing.