### PR TITLE
configUpdater: strict about number types (#369)

### DIFF
--- a/lib/core/configUpdater.cpp
+++ b/lib/core/configUpdater.cpp
@@ -3,6 +3,7 @@
 #include "Stage.hpp"
 #include "errors.h"
 #include "restServer.hpp"
+#include "visUtil.hpp"
 
 #include "fmt.hpp"
 
@@ -154,23 +155,12 @@ void configUpdater::rest_callback(connectionInstance& con, nlohmann::json& json)
             return;
         } else {
             // ...and for correct types
-            if (it.value().type_name() != _init_values[uri].at(it.key()).type_name()) {
+            if (it.value().type() != _init_values[uri].at(it.key()).type()) {
                 std::string msg = fmt::format("configUpdater: Update to endpoint '{}' contained"
                                               " value '{}' of type {} (expected type {}).",
-                                              uri.c_str(), it.key().c_str(), it.value().type_name(),
-                                              _init_values[uri].at(it.key()).type_name());
-
-                WARN(msg.c_str());
-                con.send_error(msg, HTTP_RESPONSE::BAD_REQUEST);
-                return;
-            }
-
-            if (it.value().type() == nlohmann::json::value_t::number_float
-                && _init_values[uri].at(it.key()).type() != it.value().type()) {
-                std::string msg = fmt::format("configUpdater: Update to endpoint '{}' contained"
-                                              " value '{}' of type float (expected type {}).",
                                               uri.c_str(), it.key().c_str(),
-                                              _init_values[uri].at(it.key()).type_name());
+                                              json_type_name(it.value()),
+                                              json_type_name(_init_values[uri].at(it.key())));
 
                 WARN(msg.c_str());
                 con.send_error(msg, HTTP_RESPONSE::BAD_REQUEST);

--- a/lib/core/configUpdater.hpp
+++ b/lib/core/configUpdater.hpp
@@ -5,6 +5,8 @@
 #include "Stage.hpp"
 #include "restServer.hpp"
 
+#include "json.hpp"
+
 namespace kotekan {
 
 /**

--- a/lib/utils/visUtil.cpp
+++ b/lib/utils/visUtil.cpp
@@ -76,6 +76,19 @@ void from_json(const json& j, rstack_ctype& t) {
     t.conjugate = j.at("conjugate").get<bool>();
 }
 
+std::string json_type_name(nlohmann::json& value) {
+    switch (value.type()) {
+    case (json::value_t::number_integer):
+        return "integer";
+    case (json::value_t::number_unsigned):
+        return "unsigned integer";
+    case (json::value_t::number_float):
+        return "float";
+    default:
+        return value.type_name();
+    }
+}
+
 // Copy the visibility triangle out of the buffer of data, allowing for a
 // possible reordering of the inputs
 // TODO: port this to using map_vis_triangle. Need a unit test first.

--- a/lib/utils/visUtil.hpp
+++ b/lib/utils/visUtil.hpp
@@ -174,6 +174,15 @@ void from_json(const json& j, std::complex<T>& p) {
 } // namespace std
 
 /**
+  * @brief Get type name of a JSON value.
+  * Returns a string with the name of the given json value type. Can be one of:
+  * integer, unsigned integer, float or value.type_name().
+  * @param value A JSON value.
+  * @return Type name.
+  */
+ std::string json_type_name(nlohmann::json& value);
+
+/**
  * @brief Index into a flattened upper matrix triangle.
  * @param  i Row index.
  * @param  j Column index.


### PR DESCRIPTION
configUpdater is now strict about number types and does not accept updates that were of a different number type before. The number types are `integer`, `unsigned integer` and `float`.