### PR TITLE
cmake: Turn on -Wunused-local-typedefs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,8 +199,8 @@ set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
 if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
        set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -lrt " )
 endif ()
-# TODO: remove -Wno-unused-local-typedefs once fmt fixes that (looks like in the next release after 5.3.0)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GNU_SOURCE -O3 -Wall -Wno-unused-local-typedefs -Wextra -Werror -march=native -mtune=native -I/opt/rocm/include")
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GNU_SOURCE -O3 -Wall -Wextra -Werror -march=native -mtune=native -I/opt/rocm/include")
 
 # Warning about missing override is called differently in clang and gcc
 # TODO: enable once we are using a release version of HighFive


### PR DESCRIPTION
It was disabled because the fmt library was triggering this warning until
version 5.3.0.