### PR TITLE
Exit on config error

### DIFF
--- a/kotekan/kotekan.cpp
+++ b/kotekan/kotekan.cpp
@@ -416,18 +416,27 @@ int main(int argc, char** argv) {
             delete kotekan_mode;
             kotekan_mode = nullptr;
             conn.send_error(ex.what(), HTTP_RESPONSE::BAD_REQUEST);
+            // TODO This exit shouldn't be required, but some stages aren't able
+            // to fully clean up on system failure.  This results in the system
+            // getting into a bad state if the posted config is invalid.
+            // See ticket: #464
+            // The same applies to exit (raise) statements in other parts of
+            // this try statement.
+            raise(SIGINT);
             return;
         } catch (const std::runtime_error& ex) {
             ERROR("Runtime error %s", ex.what());
             delete kotekan_mode;
             kotekan_mode = nullptr;
             conn.send_error(ex.what(), HTTP_RESPONSE::BAD_REQUEST);
+            raise(SIGINT);
             return;
         } catch (const std::exception& ex) {
             ERROR("Generic exception %s", ex.what());
             delete kotekan_mode;
             kotekan_mode = nullptr;
             conn.send_error(ex.what(), HTTP_RESPONSE::BAD_REQUEST);
+            raise(SIGINT);
             return;
         }
         conn.send_empty_reply(HTTP_RESPONSE::OK);


### PR DESCRIPTION
Resolves issue #450 by just exiting on config error.  This should be considered a temporary fix until the issues in #464 can be resolved. 