### PR TITLE
Implement metrics for number of received and completed baseband requests

### DIFF
--- a/lib/core/basebandApiManager.cpp
+++ b/lib/core/basebandApiManager.cpp
@@ -52,6 +52,13 @@ void to_json(json& j, const basebandDumpStatus& d) {
     }
 }
 
+basebandApiManager::basebandApiManager() :
+    // clang-format off
+    metrics(prometheusMetrics::instance()) // clang-format on
+{
+    metrics.add_stage_metric("kotekan_baseband_requests_total", "baseband", request_count);
+}
+
 basebandApiManager& basebandApiManager::instance() {
     static basebandApiManager _instance;
     return _instance;
@@ -166,11 +173,14 @@ void basebandApiManager::handle_request_callback(connectionInstance& conn, json&
                                                      {"start_fpga", readout_slice.start_fpga},
                                                      {"length_fpga", readout_slice.length_fpga}};
         }
+
         restServer& rest_server = restServer::instance();
         rest_server.register_get_callback("/baseband/" + std::to_string(event_id),
                                           [event_id, this](connectionInstance& nc) {
                                               status_callback_single_event(event_id, nc);
                                           });
+
+        metrics.add_stage_metric("kotekan_baseband_requests_total", "baseband", ++request_count);
 
         conn.send_json_reply(response);
     } catch (const std::exception& ex) {

--- a/lib/core/basebandApiManager.hpp
+++ b/lib/core/basebandApiManager.hpp
@@ -9,6 +9,7 @@
 
 #include "basebandReadoutManager.hpp"
 #include "gpsTime.h"
+#include "prometheusMetrics.hpp"
 #include "restServer.hpp"
 
 #include "json.hpp"
@@ -38,6 +39,10 @@ void to_json(json& j, const basebandDumpStatus& s);
  * loop, and when the result is non-null, use the returned @c basebandDumpStatus
  * to keep track of the data written so far. Once the writing of the data file
  * is completed, the ``state`` of the request should be set to ``DONE``.
+ *
+ * @par Metrics
+ * @metric kotekan_baseband_requests_total
+ *         The count of dump requests received by the REST endpoint ``/baseband``
  *
  * @author Davor Cubranic
  */
@@ -162,7 +167,7 @@ public:
 
 private:
     /// Constructor, not used directly
-    basebandApiManager() = default;
+    basebandApiManager();
 
     /// Sampling frequency (Hz)
     static constexpr double ADC_SAMPLE_RATE = 800e6;
@@ -233,6 +238,9 @@ private:
 
     /// Map of registered readout stages, indexed by `freq_id`
     basebandReadoutRegistry readout_registry;
+
+    prometheusMetrics& metrics;
+    uint32_t request_count = 0;
 };
 
 } // namespace kotekan

--- a/lib/processes/basebandReadout.hpp
+++ b/lib/processes/basebandReadout.hpp
@@ -12,6 +12,7 @@
 #include "buffer.h"
 #include "chimeMetadata.h"
 #include "gpsTime.h"
+#include "prometheusMetrics.hpp"
 #include "visUtil.hpp"
 
 #include "gsl-lite.hpp"
@@ -87,6 +88,13 @@ struct basebandDumpData {
  * @conf  write_throttle        Float, default 0. Add sleep time while writing dumps
  *                              equal to this factor times real time.
  *
+ * @par Metrics
+ * @metric kotekan_baseband_readout_total
+ *         The count of requests handled by an instance of this stage.
+ *         Labels:
+ *         - status: 'done', 'error', 'no_data'
+ *         - freq_id: channel frequency received by this stage
+ *
  * @author Kiyoshi Masui, Davor Cubranic
  */
 class basebandReadout : public kotekan::Stage {
@@ -140,6 +148,12 @@ private:
     std::unique_ptr<basebandDumpData> dump_to_write;
     std::condition_variable ready_to_write;
     std::mutex dump_to_write_mtx;
+
+    kotekan::prometheusMetrics& metrics = kotekan::prometheusMetrics::instance();
+    std::string freq_id_label;
+    uint32_t request_done_count = 0;
+    uint32_t request_error_count = 0;
+    uint32_t request_no_data_count = 0;
 };
 
 #endif


### PR DESCRIPTION
Received requests are counted at the node (kotekan) level by metric
`kotekan_baseband_requests_total`. It has no labels, other than Kotekan's
standard "stage".

Completed requests are tracked by `kotekan_baseband_readout_total`. This is kept
per-stage, and provides two useful labels: "freq_id" provides the stage's
frequency channel, and "status" separates the time series based on the outcome
of the request ("done" if successful, "error" if there was a problem writing the
data, and "no_data" if there was no available baseband data for the requested
time interval.