### PR TITLE
Reduce baseband dump buffer size.

### DIFF
--- a/config/chime_science_run_gpu.yaml
+++ b/config/chime_science_run_gpu.yaml
@@ -348,7 +348,7 @@ zero_samples:
     out_buf: network_buffer_3
 
 baseband:
-  max_dump_samples: 400000
+  max_dump_samples: 200000
   num_frames_buffer: baseband_buffer_depth - 10
   base_dir: /mnt/frb-baseband/
   write_throttle: 0


### PR DESCRIPTION
Internally the baseband buffer allocated `2 * max_dump_samples`, so this is actually keeping it the same size after the changes in #497