### PR TITLE
Check for baseband destination directory before reading out the samples (#640)

### DIFF
--- a/lib/stages/basebandReadout.cpp
+++ b/lib/stages/basebandReadout.cpp
@@ -178,6 +178,8 @@ void basebandReadout::readout_thread(const uint32_t freq_id, basebandReadoutMana
             struct stat path_status;
             int stat_rc = stat((_base_dir + request.file_path).c_str(), &path_status);
             if (!(stat_rc == 0 && path_status.st_mode & S_IFDIR)) {
+                WARN("Baseband destination path {} for request {:d} is not valid",
+                     request.file_path, event_id);
                 std::lock_guard<std::mutex> lock(request_mtx);
                 dump_status.finished = dump_status.started =
                     std::make_shared<std::chrono::system_clock::time_point>(


### PR DESCRIPTION
Because `BasebandApiManager` is not a Stage, we don't have access to the running
configuration to construct the destination relative to `base_dir`, so the error
handling has to be done in the BasebandReadout. This is a little less ideal,
because this way we can't respond with an HTTP error as part of the request, but
still prevents using up the time to read out the samples that cannot be saved to
the requested destination.