### PR TITLE
explicitly mark overriding functions, closes #86

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,6 +187,14 @@ if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 endif ()
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GNU_SOURCE -O3 -Wall -Wextra -Werror -march=native -mtune=native -I/opt/rocm/include")
 
+# Warning about missing override is called differently in clang and gcc
+# TODO: enable once we are using a release version of HighFive
+#if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+#    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}  -Winconsistent-missing-override")
+#else()
+#    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}  -Wsuggest-override")
+#endif()
+
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} ${CMAKE_CXX_FLAGS} -ggdb -O2")
 
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/")

--- a/lib/core/processFactory.hpp
+++ b/lib/core/processFactory.hpp
@@ -79,7 +79,7 @@ class kotekanProcessMakerTemplate : public kotekanProcessMaker
             processFactoryRegistry::kotekan_register_process(key, this);
         }
         virtual KotekanProcess *create(Config &config, const string &unique_name,
-                    bufferContainer &host_buffers) const
+                    bufferContainer &host_buffers) const override
         {
             return new T(config, unique_name, host_buffers);
         }

--- a/lib/core/prometheusMetrics.hpp
+++ b/lib/core/prometheusMetrics.hpp
@@ -145,7 +145,7 @@ private:
         /**
          * @brief Returns the stored value as a string.
          */
-        string to_string() {
+        string to_string() override {
             return std::to_string(value);
         }
     };

--- a/lib/dpdk/dpdkCore.hpp
+++ b/lib/dpdk/dpdkCore.hpp
@@ -163,7 +163,7 @@ public:
              bufferContainer &buffer_container);
     ~dpdkCore();
 
-    void main_thread();
+    void main_thread() override;
 
 private:
 

--- a/lib/dpdk/invalidateVDIFframes.hpp
+++ b/lib/dpdk/invalidateVDIFframes.hpp
@@ -42,7 +42,7 @@ public:
     ~invalidateVDIFframes();
 
     /// Main thead which zeros the data from the lost_samples_buf
-    void main_thread();
+    void main_thread() override;
 
 private:
 

--- a/lib/dpdk/zeroSamples.hpp
+++ b/lib/dpdk/zeroSamples.hpp
@@ -49,7 +49,7 @@ public:
     ~zeroSamples();
 
     /// Main thead which zeros the data from the lost_samples_buf
-    void main_thread();
+    void main_thread() override;
 
 private:
 

--- a/lib/hcc/hccGPUThread.hpp
+++ b/lib/hcc/hccGPUThread.hpp
@@ -12,7 +12,7 @@ public:
                 struct Buffer &out_buf,
                 uint32_t gpu_id);
     virtual ~hccGPUThread();
-    void main_thread();
+    void main_thread() override;
 
 private:
     struct Buffer &in_buf;

--- a/lib/hsa/hsaProcess.hpp
+++ b/lib/hsa/hsaProcess.hpp
@@ -28,7 +28,7 @@ public:
               bufferContainer &buffer_container);
     virtual ~hsaProcess();
 
-    void main_thread();
+    void main_thread() override;
 
     void results_thread();
 

--- a/lib/processes/applyGains.hpp
+++ b/lib/processes/applyGains.hpp
@@ -67,7 +67,7 @@ public:
               bufferContainer &buffer_container);
 
     /// Main loop for the process
-    void main_thread();
+    void main_thread() override;
 
     /// Callback function to receive updates on timestamps from configUpdater
     bool receive_update(nlohmann::json &json);

--- a/lib/processes/beamformingPostProcess.hpp
+++ b/lib/processes/beamformingPostProcess.hpp
@@ -15,7 +15,7 @@ public:
                   const string& unique_name,
                   bufferContainer &buffer_container);
     virtual ~beamformingPostProcess();
-    void main_thread();
+    void main_thread() override;
 
 private:
     void fill_headers(unsigned char * out_buf,

--- a/lib/processes/bufferRecv.hpp
+++ b/lib/processes/bufferRecv.hpp
@@ -81,7 +81,7 @@ public:
                   const string& unique_name,
                   bufferContainer &buffer_container);
     ~bufferRecv();
