### PR TITLE
Fix RFI bad inputs update problems

### DIFF
--- a/config/chime_science_run_gpu.yaml
+++ b/config/chime_science_run_gpu.yaml
@@ -387,6 +387,25 @@ monitor_2:
   timeout: 10
   fill_threshold: 0.80
 
+# Bad inputs buffer
+bad_input_buffer:
+  num_frames: buffer_depth
+  frame_size: num_elements
+  metadata_pool: main_pool
+  bad_inputs_buffer:
+    kotekan_buffer: standard
+
+# Buffer bad input updates
+# 1) Reorder list
+# 2) Zero bad inputs mask
+# 3) Add current bad input mask
+buffer_bad_input_update:
+  kotekan_stage: bufferBadInputs
+  updatable_config:
+    bad_inputs: /updatable_config/bad_inputs
+  out_buf: bad_inputs_buffer
+
+# GPU processing section
 gpu:
   kernel_path: "/var/lib/kotekan/hsa_kernels/"
   commands: &command_list
@@ -467,7 +486,6 @@ gpu:
     gpu_id: 0
     updatable_config:
       psr_pt: /updatable_config/pulsar_pointing
-      bad_inputs: /updatable_config/bad_inputs
       rfi_zeroing_toggle: /updatable_config/rfi_zeroing_toggle
       rfi_var_element_index: /updatable_config/rfi_var_element_index
     ew_spacing: [-0.4,0,0.4,0.8]
@@ -478,6 +496,7 @@ gpu:
       gain_frb_buf: gain_frb_buffer_0
       gain_psr_buf: gain_psr_buffer_0
       lost_samples_buf: lost_samples_buffer
+      bad_inputs_buf: bad_inputs_buffer
     out_buffers:
       output_buf: gpu_n2_output_buffer_0
       beamform_output_buf: gpu_beamform_output_buffer_0
@@ -491,7 +510,6 @@ gpu:
     gpu_id: 1
     updatable_config:
       psr_pt: /updatable_config/pulsar_pointing
-      bad_inputs: /updatable_config/bad_inputs
       rfi_zeroing_toggle: /updatable_config/rfi_zeroing_toggle
       rfi_var_element_index: /updatable_config/rfi_var_element_index
     ew_spacing: [-0.4,0,0.4,0.8]
@@ -502,6 +520,7 @@ gpu:
       gain_frb_buf: gain_frb_buffer_1
       gain_psr_buf: gain_psr_buffer_1
       lost_samples_buf: lost_samples_buffer
+      bad_inputs_buf: bad_inputs_buffer
     out_buffers:
       output_buf: gpu_n2_output_buffer_1
       beamform_output_buf: gpu_beamform_output_buffer_1
@@ -515,7 +534,6 @@ gpu:
     gpu_id: 2
     updatable_config:
       psr_pt: /updatable_config/pulsar_pointing
-      bad_inputs: /updatable_config/bad_inputs
       rfi_zeroing_toggle: /updatable_config/rfi_zeroing_toggle
       rfi_var_element_index: /updatable_config/rfi_var_element_index
     ew_spacing: [-0.4,0,0.4,0.8]
@@ -526,6 +544,7 @@ gpu:
       gain_frb_buf: gain_frb_buffer_2
       gain_psr_buf: gain_psr_buffer_2
       lost_samples_buf: lost_samples_buffer
+      bad_inputs_buf: bad_inputs_buffer
     out_buffers:
       output_buf: gpu_n2_output_buffer_2
       beamform_output_buf: gpu_beamform_output_buffer_2
@@ -539,7 +558,6 @@ gpu:
     gpu_id: 3
     updatable_config:
       psr_pt: /updatable_config/pulsar_pointing
-      bad_inputs: /updatable_config/bad_inputs
       rfi_zeroing_toggle: /updatable_config/rfi_zeroing_toggle
       rfi_var_element_index: /updatable_config/rfi_var_element_index
     ew_spacing: [-0.4,0,0.4,0.8]
