### PR TITLE
Clean up boost test cmake dependencies

### DIFF
--- a/tests/boost/CMakeLists.txt
+++ b/tests/boost/CMakeLists.txt
@@ -3,8 +3,9 @@ project( kotekan_boost_tests )
 # Prep ourselves for compiling boost
 find_package(Boost COMPONENTS unit_test_framework REQUIRED)
 include_directories (${Boost_INCLUDE_DIRS} $BOOST_TESTS_DIR)
-include_directories (${KOTEKAN_SOURCE_DIR}/lib/utils)
+
 include_directories (${KOTEKAN_SOURCE_DIR}/lib/stages)
+include_directories (${KOTEKAN_SOURCE_DIR}/lib/utils)
 include_directories (${KOTEKAN_SOURCE_DIR}/lib/core)
 include_directories (${KOTEKAN_SOURCE_DIR}/lib)
 include_directories (${KOTEKAN_SOURCE_DIR}/lib/metadata)
@@ -38,8 +39,12 @@ endif()
 
 # Run through each source
 foreach(testSrc ${KOTEKAN_BOOST_TEST_SOURCES})
-	get_filename_component(testName ${testSrc} NAME_WE)
+    get_filename_component(testName ${testSrc} NAME_WE)
     add_executable(${testName} ${testSrc})
+
+    # TODO: fix cmake build for buffer.c : It uses hsa_host_malloc etc.
+    # TODO: remove chimeFeed from visCompression files.
+    # After that it should be enough to link against kotekan_utils kotekan_core
     target_link_libraries(${testName} kotekan_libs dl m pthread)
 
     if(${USE_HDF5})
@@ -52,6 +57,5 @@ endforeach(testSrc)
 foreach(testSrc ${KOTEKAN_BROKER_TEST_SOURCES})
 	get_filename_component(testName ${testSrc} NAME_WE)
     add_executable(${testName} ${testSrc})
-    target_link_libraries(${testName} kotekan_libs dl m pthread)
-    #target_link_libraries(${testName} libinclude)
+    target_link_libraries(${testName} kotekan_utils kotekan_core dl m pthread)
 endforeach(testSrc)

--- a/tests/boost/dataset_broker_consumer.cpp
+++ b/tests/boost/dataset_broker_consumer.cpp
@@ -3,7 +3,6 @@
 #include "restClient.hpp"
 #include "restServer.hpp"
 #include "test_utils.hpp"
-#include "visCompression.hpp"
 #include "visUtil.hpp"
 
 #include "json.hpp"

--- a/tests/boost/dataset_broker_consumer.cpp
+++ b/tests/boost/dataset_broker_consumer.cpp
@@ -15,6 +15,8 @@
 // the code to test:
 #include "datasetManager.hpp"
 
+#define WAIT_TIME 4000000
+
 using kotekan::Config;
 
 using json = nlohmann::json;
@@ -104,7 +106,7 @@ BOOST_FIXTURE_TEST_CASE(_ask_broker_for_ancestors, CompareCTypes) {
     check_equal(p->get_prods(), prods);
 
     // wait a bit, to make sure we see errors in any late callbacks
-    usleep(500000);
+    usleep(WAIT_TIME);
 }
 
 BOOST_AUTO_TEST_CASE(_dataset_manager_second_root_update) {
@@ -148,7 +150,7 @@ BOOST_AUTO_TEST_CASE(_dataset_manager_second_root_update) {
     second_root_update = dm.add_dataset(states, second_root);
 
     // wait a bit, to make sure we see errors in any late callbacks
-    usleep(1000000);
+    usleep(WAIT_TIME);
 }
 
 BOOST_FIXTURE_TEST_CASE(_ask_broker_for_second_root, CompareCTypes) {
@@ -210,7 +212,7 @@ BOOST_FIXTURE_TEST_CASE(_ask_broker_for_second_root, CompareCTypes) {
         std::cout << s.second.state() << " - " << s.second.base_dset() << std::endl;
 
     // wait a bit, to make sure we see errors in any late callbacks
-    usleep(500000);
+    usleep(WAIT_TIME);
 }
 
 BOOST_FIXTURE_TEST_CASE(_ask_broker_for_second_root_update, CompareCTypes) {
@@ -267,5 +269,5 @@ BOOST_FIXTURE_TEST_CASE(_ask_broker_for_second_root_update, CompareCTypes) {
 
 
     // wait a bit, to make sure we see errors in any late callbacks
-    usleep(600000);
+    usleep(WAIT_TIME);
 }

--- a/tests/boost/dataset_broker_producer.cpp
+++ b/tests/boost/dataset_broker_producer.cpp
@@ -2,7 +2,6 @@
 
 #include "restClient.hpp"
 #include "restServer.hpp"
-#include "visCompression.hpp"
 #include "visUtil.hpp"
 
 #include "json.hpp"

--- a/tests/boost/dataset_broker_producer.cpp
+++ b/tests/boost/dataset_broker_producer.cpp
@@ -15,6 +15,8 @@
 // the code to test:
 #include "datasetManager.hpp"
 
+#define WAIT_TIME 4000000
+
 using kotekan::Config;
 
 using json = nlohmann::json;
@@ -101,7 +103,7 @@ BOOST_AUTO_TEST_CASE(_dataset_manager_general) {
     for (auto s : dm.datasets())
         std::cout << s.second.state() << " - " << s.second.base_dset() << std::endl;
 
-    usleep(1000000);
+    usleep(WAIT_TIME);
 }
 
 
@@ -136,7 +138,7 @@ BOOST_AUTO_TEST_CASE(_dataset_manager_state_known_to_broker) {
     dm.add_dataset(states1);
 
     // wait a bit, to make sure we see errors in any late callbacks
-    usleep(500000);
+    usleep(WAIT_TIME);
 }
 
 BOOST_AUTO_TEST_CASE(_dataset_manager_second_root) {
@@ -173,5 +175,5 @@ BOOST_AUTO_TEST_CASE(_dataset_manager_second_root) {
     o.close();
 
     // wait a bit, to make sure we see errors in any late callbacks
-    usleep(1000000);
+    usleep(WAIT_TIME);
 }

--- a/tests/boost/dataset_broker_producer2.cpp
+++ b/tests/boost/dataset_broker_producer2.cpp
@@ -3,7 +3,6 @@
 #include "restClient.hpp"
 #include "restServer.hpp"
 #include "test_utils.hpp"
-#include "visCompression.hpp"
 #include "visUtil.hpp"
 
 #include "json.hpp"

--- a/tests/boost/dataset_broker_producer2.cpp
+++ b/tests/boost/dataset_broker_producer2.cpp
@@ -15,6 +15,8 @@
 // the code to test:
 #include "datasetManager.hpp"
 
+#define WAIT_TIME 4000000
+
 using kotekan::Config;
 
 using json = nlohmann::json;
@@ -117,5 +119,5 @@ BOOST_FIXTURE_TEST_CASE(_dataset_manager_general, CompareCTypes) {
         std::cout << s.second.state() << " - " << s.second.base_dset() << std::endl;
 
     // wait a bit, to make sure we see errors in any late callbacks
-    usleep(2000000);
+    usleep(WAIT_TIME);
 }


### PR DESCRIPTION
I removed the linker dependency of kotekan_libs for the comet tests, to speed up building those on comet's travis CI. But this should also speed up the linking here a little bit. Note that I tried and failed doing the same for the other boost tests. I looks like there are some bugs in the cmake configuration for kotekan_core / buffer.c.