### PR TITLE
Pulsar gain calculation hotfix for 26m passthrough

### DIFF
--- a/lib/hsa/hsaPulsarUpdatePhase.cpp
+++ b/lib/hsa/hsaPulsarUpdatePhase.cpp
@@ -177,7 +177,7 @@ void hsaPulsarUpdatePhase::calculate_phase(struct psrCoord psr_coord, timespec t
         double hour_angle = LST * 15. - psr_coord.ra[b];
         double alt = sin(psr_coord.dec[b] * D2R) * sin(inst_lat * D2R)
                      + cos(psr_coord.dec[b] * D2R) * cos(inst_lat * D2R) * cos(hour_angle * D2R);
-        alt = asin(alt);
+        alt = asin(std::clamp(alt, -1.0, 1.0));
         double az = (sin(psr_coord.dec[b] * D2R) - sin(alt) * sin(inst_lat * D2R))
                     / (cos(alt) * cos(inst_lat * D2R));
         az = acos(std::clamp(az, -1.0, 1.0));

--- a/lib/hsa/hsaPulsarUpdatePhase.cpp
+++ b/lib/hsa/hsaPulsarUpdatePhase.cpp
@@ -9,6 +9,7 @@
 #include "hsaBase.h"
 #include "restServer.hpp"
 
+#include <algorithm>
 #include <math.h>
 #include <signal.h>
 #include <string>
@@ -173,7 +174,7 @@ void hsaPulsarUpdatePhase::calculate_phase(struct psrCoord psr_coord, timespec t
         alt = asin(alt);
         double az = (sin(psr_coord.dec[b] * D2R) - sin(alt) * sin(inst_lat * D2R))
                     / (cos(alt) * cos(inst_lat * D2R));
-        az = acos(az);
+        az = acos(std::clamp(az, -1.0, 1.0));
         if (sin(hour_angle * D2R) >= 0) {
             az = TAU - az;
         }

--- a/lib/hsa/hsaPulsarUpdatePhase.cpp
+++ b/lib/hsa/hsaPulsarUpdatePhase.cpp
@@ -168,6 +168,12 @@ void hsaPulsarUpdatePhase::calculate_phase(struct psrCoord psr_coord, timespec t
     }
     LST = fmod(LST, 24);
     for (int b = 0; b < _num_beams; b++) {
+        if (psr_coord.scaling[b] == 1) {
+            for (uint32_t i = 0; i < _num_elements * 2; ++i) {
+                output[b * _num_elements * 2 + i] = gains[b * _num_elements * 2 + i];
+            }
+            continue;
+        }
         double hour_angle = LST * 15. - psr_coord.ra[b];
         double alt = sin(psr_coord.dec[b] * D2R) * sin(inst_lat * D2R)
                      + cos(psr_coord.dec[b] * D2R) * cos(inst_lat * D2R) * cos(hour_angle * D2R);


### PR DESCRIPTION
* Clamp a variable which was resulting in `NAN` in the case of a static pointing
* Disable tracking for beams with when `scaling == 1`