### PR TITLE
Make the parameter of `connectionInstance::send_json_reply` a const reference

### DIFF
--- a/lib/core/restServer.cpp
+++ b/lib/core/restServer.cpp
@@ -291,7 +291,7 @@ void connectionInstance::send_error(const string& message, const HTTP_RESPONSE &
     mg_send_head(nc, static_cast<int>(status), 0, error_message.c_str());
 }
 
-void connectionInstance::send_json_reply(json &json_reply) {
+void connectionInstance::send_json_reply(const json &json_reply) {
     string json_string = json_reply.dump(0);
     mg_send_head(nc, static_cast<int>(HTTP_RESPONSE::OK), json_string.size(), NULL);
     mg_send(nc, (void*) json_string.c_str(), json_string.size());

--- a/lib/core/restServer.hpp
+++ b/lib/core/restServer.hpp
@@ -47,7 +47,7 @@ public:
      *
      * @param json_reply The json object to send to the client.
      */
-    void send_json_reply(nlohmann::json &json_reply);
+    void send_json_reply(const nlohmann::json &json_reply);
 
     /**
      * @brief Sends a binary reply to the client


### PR DESCRIPTION
This allows passing an anonymous temporary (e.g., `conn.send_json_reply(json(cpp_obj))`), and is sufficient/correct for its use in the method.