### PR TITLE
Fix double counting of RFI and lost packets

### DIFF
--- a/lib/hsa/hsaRfiMaskOutput.cpp
+++ b/lib/hsa/hsaRfiMaskOutput.cpp
@@ -85,7 +85,7 @@ void hsaRfiMaskOutput::finalize_frame(int frame_id) {
         // Total number of samples flaged as RFI
         uint32_t flagged_samples = 0;
 
-        // The number of samples flaged as RFI less the number of
+        // The number of samples flagged as RFI less the number of
         // samples flaged as missing (i.e. packet loss/currupt packet).
         uint32_t net_lost_samples = 0;
 

--- a/lib/hsa/hsaRfiMaskOutput.cpp
+++ b/lib/hsa/hsaRfiMaskOutput.cpp
@@ -98,8 +98,7 @@ void hsaRfiMaskOutput::finalize_frame(int frame_id) {
                 // Remove any samples which were also counted as lost samples
                 // in this block of data.
                 for (uint32_t j = 0; j < _sk_step; ++j) {
-                    uint32_t lost_samples_idx = subframe * _sub_frame_samples +
-                                                i * _sk_step + j;
+                    uint32_t lost_samples_idx = subframe * _sub_frame_samples + i * _sk_step + j;
                     assert(lost_samples_idx < (uint32_t)_lost_samples_buf->frame_size);
                     if (lost_samples_frame[lost_samples_idx] == 1)
                         net_lost_samples--;

--- a/lib/hsa/hsaRfiMaskOutput.cpp
+++ b/lib/hsa/hsaRfiMaskOutput.cpp
@@ -86,7 +86,7 @@ void hsaRfiMaskOutput::finalize_frame(int frame_id) {
         uint32_t flagged_samples = 0;
 
         // The number of samples flagged as RFI less the number of
-        // samples flaged as missing (i.e. packet loss/currupt packet).
+        // samples flagged as missing (i.e. packet loss/corrupt packet).
         uint32_t net_lost_samples = 0;
 
         for (uint32_t i = 0; i < sub_frame_mask_len; ++i) {

--- a/lib/hsa/hsaRfiMaskOutput.cpp
+++ b/lib/hsa/hsaRfiMaskOutput.cpp
@@ -82,7 +82,7 @@ void hsaRfiMaskOutput::finalize_frame(int frame_id) {
 
     for (uint32_t subframe = 0; subframe < _num_sub_frames; ++subframe) {
 
-        // Total number of samples flaged as RFI
+        // Total number of samples flagged as RFI
         uint32_t flagged_samples = 0;
 
         // The number of samples flagged as RFI less the number of

--- a/lib/hsa/hsaRfiMaskOutput.cpp
+++ b/lib/hsa/hsaRfiMaskOutput.cpp
@@ -14,8 +14,13 @@ hsaRfiMaskOutput::hsaRfiMaskOutput(Config& config, const string& unique_name,
     // Get buffers
     _network_buf = host_buffers.get_buffer("network_buf");
     register_consumer(_network_buf, unique_name.c_str());
+
+    _lost_samples_buf = host_buffers.get_buffer("lost_samples_buf");
+    register_consumer(_lost_samples_buf, unique_name.c_str());
+
     _rfi_mask_output_buf = host_buffers.get_buffer("rfi_mask_output_buf");
     register_producer(_rfi_mask_output_buf, unique_name.c_str());
+
     _output_buf = host_buffers.get_buffer("output_buf");
     register_producer(_output_buf, unique_name.c_str());
 
@@ -27,6 +32,7 @@ hsaRfiMaskOutput::hsaRfiMaskOutput(Config& config, const string& unique_name,
     _sk_step = config.get_default<uint32_t>(unique_name, "sk_step", 256);
     // Initialize ID's
     _network_buf_id = 0;
+    _lost_samples_buf_id = 0;
     _output_buf_id = 0;
     _rfi_mask_output_buf_id = 0;
     _rfi_mask_output_buf_precondition_id = 0;
@@ -66,40 +72,72 @@ hsa_signal_t hsaRfiMaskOutput::execute(int gpu_frame_id, hsa_signal_t precede_si
 void hsaRfiMaskOutput::finalize_frame(int frame_id) {
     hsaCommand::finalize_frame(frame_id);
 
-    if (get_rfi_zeroed(_network_buf, _network_buf_id)) {
-        uint8_t* frame_mask = _rfi_mask_output_buf->frames[_rfi_mask_output_buf_id];
-        uint32_t total_lost = 0;
-        // Copy RFI mask to array
-        for (uint32_t subframe = 0; subframe < _num_sub_frames; ++subframe) {
-            uint32_t lost_in_subframe = 0;
-            for (uint32_t i = subframe * _sub_frame_samples / _sk_step;
-                 i < (subframe + 1) * _sub_frame_samples / _sk_step; i++) {
-                assert(i < (uint32_t)_rfi_mask_output_buf->frame_size);
-                if (frame_mask[i] == 1)
-                    lost_in_subframe += _sk_step;
-            }
-            atomic_add_lost_timesamples(_output_buf, _output_buf_id, lost_in_subframe);
-            mark_frame_full(_output_buf, unique_name.c_str(), _output_buf_id);
-            _output_buf_id = (_output_buf_id + 1) % _output_buf->num_frames;
+    uint8_t* mask_frame = _rfi_mask_output_buf->frames[_rfi_mask_output_buf_id];
+    uint8_t* lost_samples_frame = _lost_samples_buf->frames[_lost_samples_buf_id];
 
-            total_lost += lost_in_subframe;
+    // Add the number of flagged samples to the metadata
+    uint32_t total_flagged = 0;
+    uint32_t total_net_lost_samples = 0;
+    uint32_t sub_frame_mask_len = _sub_frame_samples / _sk_step;
+
+    for (uint32_t subframe = 0; subframe < _num_sub_frames; ++subframe) {
+
+        // Total number of samples flaged as RFI
+        uint32_t flagged_samples = 0;
+
+        // The number of samples flaged as RFI less the number of
+        // samples flaged as missing (i.e. packet loss/currupt packet).
+        uint32_t net_lost_samples = 0;
+
+        for (uint32_t i = 0; i < sub_frame_mask_len; ++i) {
+            uint32_t mask_idx = subframe * sub_frame_mask_len + i;
+            assert(mask_idx < (uint32_t)_rfi_mask_output_buf->frame_size);
+            if (mask_frame[mask_idx] == 1) {
+                flagged_samples += _sk_step;
+                net_lost_samples += _sk_step;
+                // Remove any samples which were also counted as lost samples
+                // in this block of data.
+                for (uint32_t j = 0; j < _sk_step; ++j) {
+                    uint32_t lost_samples_idx = subframe * _sub_frame_samples +
+                                                i * _sk_step + j;
+                    assert(lost_samples_idx < (uint32_t)_lost_samples_buf->frame_size);
+                    if (lost_samples_frame[lost_samples_idx] == 1)
+                        net_lost_samples--;
+                }
+            }
         }
-        atomic_add_lost_timesamples(_network_buf, _network_buf_id, total_lost);
-    } else {
-        // Since we are a producer we always need to sign off on the frame
-        for (uint32_t subframe = 0; subframe < _num_sub_frames; ++subframe) {
-            mark_frame_full(_output_buf, unique_name.c_str(), _output_buf_id);
-            _output_buf_id = (_output_buf_id + 1) % _output_buf->num_frames;
+        DEBUG("flagged_samples: %d, net_lost_samples: %d", flagged_samples, net_lost_samples);
+        atomic_add_rfi_flagged_samples(_output_buf, _output_buf_id, flagged_samples);
+
+        if (get_rfi_zeroed(_network_buf, _network_buf_id)) {
+            atomic_add_lost_timesamples(_output_buf, _output_buf_id, net_lost_samples);
         }
+
+        mark_frame_full(_output_buf, unique_name.c_str(), _output_buf_id);
+        _output_buf_id = (_output_buf_id + 1) % _output_buf->num_frames;
+
+        total_net_lost_samples += net_lost_samples;
+        total_flagged += flagged_samples;
     }
+
+    // Add total numbers to the input buffer metadata for systems using
+    // the normal (non-subframe) counts.
+    atomic_add_rfi_flagged_samples(_network_buf, _network_buf_id, total_flagged);
+    if (get_rfi_zeroed(_network_buf, _network_buf_id)) {
+        atomic_add_lost_timesamples(_network_buf, _network_buf_id, total_net_lost_samples);
+    }
+
     // Pass the information contained in the input buffer
     pass_metadata(_network_buf, _network_buf_id, _rfi_mask_output_buf, _rfi_mask_output_buf_id);
 
     // Mark the input buffer as "empty" so that it can be reused.
     mark_frame_empty(_network_buf, unique_name.c_str(), _network_buf_id);
+    // Mark the lost samples buffer as empty
+    mark_frame_empty(_lost_samples_buf, unique_name.c_str(), _lost_samples_buf_id);
     // Mark the output buffer as full, so it can be processed.
     mark_frame_full(_rfi_mask_output_buf, unique_name.c_str(), _rfi_mask_output_buf_id);
     // Note this will change once we do accumulation in the GPU
     _network_buf_id = (_network_buf_id + 1) % _network_buf->num_frames;
+    _lost_samples_buf_id = (_lost_samples_buf_id + 1) % _lost_samples_buf->num_frames;
     _rfi_mask_output_buf_id = (_rfi_mask_output_buf_id + 1) % _rfi_mask_output_buf->num_frames;
 }

--- a/lib/hsa/hsaRfiMaskOutput.hpp
+++ b/lib/hsa/hsaRfiMaskOutput.hpp
@@ -44,14 +44,18 @@ public:
     void finalize_frame(int frame_id) override;
 
 private:
-    /// The very first input data from dpdk
+    /// The raw time series data from the FPGAs
     Buffer* _network_buf;
+    /// The array of missing sample flags for _network_buf
+    Buffer* _lost_samples_buf;
     /// Output buffer from the FRB pipeline
     Buffer* _rfi_mask_output_buf;
     /// Output of the N2 correlation products
     Buffer* _output_buf;
     /// ID for _network_buf
     int32_t _network_buf_id;
+    /// ID for _lost_samples_buf
+    int32_t _lost_samples_buf_id;
     /// ID for _output_buf;
     int32_t _output_buf_id;
     /// ID for _rfi_mask_output_buf

--- a/lib/metadata/chimeMetadata.h
+++ b/lib/metadata/chimeMetadata.h
@@ -19,12 +19,29 @@ struct psrCoord {
 };
 
 struct chimeMetadata {
+    /// The ICEBoard sequence number
     int64_t fpga_seq_num;
+    /// The system time when the first packet in the frame was captured
     struct timeval first_packet_recv_time;
-    struct timespec gps_time; // The GPS time of the fpga_seq_num.
+    /// The GPS time of @c fpga_seq_num.
+    struct timespec gps_time;
+    /// The total lost time samples for lost/currupt packets and RFI zeroing.
+    /// This value only include RFI losses if RFI zeroing was used.
     int32_t lost_timesamples;
+    /// The number of 2.56us samples flaged as containg RFI.
+    /// NOTE: This value might contain overlap with lost samples, so it can count
+    /// missing samples as samples with RFI.  For renormalization this value
+    /// should NOT be used, use @c lost_timesamples instead.
+    /// This value will be filled even if RFI zeroing is disabled.
+    int32_t rfi_flagged_samples;
+    /// The stream ID from the ICEBoard
+    /// Note in the case of CHIME-2048 the normally unused section
+    /// Encodes the port-shuffle freqeuncy information
     uint16_t stream_ID;
+    /// The corrdinates of the pulsar beam (if applicable)
     struct psrCoord psr_coord;
+    /// This value is set to 1 if the RFI containing samples were zeroed
+    /// in the correlation, and 0 otherwise.
     uint32_t rfi_zeroed;
 };
 
@@ -52,6 +69,19 @@ inline int32_t get_lost_timesamples(struct Buffer * buf, int ID) {
     struct chimeMetadata * chime_metadata =
      (struct chimeMetadata *) buf->metadata[ID]->metadata;
     return chime_metadata->lost_timesamples;
+}
+
+/**
+ * @brief Get the number of RFI flagged samples
+ *
+ * @param buf The buffer containing the frame
+ * @param ID The frame to get metadata from
+ * @return The number of RFI flagged samples
+ */
+inline int32_t get_rfi_flaged_samples(struct Buffer * buf, int ID) {
+    struct chimeMetadata * chime_metadata =
+     (struct chimeMetadata *) buf->metadata[ID]->metadata;
+    return chime_metadata->rfi_flagged_samples;
 }
 
 inline uint16_t get_stream_id(struct Buffer * buf, int ID) {
@@ -84,6 +114,22 @@ inline void atomic_add_lost_timesamples(struct Buffer * buf, int ID,
     lock_metadata(mc);
     struct chimeMetadata * chime_metadata = (struct chimeMetadata *) mc->metadata;
     chime_metadata->lost_timesamples += num_lost_samples;
+    unlock_metadata(mc);
+}
+
+/**
+ * @brief Add RFI flagged samples to the metadata
+ *
+ * @param buf The buffer with the metadata
+ * @param ID The frame in the buffer to add metadata too
+ * @param num_flagged_samples The number of flagged samples to add
+ */
+inline void atomic_add_rfi_flagged_samples(struct Buffer * buf, int ID,
+                                           int64_t num_flagged_samples) {
+    struct metadataContainer * mc = buf->metadata[ID];
+    lock_metadata(mc);
+    struct chimeMetadata * chime_metadata = (struct chimeMetadata *) mc->metadata;
+    chime_metadata->rfi_flagged_samples += num_flagged_samples;
     unlock_metadata(mc);
 }
 

--- a/lib/processes/visAccumulate.cpp
+++ b/lib/processes/visAccumulate.cpp
@@ -420,13 +420,14 @@ void visAccumulate::main_thread() {
             }
 
             // Accumulate the total number of samples, accounting for lost ones
-            assert((int64_t)samples_per_data_set - (int64_t)get_lost_timesamples(in_buf, in_frame_id) >= 0);
+            assert((int64_t)samples_per_data_set
+                       - (int64_t)get_lost_timesamples(in_buf, in_frame_id)
+                   >= 0);
             total_samples += samples_per_data_set - get_lost_timesamples(in_buf, in_frame_id);
 
             DEBUG("Lost samples %d, RFI flagged samples %d, total_samples: %u",
-                 get_lost_timesamples(in_buf, in_frame_id),
-                 get_rfi_flaged_samples(in_buf, in_frame_id),
-                 total_samples);
+                  get_lost_timesamples(in_buf, in_frame_id),
+                  get_rfi_flaged_samples(in_buf, in_frame_id), total_samples);
         }
 
         // Move the input buffer on one step

--- a/lib/processes/visAccumulate.cpp
+++ b/lib/processes/visAccumulate.cpp
@@ -420,7 +420,13 @@ void visAccumulate::main_thread() {
             }
 
             // Accumulate the total number of samples, accounting for lost ones
+            assert((int64_t)samples_per_data_set - (int64_t)get_lost_timesamples(in_buf, in_frame_id) >= 0);
             total_samples += samples_per_data_set - get_lost_timesamples(in_buf, in_frame_id);
+
+            DEBUG("Lost samples %d, RFI flagged samples %d, total_samples: %u",
+                 get_lost_timesamples(in_buf, in_frame_id),
+                 get_rfi_flaged_samples(in_buf, in_frame_id),
+                 total_samples);
         }
 
         // Move the input buffer on one step


### PR DESCRIPTION
It's possible that `hsaRfiMaskOutput.cpp` will count packet loss zeroed samples from `zeroSamples.cpp` twice.   This is because first `zeroSamples` adds to the lost samples counter for packet loss, and then later the RFI system might zero out the same samples (but in 256 time sample blocks), leading to double counting.   This fix checks if any of the samples zeroed in `zeroSamples` would be counted twice in `hsaRfiMaskOutput` and corrects for them. 

Also adds a new metadata value for number of RFI flagged samples.

