### PR TITLE
Added a minimum fraction of samples for a valid frame

### DIFF
--- a/lib/processes/visProcess.cpp
+++ b/lib/processes/visProcess.cpp
@@ -191,6 +191,7 @@ visAccumulate::visAccumulate(Config& config,
     block_size = config.get<size_t>(unique_name, "block_size");
     num_eigenvectors =  config.get<size_t>(unique_name, "num_ev");
     samples_per_data_set = config.get<size_t>(unique_name, "samples_per_data_set");
+    minimum_fraction = config.get_default<double>(unique_name, "minimum_fraction", 0.01);
 
     // Get the indices for reordering
     input_remap = std::get<0>(parse_reorder_default(config, unique_name));
@@ -257,12 +258,29 @@ void visAccumulate::main_thread() {
         // initially set to UINT_MAX to ensure this doesn't happen immediately.
         bool wrapped = (last_frame_count / num_gpu_frames) < (frame_count / num_gpu_frames);
         if (init && wrapped) {
+
             auto output_frame = visFrameView(out_buf, out_frame_id);
 
+            // Set the actual amount of time we accumulated for
+            output_frame.fpga_seq_total = total_samples;
             DEBUG("Total samples accumulate %i", total_samples);
 
+            // Reset the cycle
+            init = false;
+            frames_in_this_cycle = 0;
+            total_samples = 0;
+
+            // Check if we have exceeded the minimum number of required samples,
+            // if not immediately skip without releasing the frame
+            size_t min_length = minimum_fraction * output_frame.fpga_seq_length;
+            if (output_frame.fpga_seq_total < min_length) {
+                DEBUG("Too few samples in frame %i (minimum %i)",
+                      output_frame.fpga_seq_total, min_length);
+                continue;
+            }
+
             // Unpack the main visibilities
-            float w1 = 1.0 / total_samples;
+            float w1 = 1.0 / output_frame.fpga_seq_total;
 
             map_vis_triangle(input_remap, block_size, num_elements,
                 [&](int32_t pi, int32_t bi, bool conj) {
@@ -280,14 +298,8 @@ void visAccumulate::main_thread() {
                 }
             );
 
-            // Set the actual amount of time we accumulated for
-            output_frame.fpga_seq_total = total_samples;
-
             mark_frame_full(out_buf, unique_name.c_str(), out_frame_id);
             out_frame_id = (out_frame_id + 1) % out_buf->num_frames;
-            init = false;
-            frames_in_this_cycle = 0;
-            total_samples = 0;
         }
 
         // We've started accumulating a new frame. Initialise the output and

--- a/lib/processes/visProcess.hpp
+++ b/lib/processes/visProcess.hpp
@@ -139,6 +139,10 @@ private:
  *                              of `num_gpu_frames`.
  * @conf  num_elements          Int. The number of elements (i.e. inputs) in the
  *                              correlator data.
+ * @conf  minimum_fraction      Float. The minimum number of samples a frame needs to
+ *                              be generated. Frames with less than this will be
+ *                              skipped and not added into the buffer. Specified as a
+ *                              fraction of the total number of expected samples (default=1%).
  * @conf  block_size            Int. The block size of the packed data.
  * @conf  num_ev                Int. The number of eigenvectors to be stored
  * @conf  input_reorder         Array of [int, int, string]. The reordering mapping.
@@ -166,6 +170,7 @@ private:
     // Parameters saved from the config files
     size_t num_elements, num_eigenvectors, block_size;
     size_t samples_per_data_set, num_gpu_frames;
+    double minimum_fraction;
 
     // The mapping from buffer element order to output file element ordering
     std::vector<uint32_t> input_remap;


### PR DESCRIPTION
Causes frames with less than this amount to be skipped by the accumulation process.

I think this (in conjunction with the buffer timeout in the merging) should fix the RFI issues you are having. I hope so as I won't have any more time to work on this until Monday.