### PR TITLE
fix(visUtil): add custom fmt formatter for frameID

### DIFF
--- a/lib/stages/bufferMerge.cpp
+++ b/lib/stages/bufferMerge.cpp
@@ -85,7 +85,7 @@ void bufferMerge::main_thread() {
 
             /// Wait for an input frame
             if (_timeout < 0) {
-                DEBUG2("Waiting for {:s}[{:d}]", in_buf->buffer_name, (int)in_frame_id);
+                DEBUG2("Waiting for {:s}[{:d}]", in_buf->buffer_name, in_frame_id);
                 uint8_t* input_frame =
                     wait_for_full_frame(in_buf, unique_name.c_str(), in_frame_id);
                 if (input_frame == NULL)

--- a/lib/stages/receiveFlags.cpp
+++ b/lib/stages/receiveFlags.cpp
@@ -151,7 +151,7 @@ void receiveFlags::main_thread() {
             // --> Use the last update we have
             WARN("receiveFlags: Flags for frame {:d} with timestamp {:f} are not in memory. "
                  "Applying oldest flags found ({:f}). Concider increasing num_kept_updates.",
-                 (int)frame_id_in, ts_to_double(ts_frame), ts_to_double(update.first));
+                 frame_id_in, ts_to_double(ts_frame), ts_to_double(update.first));
             receiveflags_late_frame_counter.inc();
         }
         // actually copy the new flags and apply them from now

--- a/lib/stages/valve.cpp
+++ b/lib/stages/valve.cpp
@@ -58,7 +58,7 @@ void Valve::main_thread() {
             }
             mark_frame_full(_buf_out, unique_name.c_str(), frame_id_out++);
         } else {
-            WARN("Output buffer full. Dropping incoming frame {:d}.", (int)frame_id_in);
+            WARN("Output buffer full. Dropping incoming frame {:d}.", frame_id_in);
             dropped_total.inc();
         }
         mark_frame_empty(_buf_in, unique_name.c_str(), frame_id_in++);

--- a/lib/stages/visTestPattern.cpp
+++ b/lib/stages/visTestPattern.cpp
@@ -199,8 +199,8 @@ void visTestPattern::main_thread() {
                                "{:f}j in frame {:d} with freq_id {:d}.",
                                i, (float)expected.at(frame.freq_id).at(i).real(),
                                (float)expected.at(frame.freq_id).at(i).imag(),
-                               (float)frame.vis[i].real(), (float)frame.vis[i].imag(),
-                               (int)frame_id, frame.freq_id);
+                               (float)frame.vis[i].real(), (float)frame.vis[i].imag(), frame_id,
+                               frame.freq_id);
                         num_bad++;
 
                         // Calculate the error here, this square root is then

--- a/lib/testing/hexDump.cpp
+++ b/lib/testing/hexDump.cpp
@@ -38,7 +38,7 @@ void hexDump::main_thread() {
         if (frame == NULL)
             break;
 
-        DEBUG("hexDump: Got buffer {:s}[{:d}]", in_buf->buffer_name, (int)frame_id);
+        DEBUG("hexDump: Got buffer {:s}[{:d}]", in_buf->buffer_name, frame_id);
 
         // Prints the hex data to screen
         hex_dump(16, (void*)&frame[_offset], _len);

--- a/lib/utils/visUtil.hpp
+++ b/lib/utils/visUtil.hpp
@@ -713,5 +713,17 @@ public:
     frameID(const Buffer* buf) : modulo<int>(buf->num_frames) {}
 };
 
+/**
+ *@brief FMT formatter that casts frameIDs to int so that `format("{:d}", frame_id)` works.
+ */
+namespace fmt {
+template<>
+struct formatter<frameID> : formatter<int> {
+    auto format(const frameID id, format_context& ctx) {
+        return formatter<int>::format((int)id, ctx);
+    }
+};
+} // namespace fmt
+
 
 #endif


### PR DESCRIPTION
`fmt::format("{:d}", frame_id)` failed on run time.
Add custom formatter that casts `frameID`s to `int` to fix this.