### PR TITLE
Fixed updateQueue segfault.

### DIFF
--- a/lib/utils/updateQueue.hpp
+++ b/lib/utils/updateQueue.hpp
@@ -66,7 +66,7 @@ public:
                         break;
                 }
                 // check if timestamp is identical -> replace update
-                if (u->first == timestamp)
+                if (u != values.crend() && u->first == timestamp)
                     u->second = move(update);
                 else
                     // insert the new update where it belongs in the queue


### PR DESCRIPTION
updateQueue could segfault if you asked it to insert an item before any
others. This would happen because in checking if a timestamp was
identical it could dereference before the start of the queue.

