### PR TITLE
Fix #667: use the right name for "dead_ping_threshold" in the config

### DIFF
--- a/config/chime_science_run_gpu.yaml
+++ b/config/chime_science_run_gpu.yaml
@@ -960,7 +960,7 @@ frb:
     #column_mode: true
     beam_offset: 0
     time_interval: 125829120
-    dead_ping_threshold: 0
+    ping_dead_threshold: 0
     L1_node_ips:
       # Rack 1
       - 10.6.201.10

--- a/config/chime_science_run_gpu_no_output.yaml
+++ b/config/chime_science_run_gpu_no_output.yaml
@@ -960,7 +960,7 @@ frb:
     #column_mode: true
     beam_offset: 0
     time_interval: 125829120
-    dead_ping_threshold: 0
+    ping_dead_threshold: 0
     L1_node_ips:
       # Rack 1
       - 10.6.201.10


### PR DESCRIPTION
(Note that this is based off `master`, in case we want to deploy it as a quick fix during February power shutdown.)