### PR TITLE
Enable baseband dump process in the config

### DIFF
--- a/config/chime_science_run_gpu.yaml
+++ b/config/chime_science_run_gpu.yaml
@@ -28,7 +28,7 @@ num_local_freq: 1
 num_data_sets: 1
 samples_per_data_set: 49152
 buffer_depth: 12
-baseband_buffer_depth: 12    # was 120, 48Gb, 15s buffer.
+baseband_buffer_depth: 120  # 48Gb, 15s buffer.
 vbuffer_depth: 32
 num_links: 4
 timesamples_per_packet: 2
@@ -274,50 +274,47 @@ zero_samples:
     zero_0:
         kotekan_process: zeroSamples
         out_buf: network_buffer_0
-        out_lost_sample_buffers:
-            - lost_samples_buffer_0
+#        out_lost_sample_buffers:
+#            - lost_samples_buffer_0
     zero_1:
         kotekan_process: zeroSamples
         out_buf: network_buffer_1
-        out_lost_sample_buffers:
-            - lost_samples_buffer_1
+#        out_lost_sample_buffers:
+#            - lost_samples_buffer_1
     zero_2:
         kotekan_process: zeroSamples
         out_buf: network_buffer_2
-        out_lost_sample_buffers:
-            - lost_samples_buffer_2
+#        out_lost_sample_buffers:
+#            - lost_samples_buffer_2
     zero_3:
         kotekan_process: zeroSamples
         out_buf: network_buffer_3
-        out_lost_sample_buffers:
-            - lost_samples_buffer_3
+#        out_lost_sample_buffers:
+#            - lost_samples_buffer_3
 
-#baseband:
-#    max_dump_samples: 100000
-#    #num_frames_buffer: ( baseband_buffer_depth - 4 )   # XXX Why does this fail?
-#    num_frames_buffer: 110
-#    base_dir: /mnt/frb-archiver/
-#    write_throttle: 0
-#    baseband0:
-#      kotekan_process: basebandReadout
-#      in_buf: network_buffer_0
-#    baseband1:
-#      kotekan_process: basebandReadout
-#      in_buf: network_buffer_1
-#    baseband2:
-#      kotekan_process: basebandReadout
-#      in_buf: network_buffer_2
-#    baseband3:
-#      kotekan_process: basebandReadout
-#      in_buf: network_buffer_3
+baseband:
+    max_dump_samples: 100000
+    #num_frames_buffer: ( baseband_buffer_depth - 4 )   # XXX Why does this fail?
+    num_frames_buffer: 110
+    base_dir: /mnt/frb-archiver/
+    write_throttle: 0
+    baseband0:
+      kotekan_process: basebandReadout
+      in_buf: network_buffer_0
+    baseband1:
+      kotekan_process: basebandReadout
+      in_buf: network_buffer_1
+    baseband2:
+      kotekan_process: basebandReadout
+      in_buf: network_buffer_2
+    baseband3:
+      kotekan_process: basebandReadout
+      in_buf: network_buffer_3
 
 monitor:
     kotekan_process: monitorBuffer
     bufs:
-      - network_buffer_0
-      - network_buffer_1
-      - network_buffer_2
-      - network_buffer_3
+      - lost_samples_buffer
     timeout: 5
     fill_threshold: 0.8
 


### PR DESCRIPTION
Also adjusts the monitoring condition for system backups, and comments out some currently unused RFI options related to packet renormalization.