### PR TITLE
configUpdater: more strict about number types (#369)

### DIFF
--- a/lib/core/configUpdater.hpp
+++ b/lib/core/configUpdater.hpp
@@ -5,6 +5,8 @@
 #include "KotekanProcess.hpp"
 #include "Config.hpp"
 
+#include "json.hpp"
+
 /**
  * @brief Kotekan core component that creates endpoints defined in the config
  * that processes can subscribe to to receive updates.

--- a/lib/utils/visUtil.cpp
+++ b/lib/utils/visUtil.cpp
@@ -76,6 +76,19 @@ void from_json(const json& j, rstack_ctype& t) {
     t.conjugate = j.at("conjugate").get<bool>();
 }
 
+std::string json_type_name(nlohmann::json& value) {
+    switch (value.type()) {
+    case (json::value_t::number_integer):
+        return "integer";
+    case (json::value_t::number_unsigned):
+        return "integer";
+    case (json::value_t::number_float):
+        return "float";
+    default:
+        return value.type_name();
+    }
+}
+
 // Copy the visibility triangle out of the buffer of data, allowing for a
 // possible reordering of the inputs
 // TODO: port this to using map_vis_triangle. Need a unit test first.

--- a/lib/utils/visUtil.hpp
+++ b/lib/utils/visUtil.hpp
@@ -175,6 +175,15 @@ namespace std {
 }
 
 /**
+  * @brief Get type name of a JSON value.
+  * Returns a string with the name of the given json value type. Can be one of:
+  * integer, float or value.type_name().
+  * @param value A JSON value.
+  * @return Type name.
+  */
+ std::string json_type_name(nlohmann::json& value);
+
+/**
  * @brief Index into a flattened upper matrix triangle.
  * @param  i Row index.
  * @param  j Column index.


### PR DESCRIPTION
configUpdater is now more strict about number types and does not accept `float` updates that were of a number type `integer` or `unsigned` before. `integer` and `unsigned` values are allowed to be used to update each other.