### PR TITLE
Try to fix problem with SCM stage on macOS builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,20 +29,15 @@ pipeline {
                   make'''
           }
         }
-        stage('Build Minimal MacOS kotekan') {
+        stage('Build MacOS kotekan') {
           agent {label 'macos'}
           steps {
             sh '''export PATH=${PATH}:/usr/local/bin/
                   mkdir build_base
                   cd build_base/
                   cmake ..
-                  make'''
-          }
-        }
-        stage('Build Maximal MacOS kotekan') {
-          agent {label 'macos'}
-          steps {
-            sh '''export PATH=${PATH}:/usr/local/bin/
+                  make
+                  cd ..
                   mkdir build_full
                   cd build_full/
                   cmake -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DUSE_FFTW=ON -DUSE_AIRSPY=ON \


### PR DESCRIPTION
Merge the two builds into one step so that the SCM strage doesn't run twice on the macOS build server.