### PR TITLE
bugfix: missing throw keyword

### DIFF
--- a/lib/processes/visRawReader.cpp
+++ b/lib/processes/visRawReader.cpp
@@ -165,8 +165,8 @@ visRawReader::visRawReader(Config& config, const string& unique_name,
 
 visRawReader::~visRawReader() {
     if (munmap(mapped_file, ntime * nfreq * file_frame_size) == -1) {
-        std::runtime_error(
-            fmt::format("Failed to unmap file {}: {}.", filename + ".data", strerror(errno)));
+        ERROR(fmt::format("Failed to unmap file {}: {}.", filename + ".data", strerror(errno))
+              .c_str());
     }
 
     close(fd);

--- a/lib/utils/visFileRaw.cpp
+++ b/lib/utils/visFileRaw.cpp
@@ -112,7 +112,7 @@ void visFileRaw::create_file(const std::string& name,
     metadata_file = std::ofstream(name + ".meta", std::ios::binary);
     if ((fd = open((name + ".data").c_str(), oflags, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH))
         == -1) {
-        std::runtime_error(
+        throw std::runtime_error(
             fmt::format("Failed to open file {}: {}.", name + ".data", strerror(errno)));
     }
 


### PR DESCRIPTION
Without `throw` these Exceptions were only created, but probably never seen by anyone.

In the case of `visRawReader`, `munmap` could also be moved to the end of `main_thread` (destructors shouldn't throw). But in any case, how would throwing an exception there make sense anyways? I think it's not caught and kotekan would be exiting already anyways.