### PR TITLE
Add missing AVX header needed in some build configurations

### DIFF
--- a/lib/processes/frbPostProcess.cpp
+++ b/lib/processes/frbPostProcess.cpp
@@ -4,6 +4,8 @@
 
 #include "frbPostProcess.hpp"
 
+#include <immintrin.h>
+
 REGISTER_KOTEKAN_PROCESS(frbPostProcess);
 
 frbPostProcess::frbPostProcess(Config& config_,


### PR DESCRIPTION
This addresses the bug in #200 