### PR TITLE
test(dataset_broker): ignore argv[1]=="--"

### DIFF
--- a/tests/boost/dataset_broker_consumer.cpp
+++ b/tests/boost/dataset_broker_consumer.cpp
@@ -24,8 +24,19 @@ using namespace std::string_literals;
 dset_id_t second_root_update;
 
 BOOST_FIXTURE_TEST_CASE(_ask_broker_for_ancestors, CompareCTypes) {
-    BOOST_CHECK(boost::unit_test::framework::master_test_suite().argc == 2);
-    int broker_port = atoi(boost::unit_test::framework::master_test_suite().argv[1]);
+    // The randomly chosen port for the dataset broker is passed to this test as a command line
+    // argument.
+    // At some point boost stopped requiring the `--` to pass command line arguments, so we
+    // should be ready for both.
+    BOOST_CHECK(boost::unit_test::framework::master_test_suite().argc >= 2);
+    int broker_port;
+    if (!std::string("--").compare(boost::unit_test::framework::master_test_suite().argv[1])) {
+        BOOST_CHECK(boost::unit_test::framework::master_test_suite().argc == 3);
+        broker_port = atoi(boost::unit_test::framework::master_test_suite().argv[2]);
+    } else {
+        BOOST_CHECK(boost::unit_test::framework::master_test_suite().argc == 2);
+        broker_port = atoi(boost::unit_test::framework::master_test_suite().argv[1]);
+    }
     BOOST_CHECK(broker_port);
 
     _global_log_level = 4;
@@ -92,8 +103,19 @@ BOOST_FIXTURE_TEST_CASE(_ask_broker_for_ancestors, CompareCTypes) {
 }
 
 BOOST_AUTO_TEST_CASE(_dataset_manager_second_root_update) {
-    BOOST_CHECK(boost::unit_test::framework::master_test_suite().argc == 2);
-    int broker_port = atoi(boost::unit_test::framework::master_test_suite().argv[1]);
+    // The randomly chosen port for the dataset broker is passed to this test as a command line
+    // argument.
+    // At some point boost stopped requiring the `--` to pass command line arguments, so we
+    // should be ready for both.
+    BOOST_CHECK(boost::unit_test::framework::master_test_suite().argc >= 2);
+    int broker_port;
+    if (!std::string("--").compare(boost::unit_test::framework::master_test_suite().argv[1])) {
+        BOOST_CHECK(boost::unit_test::framework::master_test_suite().argc == 3);
+        broker_port = atoi(boost::unit_test::framework::master_test_suite().argv[2]);
+    } else {
+        BOOST_CHECK(boost::unit_test::framework::master_test_suite().argc == 2);
+        broker_port = atoi(boost::unit_test::framework::master_test_suite().argv[1]);
+    }
     BOOST_CHECK(broker_port);
 
     _global_log_level = 5;
@@ -138,8 +160,19 @@ BOOST_AUTO_TEST_CASE(_dataset_manager_second_root_update) {
 }
 
 BOOST_FIXTURE_TEST_CASE(_ask_broker_for_second_root, CompareCTypes) {
-    BOOST_CHECK(boost::unit_test::framework::master_test_suite().argc == 2);
-    int broker_port = atoi(boost::unit_test::framework::master_test_suite().argv[1]);
+    // The randomly chosen port for the dataset broker is passed to this test as a command line
+    // argument.
+    // At some point boost stopped requiring the `--` to pass command line arguments, so we
+    // should be ready for both.
+    BOOST_CHECK(boost::unit_test::framework::master_test_suite().argc >= 2);
+    int broker_port;
+    if (!std::string("--").compare(boost::unit_test::framework::master_test_suite().argv[1])) {
+        BOOST_CHECK(boost::unit_test::framework::master_test_suite().argc == 3);
+        broker_port = atoi(boost::unit_test::framework::master_test_suite().argv[2]);
+    } else {
+        BOOST_CHECK(boost::unit_test::framework::master_test_suite().argc == 2);
+        broker_port = atoi(boost::unit_test::framework::master_test_suite().argv[1]);
+    }
     BOOST_CHECK(broker_port);
 
     _global_log_level = 4;
@@ -202,8 +235,19 @@ BOOST_FIXTURE_TEST_CASE(_ask_broker_for_second_root, CompareCTypes) {
 }
 
 BOOST_FIXTURE_TEST_CASE(_ask_broker_for_second_root_update, CompareCTypes) {
-    BOOST_CHECK(boost::unit_test::framework::master_test_suite().argc == 2);
-    int broker_port = atoi(boost::unit_test::framework::master_test_suite().argv[1]);
+    // The randomly chosen port for the dataset broker is passed to this test as a command line
+    // argument.
+    // At some point boost stopped requiring the `--` to pass command line arguments, so we
+    // should be ready for both.
+    BOOST_CHECK(boost::unit_test::framework::master_test_suite().argc >= 2);
+    int broker_port;
+    if (!std::string("--").compare(boost::unit_test::framework::master_test_suite().argv[1])) {
+        BOOST_CHECK(boost::unit_test::framework::master_test_suite().argc == 3);
+        broker_port = atoi(boost::unit_test::framework::master_test_suite().argv[2]);
+    } else {
+        BOOST_CHECK(boost::unit_test::framework::master_test_suite().argc == 2);
+        broker_port = atoi(boost::unit_test::framework::master_test_suite().argv[1]);
+    }
     BOOST_CHECK(broker_port);
 
     _global_log_level = 4;

--- a/tests/boost/dataset_broker_producer.cpp
+++ b/tests/boost/dataset_broker_producer.cpp
@@ -25,8 +25,17 @@ BOOST_AUTO_TEST_CASE(_dataset_manager_general) {
 
     // The randomly chosen port for the dataset broker is passed to this test as a command line
     // argument.
-    BOOST_CHECK(boost::unit_test::framework::master_test_suite().argc == 2);
-    int broker_port = atoi(boost::unit_test::framework::master_test_suite().argv[1]);
+    // At some point boost stopped requiring the `--` to pass command line arguments, so we
+    // should be ready for both.
+    BOOST_CHECK(boost::unit_test::framework::master_test_suite().argc >= 2);
+    int broker_port;
+    if (!std::string("--").compare(boost::unit_test::framework::master_test_suite().argv[1])) {
+        BOOST_CHECK(boost::unit_test::framework::master_test_suite().argc == 3);
+        broker_port = atoi(boost::unit_test::framework::master_test_suite().argv[2]);
+    } else {
+        BOOST_CHECK(boost::unit_test::framework::master_test_suite().argc == 2);
+        broker_port = atoi(boost::unit_test::framework::master_test_suite().argv[1]);
+    }
     BOOST_CHECK(broker_port);
 
     _global_log_level = 5;
@@ -90,8 +99,19 @@ BOOST_AUTO_TEST_CASE(_dataset_manager_general) {
 
 
 BOOST_AUTO_TEST_CASE(_dataset_manager_state_known_to_broker) {
-    BOOST_CHECK(boost::unit_test::framework::master_test_suite().argc == 2);
-    int broker_port = atoi(boost::unit_test::framework::master_test_suite().argv[1]);
+    // The randomly chosen port for the dataset broker is passed to this test as a command line
+    // argument.
+    // At some point boost stopped requiring the `--` to pass command line arguments, so we
+    // should be ready for both.
+    BOOST_CHECK(boost::unit_test::framework::master_test_suite().argc >= 2);
+    int broker_port;
+    if (!std::string("--").compare(boost::unit_test::framework::master_test_suite().argv[1])) {
+        BOOST_CHECK(boost::unit_test::framework::master_test_suite().argc == 3);
+        broker_port = atoi(boost::unit_test::framework::master_test_suite().argv[2]);
+    } else {
+        BOOST_CHECK(boost::unit_test::framework::master_test_suite().argc == 2);
+        broker_port = atoi(boost::unit_test::framework::master_test_suite().argv[1]);
+    }
     BOOST_CHECK(broker_port);
 
     _global_log_level = 5;
@@ -126,8 +146,19 @@ BOOST_AUTO_TEST_CASE(_dataset_manager_state_known_to_broker) {
 }
 
 BOOST_AUTO_TEST_CASE(_dataset_manager_second_root) {
-    BOOST_CHECK(boost::unit_test::framework::master_test_suite().argc == 2);
-    int broker_port = atoi(boost::unit_test::framework::master_test_suite().argv[1]);
+    // The randomly chosen port for the dataset broker is passed to this test as a command line
+    // argument.
+    // At some point boost stopped requiring the `--` to pass command line arguments, so we
+    // should be ready for both.
+    BOOST_CHECK(boost::unit_test::framework::master_test_suite().argc >= 2);
+    int broker_port;
+    if (!std::string("--").compare(boost::unit_test::framework::master_test_suite().argv[1])) {
+        BOOST_CHECK(boost::unit_test::framework::master_test_suite().argc == 3);
+        broker_port = atoi(boost::unit_test::framework::master_test_suite().argv[2]);
+    } else {
+        BOOST_CHECK(boost::unit_test::framework::master_test_suite().argc == 2);
+        broker_port = atoi(boost::unit_test::framework::master_test_suite().argv[1]);
+    }
     BOOST_CHECK(broker_port);
 
     _global_log_level = 5;

--- a/tests/boost/dataset_broker_producer2.cpp
+++ b/tests/boost/dataset_broker_producer2.cpp
@@ -22,11 +22,19 @@ using json = nlohmann::json;
 using namespace std::string_literals;
 
 BOOST_FIXTURE_TEST_CASE(_dataset_manager_general, CompareCTypes) {
-
     // The randomly chosen port for the dataset broker is passed to this test as a command line
     // argument.
-    BOOST_CHECK(boost::unit_test::framework::master_test_suite().argc == 2);
-    int broker_port = atoi(boost::unit_test::framework::master_test_suite().argv[1]);
+    // At some point boost stopped requiring the `--` to pass command line arguments, so we
+    // should be ready for both.
+    BOOST_CHECK(boost::unit_test::framework::master_test_suite().argc >= 2);
+    int broker_port;
+    if (!std::string("--").compare(boost::unit_test::framework::master_test_suite().argv[1])) {
+        BOOST_CHECK(boost::unit_test::framework::master_test_suite().argc == 3);
+        broker_port = atoi(boost::unit_test::framework::master_test_suite().argv[2]);
+    } else {
+        BOOST_CHECK(boost::unit_test::framework::master_test_suite().argc == 2);
+        broker_port = atoi(boost::unit_test::framework::master_test_suite().argv[1]);
+    }
     BOOST_CHECK(broker_port);
 
     _global_log_level = 5;


### PR DESCRIPTION
boost required "--" before command line arguments that are passed into
the test, but they stopped requiring this apparently. So now we can
handle both cases.