@@ -550,6 +568,7 @@ gpu:
       gain_frb_buf: gain_frb_buffer_3
       gain_psr_buf: gain_psr_buffer_3
       lost_samples_buf: lost_samples_buffer
+      bad_inputs_buf: bad_inputs_buffer
     out_buffers:
       output_buf: gpu_n2_output_buffer_3
       beamform_output_buf: gpu_beamform_output_buffer_3

--- a/lib/hsa/hsaRfiUpdateBadInputs.cpp
+++ b/lib/hsa/hsaRfiUpdateBadInputs.cpp
@@ -18,9 +18,6 @@ hsaRfiUpdateBadInputs::hsaRfiUpdateBadInputs(Config& config, const string& uniqu
     uint32_t num_elements = config.get<uint32_t>(unique_name, "num_elements");
     input_mask_len = sizeof(uint8_t) * num_elements;
 
-    auto input_reorder = parse_reorder_default(config, unique_name);
-    input_remap = std::get<0>(input_reorder);
-
     host_mask = (uint8_t*)hsa_host_malloc(input_mask_len, device.get_gpu_numa_node());
     CHECK_MEM(host_mask);
 
@@ -32,31 +29,68 @@ hsaRfiUpdateBadInputs::hsaRfiUpdateBadInputs(Config& config, const string& uniqu
     _network_buf_execute_id = 0;
     _network_buf_finalize_id = 0;
 
-    update_bad_inputs = false;
+    _in_buf = host_buffers.get_buffer("bad_inputs_buf");
+    register_consumer(_in_buf, unique_name.c_str());
+    _in_buf_precondition_id = 0;
+    first_pass = true;
+    num_bad_inputs = 0;
+
     frames_to_update = 0;
-    frames_to_update_finalize = 0;
+    frame_copy_active.insert(std::begin(frame_copy_active), device.get_gpu_buffer_depth(), false);
 
     // Alloc memory on GPU
     device.get_gpu_memory_array("input_mask", 0, input_mask_len);
-
-    kotekan::configUpdater::instance().subscribe(
-        config.get<std::string>(unique_name, "updatable_config/bad_inputs"),
-        std::bind(&hsaRfiUpdateBadInputs::update_bad_inputs_callback, this, std::placeholders::_1));
 }
 
 hsaRfiUpdateBadInputs::~hsaRfiUpdateBadInputs() {
     hsa_host_free(host_mask);
 }
 
+inline void hsaRfiUpdateBadInputs::copy_frame(int gpu_frame_id) {
+    (void)gpu_frame_id;
+
+    frames_to_update = device.get_gpu_buffer_depth();
+    memcpy(host_mask, _in_buf->frames[_in_buf_precondition_id], input_mask_len);
+    num_bad_inputs = get_rfi_num_bad_inputs(_in_buf, _in_buf_precondition_id);
+    DEBUG("gpu_frame_id={:d} using _in_buf_precondition_id={:d}", gpu_frame_id,
+          _in_buf_precondition_id);
+    mark_frame_empty(_in_buf, unique_name.c_str(), _in_buf_precondition_id);
+    _in_buf_precondition_id = (_in_buf_precondition_id + 1) % _in_buf->num_frames;
+}
+
 int hsaRfiUpdateBadInputs::wait_on_precondition(int gpu_frame_id) {
     (void)gpu_frame_id;
 
-    uint8_t* frame =
-        wait_for_full_frame(_network_buf, unique_name.c_str(), _network_buf_precondition_id);
-    if (frame == nullptr)
-        return -1;
-
-    _network_buf_precondition_id = (_network_buf_precondition_id + 1) % _network_buf->num_frames;
+    // Check for bad input updates
+    std::lock_guard<std::mutex> lock(update_mutex);
+    if (first_pass) {
+        uint8_t* frame = wait_for_full_frame(_in_buf, unique_name.c_str(), _in_buf_precondition_id);
+        if (frame == NULL)
+            return -1;
+        first_pass = false;
+        copy_frame(gpu_frame_id);
+    } else {
+        // Check for new bad inputs only if all gpu frames have been updated (not currently updating
+        // frame)
+        bool current_update_active = false;
+        for (bool in_use : frame_copy_active) {
+            if (in_use) {
+                current_update_active = true;
+                break;
+            }
+        }
+        if (frames_to_update == 0 && !current_update_active) {
+            auto timeout = double_to_ts(0);
+            int status = wait_for_full_frame_timeout(_in_buf, unique_name.c_str(),
+                                                     _in_buf_precondition_id, timeout);
+            DEBUG("status of bad inputs _in_buf_precondition_id[{:d}]={:d} (0=ready 1=not)",
+                  _in_buf_precondition_id, status);
+            if (status == 0)
+                copy_frame(gpu_frame_id);
+            if (status == -1)
+                return -1;
+        }
+    }
     return 0;
 }
 
@@ -64,17 +98,16 @@ hsa_signal_t hsaRfiUpdateBadInputs::execute(int gpu_frame_id, hsa_signal_t prece
     std::lock_guard<std::mutex> lock(update_mutex);
 
     // We need to set the number of bad inputs used in this frame
-    set_rfi_num_bad_inputs(_network_buf, _network_buf_execute_id, bad_inputs_correlator.size());
+    set_rfi_num_bad_inputs(_network_buf, _network_buf_execute_id, num_bad_inputs);
     _network_buf_execute_id = (_network_buf_execute_id + 1) % _network_buf->num_frames;
 
-    if (update_bad_inputs && frames_to_update > 0) {
+    if (frames_to_update > 0) {
         frames_to_update--;
+        frame_copy_active.at(gpu_frame_id) = true;
 
         // Copy memory to GPU
-        DEBUG("Coping bad input list to GPU[{:d}], frames to update: {:d}, update: {}, cylinder "
-              "order: {}, correlator order: {}",
-              device.get_gpu_id(), frames_to_update, update_bad_inputs, bad_inputs_cylinder,
-              bad_inputs_correlator);
+        DEBUG("Copying bad input list to GPU[{:d}], frames to update: {:d}", device.get_gpu_id(),
+              frames_to_update);
         void* gpu_mem = device.get_gpu_memory_array("input_mask", gpu_frame_id, input_mask_len);
         device.async_copy_host_to_gpu(gpu_mem, (void*)host_mask, input_mask_len, precede_signal,
                                       signals[gpu_frame_id]);
@@ -87,64 +120,14 @@ hsa_signal_t hsaRfiUpdateBadInputs::execute(int gpu_frame_id, hsa_signal_t prece
 
 void hsaRfiUpdateBadInputs::finalize_frame(int frame_id) {
     std::lock_guard<std::mutex> lock(update_mutex);
-    if (update_bad_inputs && frames_to_update_finalize > 0) {
-        frames_to_update_finalize--;
+
+    // Only mark input empty if filling frame and
+    // no more frames to finalize.
+    if (frame_copy_active.at(frame_id)) {
+        frame_copy_active.at(frame_id) = false;
         hsaCommand::finalize_frame(frame_id);
-        // Check if we've finished loading the new bad input mask in all frames.
-        if (frames_to_update_finalize == 0) {
-            update_bad_inputs = false;
-        }
     }
 
     mark_frame_empty(_network_buf, unique_name.c_str(), _network_buf_finalize_id);
     _network_buf_finalize_id = (_network_buf_finalize_id + 1) % _network_buf->num_frames;
-}
-
-bool hsaRfiUpdateBadInputs::update_bad_inputs_callback(nlohmann::json& json) {
-
-    // It might be possible to reduce the scope of this lock.
-    // However all the operations in this command object are async, so it should be fast.
-    std::lock_guard<std::mutex> lock(update_mutex);
-
-    // TODO this isn't ideal, we could read off a buffer and then apply bad inputs coming from
-    // that buffer fed by a stage.  However for the bad inputs list, we are very unlikely to hit
-    // this condition. This will be fixed when we refactor the command objects and create
-    // a generic command object for optional memory array copies.
-    // Note for this to happen we'd need two bad input list updates within less than ~0.5 seconds.
-    if (update_bad_inputs) {
-        WARN("Got new bad inputs list before applying the last list, not applying new bad inputs!");
-        return true;
-    }
-
-    try {
-        bad_inputs_cylinder = json["bad_inputs"].get<std::vector<int>>();
-    } catch (std::exception const& e) {
-        ERROR("Failed to parse bad input list {:s}", e.what());
-        return false;
-    }
-
-    // Reorder list
-    bad_inputs_correlator.clear();
-    for (auto element : bad_inputs_cylinder)
-        bad_inputs_correlator.push_back(input_remap[element]);
-
-    // Zero bad inputs mask
-    for (uint32_t i = 0; i < input_mask_len; ++i) {
-        host_mask[i] = 1;
-    }
-
-    // Add current bad input mask
-    for (auto element : bad_inputs_correlator) {
-        if (element < (int)input_mask_len && element >= 0) {
-            host_mask[element] = 0;
-        } else {
-            ERROR("Got a bad input with invalid index");
-            return false;
-        }
-    }
-
-    update_bad_inputs = true;
-    frames_to_update = device.get_gpu_buffer_depth();
-    frames_to_update_finalize = frames_to_update;
-    return true;
 }

--- a/lib/stages/CMakeLists.txt
+++ b/lib/stages/CMakeLists.txt
@@ -55,6 +55,7 @@ set ( KOTEKAN_PROCESS_LIB_SOURCES
       visTestPattern.cpp
       visDebug.cpp
       removeEv.cpp
+      bufferBadInputs.cpp
     )
 
 if (${USE_AIRSPY})

--- a/lib/stages/bufferBadInputs.cpp
+++ b/lib/stages/bufferBadInputs.cpp
@@ -1,0 +1,88 @@
+#include "bufferBadInputs.hpp"
+
+#include "chimeMetadata.h"
+#include "configUpdater.hpp"
+#include "visUtil.hpp"
+
+using kotekan::bufferContainer;
+using kotekan::Config;
+using kotekan::configUpdater;
+using kotekan::Stage;
+
+REGISTER_KOTEKAN_STAGE(bufferBadInputs);
+
+bufferBadInputs::bufferBadInputs(Config& config_, const string& unique_name,
+                                 bufferContainer& buffer_container) :
+    Stage(config_, unique_name, buffer_container, std::bind(&bufferBadInputs::main_thread, this)) {
+
+    uint32_t num_elements = config.get<uint32_t>(unique_name, "num_elements");
+    input_mask_len = sizeof(uint8_t) * num_elements;
+
+    auto input_reorder = parse_reorder_default(config, unique_name);
+    input_remap = std::get<0>(input_reorder);
+
+    out_buf = get_buffer("out_buf");
+    register_producer(out_buf, unique_name.c_str());
+
+    out_buffer_ID = 0;
+}
+
+bufferBadInputs::~bufferBadInputs() {}
+
+bool bufferBadInputs::update_bad_inputs_callback(nlohmann::json& json) {
+
+    DEBUG("update_bad_inputs_callback(): Update to bad inputs list.");
+
+    // Get the first output buffer which will always be id = 0 to start.
+    uint8_t* host_mask = wait_for_empty_frame(out_buf, unique_name.c_str(), out_buffer_ID);
+
+    try {
+        bad_inputs_cylinder = json["bad_inputs"].get<std::vector<int>>();
+    } catch (std::exception const& e) {
+        ERROR("Failed to parse bad input list {:s}", e.what());
+        return false;
+    }
+
+    // Reorder list
+    bad_inputs_correlator.clear();
+    for (auto element : bad_inputs_cylinder)
+        bad_inputs_correlator.push_back(input_remap[element]);
+
+    // Zero bad inputs mask
+    for (uint32_t i = 0; i < input_mask_len; ++i) {
+        host_mask[i] = 1;
+    }
+
+    // Add current bad input mask
+    for (auto element : bad_inputs_correlator) {
+        if (element < (int)input_mask_len && element >= 0) {
+            host_mask[element] = 0;
+        } else {
+            ERROR("Got a bad input with invalid index");
+            return false;
+        }
+    }
+
+    // Create new metadata
+    allocate_new_metadata_object(out_buf, out_buffer_ID);
+
+    // Set no. of bad inputs in the metadata
+    set_rfi_num_bad_inputs(out_buf, out_buffer_ID, bad_inputs_correlator.size());
+
+    mark_frame_full(out_buf, unique_name.c_str(), out_buffer_ID);
+
+    DEBUG("update_bad_inputs_callback(): Bad inputs reordered and buffered.");
+
+    // Increment frame ID
+    out_buffer_ID = (out_buffer_ID + 1) % out_buf->num_frames;
+
+    return true;
+}
+
+void bufferBadInputs::main_thread() {
+    // Listen for bad input list updates
+    string badInputs = config.get<std::string>(unique_name, "updatable_config/bad_inputs");
+    configUpdater::instance().subscribe(
+        badInputs,
+        std::bind(&bufferBadInputs::update_bad_inputs_callback, this, std::placeholders::_1));
+}

--- a/lib/stages/bufferBadInputs.hpp
+++ b/lib/stages/bufferBadInputs.hpp
@@ -1,0 +1,69 @@
+/**
+ * @file
+ * @brief Buffers bad input data.
+ *  - bufferBadInputs : public kotekan::Stage
+ */
+
+#ifndef BUFFER_BAD_INPUT_DATA
+#define BUFFER_BAD_INPUT_DATA
+
+#include "Stage.hpp"
+
+/**
+ * @class bufferBadInputs
+ * @brief Buffers updates to the bad input list.
+ *
+ * This engine reorders, inverts and generates a mask of bad inputs then stores the mask in a buffer
+ *
+ * @par Buffers
+ * @buffer out_buf Kotekan buffer of bad inputs.
+ *     @buffer_format Array of @c uint8_t
+ *
+ * @conf   updatable_config/bad_inputs  String.  String pointing to the location of the
+ *                                      config block containing the following properties:
+ *                                      "bad_inputs"  An array of bad inputs in cylinder order.
+ *
+ * @author James Willis
+ *
+ */
+
+class bufferBadInputs : public kotekan::Stage {
+public:
+    /// Constructor.
+    bufferBadInputs(kotekan::Config& config_, const string& unique_name,
+                    kotekan::bufferContainer& buffer_container);
+    /// Destructor
+    virtual ~bufferBadInputs();
+    /// Primary loop to wait for buffers, dig through data,
+    /// stuff packets lather, rinse and repeat.
+    void main_thread() override;
+
+    /// Endpoint for providing new bad input updates
+    bool update_bad_inputs_callback(nlohmann::json& json);
+
+private:
+    struct Buffer* in_buf;
+    struct Buffer* out_buf;
+
+    /// Stage variables
+
+    /// List of current bad inputs in cylinder order
+    std::vector<int> bad_inputs_cylinder;
+
+    /// List of current bad inputs in correlator order.
+    std::vector<int> bad_inputs_correlator;
+
+    /// The size of the bad input mask.
+    uint32_t input_mask_len;
+
+    /// The host memory region which holds the input mask
+    /// Note 1 means the element is good, 0 means flagged.
+    uint8_t* host_mask;
+
+    /// The mapping from correlator to cylinder element indexing.
+    std::vector<uint32_t> input_remap;
+
+    uint32_t out_buffer_ID = 0;
+};
+
+#endif


### PR DESCRIPTION
Buffers updates to the bad input list, which is fed to the hsaRfiUpdateBadInputs command object.

Fixes a bug where two consecutive updates to the bad input list in <0.5s would result in the second update being lost. The bug was found as a result of investigating #594.

Also applies a fix for the race condition found in #600 which closes #594

Co-authored-by: andrerenard <andre@renard.io>
(cherry picked from commit b5fd669d89947a4a02bccfd4f942c736ac952d98)