### PR TITLE
refactor(RfiFrameDrop): shared_ptr instead of copy updates

### DIFF
--- a/lib/stages/RfiFrameDrop.cpp
+++ b/lib/stages/RfiFrameDrop.cpp
@@ -69,10 +69,8 @@ void RfiFrameDrop::main_thread() {
 
     std::vector<float> sk_delta(sk_samples_per_frame);
 
-    // shared pointers to receive updates from the callback
-    std::shared_ptr<bool> enable_rfi_zero;
-    std::shared_ptr<std::vector<size_t>> sk_exceeds;
-    std::shared_ptr<std::vector<std::tuple<float, size_t, float>>> thresholds;
+    // shared pointer to receive updates from the callback
+    std::shared_ptr<ThresholdData> thresholds;
 
     while (!stop_thread) {
         // Fetch the input buffers
@@ -112,21 +110,14 @@ void RfiFrameDrop::main_thread() {
         DEBUG2("Frames are synced. Vis frame: {}; SK frame: {}, diff {}", vis_seq, sk_seq,
                vis_seq - sk_seq);
 
-        // Point the shared pointers to the newest updates
-        {
-            std::lock_guard<std::mutex> guard(lock_updatables);
-            thresholds = _thresholds;
-            enable_rfi_zero = _enable_rfi_zero;
-            sk_exceeds = _sk_exceeds;
-        }
+        // Point the shared pointer to the newest updates
+        thresholds = std::atomic_load(&_thresholds);
 
         // Calculate the scaling to turn kurtosis value into sigma
         size_t num_inputs = num_elements - metadata_vis->rfi_num_bad_inputs;
         float sigma_scale = sqrt((num_inputs * (sk_step - 1) * (sk_step + 2) * (sk_step + 3))
                                  / (4.0 * sk_step * sk_step));
 
-        // Disable updates on enable_rfi_zero and thresholds while accessing these
-        std::lock_guard<std::mutex> guard(lock_updatables);
         for (size_t ii = 0; ii < num_sub_frames; ii++) {
 
             if (wait_for_full_frame(_buf_in_vis, unique_name.c_str(), frame_id_in_vis) == nullptr) {
@@ -155,29 +146,30 @@ void RfiFrameDrop::main_thread() {
 
                 // INFO("SK: {}; SKraw: {}", sk_sig, frame_in_sk[ii * sk_samples_per_frame +
                 // jj]);
-                for (size_t kk = 0; kk < thresholds->size(); kk++) {
-                    sk_exceeds->at(kk) += (sk_sig > std::get<0>(thresholds->at(kk)));
+                for (size_t kk = 0; kk < thresholds->thresholds.size(); kk++) {
+                    thresholds->sk_exceeds.at(kk) +=
+                        (sk_sig > std::get<0>(thresholds->thresholds.at(kk)));
                     // INFO("threshold {}", std::get<0>(_thresholds[kk]));
                 }
             }
 
-            for (size_t kk = 0; kk < thresholds->size(); kk++) {
-                if (sk_exceeds->at(kk) > std::get<1>(thresholds->at(kk))) {
+            for (size_t kk = 0; kk < thresholds->thresholds.size(); kk++) {
+                if (thresholds->sk_exceeds.at(kk) > std::get<1>(thresholds->thresholds.at(kk))) {
                     skip = true;
                     failing_frame_counter
                         .labels({std::to_string(freq_id),
-                                 std::to_string(std::get<0>(thresholds->at(kk))),
-                                 std::to_string(std::get<2>(thresholds->at(kk)))})
+                                 std::to_string(std::get<0>(thresholds->thresholds.at(kk))),
+                                 std::to_string(std::get<2>(thresholds->thresholds.at(kk)))})
                         .inc();
                 }
                 // Reset counters for the next sub_frame
-                sk_exceeds->at(kk) = 0;
+                thresholds->sk_exceeds.at(kk) = 0;
             }
 
             // If no frame exceeded it's threshold then we should transfer the
             // frame over to the output and release it. If we want to drop the
             // incoming frame then we leave the output as is.
-            if (!skip || !(*enable_rfi_zero)) {
+            if (!skip || !(_enable_rfi_zero)) {
 
                 if (wait_for_empty_frame(_buf_out, unique_name.c_str(), frame_id_out) == nullptr) {
                     break;
@@ -223,25 +215,22 @@ void RfiFrameDrop::copy_frame(Buffer* buf_src, int frame_id_src, Buffer* buf_des
 }
 
 bool RfiFrameDrop::rest_enable_callback(nlohmann::json& update) {
-    auto enable_rfi_zero_new = std::make_shared<bool>();
+    bool enable_rfi_zero_new;
 
     try {
-        *enable_rfi_zero_new = update.at("rfi_zeroing").get<bool>();
+        enable_rfi_zero_new = update.at("rfi_zeroing").get<bool>();
     } catch (json::exception& e) {
         WARN("Failure parsing update: Can't read 'rfi_zeroing' (bool): {:s}", e.what());
         return false;
     }
 
-    {
-        std::lock_guard<std::mutex> guard(lock_updatables);
-        _enable_rfi_zero = enable_rfi_zero_new;
-    }
-
-    if (*enable_rfi_zero_new) {
+    if (enable_rfi_zero_new) {
         INFO("Enabled RFI frame dropping.");
     } else {
         INFO("Disabled RFI frame dropping.");
     }
+
+    _enable_rfi_zero = enable_rfi_zero_new;
 
     return true;
 }
@@ -259,7 +248,7 @@ bool RfiFrameDrop::rest_thresholds_callback(nlohmann::json& update) {
         return false;
     }
 
-    auto thresholds_new = std::make_shared<std::vector<std::tuple<float, size_t, float>>>();
+    auto thresholds_new = std::make_shared<ThresholdData>();
     for (const auto& t : j) {
         if (!t.is_object()) {
             WARN("Failure parsing update: item in list 'thresholds' is not a dict : {}", t.dump());
@@ -282,20 +271,20 @@ bool RfiFrameDrop::rest_thresholds_callback(nlohmann::json& update) {
             return false;
         }
 
-        thresholds_new->push_back({threshold, (size_t)(fraction * sk_samples_per_frame), fraction});
+        thresholds_new->thresholds.push_back(
+            {threshold, (size_t)(fraction * sk_samples_per_frame), fraction});
     }
 
-    {
-        // make the updates available to the main thread by shared pointers
-        std::lock_guard<std::mutex> guard(lock_updatables);
-        _sk_exceeds = std::make_shared<std::vector<size_t>>(thresholds_new->size());
-        _thresholds = thresholds_new;
-    }
+    thresholds_new->sk_exceeds.resize(thresholds_new->thresholds.size(), 0);
 
     INFO("Setting new RFI excision cuts:");
-    for (auto& [threshold, t, fraction] : *thresholds_new) {
+    for (auto& [threshold, t, fraction] : thresholds_new->thresholds) {
         (void)t;
         INFO("  added cut with threshold={}, fraction={}", threshold, fraction);
     }
+
+    // make the updates available to the main thread by shared pointers
+    std::atomic_store(&_thresholds, thresholds_new);
+
     return true;
 }

--- a/lib/stages/RfiFrameDrop.cpp
+++ b/lib/stages/RfiFrameDrop.cpp
@@ -14,6 +14,7 @@
 #include <csignal>
 #include <cstring>
 #include <functional>
+#include <memory>
 #include <pthread.h>
 #include <string>
 
@@ -68,6 +69,11 @@ void RfiFrameDrop::main_thread() {
 
     std::vector<float> sk_delta(sk_samples_per_frame);
 
+    // shared pointers to receive updates from the callback
+    std::shared_ptr<bool> enable_rfi_zero;
+    std::shared_ptr<std::vector<size_t>> sk_exceeds;
+    std::shared_ptr<std::vector<std::tuple<float, size_t, float>>> thresholds;
+
     while (!stop_thread) {
         // Fetch the input buffers
         uint8_t* frame_in_vis =
@@ -106,82 +112,84 @@ void RfiFrameDrop::main_thread() {
         DEBUG2("Frames are synced. Vis frame: {}; SK frame: {}, diff {}", vis_seq, sk_seq,
                vis_seq - sk_seq);
 
+        // Point the shared pointers to the newest updates
         {
-            // Calculate the scaling to turn kurtosis value into sigma
-            size_t num_inputs = num_elements - metadata_vis->rfi_num_bad_inputs;
-            float sigma_scale = sqrt((num_inputs * (sk_step - 1) * (sk_step + 2) * (sk_step + 3))
-                                     / (4.0 * sk_step * sk_step));
-
-            // Disable updates on enable_rfi_zero and thresholds while accessing these
             std::lock_guard<std::mutex> guard(lock_updatables);
-            for (size_t ii = 0; ii < num_sub_frames; ii++) {
+            thresholds = _thresholds;
+            enable_rfi_zero = _enable_rfi_zero;
+            sk_exceeds = _sk_exceeds;
+        }
 
-                if (wait_for_full_frame(_buf_in_vis, unique_name.c_str(), frame_id_in_vis)
-                    == nullptr) {
-                    break;
-                }
+        // Calculate the scaling to turn kurtosis value into sigma
+        size_t num_inputs = num_elements - metadata_vis->rfi_num_bad_inputs;
+        float sigma_scale = sqrt((num_inputs * (sk_step - 1) * (sk_step + 2) * (sk_step + 3))
+                                 / (4.0 * sk_step * sk_step));
 
-                auto sf_seq = get_fpga_seq_num(_buf_in_vis, frame_id_in_vis);
+        // Disable updates on enable_rfi_zero and thresholds while accessing these
+        std::lock_guard<std::mutex> guard(lock_updatables);
+        for (size_t ii = 0; ii < num_sub_frames; ii++) {
 
-                // Check that we are still synchronized with the frame we are
-                // expecting. If not (and this may happen if the Valve process is
-                // active), we will just skip the set of sub frames and hopefully we
-                // will resync
-                if (sf_seq != (int64_t)(sk_seq + ii * samples_per_sub_frame)) {
-                    DEBUG("Lost synchronization. Dropping data and resetting.");
-                    mark_frame_empty(_buf_in_vis, unique_name.c_str(), frame_id_in_vis++);
-                    break;
-                }
-
-                bool skip = false;
-
-                // Process all the SK values to their deltas and for each threshold
-                // we need to count how many samples exceed that threshold
-                for (size_t jj = 0; jj < sk_samples_per_frame; jj++) {
-                    float sk_sig =
-                        fabs(sigma_scale * (frame_in_sk[ii * sk_samples_per_frame + jj] - 1.0f));
-
-                    // INFO("SK: {}; SKraw: {}", sk_sig, frame_in_sk[ii * sk_samples_per_frame +
-                    // jj]);
-                    for (size_t kk = 0; kk < _thresholds.size(); kk++) {
-                        sk_exceeds[kk] += (sk_sig > std::get<0>(_thresholds[kk]));
-                        // INFO("threshold {}", std::get<0>(_thresholds[kk]));
-                    }
-                }
-
-                for (size_t kk = 0; kk < _thresholds.size(); kk++) {
-                    // INFO("Threshold: {}; Count: {}; Limit: {}", std::get<0>(_thresholds[kk]),
-                    //     sk_exceeds[kk], std::get<1>(_thresholds[kk]));
-                    if (sk_exceeds[kk] > std::get<1>(_thresholds[kk])) {
-                        skip = true;
-                        failing_frame_counter
-                            .labels({std::to_string(freq_id),
-                                     std::to_string(std::get<0>(_thresholds[kk])),
-                                     std::to_string(std::get<2>(_thresholds[kk]))})
-                            .inc();
-                    }
-                    // Reset counters for the next sub_frame
-                    sk_exceeds[kk] = 0;
-                }
-
-                // If no frame exceeded it's threshold then we should transfer the
-                // frame over to the output and release it. If we want to drop the
-                // incoming frame then we leave the output as is.
-                if (!skip || !_enable_rfi_zero) {
-
-                    if (wait_for_empty_frame(_buf_out, unique_name.c_str(), frame_id_out)
-                        == nullptr) {
-                        break;
-                    }
-                    copy_frame(_buf_in_vis, frame_id_in_vis, _buf_out, frame_id_out);
-                    mark_frame_full(_buf_out, unique_name.c_str(), frame_id_out++);
-                } else {
-                    dropped_frame_counter.labels({std::to_string(freq_id)}).inc();
-                }
-
-                mark_frame_empty(_buf_in_vis, unique_name.c_str(), frame_id_in_vis++);
-                frame_counter.labels({std::to_string(freq_id)}).inc();
+            if (wait_for_full_frame(_buf_in_vis, unique_name.c_str(), frame_id_in_vis) == nullptr) {
+                break;
             }
+
+            auto sf_seq = get_fpga_seq_num(_buf_in_vis, frame_id_in_vis);
+
+            // Check that we are still synchronized with the frame we are
+            // expecting. If not (and this may happen if the Valve process is
+            // active), we will just skip the set of sub frames and hopefully we
+            // will resync
+            if (sf_seq != (int64_t)(sk_seq + ii * samples_per_sub_frame)) {
+                DEBUG("Lost synchronization. Dropping data and resetting.");
+                mark_frame_empty(_buf_in_vis, unique_name.c_str(), frame_id_in_vis++);
+                break;
+            }
+
+            bool skip = false;
+
+            // Process all the SK values to their deltas and for each threshold
+            // we need to count how many samples exceed that threshold
+            for (size_t jj = 0; jj < sk_samples_per_frame; jj++) {
+                float sk_sig =
+                    fabs(sigma_scale * (frame_in_sk[ii * sk_samples_per_frame + jj] - 1.0f));
+
+                // INFO("SK: {}; SKraw: {}", sk_sig, frame_in_sk[ii * sk_samples_per_frame +
+                // jj]);
+                for (size_t kk = 0; kk < thresholds->size(); kk++) {
+                    sk_exceeds->at(kk) += (sk_sig > std::get<0>(thresholds->at(kk)));
+                    // INFO("threshold {}", std::get<0>(_thresholds[kk]));
+                }
+            }
+
+            for (size_t kk = 0; kk < thresholds->size(); kk++) {
+                if (sk_exceeds->at(kk) > std::get<1>(thresholds->at(kk))) {
+                    skip = true;
+                    failing_frame_counter
+                        .labels({std::to_string(freq_id),
+                                 std::to_string(std::get<0>(thresholds->at(kk))),
+                                 std::to_string(std::get<2>(thresholds->at(kk)))})
+                        .inc();
+                }
+                // Reset counters for the next sub_frame
+                sk_exceeds->at(kk) = 0;
+            }
+
+            // If no frame exceeded it's threshold then we should transfer the
+            // frame over to the output and release it. If we want to drop the
+            // incoming frame then we leave the output as is.
+            if (!skip || !(*enable_rfi_zero)) {
+
+                if (wait_for_empty_frame(_buf_out, unique_name.c_str(), frame_id_out) == nullptr) {
+                    break;
+                }
+                copy_frame(_buf_in_vis, frame_id_in_vis, _buf_out, frame_id_out);
+                mark_frame_full(_buf_out, unique_name.c_str(), frame_id_out++);
+            } else {
+                dropped_frame_counter.labels({std::to_string(freq_id)}).inc();
+            }
+
+            mark_frame_empty(_buf_in_vis, unique_name.c_str(), frame_id_in_vis++);
+            frame_counter.labels({std::to_string(freq_id)}).inc();
         }
         mark_frame_empty(_buf_in_sk, unique_name.c_str(), frame_id_in_sk++);
     }
@@ -215,10 +223,10 @@ void RfiFrameDrop::copy_frame(Buffer* buf_src, int frame_id_src, Buffer* buf_des
 }
 
 bool RfiFrameDrop::rest_enable_callback(nlohmann::json& update) {
-    bool enable_rfi_zero_new;
+    auto enable_rfi_zero_new = std::make_shared<bool>();
 
     try {
-        enable_rfi_zero_new = update.at("rfi_zeroing").get<bool>();
+        *enable_rfi_zero_new = update.at("rfi_zeroing").get<bool>();
     } catch (json::exception& e) {
         WARN("Failure parsing update: Can't read 'rfi_zeroing' (bool): {:s}", e.what());
         return false;
@@ -229,7 +237,7 @@ bool RfiFrameDrop::rest_enable_callback(nlohmann::json& update) {
         _enable_rfi_zero = enable_rfi_zero_new;
     }
 
-    if (enable_rfi_zero_new) {
+    if (*enable_rfi_zero_new) {
         INFO("Enabled RFI frame dropping.");
     } else {
         INFO("Disabled RFI frame dropping.");
@@ -251,10 +259,8 @@ bool RfiFrameDrop::rest_thresholds_callback(nlohmann::json& update) {
         return false;
     }
 
-    std::vector<std::tuple<float, size_t, float>> thresholds_new;
+    auto thresholds_new = std::make_shared<std::vector<std::tuple<float, size_t, float>>>();
     for (const auto& t : j) {
-        // TODO TEST send wrong type and see what it throws
-        // TODO TEST send with threshold or fraction missing
         if (!t.is_object()) {
             WARN("Failure parsing update: item in list 'thresholds' is not a dict : {}", t.dump());
             return false;
@@ -276,17 +282,18 @@ bool RfiFrameDrop::rest_thresholds_callback(nlohmann::json& update) {
             return false;
         }
 
-        thresholds_new.push_back({threshold, (size_t)(fraction * sk_samples_per_frame), fraction});
+        thresholds_new->push_back({threshold, (size_t)(fraction * sk_samples_per_frame), fraction});
     }
 
     {
+        // make the updates available to the main thread by shared pointers
         std::lock_guard<std::mutex> guard(lock_updatables);
+        _sk_exceeds = std::make_shared<std::vector<size_t>>(thresholds_new->size());
         _thresholds = thresholds_new;
-        sk_exceeds.resize(_thresholds.size(), 0);
     }
 
     INFO("Setting new RFI excision cuts:");
-    for (auto& [threshold, t, fraction] : thresholds_new) {
+    for (auto& [threshold, t, fraction] : *thresholds_new) {
         (void)t;
         INFO("  added cut with threshold={}, fraction={}", threshold, fraction);
     }

--- a/lib/stages/RfiFrameDrop.hpp
+++ b/lib/stages/RfiFrameDrop.hpp
@@ -87,16 +87,14 @@ private:
     Buffer* _buf_out;
 
     /// Thresholds
-    std::shared_ptr<std::vector<std::tuple<float, size_t, float>>> _thresholds;
+    struct ThresholdData {
+        std::vector<std::tuple<float, size_t, float>> thresholds;
+        std::vector<size_t> sk_exceeds;
+    };
+    std::shared_ptr<ThresholdData> _thresholds;
 
     /// Toggle RFI zeroing
-    std::shared_ptr<bool> _enable_rfi_zero;
-
-    /// Counter storing information between sub frames.
-    std::shared_ptr<std::vector<size_t>> _sk_exceeds;
-
-    /// Lock for access to shared pointers
-    std::mutex lock_updatables;
+    std::atomic<bool> _enable_rfi_zero;
 
     /// Prometheus metrics to export
     kotekan::prometheus::MetricFamily<kotekan::prometheus::Counter>& failing_frame_counter;

--- a/lib/stages/RfiFrameDrop.hpp
+++ b/lib/stages/RfiFrameDrop.hpp
@@ -14,6 +14,7 @@
 
 #include "json.hpp"
 
+#include <memory>
 #include <string>
 
 
@@ -86,16 +87,16 @@ private:
     Buffer* _buf_out;
 
     /// Thresholds
-    std::vector<std::tuple<float, size_t, float>> _thresholds;
+    std::shared_ptr<std::vector<std::tuple<float, size_t, float>>> _thresholds;
 
     /// Toggle RFI zeroing
-    bool _enable_rfi_zero;
+    std::shared_ptr<bool> _enable_rfi_zero;
 
-    /// Lock for access to thresholds and enable_rfi_zero
+    /// Counter storing information between sub frames.
+    std::shared_ptr<std::vector<size_t>> _sk_exceeds;
+
+    /// Lock for access to shared pointers
     std::mutex lock_updatables;
-
-    /// Counter storing information between sub frames. Resized by rest callback.
-    std::vector<size_t> sk_exceeds;
 
     /// Prometheus metrics to export
     kotekan::prometheus::MetricFamily<kotekan::prometheus::Counter>& failing_frame_counter;


### PR DESCRIPTION
Allows much shorter mutex protected section in main thread.

Closes #638