### PR TITLE
Disable the L1 destination checking if `ping_dead_threshold` is 0

### DIFF
--- a/config/chime_science_run_gpu.yaml
+++ b/config/chime_science_run_gpu.yaml
@@ -838,6 +838,7 @@ frb:
     #column_mode: true
     beam_offset: 0
     time_interval: 125829120
+    dead_ping_threshold: 0
     L1_node_ips:
       # Rack 1
       - 10.6.201.10

--- a/config/chime_science_run_gpu_no_output.yaml
+++ b/config/chime_science_run_gpu_no_output.yaml
@@ -835,6 +835,7 @@ frb:
     #column_mode: true
     beam_offset: 0
     time_interval: 125829120
+    dead_ping_threshold: 0
     L1_node_ips:
       # Rack 1
       - 10.6.201.10

--- a/lib/stages/frbNetworkProcess.hpp
+++ b/lib/stages/frbNetworkProcess.hpp
@@ -52,7 +52,8 @@
  * @conf   quick_ping_interval  Uint32 (default 5 sec) Time in seconds for sending pings when a live
  * node stops responding
  * @conf   ping_dead_threshold  Uint32 (default 30 sec) Duration in seconds of quick-checking state
- * after which a node is declared dead if it still hasn't responded
+ * after which a node is declared dead if it still hasn't responded. If 0, disable the checks
+ * entirely.
  *
  * @todo   Resolve the issue of NTP clock vs Monotonic clock.
  *


### PR DESCRIPTION
We are seeing recurring storms of nodes marking multiple destinations dead and
then live again within a few seconds, so it's clear either there is a bug in the
current implementation or the thresholds need to be fine-tuned. Since we are
pressed to start the run, it makes sense to add a way to disable this feature
from the configuration, should we want to do so without reverting it completely.