### PR TITLE
Synchronize baseband write queue with condition variables

### DIFF
--- a/lib/processes/basebandReadout.hpp
+++ b/lib/processes/basebandReadout.hpp
@@ -141,6 +141,17 @@ private:
     int add_replace_frame(int frame_id);
     void lock_range(int start_frame, int end_frame);
     void unlock_range(int start_frame, int end_frame);
+
+    /**
+     * @brief Make a private copy of the data from the ring buffer
+     *
+     * @param event_id unique identifier of the event in the FRB pipeline
+     * @param trigger_start_fpga start time, or -1 to use the earliest data available
+     * @param trigger_length_fpga number of FPGA samples to include in the dump
+     *
+     * @return A fully initialized `basebandDumpData` if the call succeeded, or
+     * an empty one if the frame data was not availabe for the time requested
+     */
     basebandDumpData get_data(
             uint64_t event_id,
             int64_t trigger_start_fpga,

--- a/tests/test_baseband_readout.py
+++ b/tests/test_baseband_readout.py
@@ -104,6 +104,30 @@ def test_io_errors_and_max_samples(tmpdir_factory):
                                    default_params['num_elements'])
 
 
+def test_negative_start_time(tmpdir_factory):
+    """Test using the 'save whatever you have' mode of the baseband dump
+
+    Using -1 as the trigger start point initiates the dump using the oldest
+    frame available in the buffers.
+    """
+
+    rest_commands = [
+            command_rest_frames(1),
+            command_trigger(-1, 3237, "file2.h5", 31),
+            wait(0.1),
+            command_rest_frames(60),
+            ]
+    params = {
+            'total_frames': 30,
+            'max_dump_samples': 2123,
+            }
+    dump_files = run_baseband(tmpdir_factory, params, rest_commands)
+    assert len(dump_files) == 1
+    f = h5py.File(dump_files[0], 'r')
+    assert f['baseband'].shape == (params['max_dump_samples'],
+                                   default_params['num_elements'])
+
+
 def test_basic(tmpdir_factory):
 
     rest_commands = [


### PR DESCRIPTION
* Addresses @andrerenard comment in #74, opened as issue #110 for tracking.

* Also added a quick-and-dirty functionality for dumping baseband with starting point at the beginning of saved data

(The two commits are not really related, so I'll merge them as a rebase-and-merge to preserve them in history.)