### PR TITLE
Hot fix for critical DPDK alignment bug

### DIFF
--- a/lib/dpdk/iceBoardShuffle.hpp
+++ b/lib/dpdk/iceBoardShuffle.hpp
@@ -381,6 +381,8 @@ inline void iceBoardShuffle::copy_packet_shuffle(struct rte_mbuf *mbuf) {
 
     sample_location = cur_seq - get_fpga_seq_num(out_bufs[0], out_buf_frame_ids[0]);
     assert(sample_location * sample_size <= out_bufs[0]->frame_size);
+    assert(sample_location >= 0);
+    assert(get_mbuf_seq_num(mbuf) == cur_seq);
     if (unlikely(sample_location * sample_size == out_bufs[0]->frame_size)) {
         // If there are no new frames to fill, we are just dropping the packet
         if (!advance_frames(cur_seq))


### PR DESCRIPTION
There was a edge case where it was possible for DPDK to misalign FPAG packets by one or more frames (blocks of `samples_per_data_set` samples, or 49152 in the CHIME case).  This of course causes de-correlation between cylinders.   

Note this is a problem that can only happen at kotekan start up.  So either it happens or it doesn't for a given run of a GPU instance.  It's not something that can come and go.   It also cannot cause small misalignments, so it should be easy to tell from the data when this has happened. 

This fix simply kills kotekan if the alignment process fails on startup.  We might want to add more code to try to realign things without killing kotekan, but as a hotfix, this seems to be the simplest and quickest way to ensure the problem doesn't impact the data going forward. 