-    void main_thread();
+    void main_thread() override;
 
     /**
      * @brief Returns a buffer ID of the next empty buffer, this must be filled

--- a/lib/processes/bufferSend.hpp
+++ b/lib/processes/bufferSend.hpp
@@ -78,7 +78,7 @@ public:
     ~bufferSend();
 
     /// Main loop for sending data
-    void main_thread();
+    void main_thread() override;
 
 private:
     /// The input buffer to send frames from.

--- a/lib/processes/bufferStatus.hpp
+++ b/lib/processes/bufferStatus.hpp
@@ -35,7 +35,7 @@ public:
     bufferStatus(Config& config, const string& unique_name,
                          bufferContainer &buffer_container);
     virtual ~bufferStatus();
-    void main_thread();
+    void main_thread() override;
 private:
     map<string, Buffer*> buffers;
 

--- a/lib/processes/calibration_io.hpp
+++ b/lib/processes/calibration_io.hpp
@@ -131,7 +131,7 @@ public:
     ~eigenWriter();
 
     /// Primary loop
-    void main_thread();
+    void main_thread() override;
 
 private:
     /// Number of eigenvectors that will be provided

--- a/lib/processes/chrxUplink.hpp
+++ b/lib/processes/chrxUplink.hpp
@@ -13,7 +13,7 @@ public:
                const string& unique_name,
                bufferContainer &buffer_container);
     virtual ~chrxUplink();
-    void main_thread();
+    void main_thread() override;
 
 private:
     struct Buffer *vis_buf;

--- a/lib/processes/computeDualpolPower.hpp
+++ b/lib/processes/computeDualpolPower.hpp
@@ -10,7 +10,7 @@ public:
     computeDualpolPower(Config &config, const string& unique_name,
                         bufferContainer &buffer_container);
     ~computeDualpolPower();
-    void main_thread();
+    void main_thread() override;
 
 private:
     inline void fastSqSumVdif(unsigned char *data, uint *temp_buf, uint *output);

--- a/lib/processes/countCheck.hpp
+++ b/lib/processes/countCheck.hpp
@@ -43,7 +43,7 @@ public:
               bufferContainer &buffer_container);
 
     // Main loop for the process
-    void main_thread();
+    void main_thread() override;
 
 private:
     // Store the unix time at start of correlation:

--- a/lib/processes/freqSlicer.hpp
+++ b/lib/processes/freqSlicer.hpp
@@ -47,7 +47,7 @@ public:
               bufferContainer &buffer_container);
 
     // Main loop for the process
-    void main_thread();
+    void main_thread() override;
 
 private:
     /// adds states and datasets and gets new output dataset IDs from manager
@@ -99,7 +99,7 @@ public:
                bufferContainer &buffer_container);
 
     /// Main loop for the process
-    void main_thread();
+    void main_thread() override;
 
 private:
     /// adds state and dataset and gets a new output dataset ID from manager

--- a/lib/processes/fullPacketDump.hpp
+++ b/lib/processes/fullPacketDump.hpp
@@ -11,7 +11,7 @@ public:
     fullPacketDump(Config& config, const string& unique_name,
                    bufferContainer &buffer_container);
     virtual ~fullPacketDump();
-    void main_thread();
+    void main_thread() override;
 
     void packet_grab_callback(connectionInstance& conn, json& json_request);
 

--- a/lib/processes/gpuPostProcess.hpp
+++ b/lib/processes/gpuPostProcess.hpp
@@ -19,7 +19,7 @@ public:
                     const string& unique_name,
                     bufferContainer &buffer_container);
     virtual ~gpuPostProcess();
-    void main_thread();
+    void main_thread() override;
 
     void vis_endpoint(connectionInstance &conn, json &json_request);
 private:

--- a/lib/processes/monitorBuffer.hpp
+++ b/lib/processes/monitorBuffer.hpp
@@ -41,7 +41,7 @@ public:
     virtual ~monitorBuffer();
 
     /// Watches the list of buffers for timeouts
-    void main_thread();
+    void main_thread() override;
 
 private:
     /// Internal list of buffers to check

--- a/lib/processes/networkInputPowerStream.hpp
+++ b/lib/processes/networkInputPowerStream.hpp
@@ -54,7 +54,7 @@ public:
     virtual ~networkInputPowerStream();
 
     /// Primary loop, which waits on input frames, integrates, and dumps to output.
-    void main_thread();
+    void main_thread() override;
 
 private:
     ///Simple function to receive data of @c length bytes.

--- a/lib/processes/prodSubset.hpp
+++ b/lib/processes/prodSubset.hpp
@@ -74,7 +74,7 @@ public:
                    bufferContainer &buffer_container);
 
     /// Primary loop: sorts products and passes them on to output buffer.
-    void main_thread();
+    void main_thread() override;
 
 private:
     /// keeps track of the input dataset ID

--- a/lib/processes/restInspectFrame.hpp
+++ b/lib/processes/restInspectFrame.hpp
@@ -52,7 +52,7 @@ public:
     virtual ~restInspectFrame();
 
     /// Gets the latest frame from @c in_buf and copies it to @c frame_copy
-    void main_thread();
+    void main_thread() override;
 
     /**
      * @brief Retruns the binary data in @c frame_copy to the REST client

--- a/lib/processes/rfiAVXVDIF.hpp
+++ b/lib/processes/rfiAVXVDIF.hpp
@@ -45,7 +45,7 @@ public:
     //Destructor, do nothing
     ~rfiAVXVDIF();
     //Gets frames, creates thread to perform SK estimates, marks frame empty
-    void main_thread();
+    void main_thread() override;
 
 private:
     //Performs integration and computes spectral kurtosis estimates

--- a/lib/processes/rfiBadInputFinder.hpp
+++ b/lib/processes/rfiBadInputFinder.hpp
@@ -62,7 +62,7 @@ public:
     //Deconstructor, cleans up / does nothing
     virtual ~rfiBadInputFinder();
     //Primary loop, reads buffer and sends out UDP stream
-    void main_thread();
+    void main_thread() override;
     //Callback function called by rest server
     void rest_callback(connectionInstance& conn, json& json_request);
 

--- a/lib/processes/rfiBroadcast.hpp
+++ b/lib/processes/rfiBroadcast.hpp
@@ -60,7 +60,7 @@ public:
     //Deconstructor, cleans up / does nothing
     virtual ~rfiBroadcast();
     //Primary loop, reads buffer and sends out UDP stream
-    void main_thread();
+    void main_thread() override;
     //Callback function called by rest server
     void rest_callback(connectionInstance& conn, json& json_request);
     //Callback function called by rest server

--- a/lib/processes/rfiRecord.hpp
+++ b/lib/processes/rfiRecord.hpp
@@ -55,7 +55,7 @@ public:
     //Deconstructor, cleans up / does nothing
     virtual ~rfiRecord();
     //Primary loop, reads buffer and sends out UDP stream
-    void main_thread();
+    void main_thread() override;
     //Callback function called by rest server
     void rest_callback(connectionInstance& conn, json& json_request);
 

--- a/lib/processes/timeDownsample.hpp
+++ b/lib/processes/timeDownsample.hpp
@@ -49,7 +49,7 @@ public:
                    bufferContainer &buffer_container);
 
     /// Main loop for the process
-    void main_thread();
+    void main_thread() override;
 
 private:
 

--- a/lib/processes/vdifStream.hpp
+++ b/lib/processes/vdifStream.hpp
@@ -10,7 +10,7 @@ public:
     vdifStream(Config& config, const string& unique_name,
                bufferContainer &buffer_container);
     virtual ~vdifStream();
-    void main_thread();
+    void main_thread() override;
 
 private:
     struct Buffer *buf;

--- a/lib/processes/visProcess.hpp
+++ b/lib/processes/visProcess.hpp
@@ -56,7 +56,7 @@ public:
                 bufferContainer &buffer_container);
 
     // Main loop for the process
-    void main_thread();
+    void main_thread() override;
 
 private:
 
@@ -97,7 +97,7 @@ public:
              const string& unique_name,
              bufferContainer &buffer_container);
 
-    void main_thread();
+    void main_thread() override;
 
 private:
     Buffer * in_buf;
@@ -137,7 +137,7 @@ public:
              bufferContainer &buffer_container);
 
     // Main loop for the process
-    void main_thread();
+    void main_thread() override;
 
 private:
 
@@ -204,7 +204,7 @@ public:
              const string& unique_name,
              bufferContainer &buffer_container);
 
-    void main_thread();
+    void main_thread() override;
 
 private:
     Buffer * in_buf;

--- a/lib/processes/visRawReader.hpp
+++ b/lib/processes/visRawReader.hpp
@@ -52,7 +52,7 @@ public:
     ~visRawReader();
 
     /// Main loop over buffer frames
-    void main_thread();
+    void main_thread() override;
 
     /**
      * @brief Get the times in the file.

--- a/lib/processes/visWriter.hpp
+++ b/lib/processes/visWriter.hpp
@@ -77,7 +77,7 @@ public:
               const string& unique_name,
               bufferContainer &buffer_container);
 
-    void main_thread();
+    void main_thread() override;
 
 
 protected:

--- a/lib/testing/fakeVis.hpp
+++ b/lib/testing/fakeVis.hpp
@@ -73,7 +73,7 @@ public:
             bufferContainer &buffer_container);
 
     /// Primary loop to wait for buffers, stuff in data, mark full, lather, rinse and repeat.
-    void main_thread();
+    void main_thread() override;
 
     /**
      * @brief Default fill pattern.
@@ -204,7 +204,7 @@ public:
                bufferContainer& buffer_container);
 
     /// Primary loop to wait for buffers, stuff in data, mark full, lather, rinse and repeat.
-    void main_thread();
+    void main_thread() override;
 
 private:
     /// Buffers

--- a/lib/testing/networkOutputSim.hpp
+++ b/lib/testing/networkOutputSim.hpp
@@ -15,7 +15,7 @@ public:
                      const string& unique_name,
                      bufferContainer &buffer_container);
     virtual ~networkOutputSim();
-    void main_thread();
+    void main_thread() override;
 
 private:
     struct Buffer * buf;


### PR DESCRIPTION
Does not activate `-Wsuggest-override` yet, because HighFive is not clean of those.
To make it easy for everyone, let's wait for HighFive to merge [#142](https://github.com/BlueBrain/HighFive/pull/142) and [#78](https://github.com/BlueBrain/HighFive/pull/78) before activating it (commented out lines in `CMakeList.txt`).

closes #86