### PR TITLE
Fix compile errors in osxBindCPU.cpp

### DIFF
--- a/lib/utils/osxBindCPU.cpp
+++ b/lib/utils/osxBindCPU.cpp
@@ -1,5 +1,7 @@
 #include "osxBindCPU.hpp"
 
+#include "kotekanLogging.hpp"
+
 int sched_getaffinity(pid_t pid, size_t cpu_size, cpu_set_t* cpu_set) {
     // Unused parameters, FIXME: can we remove them?
     (void)pid;
@@ -9,7 +11,7 @@ int sched_getaffinity(pid_t pid, size_t cpu_size, cpu_set_t* cpu_set) {
     size_t len = sizeof(core_count);
     int ret = sysctlbyname(SYSCTL_CORE_COUNT, &core_count, &len, 0, 0);
     if (ret) {
-        ERROR("error while get core count {:d}\n", ret);
+        ERROR_NON_OO("error while get core count {:d}\n", ret);
         return -1;
     }
     cpu_set->count = 0;

--- a/lib/utils/osxBindCPU.hpp
+++ b/lib/utils/osxBindCPU.hpp
@@ -11,8 +11,6 @@
 #ifndef OSXBINDCPU_H
 #define OSXBINDCPU_H
 
-#include "errors.h"
-
 #include <mach/thread_act.h>
 #include <mach/thread_policy.h>
 #include <pthread.h>


### PR DESCRIPTION
This was probably caused by #483, which didn't update this OSX-only file for
changes in the logging API.