### PR TITLE
Redesign of baseband processing flow and synchronization (fixes #497)

### DIFF
--- a/lib/core/basebandReadoutManager.cpp
+++ b/lib/core/basebandReadoutManager.cpp
@@ -14,9 +14,10 @@ basebandDumpData::basebandDumpData(uint64_t event_id_, uint32_t freq_id_, uint32
     data_length_fpga(data_length_fpga_),
     data_start_ctime(data_start_ctime_),
     data(span_from_length_aligned(data_)),
-    reservation_length(data_.size()) {}
+    reservation_length(data_.size()),
+    status(basebandDumpData::Status::Ok) {}
 
-basebandDumpData::basebandDumpData() :
+basebandDumpData::basebandDumpData(basebandDumpData::Status status_) :
     event_id(0),
     freq_id(0),
     num_elements(0),
@@ -24,7 +25,8 @@ basebandDumpData::basebandDumpData() :
     data_length_fpga(0),
     data_start_ctime({0, 0}),
     data(),
-    reservation_length(0) {}
+    reservation_length(0),
+    status(status_) {}
 
 gsl::span<uint8_t> basebandDumpData::span_from_length_aligned(const gsl::span<uint8_t>& span_) {
 

--- a/lib/core/basebandReadoutManager.cpp
+++ b/lib/core/basebandReadoutManager.cpp
@@ -3,45 +3,93 @@
 
 namespace kotekan {
 
+
+basebandDumpData::basebandDumpData(uint64_t event_id_, uint32_t freq_id_, uint32_t num_elements_,
+                                   int64_t data_start_fpga_, uint64_t data_length_fpga_,
+                                   timespec data_start_ctime_, const gsl::span<uint8_t>& data_) :
+    event_id(event_id_),
+    freq_id(freq_id_),
+    num_elements(num_elements_),
+    data_start_fpga(data_start_fpga_),
+    data_length_fpga(data_length_fpga_),
+    data_start_ctime(data_start_ctime_),
+    data(span_from_length_aligned(data_)),
+    reservation_length(data_.size()) {}
+
+basebandDumpData::basebandDumpData() :
+    event_id(0),
+    freq_id(0),
+    num_elements(0),
+    data_start_fpga(0),
+    data_length_fpga(0),
+    data_start_ctime({0, 0}),
+    data(),
+    reservation_length(0) {}
+
+gsl::span<uint8_t> basebandDumpData::span_from_length_aligned(const gsl::span<uint8_t>& span_) {
+
+    intptr_t span_start_int = (intptr_t)span_.data() + 15;
+    span_start_int -= span_start_int % 16;
+    uint8_t* span_start = (uint8_t*)span_start_int;
+    size_t length = span_.size();
+    if (span_start > span_.data()) {
+        length -= (span_start - span_.data());
+    }
+    uint8_t* span_end = span_start + length;
+
+    return gsl::span<uint8_t>(span_start, span_end);
+}
+
+
 void basebandReadoutManager::add(basebandRequest req) {
     std::unique_lock<std::mutex> lock(requests_mtx);
 
     basebandDumpStatus ev{req};
-    requests.insert_after(tail, ev);
-    tail++;
+    requests.push_front(ev);
 
-    has_request.notify_all();
+    waiting_queue.put(std::ref(requests.front()));
 }
 
+
+void basebandReadoutManager::ready(const basebandReadoutManager::ReadyRequest& req) {
+    ready_queue.put(req);
+}
+
+void basebandReadoutManager::stop() {
+    waiting_queue.cancel();
+    ready_queue.cancel();
+}
 
 std::unique_ptr<basebandReadoutManager::requestStatusMutex>
 basebandReadoutManager::get_next_waiting_request() {
-    std::unique_lock<std::mutex> lock(requests_mtx);
-
-    // NB: the requests_mtx is released while the thread is waiting on
-    // `has_request`, and reacquired once woken
-    using namespace std::chrono_literals;
-    has_request.wait_for(lock, 0.1s);
-
-    if (waiting == tail) {
-        return nullptr;
+    {
+        std::unique_lock<std::mutex> lock(requests_mtx);
+        readout_current = nullptr;
     }
-    basebandDumpStatus& ev = *++waiting;
-    return std::make_unique<basebandReadoutManager::requestStatusMutex>(ev, waiting_mtx);
+    auto req = waiting_queue.get();
+    if (req) {
+        std::unique_lock<std::mutex> lock(requests_mtx);
+        readout_current = &(req->get());
+        return std::make_unique<requestStatusMutex>(*req, readout_mtx);
+    }
+    return nullptr;
 }
 
 
-basebandReadoutManager::requestStatusMutex basebandReadoutManager::get_next_ready_request() {
-    std::unique_lock<std::mutex> lock(requests_mtx);
-
-    while (current != waiting && current != tail) {
-        basebandDumpStatus& ev = *++current;
-        if (ev.state == basebandDumpStatus::State::INPROGRESS) {
-            return {ev, current_mtx};
-        }
+std::unique_ptr<basebandReadoutManager::ReadyRequestMutex>
+basebandReadoutManager::get_next_ready_request() {
+    {
+        std::unique_lock<std::mutex> lock(requests_mtx);
+        writeout_current = nullptr;
+    }
+    auto req = ready_queue.get();
+    if (req) {
+        std::unique_lock<std::mutex> lock(requests_mtx);
+        writeout_current = &(std::get<0>(*req));
+        return std::make_unique<ReadyRequestMutex>(*req, writeout_mtx);
     }
 
-    throw std::runtime_error("No ready request");
+    return nullptr;
 }
 
 
@@ -49,13 +97,13 @@ std::vector<basebandDumpStatus> basebandReadoutManager::all() {
     std::vector<basebandDumpStatus> v;
     std::lock_guard<std::mutex> lock(requests_mtx);
     for (auto it = requests.begin(); it != requests.end(); it++) {
-        std::unique_lock<std::mutex> waiting_lock(waiting_mtx, std::defer_lock);
-        std::unique_lock<std::mutex> current_lock(current_mtx, std::defer_lock);
-        if (it == waiting) {
-            waiting_lock.lock();
+        std::unique_lock<std::mutex> readout_lock(readout_mtx, std::defer_lock);
+        std::unique_lock<std::mutex> writeout_lock(writeout_mtx, std::defer_lock);
+        if (&(*it) == readout_current) {
+            readout_lock.lock();
         }
-        if (it == current) {
-            current_lock.lock();
+        if (&(*it) == writeout_current) {
+            writeout_lock.lock();
         }
         v.push_back(*it);
     }
@@ -67,13 +115,13 @@ std::vector<basebandDumpStatus> basebandReadoutManager::all() {
 std::unique_ptr<basebandDumpStatus> basebandReadoutManager::find(uint64_t event_id) {
     std::lock_guard<std::mutex> lock(requests_mtx);
     for (auto it = requests.begin(); it != requests.end(); it++) {
-        std::unique_lock<std::mutex> waiting_lock(waiting_mtx, std::defer_lock);
-        std::unique_lock<std::mutex> current_lock(current_mtx, std::defer_lock);
-        if (it == waiting) {
-            waiting_lock.lock();
+        std::unique_lock<std::mutex> readout_lock(readout_mtx, std::defer_lock);
+        std::unique_lock<std::mutex> writeout_lock(writeout_mtx, std::defer_lock);
+        if (&(*it) == readout_current) {
+            readout_lock.lock();
         }
-        if (it == current) {
-            current_lock.lock();
+        if (&(*it) == writeout_current) {
+            writeout_lock.lock();
         }
         if (it->request.event_id == event_id) {
             return std::make_unique<basebandDumpStatus>(*it);

--- a/lib/core/basebandReadoutManager.hpp
+++ b/lib/core/basebandReadoutManager.hpp
@@ -84,8 +84,11 @@ struct basebandDumpStatus {
  * @author Kiyoshi Masui
  */
 struct basebandDumpData {
-    /// Default constructor used to indicate error
-    basebandDumpData();
+    /// Indicates the reason why data could not be read, if it is not `Ok`
+    enum class Status { Ok, TooLong, Late, ReserveFailed, Cancelled };
+
+    /// Constructor used to indicate error
+    basebandDumpData(Status);
     /// Initialize the container with all parameters but does not fill in the data.
     basebandDumpData(uint64_t event_id_, uint32_t freq_id_, uint32_t num_elements_,
                      int64_t data_start_fpga_, uint64_t data_length_fpga_,
@@ -100,9 +103,14 @@ struct basebandDumpData {
     const uint64_t data_length_fpga;
     const timespec data_start_ctime;
     //@}
-    /// Data access. Array has length `num_elements * data_length_fpga`.
+    /// Data access. Array has length `num_elements * data_length_fpga` and is aligned on a 16-byte
+    /// boundary.
     const gsl::span<uint8_t> data;
+    /// Original size of the write reservation, regardless of the boundary
     const size_t reservation_length;
+
+    /// Status::Ok if the `data` is valid, or the reason why it was not read out
+    const Status status;
 
     /**
      * @brief Narrows the span to align it on a 16 byte boundary.

--- a/lib/core/basebandReadoutManager.hpp
+++ b/lib/core/basebandReadoutManager.hpp
@@ -9,11 +9,12 @@
 #ifndef BASEBAND_READOUT_MANAGER_HPP
 #define BASEBAND_READOUT_MANAGER_HPP
 
-#include "json.hpp"
+#include "SynchronizedQueue.hpp"
 
-#include <condition_variable>
-#include <deque>
+#include "gsl-lite.hpp"
+
 #include <forward_list>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -73,12 +74,63 @@ struct basebandDumpStatus {
 
 
 /**
+ * @struct basebandDumpData
+ * @brief A container for baseband data and metadata.
+ *
+ * @note This class does not own the underlying data buffer, but provides a view
+ *       (i.e., a `gsl::span`) to it. Users are responsible for managing the
+ *       memory storage.
+ *
+ * @author Kiyoshi Masui
+ */
+struct basebandDumpData {
+    /// Default constructor used to indicate error
+    basebandDumpData();
+    /// Initialize the container with all parameters but does not fill in the data.
+    basebandDumpData(uint64_t event_id_, uint32_t freq_id_, uint32_t num_elements_,
+                     int64_t data_start_fpga_, uint64_t data_length_fpga_,
+                     timespec data_start_ctime_, const gsl::span<uint8_t>&);
+
+    //@{
+    /// Metadata.
+    const uint64_t event_id;
+    const uint32_t freq_id;
+    const uint32_t num_elements;
+    const int64_t data_start_fpga;
+    const uint64_t data_length_fpga;
+    const timespec data_start_ctime;
+    //@}
+    /// Data access. Array has length `num_elements * data_length_fpga`.
+    const gsl::span<uint8_t> data;
+    const size_t reservation_length;
+
+    /**
+     * @brief Narrows the span to align it on a 16 byte boundary.
+     *
+     * Helper for basebandDumpData constructor.
+     *
+     * @note The original span should be oversized by at least 15 bytes, since that's how much can
+     * be lost by aligning.
+     */
+    static gsl::span<uint8_t> span_from_length_aligned(const gsl::span<uint8_t>&);
+};
+
+
+/**
  * @class basebandReadoutManager
  * @brief Class for managing readout state
  */
 class basebandReadoutManager {
 public:
+    // convenience type alias for keeping a status and mutex required for modifying it
     using requestStatusMutex = std::pair<basebandDumpStatus&, std::mutex&>;
+
+    // convenience type alias for a request ready to be written to a file, together with its
+    // read-out data
+    using ReadyRequest = std::pair<basebandDumpStatus&, basebandDumpData>;
+
+    // convenience type alias for a ReadyRequest and mutex required for modifying it
+    using ReadyRequestMutex = std::pair<ReadyRequest, std::mutex&>;
 
     /**
      * @brief Adds a new baseband dump request to the `requests` queue and
@@ -107,6 +159,17 @@ public:
     std::unique_ptr<basebandReadoutManager::requestStatusMutex> get_next_waiting_request();
 
     /**
+     * @brief Adds a baseband dump request to the `ready` queue and
+     * notifier threads waiting on `has_next_ready_request`
+     */
+    void ready(const ReadyRequest&);
+
+    /**
+     * @brief Interrupts all threads blocked on "waiting" and "ready" dump request queues
+     */
+    void stop();
+
+    /**
      * @brief Tries to get the next dump request whose data is ready for writing
      *
      * This is the element in the `requests` pointed to by `waiting`, unless
@@ -131,7 +194,7 @@ public:
      *        elements of the request object are being accessed.
      *
      */
-    basebandReadoutManager::requestStatusMutex get_next_ready_request();
+    std::unique_ptr<ReadyRequestMutex> get_next_ready_request();
 
     /// Returns a unique pointer to the copy of the event status for `event_id`,
     /// or nullptr if not known
@@ -143,9 +206,9 @@ public:
 private:
     /**
      * Sequence of baseband dump requests and their status. New events are
-     * appended at the end. Events are never removed from the queue, they are
+     * appended at the head. Events are never removed from the queue, they are
      * passed to worker threads by a non-owning pointer, and their state is
-     * updated in-place. Worker threads having a pointer into the elements is
+     * updated in-place. Worker threads' having a pointer into the elements is
      * safe as long as the readout manager is guaranteed to outlive them, which
      * it will be as the manager is itself owned by the
      * `basebandApiManager`, and is created in the main thread.
@@ -154,39 +217,30 @@ private:
 
     /**
      * `requests`-updating lock. Held only while elements are added to the queue
-     * or internal pointers (`waiting`, `tail`) moved around.
+     * or internal pointers (`readout_current`, `writeout_current`) moved around.
      */
     std::mutex requests_mtx;
 
-    /**
-     * Condition used to notify that there is a valid new request in `requests`.
-     */
-    std::condition_variable has_request;
+    /// requests that have been received by the baseband API, but that the readout thread hasn't
+    /// processed yet
+    SynchronizedQueue<std::reference_wrapper<basebandDumpStatus>> waiting_queue;
 
-    using iterator = std::forward_list<basebandDumpStatus>::iterator;
-
-    /**
-     * Pointer just before the next unprocessed request (i.e., the least
-     * recently added element with `state` "waiting") in `requests`.
-     */
-    iterator waiting = requests.before_begin();
-    /// Lock to hold while accessing or updating the `waiting` element.
-    std::mutex waiting_mtx;
+    /// requests that have been processed by the readout thread, and are now ready to be written out
+    SynchronizedQueue<ReadyRequest> ready_queue;
 
     /**
-     * Pointer the element in `requests` whose data are in the process of being
-     * written (by the write thread of the readout stage).
+     * Pointer to the element in `requests` that the readout thread is currently working on
      */
-    iterator current = requests.before_begin();
-    /// Lock to hold while accessing or updating the `current` element.
-    std::mutex current_mtx;
+    basebandDumpStatus* readout_current = nullptr;
+    /// Lock to hold while accessing or updating the `readout_current` element.
+    std::mutex readout_mtx;
 
     /**
-     * Pointer to the last (most recently added) event in `requests`. We need
-     * this to append new elements without traversing the queue from the
-     * beginning.
+     * Pointer to the element in `requests` that the write thread is currently working on
      */
-    iterator tail = requests.before_begin();
+    basebandDumpStatus* writeout_current = nullptr;
+    /// Lock to hold while accessing or updating the `writeout_current` element.
+    std::mutex writeout_mtx;
 };
 
 } // namespace kotekan

--- a/lib/stages/basebandReadout.cpp
+++ b/lib/stages/basebandReadout.cpp
@@ -122,9 +122,9 @@ void basebandReadout::main_thread() {
 
             INFO("Starting request-listening thread for freq_id: {:d}", freq_id);
             mgr = &basebandApiManager::instance().register_readout_stage(freq_id);
-            lt = std::make_unique<std::thread>([&] { this->listen_thread(freq_id, *mgr); });
+            lt = std::make_unique<std::thread>([&] { this->readout_thread(freq_id, *mgr); });
 
-            wt = std::make_unique<std::thread>([&] { this->write_thread(*mgr); });
+            wt = std::make_unique<std::thread>([&] { this->writeout_thread(*mgr); });
         }
 
         int done_frame = add_replace_frame(frame_id);
@@ -146,7 +146,7 @@ void basebandReadout::main_thread() {
     }
 }
 
-void basebandReadout::listen_thread(const uint32_t freq_id, basebandReadoutManager& mgr) {
+void basebandReadout::readout_thread(const uint32_t freq_id, basebandReadoutManager& mgr) {
     auto& request_no_data_counter = readout_counter.labels({std::to_string(freq_id), "no_data"});
 
     while (!stop_thread) {
@@ -213,7 +213,7 @@ void basebandReadout::listen_thread(const uint32_t freq_id, basebandReadoutManag
     }
 }
 
-void basebandReadout::write_thread(basebandReadoutManager& mgr) {
+void basebandReadout::writeout_thread(basebandReadoutManager& mgr) {
 
     while (!stop_thread) {
         auto next_request = mgr.get_next_ready_request();

--- a/lib/stages/basebandReadout.cpp
+++ b/lib/stages/basebandReadout.cpp
@@ -47,8 +47,8 @@ basebandReadout::basebandReadout(Config& config, const string& unique_name,
     next_frame(0),
     oldest_frame(-1),
     frame_locks(_num_frames_buffer),
-    // Over allocate so we can align the memory.
-    data_buffer(_num_elements * _max_dump_samples + 15),
+    // Over allocate so we can align the memory and can't get stuck halfway in BipBuffer
+    data_buffer(2 * (_num_elements * _max_dump_samples + 16)),
     readout_counter(kotekan::prometheus::Metrics::instance().add_counter(
         "kotekan_baseband_readout_total", unique_name, {"freq_id", "status"})),
     readout_in_progress_metric(kotekan::prometheus::Metrics::instance().add_gauge(

--- a/lib/stages/basebandReadout.hpp
+++ b/lib/stages/basebandReadout.hpp
@@ -84,8 +84,14 @@ private:
 
     std::mutex manager_lock;
 
-    void listen_thread(const uint32_t freq_id, kotekan::basebandReadoutManager& readout_manager);
-    void write_thread(kotekan::basebandReadoutManager& readout_manager);
+    /**
+     * @brief Process incoming requests by copying the baseband data from the ring buffer
+     */
+    void readout_thread(const uint32_t freq_id, kotekan::basebandReadoutManager& readout_manager);
+    /**
+     * @brief Loops over requests whose data has been read out and writes it to a file
+     */
+    void writeout_thread(kotekan::basebandReadoutManager& readout_manager);
     void write_dump(kotekan::basebandDumpData data, kotekan::basebandDumpStatus& dump_status,
                     std::mutex& request_mtx);
     int add_replace_frame(int frame_id);

--- a/lib/utils/BipBuffer.cpp
+++ b/lib/utils/BipBuffer.cpp
@@ -1,0 +1,215 @@
+#include "BipBuffer.hpp"
+
+#include "kotekanLogging.hpp"
+
+#include <algorithm>
+#include <cassert>
+#include <limits>
+
+
+BipWriteReservation::BipWriteReservation(uint8_t* const start, const size_t length,
+                                         const size_t write, const bool wraparound) :
+    data(start, length),
+    length(length),
+    write(write),
+    wraparound(wraparound) {}
+
+BipReadReservation::BipReadReservation(uint8_t const* const start, const size_t length,
+                                       const size_t read, const bool wraparound) :
+    data(start, length),
+    length(length),
+    read(read),
+    wraparound(wraparound) {}
+
+std::unique_ptr<BipWriteReservation> BipBufferWriter::reserve(const size_t length) {
+    if (length > buffer.len) {
+        return nullptr;
+    }
+
+    auto read = buffer.read.load();
+    auto write = buffer.write.load();
+
+    if (write >= read) {
+        // no wraparound: can write to the end if there is space, or try at the
+        // beginning
+        auto available = buffer.len - write;
+        available &= -(available <= buffer.len);
+        if (available >= length) {
+            // reserve the space from `write` onwards
+            // to advance: buffer.write.store(write + length);
+            DEBUG2_NON_OO("reserve {}, starting at {}", length, write);
+            return std::unique_ptr<BipWriteReservation>(
+                new BipWriteReservation{buffer.data.get() + write, length, write, false});
+        } else {
+            DEBUG2_NON_OO("Available for wraparound: {}", read);
+            if (read > length) {
+                DEBUG2_NON_OO("reserve {}, starting at beginning (wraparound); watermark: {}",
+                              length, write);
+                // to advance:
+                // 1. buffer.watermark.store(write);
+                // 2. buffer.write.store(length);
+                return std::unique_ptr<BipWriteReservation>(
+                    new BipWriteReservation{buffer.data.get(), length, write, true});
+            } else {
+                DEBUG2_NON_OO("Reserving {} failed: not enough space ahead or wraparound", length);
+                return nullptr; // no space available
+            }
+        }
+    } else {
+        // wraparound case, can write up to before `read`
+        auto available = read - write - 1;
+        available &= -(available <= read);
+        DEBUG2_NON_OO("Available ahead: {} (read: {})", available, read);
+        if (available >= length) {
+            DEBUG2_NON_OO("reserve {}, starting at {} (up to read: {})", length, write, read);
+            // to advance: buffer.write.store(write + length);
+            return std::unique_ptr<BipWriteReservation>(
+                new BipWriteReservation{buffer.data.get() + write, length, write, false});
+        } else {
+            DEBUG2_NON_OO("Reserving {} failed: not enough space ahead up to read", length);
+            return nullptr; // no space available
+        }
+    }
+}
+
+std::unique_ptr<BipWriteReservation> BipBufferWriter::reserve_max(const size_t length) {
+    auto read = buffer.read.load();
+    auto write = buffer.write.load();
+    if (length == 0) {
+        // we can always fullfill a reservation with zero length
+        return std::unique_ptr<BipWriteReservation>(
+            new BipWriteReservation{buffer.data.get() + write, 0, write, false});
+    }
+
+    size_t available;
+    if (write >= read) {
+        // no wraparound: can write to the end if there is space, or try at the
+        // beginning up to before `read`, whichever works better
+        size_t available_tail = buffer.len - write;
+        available_tail &= -(available_tail <= buffer.len);
+        size_t available_head = read - 1;
+        available_head &= -(available_head <= read);
+        available = std::max(available_head, available_tail);
+    } else {
+        // wraparound case, can write up to before `read`
+        available = read - write - 1;
+        available &= -(available <= read);
+    }
+
+    DEBUG2_NON_OO("Max available: {}; write: {}, read: {}, watermark: {}", available, write, read,
+                  buffer.watermark.load());
+    if (available > 0) {
+        return reserve(std::min(length, available));
+    } else {
+        return nullptr; // no space available
+    }
+}
+
+
+void BipBufferWriter::commit(const BipWriteReservation& r) {
+    assert(r.write == buffer.write.load());
+    if (r.wraparound) {
+        buffer.watermark.store(r.write);
+        buffer.write.store(r.length);
+        DEBUG2_NON_OO("Write wraparound to {}; read: {}, watermark {}", r.length,
+                      buffer.read.load(), buffer.watermark.load());
+    } else {
+        DEBUG2_NON_OO("Commit {} to {}; watermark: {}, read: {}", r.length, r.write,
+                      buffer.watermark.load(), buffer.read.load());
+        // Note: we don't move the watermark because we don't know if `read` has
+        // caught up to it when `write` is wrapped around.
+        buffer.write.store(r.write + r.length);
+    }
+}
+
+
+std::unique_ptr<BipReadReservation> BipBufferReader::access(const size_t length) {
+    if (length > buffer.len) {
+        return nullptr;
+    }
+
+    auto read = buffer.read.load();
+    auto write = buffer.write.load();
+    auto watermark = buffer.watermark.load();
+    if (read <= write) {
+        // straightforward case: write is ahead, just catch up to it
+        size_t available = write - read;
+        if (available < length) {
+            return nullptr;
+        };
+
+        DEBUG2_NON_OO("access {}, starting at {}", length, read);
+        // to advance: buffer.read.store(read + length);
+        return std::unique_ptr<BipReadReservation>(
+            new BipReadReservation{buffer.data.get() + read, length, read, false});
+    } else if (read < watermark) {
+        // write has wrapped around, but read still has some catching up to do
+        size_t available = watermark - read;
+        DEBUG2_NON_OO("Readable to watermark: {}", available);
+        if (available < length) {
+            return nullptr;
+        };
+
+        DEBUG2_NON_OO("access {}, starting at {}; watermark: {}", length, read, watermark);
+        // to advance: buffer.read.store(read + length)
+        return std::unique_ptr<BipReadReservation>(
+            new BipReadReservation{buffer.data.get() + read, length, read, false});
+    } else {
+        // start from the beginning
+        size_t available = write;
+        DEBUG2_NON_OO("Readable at the head: {}", available);
+        if (available < length) {
+            return nullptr;
+        };
+
+        // to advance: buffer.read.store(length);
+        return std::unique_ptr<BipReadReservation>(
+            new BipReadReservation{buffer.data.get(), length, read, true});
+    }
+}
+
+std::unique_ptr<BipReadReservation> BipBufferReader::access_max(const size_t length) {
+    auto read = buffer.read.load();
+    if (length == 0) {
+        // we can always fullfill a reservation with zero length
+        return std::unique_ptr<BipReadReservation>(
+            new BipReadReservation{buffer.data.get() + read, 0, read, false});
+    }
+
+    auto write = buffer.write.load();
+    auto watermark = buffer.watermark.load();
+    size_t available;
+    if (read <= write) {
+        // straightforward case: write is ahead, just catch up to it
+        available = write - read;
+    } else if (read < watermark) {
+        // write has wrapped around, but read still has some catching up to do
+        available = watermark - read;
+    } else {
+        // start from the beginning
+        available = write;
+    }
+
+    DEBUG2_NON_OO("Max readable: {}; write: {}, read: {}, watermark: {}", available, write, read,
+                  buffer.watermark.load());
+    if (available > 0) {
+        return access(std::min(length, available));
+    } else {
+        return nullptr; // no space available
+    }
+}
+
+
+void BipBufferReader::advance(const BipReadReservation& r) {
+    assert(r.read == buffer.read.load()); // basic sanity check to avoid using old reservation
+
+    if (r.wraparound) {
+        DEBUG2_NON_OO("Read wraparound to {}; write: {}, watermark {}", r.length,
+                      buffer.write.load(), buffer.watermark.load());
+        buffer.read.store(r.length);
+    } else {
+        DEBUG2_NON_OO("Advance by {} from {}; write: {}, watermark {}", r.length, r.read,
+                      buffer.write.load(), buffer.watermark.load());
+        buffer.read.store(r.read + r.length);
+    }
+}

--- a/lib/utils/BipBuffer.hpp
+++ b/lib/utils/BipBuffer.hpp
@@ -1,0 +1,202 @@
+/**
+ * @file
+ * @brief BipBuffer data structure and associated classes for operating on it safely
+ - BipBuffer
+ - BipBufferWriter
+ - BipWriteReservation
+ - BipBufferReader
+ - BipReadReservation
+ */
+#ifndef BIP_BUFFER_HPP
+#define BIP_BUFFER_HPP
+
+#include "gsl-lite.hpp"
+
+#include <atomic>
+#include <memory>
+#include <vector>
+
+/**
+ * @class BipBuffer
+ * @brief A single-producer single-consumer circular buffer that always supports writing a
+ * contiguous chunk of data.
+ *
+ * BipBuffer, short of "bipartite buffer", is a data structure first described by Simon Cooke
+ * (https://www.codeproject.com/articles/3479/the-bip-buffer-the-circular-buffer-with-a-twist). This
+ * version is based on a lockless implementation described by Andrea Lattuada and James Munns
+ * (https://andrea.lattuada.me/blog/2019/the-design-and-implementation-of-a-lock-free-ring-buffer-with-contiguous-reservations.html).
+ *
+ * This design facilitates operating on the buffer by two threads, one doing the writing, and the
+ * other the reading. These threads don't work on the buffer directly, but instead use the
+ * `BipBufferWriter` and `BipBufferReader` classes, respectively.
+ *
+ * @author Davor Cubranic
+ */
+class BipBuffer {
+public:
+    /**
+     * Construct a BipBuffer with the specified size of the underlying memory store.
+     */
+    BipBuffer(const int size) :
+        data(std::make_unique<uint8_t[]>(size)),
+        len(size),
+        read(0),
+        write(0),
+        watermark(0) {}
+
+public:
+    /// Array for the buffer data
+    const std::unique_ptr<uint8_t[]> data;
+
+    /// Length of the buffer data
+    const size_t len;
+
+    /// Head of the "read" region, starting at `data`
+    std::atomic_size_t read;
+
+    /// Head of the "write" region, starting at `data`
+    std::atomic_size_t write;
+
+    /// The value of `write` before it was wrapped back to the beginning
+    std::atomic_size_t watermark;
+};
+
+
+/**
+ * @class BipWriteReservaton
+ * @brief Represents a contiguous region of memory that may be written to, and optionally
+ * "committed" to the queue to make it available to the reader.
+ *
+ * Instances can only be created by the `BipBufferWriter`, but once created
+ * provide access to the writeable region through the `start` pointer and
+ * `length`.
+ *
+ * @author Davor Cubranic
+ */
+struct BipWriteReservation {
+    /// Reserved writeable area
+    const gsl::span<uint8_t> data;
+    /// Length of the reserved writeable area
+    const size_t length;
+
+    // Allow buffer Writer access to the private members
+    friend class BipBufferWriter;
+
+private:
+    /**
+     * Constructor called by `BipBufferWriter`, specifying the reservation's member values
+     */
+    BipWriteReservation(uint8_t* const start, const size_t length, const size_t write,
+                        const bool wraparound);
+
+    /// Value of `BipBuffer.write` when the reservation was issued
+    const size_t write;
+    /// Flag indicating if the reservation jumped ahead of `read`
+    const bool wraparound;
+};
+
+
+/**
+ * @class BipBufferWriter
+ * @brief Provides the interface to request access to continuous writeable regions of BipBuffer
+ *
+ * @author Davor Cubranic
+ */
+class BipBufferWriter {
+public:
+    /**
+     * Constructor wrapping an underlying `BipBuffer`
+     */
+    BipBufferWriter(BipBuffer& buffer) : buffer(buffer) {}
+
+    /// Reserve a contiguous region of memory in the buffer of size `length`
+    /// Return nullptr if the buffer does not contain enough free space.
+    std::unique_ptr<BipWriteReservation> reserve(const size_t length);
+
+    /// Reserve a contiguous region of memory in the buffer of size up to `length`
+    /// Return nullptr if the buffer does not contain no free space.
+    std::unique_ptr<BipWriteReservation> reserve_max(const size_t length);
+
+    /// Mark the reserved region available to the reader
+    void commit(const BipWriteReservation& r);
+
+private:
+    /// The BipBuffer instance that this writer operates on
+    BipBuffer& buffer;
+};
+
+/**
+ * @class BipReadReservation
+ * @brief Represents a contiguous region of memory that has the next chunk of committed data that
+ * can be read. Once read, the region can released so that it is available to be reused for writing
+ * again.
+ *
+ * Instances can only be created by the `BipBufferReader`, but once created
+ * provide access to the readable region through the `start` pointer and
+ * `length`.
+ *
+ * @author Davor Cubranic
+ */
+
+struct BipReadReservation {
+    /// Reserved readable area
+    const gsl::span<const uint8_t> data;
+    /// For convenience, length of the reserved readable area
+    const size_t length;
+
+    // Allow buffer Writer access to the private members
+    friend class BipBufferReader;
+
+private:
+    /**
+     * Constructor called by `BipBufferReader`, specifying the reservation's member values
+     */
+    BipReadReservation(uint8_t const* const start, const size_t length, const size_t read,
+                       const bool wraparound);
+
+    /// Value of `BipBuffer.read` when the reservation was issued
+    const size_t read;
+    /// Flag indicating if the reservation jumped back ahead of `write`
+    const bool wraparound;
+};
+
+/**
+ * @class BipBufferReader
+ * @brief Provides the interface to request access to continuous readable regions of BipBuffer
+ *
+ * @author Davor Cubranic
+ */
+
+class BipBufferReader {
+public:
+    /**
+     * Constructor wrapping an underlying `BipBuffer`
+     */
+    BipBufferReader(BipBuffer& buffer) : buffer(buffer) {}
+
+    /**
+     * Request a contiguous region of data ready for reading of size `length`
+     *
+     * @return a unique_ptr to `BipReadReservation` for a readable region of
+     * size `length`, or a `nullptr`` if the buffer does not contain enough
+     * readable space.
+     */
+    std::unique_ptr<BipReadReservation> access(const size_t length);
+
+    /**
+     * Request a contiguous region of data ready for reading of size up to `length`
+     *
+     * @return `nullptr`` if the buffer does not contain any readable space, or
+     * a unique_ptr to `BipReadReservation` for a readable region of size up to `length`.
+     */
+    std::unique_ptr<BipReadReservation> access_max(const size_t length);
+
+    /// Mark the reserved region as read and available to the writer
+    void advance(const BipReadReservation& r);
+
+private:
+    /// The BipBuffer instance that this reader operates on
+    BipBuffer& buffer;
+};
+
+#endif // BIP_BUFFER_HPP

--- a/lib/utils/CMakeLists.txt
+++ b/lib/utils/CMakeLists.txt
@@ -23,6 +23,7 @@ set ( KOTEKAN_UTIL_SOURCES
       pulsarTiming.cpp
       datasetState.cpp
       restClient.cpp
+      BipBuffer.cpp
     )
 
 if (${USE_HDF5})

--- a/lib/utils/SynchronizedQueue.hpp
+++ b/lib/utils/SynchronizedQueue.hpp
@@ -1,0 +1,94 @@
+#ifndef SYNCHRONIZED_QUEUE_HPP
+#define SYNCHRONIZED_QUEUE_HPP
+
+#include <condition_variable>
+#include <deque>
+#include <memory>
+#include <mutex>
+
+
+/**
+ * @class SynchronizedQueue
+ * @brief Generic FIFO that protects accesses with locks
+ *
+ * This class wraps std::deque and synchronizes access and modification methods using a mutex.
+ * All blocking callers can be interrupted by calling the `cancel` method, after which the queue
+ * will not produce any more results.
+ *
+ * @author Davor Cubranic
+ */
+template<typename T>
+class SynchronizedQueue {
+public:
+    SynchronizedQueue() = default;
+
+    /**
+     * @brief Appends an element at the back of the queue
+     *
+     * Synchronizes access to prevent multiple threads modifying the list at the same time, and
+     * blocks until an element is available. Blocked callers will be interrupted when the `cancel`
+     * method is called on the queue.
+     */
+    void put(const T& v) {
+        {
+            if (stop) {
+                return;
+            };
+            std::lock_guard<std::mutex> lock(mtx);
+
+            queue.push_back(v);
+        }
+
+        cv.notify_one();
+    }
+
+    /**
+     * @brief Removes the first element from the front of the queue and returns it
+     *
+     * Synchronizes access to prevent multiple threads modifying the list at the same time, and
+     * blocks until an element is available. Blocked callers will be interrupted when the `cancel`
+     * method is called on the queue.
+     *
+     * @returns nullptr if the queue is cancelled, and a unique_ptr to the element otherwise
+     */
+    std::unique_ptr<T> get() {
+        std::unique_lock<std::mutex> lock(mtx);
+
+        while (queue.empty() && !stop) {
+            cv.wait(lock);
+        }
+        if (stop) {
+            return nullptr;
+        }
+
+        auto v = std::make_unique<T>(queue.front());
+        queue.pop_front();
+        return v;
+    }
+
+    /**
+     * @brief Interrupts all blocked callers and prevents further modification.
+     */
+    void cancel() {
+        {
+            std::lock_guard<std::mutex> lock(mtx);
+            stop = true;
+        }
+        cv.notify_all();
+    }
+
+private:
+    /// backing queue that stores the actual elements
+    std::deque<T> queue;
+
+    /// disables all queue operations when true
+    bool stop = false;
+
+    /// synchronizes access to the queue
+    std::mutex mtx;
+
+    /// notifying blocked callers
+    std::condition_variable cv;
+};
+
+#endif // SYNCHRONIZED_QUEUE_HPP

--- a/lib/utils/SynchronizedQueue.hpp
+++ b/lib/utils/SynchronizedQueue.hpp
@@ -1,3 +1,8 @@
+/**
+ * @file
+ * @brief A generic queue with synchronized access
+ * - SynchronizedQueue
+ */
 #ifndef SYNCHRONIZED_QUEUE_HPP
 #define SYNCHRONIZED_QUEUE_HPP
 

--- a/tests/boost/CMakeLists.txt
+++ b/tests/boost/CMakeLists.txt
@@ -11,6 +11,7 @@ include_directories (${KOTEKAN_SOURCE_DIR}/lib/metadata)
 include_directories (${KOTEKAN_SOURCE_DIR}/include)
 
 set ( KOTEKAN_BOOST_TEST_SOURCES
+      test_bip_buffer.cpp
       test_dataset_manager.cpp
       # TODO: disabled until we can fix the Libevent issues
       #test_dataset_manager_rest.cpp

--- a/tests/boost/CMakeLists.txt
+++ b/tests/boost/CMakeLists.txt
@@ -20,6 +20,7 @@ set ( KOTEKAN_BOOST_TEST_SOURCES
       test_chime_stacking.cpp
       test_config.cpp
       test_prometheus_metrics.cpp
+      test_synchronized_queue.cpp
     )
 
 # source files for broker test

--- a/tests/boost/test_bip_buffer.cpp
+++ b/tests/boost/test_bip_buffer.cpp
@@ -1,0 +1,215 @@
+/*
+ * Boost tests for BipBuffer
+ */
+#define BOOST_TEST_MODULE "test_BipBuffer"
+
+#include "BipBuffer.hpp"
+#include "SynchronizedQueue.hpp"
+#include "kotekanLogging.hpp"
+
+#include <boost/test/included/unit_test.hpp>
+#include <chrono>
+#include <random>
+#include <thread>
+#include <vector>
+
+/*
+ * To see log output, assign 0 to `__enable_syslog` so the messages go to
+ * stderr.
+ *
+ * The starting log level is INFO (3). To change it, assign the desired level to
+ * `_global_log_level` (ERROR=1, DEBUG2=5)
+ */
+// __enable_syslog = 0;
+// DEFAULT: _global_log_level = 3;
+
+/*
+ * A basic check of creating the buffer.
+ */
+BOOST_AUTO_TEST_CASE(buffer_api) {
+    BipBuffer buffer(10);
+    BOOST_CHECK(buffer.len == 10);
+    BOOST_CHECK(buffer.read.load() == 0);
+    BOOST_CHECK(buffer.write.load() == 0);
+    BOOST_CHECK(buffer.watermark.load() == 0);
+}
+
+
+/*
+ * Tests alternate writes and reads from the buffer, including the cases where the writer wraps
+ * around, and when there isn't a large enough segment to accommodate the requested size.
+ */
+BOOST_AUTO_TEST_CASE(buffer_write_read_loop) {
+    BipBuffer buffer(10);
+    BipBufferWriter writer(buffer);
+    BipBufferReader reader(buffer);
+
+    std::vector<size_t> expected = {0, 1, 2, 3, 4, 5};
+    std::vector<size_t> actual;
+    for (size_t v = 0; v < 10; ++v) {
+        auto reservation = writer.reserve(v);
+        if (reservation) {
+            actual.push_back(v);
+            writer.commit(*reservation);
+            auto read_res = reader.access(reservation->length);
+            BOOST_CHECK(read_res);
+            reader.advance(*read_res);
+        }
+    }
+    BOOST_CHECK(expected == actual);
+}
+
+/*
+ * Tests reading and writing from separate threads, with both sides using the `_max` version of the
+ * reservation to accept smaller reservation sizes. The writer writes a sequence of numbers into the
+ * reserved cells, so that the reader can easily check that each read cell constains the expected
+ * value.
+ */
+BOOST_AUTO_TEST_CASE(buffer_max_write_read_independent_threads) {
+    BipBuffer buffer(100);
+    constexpr int count = 300;
+    std::thread t1([&buffer, count]() {
+        // std::cout << "writer\n";
+        std::random_device rd;
+        std::mt19937 gen(rd());
+        std::uniform_int_distribution<> dis(3, 40);
+
+        BipBufferWriter writer(buffer);
+        for (int v = 0, size = dis(gen); v < count; size = std::min(dis(gen), count - v)) {
+            auto reservation = writer.reserve_max(size);
+            if (reservation) {
+                BOOST_CHECK(reservation->length <= size_t(size));
+                DEBUG_NON_OO("Writing {} bytes starting at {} (value {}).", reservation->length,
+                             reservation->data.data() - buffer.data.get(), uint8_t(v));
+                std::this_thread::sleep_for(std::chrono::milliseconds(size * 5));
+                for (size_t i = 0; i < reservation->length; ++i) {
+                    reservation->data[i] = uint8_t(v);
+                    v++;
+                }
+                writer.commit(*reservation);
+                DEBUG_NON_OO("Written {} out of {} bytes. {} bytes remaining.", v, count,
+                             count - v);
+            } else {
+                DEBUG_NON_OO("Reserve not successful: {}", size);
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(dis(gen) * 5));
+        }
+    });
+    std::thread t2([&buffer, count]() {
+        std::random_device rd;
+        std::mt19937 gen(rd());
+        std::uniform_int_distribution<> dis(3, 30);
+
+        BipBufferReader reader(buffer);
+        for (int v = 0, size = dis(gen); v < count; size = std::min(dis(gen), count - v)) {
+            auto reservation = reader.access_max(size);
+            if (reservation) {
+                DEBUG_NON_OO("Reading {} bytes from {} (expecting value {}).", reservation->length,
+                             reservation->data.data() - buffer.data.get(), uint8_t(v));
+                std::this_thread::sleep_for(std::chrono::milliseconds(size * 10));
+                for (size_t i = 0; i < reservation->length; ++i) {
+                    DEBUG2_NON_OO("Read: {} (exp. {})", int(reservation->data[i]), (v & 0xff));
+                    BOOST_CHECK(reservation->data[i] == uint8_t(v));
+                    v++;
+                }
+                reader.advance(*reservation);
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(dis(gen) * 5));
+        }
+    });
+    t1.join();
+    BOOST_CHECK(!t1.joinable());
+    t2.join();
+    BOOST_CHECK(!t2.joinable());
+}
+
+
+/*
+ * Auxiliary structure used by the next test case
+ */
+struct TestTask {
+    // value written into all cells of this segment
+    uint8_t value;
+    // segment's start (== BipWriteReservation.data)
+    uint8_t const* start;
+    // segment's length (== BipWriteReservation.length)
+    size_t length;
+};
+
+/*
+ * Tests reading and writing from separate threads, with both sides using the exact-size version of
+ * the reservations, with the writer communicating the reservation sizes as `TestTask` instances in
+ * a `SynchronizedQueue` that the reader uses to determine the size of the requested read
+ * reservation sizes. (This roughly approximates how the basebandReadout threads are going to
+ * coordinate handling baseband dumps between reading out the baseband buffer and writing out to the
+ * HDF file).
+ *
+ * The writer writes a sequence of numbers into the reserved cells, so that the reader can easily
+ * check that each read cell constains the expected value.
+ */
+BOOST_AUTO_TEST_CASE(buffer_write_read_task_threads) {
+    SynchronizedQueue<TestTask> q;
+    BipBuffer buffer(100);
+    constexpr int count = 300;
+    std::vector<int> expected, actual;
+    std::thread t1([&q, &buffer, &expected]() {
+        std::random_device rd;
+        std::mt19937 gen(rd());
+        std::uniform_int_distribution<> dis(10, 40);
+
+        BipBufferWriter writer(buffer);
+        for (int v = 0, size = dis(gen); v < count; size = std::min(dis(gen), count - v)) {
+            auto reservation = writer.reserve(size);
+            if (reservation) {
+                BOOST_CHECK(reservation->length == size_t(size));
+                DEBUG_NON_OO("Writing {} bytes from {} (value {}). {} bytes remaining.",
+                             reservation->length, reservation->data.data() - buffer.data.get(),
+                             uint8_t(v), count - v - size);
+                std::this_thread::sleep_for(std::chrono::milliseconds(size * 5));
+                for (size_t i = 0; i < reservation->length; ++i) {
+                    reservation->data[i] = uint8_t(v);
+                }
+                writer.commit(*reservation);
+                expected.push_back(uint8_t(v));
+                q.put(TestTask{uint8_t(v), reservation->data.data(), reservation->length});
+                v += size;
+            } else {
+                DEBUG_NON_OO("Reserve not successful: {}", size);
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(dis(gen) * 5));
+        }
+        q.put(TestTask{0, 0, 0});
+    });
+    std::thread t2([&q, &buffer, &actual]() {
+        std::random_device rd;
+        std::mt19937 gen(rd());
+        std::uniform_int_distribution<> dis(10, 40);
+
+        BipBufferReader reader(buffer);
+        while (auto t = q.get()) {
+            if (t->start == 0) {
+                return;
+            }
+            auto reservation = reader.access(t->length);
+            BOOST_CHECK(reservation && reservation->length == t->length
+                        && reservation->data.data() == t->start);
+            DEBUG_NON_OO("Reading {} bytes from {} (expecting value {})", t->length,
+                         t->start - buffer.data.get(), t->value);
+            for (size_t i = 0; i < reservation->length; i++) {
+                BOOST_CHECK(reservation->data[i] == t->value);
+            }
+            actual.push_back(t->value);
+            reader.advance(*reservation);
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(dis(gen) * 10));
+    });
+
+    t1.join();
+    BOOST_CHECK(!t1.joinable());
+
+    t2.join();
+    BOOST_CHECK(!t2.joinable());
+
+    BOOST_CHECK(expected == actual);
+    DEBUG_NON_OO("successful tasks: {}", expected.size());
+}

--- a/tests/boost/test_synchronized_queue.cpp
+++ b/tests/boost/test_synchronized_queue.cpp
@@ -1,0 +1,74 @@
+#define BOOST_TEST_MODULE "test_SynchronizedQueue"
+
+#include "SynchronizedQueue.hpp"
+
+#include <boost/test/included/unit_test.hpp>
+#include <thread>
+
+/*
+ * A basic check that you `get` what you `put` into the queue.
+ */
+BOOST_AUTO_TEST_CASE(put_get) {
+    SynchronizedQueue<int> q;
+    q.put(42);
+    q.put(41);
+    BOOST_CHECK(*q.get() == 42);
+    BOOST_CHECK(*q.get() == 41);
+}
+
+/*
+ * Start a producer and a consumer on the queue. The producer `put`s numbers [10..0] into the queue.
+ * The consumer `get`s from the queue and expects the same sequence, returning from the thread on
+ * `0`. It is an error if the queue does not return a value (since it is not going to be cancelled),
+ * and if the lambda does not return out of its receiving loop.
+ */
+BOOST_AUTO_TEST_CASE(put_get_with_threads) {
+    SynchronizedQueue<int> q;
+    std::thread t1([&q]() {
+        for (int i = 10; i >= 0; --i) {
+            q.put(i);
+        }
+    });
+    std::thread t2([&q]() {
+        for (int expected = 10; expected >= 0; --expected) {
+            auto v = q.get();
+            BOOST_CHECK(v);
+            BOOST_CHECK(*v == expected);
+            if (*v == 0) {
+                return;
+            }
+        }
+        // We should never end up here, because of the `return` on `get`ting a zero value from the
+        // queue
+        BOOST_CHECK(false);
+    });
+    t1.join();
+    BOOST_CHECK(!t1.joinable());
+    t2.join();
+    BOOST_CHECK(!t2.joinable());
+}
+
+/*
+ * A `cancel`led queue does not produce any more values, even if it still has unconsumed ones.
+ */
+BOOST_AUTO_TEST_CASE(cancel) {
+    SynchronizedQueue<int> q;
+    q.put(42);
+    q.cancel();
+    BOOST_CHECK(q.get() == nullptr);
+}
+
+/*
+ * Same with multiple threads waiting to consume from a `cancel`led queue.
+ */
+BOOST_AUTO_TEST_CASE(cancel_with_threads) {
+    SynchronizedQueue<int> q;
+    std::thread t1([&q]() { BOOST_CHECK(q.get() == nullptr); });
+    std::thread t2([&q]() { BOOST_CHECK(q.get() == nullptr); });
+    q.cancel();
+
+    t1.join();
+    BOOST_CHECK(!t1.joinable());
+    t2.join();
+    BOOST_CHECK(!t2.joinable());
+}

--- a/tests/test_baseband_readout.py
+++ b/tests/test_baseband_readout.py
@@ -162,7 +162,6 @@ def test_negative_start_time(tmpdir_factory):
     assert f["baseband"].shape == (3237, default_params["num_elements"])
 
 
-@pytest.mark.xfail(reason="Fragile test.")
 def test_basic(tmpdir_factory):
 
     rest_commands = [
@@ -203,7 +202,6 @@ def test_basic(tmpdir_factory):
         assert np.all(f["baseband"][:] == edata)
 
 
-@pytest.mark.xfail(reason="Fragile test.")
 def test_missed(tmpdir_factory):
 
     good_trigger = (2437, 3123)


### PR DESCRIPTION
Makes baseband dump stages operate in parallel with each other, rather than blocking at each processing step of a single baseband request.

- readout data area is shared by multiple events (as long as there is space), by making it a bipartite circular buffer (BipBuffer)
- the readout thread has a queue of requests `waiting` to be processed, and reads out their baseband data into a segment of the BipBuffer if there is one available. (If there isn't, the request is errored-out and the thread moves on to the next request in its queue.)
- when the readout thread is done with a requests, it adds it to the writeout thread's `ready` queue. This request includes the pointer to the request's data in the BipBuffer.
- the writeout thread processes requests in the `ready` queue, creating the HDF file with data from the BipBuffer, and marking that data segment available when it's done.
- there is also a list of basebandRequestStatus that is the history of all requests since Kotekan started, and is used to return the request status data by the REST API (GET to /baseband/event-id). Elements in the `waiting` and `ready` queues include pointers to elements in this list, so that the readout and writeout threads can update their state