### PR TITLE
write dataset ID

### DIFF
--- a/lib/stages/visRawReader.hpp
+++ b/lib/stages/visRawReader.hpp
@@ -123,7 +123,7 @@ private:
      * Sets the dataset ID that should be given to the dataset coming from
      * the file that is read.
      */
-    void change_dataset_state();
+    void change_dataset_state(dset_id_t ds_id);
 
     /**
      * @brief Read the next frame.

--- a/lib/utils/datasetState.cpp
+++ b/lib/utils/datasetState.cpp
@@ -83,3 +83,4 @@ REGISTER_DATASET_STATE(eigenvalueState, "eigenvalues");
 REGISTER_DATASET_STATE(timeState, "time");
 REGISTER_DATASET_STATE(metadataState, "metadata");
 REGISTER_DATASET_STATE(gatingState, "gating");
+REGISTER_DATASET_STATE(acqDatasetIdState, "acq_dataset_id");

--- a/lib/utils/datasetState.hpp
+++ b/lib/utils/datasetState.hpp
@@ -684,8 +684,8 @@ public:
 
     /**
      * @brief Constructor
-     * @param id    The dataset ID for the acquisition.
-     * @param inner An inner state (optional).
+     * @param ds_id    The dataset ID for the acquisition.
+     * @param inner    An inner state (optional).
      */
     acqDatasetIdState(dset_id_t ds_id, state_uptr inner = nullptr) :
         datasetState(move(inner)),

--- a/lib/utils/datasetState.hpp
+++ b/lib/utils/datasetState.hpp
@@ -654,4 +654,60 @@ public:
     const json gating_data;
 };
 
+
+// TODO: Remove this and integrate gossec into dataset broker
+using dset_id_t = size_t;
+/**
+ * @brief A dataset state used to communicate the dataset ID of data stored
+ *        in a raw file. This is a hack until we figure out how to propagate
+ *        dataset ID's to archive files.
+ *
+ * @author Tristan Pinsonneault-Marotte
+ */
+class acqDatasetIdState : public datasetState {
+public:
+    /**
+     * @brief Constructor
+     * @param data  The dataset ID as serialized by
+     *              acqDatasetIdState::to_json().
+     * @param inner An inner state or a nullptr.
+     */
+    acqDatasetIdState(json& data, state_uptr inner) : datasetState(move(inner)) {
+        try {
+            _ds_id = data.get<dset_id_t>();
+        } catch (std::exception& e) {
+            throw std::runtime_error(
+                fmt::format(fmt("acqDatasetIdState: Failure parsing json data ({:s}): {:s}"),
+                            data.dump(4), e.what()));
+        }
+    };
+
+    /**
+     * @brief Constructor
+     * @param id    The dataset ID for the acquisition.
+     * @param inner An inner state (optional).
+     */
+    acqDatasetIdState(dset_id_t ds_id, state_uptr inner = nullptr) :
+        datasetState(move(inner)),
+        _ds_id(ds_id){};
+
+    /**
+     * @brief Get dataset ID (read only).
+     *
+     * @return Dataset ID as a `dset_id_t`.
+     */
+    dset_id_t get_id() const {
+        return _ds_id;
+    }
+
+private:
+    dset_id_t _ds_id;
+
+    /// Serialize the data of this state in a json object
+    json data_to_json() const override {
+        json j(_ds_id);
+        return j;
+    }
+};
+
 #endif // DATASETSTATE_HPP


### PR DESCRIPTION
This is a hack to record the dataset ID in the archive files. It should be replaced eventually by making `gossec` aware of the dataset broker and using that to communicate metadata.