### PR TITLE
Add unregister consumer function

### DIFF
--- a/lib/core/buffer.h
+++ b/lib/core/buffer.h
@@ -242,6 +242,19 @@ void zero_frames(struct Buffer * buf);
 void register_consumer(struct Buffer * buf, const char *name);
 
 /**
+ * @brief Removes the consumer with the given name
+ *
+ * In some cases it may make sense to stop being a consumer of a given
+ * buffer while the pipeline is running.  However this is likely an edge
+ * case for most pipelines.  In general it is not expected for stages
+ * to unregister when they close.
+ *
+ * @param buf The buffer to unregister from
+ * @param name The name of the consumer to unregister
+ */
+void unregister_consumer(struct Buffer * buf, const char *name);
+
+/**
  * @brief Register a producer with a given name.
  *
  * In order to use a buffer a producer must first register its name so that


### PR DESCRIPTION
Allow a consumer to "unregister".  This is a requirement for #511 in the `ReadGain` stage, which needs to read the frequency metadata from the first frame of the network input buffer, but doesn't need to read the frames after learning which frequency is being managed by that stream. 