### PR TITLE
runner.py: use kotekan -c instead of -d

### DIFF
--- a/python/kotekan/runner.py
+++ b/python/kotekan/runner.py
@@ -73,7 +73,7 @@ class KotekanRunner(object):
             kotekan_cmd = './kotekan -c %s'
             wd = build_dir
         else:
-            kotekan_cmd = 'kotekan -d %s'
+            kotekan_cmd = 'kotekan -c %s'
             wd = os.curdir
 
         with tempfile.NamedTemporaryFile() as fh, \


### PR DESCRIPTION
#392 