### PR TITLE
Detect missing/dead FRB nodes (closes #449)

### DIFF
--- a/lib/stages/frbNetworkProcess.cpp
+++ b/lib/stages/frbNetworkProcess.cpp
@@ -15,16 +15,21 @@
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
-#include <functional>
 #include <iostream>
+#include <map>
 #include <math.h>
-#include <netinet/in.h>
+#include <netinet/ip.h>
+#include <netinet/ip_icmp.h>
+#include <queue>
+#include <random>
 #include <signal.h>
 #include <stdlib.h>
 #include <string.h>
 #include <string>
 #include <sys/socket.h>
+#include <thread>
 #include <unistd.h>
+
 
 using std::string;
 
@@ -44,8 +49,10 @@ REGISTER_KOTEKAN_STAGE(frbNetworkProcess);
 
 frbNetworkProcess::frbNetworkProcess(Config& config_, const string& unique_name,
                                      bufferContainer& buffer_container) :
-    Stage(config_, unique_name, buffer_container,
-          std::bind(&frbNetworkProcess::main_thread, this)) {
+    Stage(config_, unique_name, buffer_container, std::bind(&frbNetworkProcess::main_thread, this)),
+    live_check_frequency{std::chrono::milliseconds(
+        config_.get_default<unsigned long>(unique_name, "check_interval", 30000))} {
+
     in_buf = get_buffer("in_buf");
     register_consumer(in_buf, unique_name.c_str());
 
@@ -63,6 +70,7 @@ frbNetworkProcess::frbNetworkProcess(Config& config_, const string& unique_name,
 
 frbNetworkProcess::~frbNetworkProcess() {
     restServer::instance().remove_json_callback("/frb/update_beam_offset");
+    restServer::instance().remove_json_callback("/frb/update_destination");
 }
 
 
@@ -90,12 +98,17 @@ void frbNetworkProcess::main_thread() {
     int number_of_l1_links = initialize_destinations();
     INFO("number_of_l1_links: {:d}", number_of_l1_links);
 
+    auto ping_thread = std::thread([&] { this->ping_destinations(); });
+
     // rest server
     using namespace std::placeholders;
     restServer& rest_server = restServer::instance();
     string endpoint = "/frb/update_beam_offset";
     rest_server.register_post_callback(
         endpoint, std::bind(&frbNetworkProcess::update_offset_callback, this, _1, _2));
+    rest_server.register_post_callback(
+        "/frb/update_destination",
+        std::bind(&frbNetworkProcess::set_destination_active_callback, this, _1, _2));
 
     // config.update_value(unique_name, "beam_offset", beam_offset);
 
@@ -189,12 +202,14 @@ void frbNetworkProcess::main_thread() {
 
                 for (int link = 0; link < number_of_l1_links; link++) {
                     if (e_stream == local_beam_offset / 4 + link) {
-                        auto dst = dst_sockets[link];
-                        sendto(src_sockets[dst.sending_socket],
-                               &packet_buffer[(e_stream * packets_per_stream + frame)
-                                              * udp_frb_packet_size],
-                               udp_frb_packet_size, 0, (struct sockaddr*)&dst.addr,
-                               sizeof(dst.addr));
+                        DestIpSocket& dst = stream_dest[link];
+                        if (dst.active && dst.live) {
+                            sendto(src_sockets[dst.sending_socket].socket_fd,
+                                   &packet_buffer[(e_stream * packets_per_stream + frame)
+                                                  * udp_frb_packet_size],
+                                   udp_frb_packet_size, 0, (struct sockaddr*)&dst.addr,
+                                   sizeof(dst.addr));
+                        }
                     }
                 }
                 long wait_per_packet = (long)(50000);
@@ -211,7 +226,8 @@ void frbNetworkProcess::main_thread() {
         frame_id = (frame_id + 1) % in_buf->num_frames;
         count++;
     }
-    return;
+    ping_cv.notify_all();
+    ping_thread.join();
 }
 
 int frbNetworkProcess::initialize_source_sockets() {
@@ -247,7 +263,7 @@ int frbNetworkProcess::initialize_source_sockets() {
             return -1;
         }
 
-        src_sockets.push_back(sock_fd);
+        src_sockets.push_back({addr, sock_fd});
     }
 
     /* every node is introducing packets to the network. To achive load balancing a sequece_id is
@@ -271,9 +287,274 @@ int frbNetworkProcess::initialize_destinations() {
         memset(&addr, 0, sizeof(addr));
         addr.sin_family = AF_INET;
         inet_pton(AF_INET, link_ip[i].c_str(), &addr.sin_addr);
-        addr.sin_port = htons(udp_frb_port_number);
-        int sending_socket = get_vlan_from_ip(link_ip[i].c_str()) - 6;
-        dst_sockets.push_back({addr, sending_socket});
+        if (!dest_sockets.count(addr.sin_addr.s_addr)) {
+            // new destination, initialize the entry in `dest_sockets`
+            addr.sin_port = htons(udp_frb_port_number);
+            int sending_socket = get_vlan_from_ip(link_ip[i].c_str()) - 6;
+            dest_sockets.insert(
+                {addr.sin_addr.s_addr, DestIpSocket{link_ip[i], addr, sending_socket}});
+        }
+        stream_dest.push_back(std::ref(dest_sockets.at(addr.sin_addr.s_addr)));
     }
     return link_ip.size();
+}
+
+void frbNetworkProcess::set_destination_active_callback(connectionInstance& conn,
+                                                        json& json_request) {
+    string host;
+    bool active;
+    try {
+        host = json_request["host"];
+        active = json_request["active"];
+    } catch (...) {
+        conn.send_error("Couldn't parse the request.", HTTP_RESPONSE::BAD_REQUEST);
+        return;
+    }
+    bool found = false;
+    for (auto& ip_dst : dest_sockets) {
+        auto& dst = std::get<1>(ip_dst);
+        if (dst.host == host) {
+            dst.active = active;
+            found = true;
+        }
+    }
+    if (found) {
+        INFO("Set destination {} active flag to {}", host, active);
+        conn.send_empty_reply(HTTP_RESPONSE::OK);
+    } else {
+        WARN("No such destination: {}", host);
+        conn.send_error("Couldn't parse the request.", HTTP_RESPONSE::BAD_REQUEST);
+    }
+}
+
+// internal utility functions for dealing with low-level sockets APIs
+/// Send a ping packet to the destination using source socket `s`
+static bool send_ping(int s, const DestIpSocket& dst);
+/// Receive a ping response on socket `s`, returning `true` if all OK and putting its sender in
+/// `from`
+static bool receive_ping(int s, /* out */ sockaddr_in& from);
+/// Calculate internet packet checksum (based on BSD networking code)
+static int in_cksum(uint16_t*, int);
+
+// internal data type for keeping track of host checks and replies
+struct DestIpSocketTime {
+    DestIpSocket* dst;
+    std::chrono::steady_clock::time_point last_checked;
+    std::chrono::steady_clock::time_point last_responded;
+    friend bool operator<(const DestIpSocketTime& l, const DestIpSocketTime& r) {
+        if (l.last_checked == r.last_checked) {
+            // break check time ties by host address
+            return l.dst->addr.sin_addr.s_addr > r.dst->addr.sin_addr.s_addr;
+        } else
+            return l.last_checked > r.last_checked;
+    }
+};
+
+using RefDestIpSocketTime = std::reference_wrapper<DestIpSocketTime>;
+
+void frbNetworkProcess::ping_destinations() {
+
+    // raw sockets used as sources for outgoing pings
+    std::vector<int> ping_src_fd;
+    for (auto& src : src_sockets) {
+        int s = socket(AF_INET, SOCK_RAW, IPPROTO_ICMP);
+        if (s < 0) {
+            ERROR("Cannot create source socket for FRB host pings (requires root). Stopping the "
+                  "pings.");
+            return;
+        }
+        if (bind(s, (struct sockaddr*)&src.addr, sizeof(src.addr)) < 0) {
+            ERROR("Cannot bind source socket for FRB host pings (requires root). Stopping the "
+                  "pings.");
+            return;
+        }
+        ping_src_fd.push_back(s);
+    }
+    const int max_ping_src_fd = *std::max_element(ping_src_fd.begin(), ping_src_fd.end());
+
+    // quick destination lookup by IP address
+    std::map<uint32_t, DestIpSocketTime> dest_by_ip;
+    // quick destination lookup by least-recently checked time
+    // std::priority_queue<RefDestIpSocketTime, std::vector<RefDestIpSocketTime>,
+    // decltype(cmp_by_last_checked)> dest_by_time(cmp_by_last_checked);
+    std::priority_queue<RefDestIpSocketTime> dest_by_time;
+    for (auto& dst : dest_sockets) {
+        DestIpSocketTime& dest_ping_info =
+            dest_by_ip[std::get<0>(dst)] = {&std::get<1>(dst), {}, {}};
+        dest_by_time.push(std::ref(dest_ping_info));
+    }
+
+    // Random number generators to jitter the ping time between hosts (0.3-5 s)
+    std::random_device rd;  // Will be used to obtain a seed for the random number engine
+    std::mt19937 gen(rd()); // Standard mersenne_twister_engine seeded with rd()
+    std::uniform_int_distribution<> dis(300, 5000);
+
+    // it's silly to have a mutex local to a thread, but we need it for the condition variable used
+    // by the main_thread to interrupt this thread's sleep to notify of Kotekan stopping
+    std::mutex mtx;
+    std::unique_lock<std::mutex> lock(mtx);
+    while (!stop_thread) {
+        DestIpSocketTime& lru_dest = dest_by_time.top();
+        DestIpSocket* dst = lru_dest.dst;
+        auto time_since_last_check = std::chrono::steady_clock::now() - lru_dest.last_checked;
+        auto time_since_last_live = std::chrono::steady_clock::now() - lru_dest.last_responded;
+
+        DEBUG("Checking: {}", dst->host);
+        DEBUG("Last checked: {}s ago. Last responded: {}s ago",
+              std::chrono::duration_cast<std::chrono::seconds>(time_since_last_check).count(),
+              std::chrono::duration_cast<std::chrono::seconds>(time_since_last_live).count());
+        if (time_since_last_live > live_check_frequency && dst->live) {
+            INFO("Too long since last ping response, mark host {} dead.", dst->host);
+            dst->live = false;
+        }
+        if (time_since_last_check < live_check_frequency) {
+            DEBUG("Need to sleep before pinging {}", dst->host);
+            ping_cv.wait_for(lock, live_check_frequency - time_since_last_check);
+            if (stop_thread)
+                return;
+        }
+        // NOTE: we don't ping if the host is not active, but mark it checked
+        if (!dst->active || send_ping(ping_src_fd[dst->sending_socket], *dst)) {
+            dest_by_time.pop();
+            lru_dest.last_checked = std::chrono::steady_clock::now();
+            dest_by_time.push(lru_dest);
+#ifdef DEBUGGING
+            DestIpSocketTime& next_lru_dest = dest_by_time.top();
+            DEBUG("Pinged. Next host: {}", next_lru_dest.dst->host);
+#endif // DEBUGGING
+        }
+
+        // initialize the listening set of sockets for `select`
+        fd_set rfds;
+        FD_ZERO(&rfds);
+        for (int s : ping_src_fd) {
+            FD_SET(s, &rfds);
+        }
+        /*
+         * Non-blocking check for ping responses received on any of the `ping_src_fd` sockets.
+         */
+        struct timeval tv = {0, 200000}; // Don't wait more than 0.2s for a socket to be ready
+        while (int rc = select(max_ping_src_fd + 1, &rfds, nullptr, nullptr, &tv) != 0) {
+            if (stop_thread)
+                return;
+            if (rc < 0) {
+                if (errno == EINTR) {
+                    DEBUG("Select interrupted, try again");
+                    continue;
+                } else {
+                    // TODO: stop the pinging thread entirely?
+                    WARN("Ping listening error: {}.", errno);
+                    break;
+                }
+            }
+            for (int s : ping_src_fd) {
+#ifdef DEBUGGING
+                char src_addr_str[INET_ADDRSTRLEN
+                                  + 1]; // Used for decoding host IP in logging statements
+#endif                                  // DEBUGGING
+                if (FD_ISSET(s, &rfds)) {
+                    sockaddr_in from; // out-param for `recv_from(2)`
+                    if (receive_ping(s, from)) {
+                        if (dest_by_ip.count(from.sin_addr.s_addr)) {
+                            DestIpSocketTime& src = dest_by_ip[from.sin_addr.s_addr];
+                            src.last_responded = std::chrono::steady_clock::now();
+                            DEBUG("Received ping response from: {}. Update `last_responded`.",
+                                  inet_ntop(AF_INET, &from.sin_addr, src_addr_str,
+                                            INET_ADDRSTRLEN + 1));
+                            if (!dst->live) {
+                                INFO("Host {} is responding to pings again, mark live.", dst->host);
+                                dst->live = true;
+                            }
+                        } else {
+                            DEBUG("Received ping response from unknown host: {}. Ignored.",
+                                  inet_ntop(AF_INET, &from.sin_addr, src_addr_str,
+                                            INET_ADDRSTRLEN + 1));
+                        }
+                    }
+                }
+            }
+        };
+        // now sleep for a bit (0.3-5 s) before checking the next host
+        std::chrono::milliseconds sleep_time(dis(gen));
+        INFO("Sleep for {} before checking the next host", sleep_time);
+        ping_cv.wait_for(lock, sleep_time);
+        if (stop_thread)
+            return;
+    }
+}
+
+bool send_ping(int s, const DestIpSocket& dst) {
+    uint8_t outpackhdr[IP_MAXPACKET];
+    uint8_t* outpack = outpackhdr + sizeof(struct ip);
+    int cc = (64 - 8); // data length - icmp echo header len, excluding time
+    struct icmp* icp = (struct icmp*)outpack;
+    icp->icmp_type = ICMP_ECHO;
+    icp->icmp_code = 0;
+    icp->icmp_cksum = 0;
+    icp->icmp_id = getpid();
+
+    uint16_t seq = 12345;
+    icp->icmp_seq = htons(seq);
+    icp->icmp_cksum = in_cksum((uint16_t*)icp, cc);
+    int rc =
+        sendto(s, (char*)outpack, cc, 0, (struct sockaddr*)&dst.addr, sizeof(struct sockaddr_in));
+    return rc == cc;
+}
+
+bool receive_ping(int s, sockaddr_in& from) {
+    socklen_t from_length = sizeof(from);
+    uint8_t packet[4096];
+    int packet_length = sizeof(packet);
+    int rc = recvfrom(s, packet, packet_length, 0, (sockaddr*)&from, &from_length);
+
+    // Check the IP header
+    int hlen = sizeof(struct ip);
+    if (rc < (hlen + ICMP_MINLEN)) {
+        DEBUG_NON_OO("Packet too short. Ignoring.");
+        return false;
+    }
+    // Now the icmp part
+    struct icmp* icp = (struct icmp*)(packet + hlen);
+    if (icp->icmp_type == ICMP_ECHOREPLY) {
+        if (ntohs(icp->icmp_seq) != 12345) {
+            DEBUG_NON_OO("Wrong ICMP seq: {} vs {}", ntohs(icp->icmp_id), 12345);
+            return false;
+        }
+        if (icp->icmp_id != getpid()) {
+            DEBUG_NON_OO("Wrong ICMP id: {}", icp->icmp_id);
+            return false;
+        }
+    }
+    return true;
+}
+
+
+// source: https://github.com/openbsd/src/blob/master/sbin/ping/ping.c
+int in_cksum(uint16_t* addr, int len) {
+    int nleft = len;
+    uint16_t* w = addr;
+    int sum = 0;
+    uint16_t answer = 0;
+
+    /*
+     * Our algorithm is simple, using a 32 bit accumulator (sum), we add
+     * sequential 16 bit words to it, and at the end, fold back all the
+     * carry bits from the top 16 bits into the lower 16 bits.
+     */
+    while (nleft > 1) {
+        sum += *w++;
+        nleft -= 2;
+    }
+
+    /* mop up an odd byte, if necessary */
+    if (nleft == 1) {
+        *(uint8_t*)(&answer) = *(uint8_t*)w;
+        sum += answer;
+    }
+
+    /* add back carry outs from top 16 bits to low 16 bits */
+    sum = (sum >> 16) + (sum & 0xffff); /* add hi 16 to low 16 */
+    sum += (sum >> 16);                 /* add carry */
+    answer = ~sum;                      /* truncate to 16 bits */
+    return answer;
 }

--- a/lib/stages/frbNetworkProcess.cpp
+++ b/lib/stages/frbNetworkProcess.cpp
@@ -454,3 +454,17 @@ void frbNetworkProcess::ping_destinations() {
             return;
     }
 }
+
+DestIpSocket::DestIpSocket(std::string host, sockaddr_in addr, int s, bool active) :
+    host(std::move(host)),
+    addr(std::move(addr)),
+    sending_socket(s),
+    active(active),
+    live(false) {}
+
+DestIpSocket::DestIpSocket(DestIpSocket&& other) :
+    host(std::move(other.host)),
+    addr(std::move(other.addr)),
+    sending_socket(other.sending_socket),
+    active(other.active),
+    live(other.live.load()) {}

--- a/lib/stages/frbNetworkProcess.cpp
+++ b/lib/stages/frbNetworkProcess.cpp
@@ -382,7 +382,7 @@ void frbNetworkProcess::ping_destinations() {
         // jitter the initial check by a random amount 3-10 s
         auto now = std::chrono::steady_clock::now();
         auto next_check = now + std::chrono::milliseconds(dis(gen));
-        DEBUG("Check host {} at {}", dst.host, next_check.time_since_epoch());
+        DEBUG("Check host {} at {:%H:%M:%S}", dst.host, next_check.time_since_epoch());
         DestIpSocketTime& dest_ping_info = dest_by_ip[ipaddr] = {&dst, now, next_check};
         dest_by_time.push(dest_ping_info);
     }
@@ -396,8 +396,7 @@ void frbNetworkProcess::ping_destinations() {
         auto time_since_last_live = std::chrono::steady_clock::now() - lru_dest.last_responded;
 
         DEBUG("Checking: {}", lru_dest.dst->host);
-        DEBUG("Last responded: {}s ago",
-              std::chrono::duration_cast<std::chrono::seconds>(time_since_last_live).count());
+        DEBUG("Last responded: {:%S} ago", time_since_last_live);
 
         // NOTE: we don't ping if the host is not active, but behave as if it were checked
         if (send_ping(ping_src_fd[lru_dest.dst->sending_socket], lru_dest.dst->addr)) {
@@ -481,12 +480,12 @@ void frbNetworkProcess::ping_destinations() {
             std::chrono::steady_clock::now() + std::chrono::seconds(lru_dest.check_delay);
         // could add another `std::chrono::milliseconds(dis(gen))` random delay to next_check
         dest_by_time.push(lru_dest);
-        DEBUG("Check {} again in {}s", lru_dest.dst->host,
+        DEBUG("Check {} again in {:%S}", lru_dest.dst->host,
               lru_dest.next_check - std::chrono::steady_clock::now());
 
         // sleep until the next host is due
         DestIpSocketTime& next_lru_dest = dest_by_time.top();
-        DEBUG("Sleep until {} before checking the next host {}",
+        DEBUG("Sleep until {:%H:%M:%S} before checking the next host {}",
               next_lru_dest.next_check.time_since_epoch(), next_lru_dest.dst->host);
 
         // continue sleeping if received a spurious wakeup, i.e., neither the stage was stopped nor

--- a/lib/stages/frbNetworkProcess.cpp
+++ b/lib/stages/frbNetworkProcess.cpp
@@ -382,7 +382,7 @@ void frbNetworkProcess::ping_destinations() {
         // jitter the initial check by a random amount 3-10 s
         auto now = std::chrono::steady_clock::now();
         auto next_check = now + std::chrono::milliseconds(dis(gen));
-        DEBUG("Check host {} at {:%H:%M:%S}", dst.host, next_check.time_since_epoch());
+        DEBUG("Check host {} in {:%S}s", dst.host, next_check - now);
         DestIpSocketTime& dest_ping_info = dest_by_ip[ipaddr] = {&dst, now, next_check};
         dest_by_time.push(dest_ping_info);
     }
@@ -396,7 +396,7 @@ void frbNetworkProcess::ping_destinations() {
         auto time_since_last_live = std::chrono::steady_clock::now() - lru_dest.last_responded;
 
         DEBUG("Checking: {}", lru_dest.dst->host);
-        DEBUG("Last responded: {:%S} ago", time_since_last_live);
+        DEBUG("Last responded: {:%S}s ago", time_since_last_live);
 
         // NOTE: we don't ping if the host is not active, but behave as if it were checked
         if (send_ping(ping_src_fd[lru_dest.dst->sending_socket], lru_dest.dst->addr)) {
@@ -480,13 +480,13 @@ void frbNetworkProcess::ping_destinations() {
             std::chrono::steady_clock::now() + std::chrono::seconds(lru_dest.check_delay);
         // could add another `std::chrono::milliseconds(dis(gen))` random delay to next_check
         dest_by_time.push(lru_dest);
-        DEBUG("Check {} again in {:%S}", lru_dest.dst->host,
+        DEBUG("Check {} again in {:%S}s", lru_dest.dst->host,
               lru_dest.next_check - std::chrono::steady_clock::now());
 
         // sleep until the next host is due
         DestIpSocketTime& next_lru_dest = dest_by_time.top();
-        DEBUG("Sleep until {:%H:%M:%S} before checking the next host {}",
-              next_lru_dest.next_check.time_since_epoch(), next_lru_dest.dst->host);
+        DEBUG("Sleep for {:%S}s before checking the next host {}",
+              next_lru_dest.next_check - std::chrono::steady_clock::now(), next_lru_dest.dst->host);
 
         // continue sleeping if received a spurious wakeup, i.e., neither the stage was stopped nor
         // timeout occurred

--- a/lib/stages/frbNetworkProcess.cpp
+++ b/lib/stages/frbNetworkProcess.cpp
@@ -51,7 +51,9 @@ frbNetworkProcess::frbNetworkProcess(Config& config_, const string& unique_name,
     _min_ping_interval{
         std::chrono::seconds(config_.get_default<long>(unique_name, "min_ping_interval", 5))},
     _max_ping_interval{
-        std::chrono::seconds(config_.get_default<long>(unique_name, "max_ping_interval", 600))} {
+        std::chrono::seconds(config_.get_default<long>(unique_name, "max_ping_interval", 600))},
+    _ping_dead_threshold{
+        std::chrono::seconds(config_.get_default<long>(unique_name, "ping_dead_threshold", 30))} {
 
     in_buf = get_buffer("in_buf");
     register_consumer(in_buf, unique_name.c_str());
@@ -484,7 +486,7 @@ void frbNetworkProcess::ping_destinations() {
         // Mark node as dead if it's been too long since last response
         if (lru_dest.dst->live) {
             auto time_since_last_live = std::chrono::steady_clock::now() - lru_dest.last_responded;
-            if (time_since_last_live > _max_ping_interval) {
+            if (time_since_last_live > _ping_dead_threshold) {
                 INFO("Too long since last ping response ({:%M:%S}), mark host {} dead.",
                      time_since_last_live, lru_dest.dst->host);
                 lru_dest.dst->live = false;

--- a/lib/stages/frbNetworkProcess.hpp
+++ b/lib/stages/frbNetworkProcess.hpp
@@ -143,10 +143,10 @@ private:
     /// array of sending socket descriptors
     std::vector<SrcAddrSocket> src_sockets;
 
-    /// destination addresses and associated sending sockets, indexed by IP `s_addr`
+    /// destination addresses and associated sending sockets, indexed by IP @c s_addr
     std::map<uint32_t, DestIpSocket> dest_sockets;
 
-    /// stream destinations (references to `dest_sockets`, because a single destination can be used
+    /// stream destinations (references to @p dest_sockets, because a single destination can be used
     /// for multiple streams)
     std::vector<std::reference_wrapper<DestIpSocket>> stream_dest;
 
@@ -156,11 +156,11 @@ private:
     /// initialize destination addresses and determine the sending socket to use
     int initialize_destinations();
 
-    /// background thread that periodically pings destination hosts and updates their `live` status
+    /// background thread that periodically pings destination hosts and updates their @c live status
     void ping_destinations();
 
-    /// used by ping_destinations for periodic sleep interruptible by the main_thread on Kotekan
-    /// stop
+    /// used by @p ping_destinations for periodic sleep interruptible by the @p main_thread on
+    /// Kotekan stop
     std::condition_variable ping_cv;
 };
 

--- a/lib/stages/frbNetworkProcess.hpp
+++ b/lib/stages/frbNetworkProcess.hpp
@@ -140,11 +140,12 @@ private:
     // Beam kotekan::Configuration Mode
     bool column_mode;
 
-    /// Minimal interval between checks of a node's liveliness
-    const std::chrono::seconds _min_ping_interval;
+    /// Interval between checks of a node's liveliness
+    const std::chrono::seconds _ping_interval;
 
-    /// Maximal interval between checks of a node's liveliness
-    const std::chrono::seconds _max_ping_interval;
+    /// Accelerated interval between checks of a node's liveliness, used when a live node stops
+    /// responding
+    const std::chrono::seconds _quick_ping_interval;
 
     /// Duration at which a node is declared dead if it hasn't responded to pings
     const std::chrono::seconds _ping_dead_threshold;

--- a/lib/stages/frbNetworkProcess.hpp
+++ b/lib/stages/frbNetworkProcess.hpp
@@ -65,23 +65,24 @@ struct SrcAddrSocket {
 };
 
 struct DestIpSocket {
-    DestIpSocket(std::string host, sockaddr_in addr, int s) :
+    /// Regular constructor used with data from the config file
+    DestIpSocket(std::string host, sockaddr_in addr, int s, bool active = true) :
         host(std::move(host)),
         addr(std::move(addr)),
-        sending_socket(std::move(s)),
-        active(true),
+        sending_socket(s),
+        active(active),
         live(false) {}
     /// Move constructor is necessary for inserting into standard containers
     DestIpSocket(DestIpSocket&& other) :
         host(std::move(other.host)),
         addr(std::move(other.addr)),
         sending_socket(other.sending_socket),
-        active(other.active.load()),
+        active(other.active),
         live(other.live.load()) {}
     const std::string host;
     const sockaddr_in addr;
     const int sending_socket;
-    std::atomic_bool active;
+    const bool active;
     std::atomic_bool live;
 };
 

--- a/lib/stages/frbNetworkProcess.hpp
+++ b/lib/stages/frbNetworkProcess.hpp
@@ -141,10 +141,10 @@ private:
     bool column_mode;
 
     /// Minimal interval between checks of a node's liveliness
-    const std::chrono::milliseconds live_check_frequency;
+    const std::chrono::seconds min_ping_frequency_;
 
-    /// Minimal interval without a ping response before a node is declared dead
-    const std::chrono::milliseconds node_dead_interval;
+    /// Maximal interval between checks of a node's liveliness, and before a node is declared dead
+    const std::chrono::seconds max_ping_frequency_;
 
     /// array of sending socket descriptors
     std::vector<SrcAddrSocket> src_sockets;

--- a/lib/stages/frbNetworkProcess.hpp
+++ b/lib/stages/frbNetworkProcess.hpp
@@ -48,8 +48,11 @@
  * @conf   beam_offset          Int (default 0). Offset the beam_id going to L1 Process
  * @conf   time_interval        Unsigned long (default 125829120). Time per buffer in ns.
  * @conf   column_mode          bool (default false) Send beams in a single CHIME cylinder.
- * @conf   check_interval       Unsigned long (default 30s) Time in ms between sending a ping to
+ * @conf   live_check_frequency Unsigned long (default 30s) Time in ms between sending a ping to
  * check if a destination host is live.
+ * @conf   node_dead_interval   Unsigned long (default 2*live_check_frequency) Time in ms after
+ * which the host is marked dead if it hasn't sent a ping reply. check if a destination host is
+ * live.
  * @todo   Resolve the issue of NTP clock vs Monotonic clock.
  *
  * @author Arun Naidu, Davor Cubranic
@@ -133,6 +136,9 @@ private:
 
     /// Minimal interval between checks of a node's liveliness
     const std::chrono::milliseconds live_check_frequency;
+
+    /// Minimal interval without a ping response before a node is declared dead
+    const std::chrono::milliseconds node_dead_interval;
 
     /// array of sending socket descriptors
     std::vector<SrcAddrSocket> src_sockets;

--- a/lib/stages/frbNetworkProcess.hpp
+++ b/lib/stages/frbNetworkProcess.hpp
@@ -64,25 +64,30 @@ struct SrcAddrSocket {
     const int socket_fd;
 };
 
+
+/**
+ * @brief Convenience struct used to hold all relevant information about an FRB L1 destination
+ */
 struct DestIpSocket {
     /// Regular constructor used with data from the config file
-    DestIpSocket(std::string host, sockaddr_in addr, int s, bool active = true) :
-        host(std::move(host)),
-        addr(std::move(addr)),
-        sending_socket(s),
-        active(active),
-        live(false) {}
+    DestIpSocket(std::string host, sockaddr_in addr, int s, bool active = true);
+
     /// Move constructor is necessary for inserting into standard containers
-    DestIpSocket(DestIpSocket&& other) :
-        host(std::move(other.host)),
-        addr(std::move(other.addr)),
-        sending_socket(other.sending_socket),
-        active(other.active),
-        live(other.live.load()) {}
+    DestIpSocket(DestIpSocket&& other);
+
+    //@{
+    /// host address as a string and a `sockaddr` structure
     const std::string host;
     const sockaddr_in addr;
+    //@}
+
+    /// index of the entry in @p src_sockets used to communicate with the destination
     const int sending_socket;
+
+    /// flag to indicate if the destination is a "dummy" placeholder
     const bool active;
+
+    /// flag to indicate if the host has been responding to pings
     std::atomic_bool live;
 };
 

--- a/lib/stages/frbNetworkProcess.hpp
+++ b/lib/stages/frbNetworkProcess.hpp
@@ -12,6 +12,7 @@
 #include "restServer.hpp"
 
 #include <string>
+#include <vector>
 
 /**
  * @class frbNetworkProcess
@@ -49,6 +50,10 @@
  *
  */
 
+struct DestIpSocket {
+    sockaddr_in addr;
+    int sending_socket;
+};
 
 class frbNetworkProcess : public kotekan::Stage {
 public:
@@ -75,9 +80,6 @@ private:
     /// port number
     int udp_frb_port_number;
 
-    /// node ip addresses
-    char** my_ip_address;
-
     /// number of L0 nodes
     int number_of_nodes;
 
@@ -86,9 +88,6 @@ private:
 
     /// number of packets to each L1 nodes
     int packets_per_stream;
-
-    /// host name from the gethosename()
-    char* my_host_name;
 
     /// beam offset for 8-node frb system
     int beam_offset;
@@ -102,17 +101,16 @@ private:
     // Beam kotekan::Configuration Mode
     bool column_mode;
 
-    /// array of local file descriptors
-    int* sock_fd;
+    /// array of sending socket descriptors
+    std::vector<int> src_sockets;
 
-    /// array of socket endpoint addresses for pulsar links
-    struct sockaddr_in* server_address;
+    /// destination addresses and associated sending sockets
+    std::vector<DestIpSocket> dst_sockets;
 
-    /// array of socket endpoint addresses for local links
-    struct sockaddr_in* myaddr;
+    int initialize_source_sockets();
 
-    /// array of socket ids
-    int* ip_socket;
+    /// construct destination addresses and determine the sending socket to use
+    int initialize_destinations();
 };
 
 #endif

--- a/lib/stages/frbNetworkProcess.hpp
+++ b/lib/stages/frbNetworkProcess.hpp
@@ -141,10 +141,10 @@ private:
     bool column_mode;
 
     /// Minimal interval between checks of a node's liveliness
-    const std::chrono::seconds min_ping_frequency_;
+    const std::chrono::seconds _min_ping_interval;
 
     /// Maximal interval between checks of a node's liveliness, and before a node is declared dead
-    const std::chrono::seconds max_ping_frequency_;
+    const std::chrono::seconds _max_ping_interval;
 
     /// array of sending socket descriptors
     std::vector<SrcAddrSocket> src_sockets;

--- a/lib/stages/frbNetworkProcess.hpp
+++ b/lib/stages/frbNetworkProcess.hpp
@@ -48,11 +48,13 @@
  * @conf   beam_offset          Int (default 0). Offset the beam_id going to L1 Process
  * @conf   time_interval        Unsigned long (default 125829120). Time per buffer in ns.
  * @conf   column_mode          bool (default false) Send beams in a single CHIME cylinder.
- * @conf   live_check_frequency Unsigned long (default 30s) Time in ms between sending a ping to
- * check if a destination host is live.
- * @conf   node_dead_interval   Unsigned long (default 2*live_check_frequency) Time in ms after
- * which the host is marked dead if it hasn't sent a ping reply. check if a destination host is
- * live.
+ * @conf   ping_interval        Uint32 (default 6 min) Time in seconds between sending a ping to
+ * check destination is live
+ * @conf   quick_ping_interval  Uint32 (default 5 sec) Time in seconds for sending pings when a live
+ * node stops responding
+ * @conf   ping_dead_threshold  Uint32 (default 30 sec) Duration in seconds of quick-checking state
+ * after which a node is declared dead if it still hasn't responded
+ *
  * @todo   Resolve the issue of NTP clock vs Monotonic clock.
  *
  * @author Arun Naidu, Davor Cubranic

--- a/lib/stages/frbNetworkProcess.hpp
+++ b/lib/stages/frbNetworkProcess.hpp
@@ -143,8 +143,11 @@ private:
     /// Minimal interval between checks of a node's liveliness
     const std::chrono::seconds _min_ping_interval;
 
-    /// Maximal interval between checks of a node's liveliness, and before a node is declared dead
+    /// Maximal interval between checks of a node's liveliness
     const std::chrono::seconds _max_ping_interval;
+
+    /// Duration at which a node is declared dead if it hasn't responded to pings
+    const std::chrono::seconds _ping_dead_threshold;
 
     /// array of sending socket descriptors
     std::vector<SrcAddrSocket> src_sockets;

--- a/lib/utils/CMakeLists.txt
+++ b/lib/utils/CMakeLists.txt
@@ -25,6 +25,7 @@ set ( KOTEKAN_UTIL_SOURCES
       BipBuffer.cpp
       Hash.cpp
       MurmurHash3.cpp
+      network_functions.cpp
     )
 
 if (${USE_HDF5})

--- a/lib/utils/network_functions.cpp
+++ b/lib/utils/network_functions.cpp
@@ -1,0 +1,83 @@
+#include "network_functions.hpp"
+
+#include "kotekanLogging.hpp"
+
+#include <netinet/ip_icmp.h>
+#include <unistd.h>
+
+
+bool send_ping(int s, const sockaddr_in& dst) {
+    uint8_t outpackhdr[IP_MAXPACKET];
+    uint8_t* outpack = outpackhdr + sizeof(struct ip);
+    int cc = (64 - 8); // data length - icmp echo header len, excluding time
+    struct icmp* icp = (struct icmp*)outpack;
+    icp->icmp_type = ICMP_ECHO;
+    icp->icmp_code = 0;
+    icp->icmp_cksum = 0;
+    icp->icmp_id = getpid();
+
+    uint16_t seq = 12345;
+    icp->icmp_seq = htons(seq);
+    icp->icmp_cksum = in_cksum((uint16_t*)icp, cc);
+    int rc = sendto(s, (char*)outpack, cc, 0, (struct sockaddr*)&dst, sizeof(struct sockaddr_in));
+    return rc == cc;
+}
+
+
+bool receive_ping(int s, sockaddr_in& from) {
+    socklen_t from_length = sizeof(from);
+    uint8_t packet[4096];
+    int packet_length = sizeof(packet);
+    int rc = recvfrom(s, packet, packet_length, 0, (sockaddr*)&from, &from_length);
+
+    // Check the IP header
+    int hlen = sizeof(struct ip);
+    if (rc < (hlen + ICMP_MINLEN)) {
+        DEBUG_NON_OO("Packet too short. Ignoring.");
+        return false;
+    }
+    // Now the icmp part
+    struct icmp* icp = (struct icmp*)(packet + hlen);
+    if (icp->icmp_type == ICMP_ECHOREPLY) {
+        if (ntohs(icp->icmp_seq) != 12345) {
+            DEBUG_NON_OO("Wrong ICMP seq: {} vs {}", ntohs(icp->icmp_id), 12345);
+            return false;
+        }
+        if (icp->icmp_id != getpid()) {
+            DEBUG_NON_OO("Wrong ICMP id: {}", icp->icmp_id);
+            return false;
+        }
+    }
+    return true;
+}
+
+
+// source: https://github.com/openbsd/src/blob/master/sbin/ping/ping.c
+int in_cksum(uint16_t* addr, int len) {
+    int nleft = len;
+    uint16_t* w = addr;
+    int sum = 0;
+    uint16_t answer = 0;
+
+    /*
+     * Our algorithm is simple, using a 32 bit accumulator (sum), we add
+     * sequential 16 bit words to it, and at the end, fold back all the
+     * carry bits from the top 16 bits into the lower 16 bits.
+     */
+    while (nleft > 1) {
+        sum += *w++;
+        nleft -= 2;
+    }
+
+    /* mop up an odd byte, if necessary */
+    if (nleft == 1) {
+        *(uint8_t*)(&answer) = *(uint8_t*)w;
+        sum += answer;
+    }
+
+    /* add back carry outs from top 16 bits to low 16 bits */
+    sum = (sum >> 16) + (sum & 0xffff); /* add hi 16 to low 16 */
+    sum += (sum >> 16);                 /* add carry */
+    answer = ~sum;                      /* truncate to 16 bits */
+    return answer;
+}

--- a/lib/utils/network_functions.hpp
+++ b/lib/utils/network_functions.hpp
@@ -1,0 +1,43 @@
+#ifndef NETWORK_UTILITY_FUNCTIONS_H
+#define NETWORK_UTILITY_FUNCTIONS_H
+#include <netinet/ip.h>
+
+
+/*****************************************
+@file
+@brief Utility functions for dealing with low-level sockets APIs
+*****************************************/
+
+/**
+ * @brief Send a ping packet to the destination using source socket @a
+ *
+ * @param s socket to use for communication
+ * @param dst destination address to which to send
+ *
+ * @return @c true if ping was sent successfully
+ */
+bool send_ping(int s, const sockaddr_in& dst);
+
+/**
+ * @brief Receive a ping response on socket @p s, returning `true` if all OK and putting the
+ * sender's address into @a from
+ *
+ * @param s[in] socket to use for communication
+ * @param from[out] the response sender's address
+ *
+ * @return @c true if a ping response was received successfully
+ */
+bool receive_ping(int s, sockaddr_in& from);
+
+/**
+ * @brief Calculate internet packet checksum (based on BSD networking code)
+ *
+ * @param addr
+ * @param length
+
+ * @return valid IP packet checksum
+ */
+int in_cksum(uint16_t* addr, const int length);
+
+
+#endif // NETWORK_UTILITY_FUNCTIONS_H

--- a/lib/utils/network_functions.hpp
+++ b/lib/utils/network_functions.hpp
@@ -13,10 +13,11 @@
  *
  * @param s socket to use for communication
  * @param dst destination address to which to send
+ * @param seq_no sequence number to use in the packet
  *
  * @return @c true if ping was sent successfully
  */
-bool send_ping(int s, const sockaddr_in& dst);
+bool send_ping(int s, const sockaddr_in& dst, const uint16_t seq_no);
 
 /**
  * @brief Receive a ping response on socket @p s, returning `true` if all OK and putting the
@@ -25,9 +26,9 @@ bool send_ping(int s, const sockaddr_in& dst);
  * @param[in] s socket to use for communication
  * @param[out] from the response sender's address
  *
- * @return @c true if a ping response was received successfully
+ * @return sequence number of the ping response if it was received successfully, -1 otherwise
  */
-bool receive_ping(int s, sockaddr_in& from);
+int receive_ping(int s, sockaddr_in& from);
 
 /**
  * @brief Calculate internet packet checksum (based on BSD networking code)

--- a/lib/utils/network_functions.hpp
+++ b/lib/utils/network_functions.hpp
@@ -9,7 +9,7 @@
 *****************************************/
 
 /**
- * @brief Send a ping packet to the destination using source socket @a
+ * @brief Send a ping packet to the destination using source socket @a s
  *
  * @param s socket to use for communication
  * @param dst destination address to which to send
@@ -22,8 +22,8 @@ bool send_ping(int s, const sockaddr_in& dst);
  * @brief Receive a ping response on socket @p s, returning `true` if all OK and putting the
  * sender's address into @a from
  *
- * @param s[in] socket to use for communication
- * @param from[out] the response sender's address
+ * @param[in] s socket to use for communication
+ * @param[out] from the response sender's address
  *
  * @return @c true if a ping response was received successfully
  */


### PR DESCRIPTION
Add checks for FRB destination liveness and deactivation of destinations:

- add a background thread that periodically pings every FRB destination and
  keeps track of how recently they've replied
- nodes that have gone too long without replying are marked dead and packets
  aren't sent to them until they start responding to pings again
- "deactivate" sending a beam to an L1 destination by having the destination IP as an empty string in the Kotekan config.

## not accepted for this PR:
- add a REST API that allows "deactivating" a destination. Such destinations
  will still be pinged, but packets won't be sent to them until they are
  activated again
- the API works by POSTing to URL `/frb/update_destination` a dictionary with
  keys "host" (a string that must exist as an element in `L1_node_ips` config
  entry), and "active" (a boolean that set the new value of the flag)