### PR TITLE
Add support for URL query args

### DIFF
--- a/lib/core/basebandApiManager.hpp
+++ b/lib/core/basebandApiManager.hpp
@@ -62,10 +62,15 @@ public:
     void register_with_server(restServer* rest_server);
 
     /**
-     * @brief The call back function for GET requests to `/baseband`.
+     * @brief The call back function for GET requests to `/baseband[?event_id=<event_id>]`
      *
      * The function sends over `conn` an HTTP response with the status of all
      * baseband dumps received since this instance started running.
+     *
+     * If the query option `?event_id=<event_id>` is provided in the URL then
+     * the function @c status_callback_single_event() is called to return
+     * just the information related to that single event_id.
+     * See @c status_callback_single_event() for details of the return message in that case.
      *
      * The response is a JSON dictionary, with keys of unique ids of the
      * baseband events. The key's value is the status of that baseband dump, and
@@ -91,7 +96,7 @@ public:
     void status_callback_all(connectionInstance& conn);
 
     /**
-     * @brief The call back function for GET requests to `/baseband/:event_id`.
+     * @brief Helper function for GET requests to `/baseband?event_id=<event_id>`.
      *
      * The function sends over `conn` an HTTP response with the status of a
      * specified baseband dump. The response is a JSON list, with an element for

--- a/lib/core/restServer.cpp
+++ b/lib/core/restServer.cpp
@@ -508,9 +508,6 @@ std::map<std::string, std::string> connectionInstance::get_query() {
             query_map[string(cur_query->key)] = string(cur_query->value);
             cur_query = cur_query->next.tqe_next;
         }
-    } else {
-        WARN("The query part of the URL could not be parsed for URL: %s",
-            evhttp_request_get_uri(request))
     }
     evhttp_clear_headers(&queries);
     return query_map;

--- a/lib/core/restServer.cpp
+++ b/lib/core/restServer.cpp
@@ -2,6 +2,7 @@
 
 #include "errors.h"
 
+#include <event2/keyvalq_struct.h>
 #include <pthread.h>
 #include <sched.h>
 #include <signal.h>
@@ -56,7 +57,7 @@ void restServer::handle_request(struct evhttp_request* request, void* cb_data) {
 
     restServer* server = (restServer*)(cb_data);
 
-    string url = string(evhttp_request_get_uri(request));
+    string url = string(evhttp_uri_get_path(evhttp_request_get_evhttp_uri(request)));
 
     DEBUG2("restServer: Got request with url %s", url.c_str());
 
@@ -493,6 +494,26 @@ void connectionInstance::send_json_reply(const json& json_reply) {
     }
 
     evhttp_send_reply(request, static_cast<int>(HTTP_RESPONSE::OK), "OK", event_buffer);
+}
+
+std::map<std::string, std::string> connectionInstance::get_query() {
+    std::map<std::string, std::string> query_map;
+    struct evkeyvalq queries;
+    queries.tqh_first = nullptr;
+    queries.tqh_last = nullptr;
+    const char * query_string = evhttp_uri_get_query(evhttp_request_get_evhttp_uri(request));
+    if (query_string && evhttp_parse_query_str(query_string, &queries) == 0) {
+        struct evkeyval * cur_query = queries.tqh_first;
+        while(cur_query) {
+            query_map[string(cur_query->key)] = string(cur_query->value);
+            cur_query = cur_query->next.tqe_next;
+        }
+    } else {
+        WARN("The query part of the URL could not be parsed for URL: %s",
+            evhttp_request_get_uri(request))
+    }
+    evhttp_clear_headers(&queries);
+    return query_map;
 }
 
 } // namespace kotekan

--- a/lib/core/restServer.cpp
+++ b/lib/core/restServer.cpp
@@ -504,7 +504,7 @@ std::map<std::string, std::string> connectionInstance::get_query() {
     const char* query_string = evhttp_uri_get_query(evhttp_request_get_evhttp_uri(request));
     if (query_string && evhttp_parse_query_str(query_string, &queries) == 0) {
         struct evkeyval* cur_query = queries.tqh_first;
-        while(cur_query) {
+        while (cur_query) {
             query_map[string(cur_query->key)] = string(cur_query->value);
             cur_query = cur_query->next.tqe_next;
         }

--- a/lib/core/restServer.cpp
+++ b/lib/core/restServer.cpp
@@ -501,9 +501,9 @@ std::map<std::string, std::string> connectionInstance::get_query() {
     struct evkeyvalq queries;
     queries.tqh_first = nullptr;
     queries.tqh_last = nullptr;
-    const char * query_string = evhttp_uri_get_query(evhttp_request_get_evhttp_uri(request));
+    const char* query_string = evhttp_uri_get_query(evhttp_request_get_evhttp_uri(request));
     if (query_string && evhttp_parse_query_str(query_string, &queries) == 0) {
-        struct evkeyval * cur_query = queries.tqh_first;
+        struct evkeyval* cur_query = queries.tqh_first;
         while(cur_query) {
             query_map[string(cur_query->key)] = string(cur_query->value);
             cur_query = cur_query->next.tqe_next;

--- a/lib/core/restServer.hpp
+++ b/lib/core/restServer.hpp
@@ -99,8 +99,8 @@ public:
      * @brief Gets the query args as a map of key value strings
      *
      * Example "/my_endpoint?val=42&myval=hello" would return a map with items:
-     * map[myval] == 42
-     * map[val] = hello
+     * map["val"] == "42"
+     * map["myval"] == "hello"
      *
      * In the case there are no URL query args, an empty map is returned.
      *

--- a/lib/core/restServer.hpp
+++ b/lib/core/restServer.hpp
@@ -95,6 +95,19 @@ public:
      */
     std::string get_uri();
 
+    /**
+     * @brief Gets the query args as a map of key value strings
+     *
+     * Example "/my_endpoint?val=42&myval=hello" would return a map with items:
+     * map[myval] == 42
+     * map[val] = hello
+     *
+     * In the case there are no URL query args, an empty map is returned.
+     *
+     * @return A map with string keys and string values with any url query args
+     */
+    std::map<std::string, std::string> get_query();
+
 private:
     /// The request details
     struct evhttp_request* request;


### PR DESCRIPTION
Adds support for URL query args. e.g. `/my_endpoint?my_option=my_val`

Changes baseband status request API from `/baseband/<event_id>` to `/baseband?event_id=<event_id>`