### PR TITLE
fix missing throw keywords

### DIFF
--- a/lib/processes/visRawReader.cpp
+++ b/lib/processes/visRawReader.cpp
@@ -16,6 +16,7 @@
 #include <memory>
 #include <regex>
 #include <stdexcept>
+#include <signal.h>
 
 #include "gsl-lite.hpp"
 #include "json.hpp"
@@ -169,8 +170,10 @@ visRawReader::visRawReader(Config &config,
 
 visRawReader::~visRawReader() {
     if(munmap(mapped_file, ntime * nfreq * file_frame_size) == -1) {
-        std::runtime_error(fmt::format("Failed to unmap file {}: {}.",
-                                       filename + ".data", strerror(errno)));
+        ERROR(fmt::format("Failed to unmap file {}: {}.", filename + ".data", strerror(errno))
+              .c_str());
+        // Make sure kotekan is exiting...
+        raise(SIGINT);
     }
 
     close(fd);

--- a/lib/processes/visWriter.cpp
+++ b/lib/processes/visWriter.cpp
@@ -305,10 +305,14 @@ void visWriter::init_acq(dset_id_t ds_id)
     // Construct metadata
     auto metadata = make_metadata(ds_id);
 
-    acq.file_bundle = std::make_unique<visFileBundle>(
-        file_type, root_path, instrument_name, metadata, chunk_id, file_length,
-        window, ds_id, file_length
-    );
+    try {
+        acq.file_bundle = std::make_unique<visFileBundle>(
+            file_type, root_path, instrument_name, metadata, chunk_id, file_length,
+            window, ds_id, file_length);
+    } catch(std::exception& e) {
+        ERROR("Failed creating file bundle for new acquisition: %s", e.what());
+        raise(SIGINT);
+    }
 }
 
 

--- a/lib/utils/visFileRaw.cpp
+++ b/lib/utils/visFileRaw.cpp
@@ -125,7 +125,7 @@ void visFileRaw::create_file(
     metadata_file = std::ofstream(name + ".meta", std::ios::binary);
     if((fd = open((name + ".data").c_str(), oflags,
                   S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH)) == -1) {
-        std::runtime_error(fmt::format("Failed to open file {}: {}.",
+        throw std::runtime_error(fmt::format("Failed to open file {}: {}.",
                                        name + ".data", strerror(errno)));
     }
 


### PR DESCRIPTION
Without `throw` these Exceptions were only created, but probably never seen by anyone.

In the case of `visRawReader`, `munmap` could also be moved to the end of `main_thread` (destructors shouldn't throw). 

Replaces #372 with the following additions:
 - Pointed at `master` for hotfix
 - Catch exception of raw file creation
 - raise SIGINT to make sure kotekan is exiting when munmap failes in `~visRawReader`