### PR TITLE
Shared buffer for Kotekan that is sequentially written to

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,7 +230,8 @@ include_directories (${KOTEKAN_SOURCE_DIR}/include)
 
 # Note that -lrt here is needed on some versions of CentOS but not Clang
 if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-       set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -lrt " )
+    add_compile_options("-lrt")
+    link_libraries("-lrt")
 endif ()
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99 -O3 -D_GNU_SOURCE -Wall -Wextra -Werror -march=native -mtune=native -I/opt/rocm/include")
@@ -244,11 +245,6 @@ endif()
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} ${CMAKE_C_FLAGS} -ggdb -O2")
 
 set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
-
-# Note that -lrt here is needed on some versions of CentOS but not Clang
-if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND NOT ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
-       set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -lrt " )
-endif ()
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GNU_SOURCE -O3 -Wall -Wextra -Werror -Wzero-as-null-pointer-constant -march=native -mtune=native -I/opt/rocm/include")
 

--- a/lib/stages/CMakeLists.txt
+++ b/lib/stages/CMakeLists.txt
@@ -36,6 +36,7 @@ set ( KOTEKAN_PROCESS_LIB_SOURCES
       timeDownsample.cpp
       frbPostProcess.cpp
       visWriter.cpp
+      visSharedMemWriter.cpp
       visRawReader.cpp
       restInspectFrame.cpp
       frbNetworkProcess.cpp

--- a/lib/stages/visSharedMemWriter.cpp
+++ b/lib/stages/visSharedMemWriter.cpp
@@ -50,10 +50,6 @@ visSharedMemWriter::visSharedMemWriter(Config& config, const std::string& unique
         // Acquire semaphore until shared memory is created
         CHECK(sem_wait(sem));
 
-        // memory_size should be ntime * nfreq * file_frame_size (data + metadata)
-        record_addr = assign_memory<uint64_t*>(fname_access_record, ntime * 64, record_addr);
-        buf_addr = assign_memory<uint8_t*>(fname_buf, ntime * 8, buf_addr);
-        INFO("Created the shared memory segments\n");
 
 }
 
@@ -88,6 +84,27 @@ T visSharedMemWriter::assign_memory(std::string shm_name, int shm_size, T addr) 
         return addr;
 }
 
+void visSharedMemWriter::write_to_memory(const visFrameView& frame, size_t index) {
+
+        CHECK(sem_wait(sem));
+        memcpy(record_addr + index, &in_progress, access_record_size);
+        CHECK(sem_post(sem));
+
+        memcpy(buf_addr + index * frame_size, &ONE, sizeof(uint8_t));
+        memcpy(buf_addr + index * frame_size + 1, frame.metadata(), metadata_size);
+        memcpy(buf_addr + index * frame_size + metadata_size + 1, frame.data(), data_size);
+
+        struct timeval timestamp;
+
+        gettimeofday(&timestamp, nullptr);
+        uint64_t time_us = timestamp.tv_sec * 1000000 + timestamp.tv_usec;
+        INFO("Data written to location at {} us", time_us);
+
+        CHECK(sem_wait(sem));
+        memcpy(record_addr + index, &time_us, access_record_size);
+        CHECK(sem_post(sem));
+}
+
 
 void visSharedMemWriter::main_thread() {
     INFO("Reached main thread");
@@ -97,10 +114,7 @@ void visSharedMemWriter::main_thread() {
     size_t i = 0;
 
     // Set up the structure of the access record shared memory
-    struct timeval timestamp;
-    uint64_t time_us;
-    size_t access_record_size = sizeof(time_us);
-    const uint64_t in_progress = -1;
+    access_record_size = sizeof(uint64_t);
 
     record_addr = assign_memory<uint64_t*>(fname_access_record, ntime * access_record_size, record_addr);
 
@@ -108,38 +122,24 @@ void visSharedMemWriter::main_thread() {
     // Get one frame for reference
     wait_for_full_frame(in_buf, unique_name.c_str(), frame_id);
 
-    // Get a view of the current frame
-    // TODO: this frame is not getting written anywhere yet.
     auto frame = visFrameView(in_buf, frame_id);
 
-    // dset_id_t ds_id -> frame.dataset_id
-    // Frequency IDs that we are expecting
-    std::map<uint64_t, uint64_t> freq_id_map;
-    auto& dm = datasetManager::instance();
+    // Use the view to figure out the structure of the ring buffer
+    metadata_size = sizeof(visMetadata);
+    data_size = sizeof(uint8_t);
+    frame_size = data_size + metadata_size + sizeof(ONE);
 
-    // Build the frequency index
-    auto fstate_fut = std::async(&datasetManager::dataset_state<freqState>, &dm, frame.dataset_id);
-    const freqState* fstate = fstate_fut.get();
-    uint ind = 0;
-    for (auto& f : fstate->get_freqs())
-        freq_id_map[f.first] = ind++;
-
-
-    // Figure out the structure of the ring buffer
-    const uint8_t ONE = 1;
-    size_t nfreq = fstate->get_freqs().size();
-    size_t metadata_size = sizeof(visMetadata);
-    size_t data_size = sizeof(uint8_t);
-    size_t frame_size = data_size + metadata_size + sizeof(ONE);
-
-    // memory_size should be ntime * nfreq * file_frame_size (data + metadata)
-    buf_addr = assign_memory<uint8_t*>(fname_buf, ntime * nfreq * frame_size, buf_addr);
+    // memory_size should be ntime * file_frame_size (data + metadata)
+    buf_addr = assign_memory<uint8_t*>(fname_buf, ntime * frame_size, buf_addr);
     INFO("Created the shared memory segments\n");
     CHECK(sem_post(sem));
 
+    write_to_memory(frame, i);
+
+    ++i;
+
     // gets called once when kotekan is running
     while (!stop_thread) {
-
 
         // Wait for the buffer to be filled with data
         if (wait_for_full_frame(in_buf, unique_name.c_str(), frame_id) == nullptr) {
@@ -149,41 +149,13 @@ void visSharedMemWriter::main_thread() {
         // Get a view of the current frame
         auto frame = visFrameView(in_buf, frame_id);
 
-        // dset_id_t ds_id -> frame.dataset_id
-        // Frequency IDs that we are expecting
-
-        // Get the time and frequency of the frame
-        auto ftime = frame.time;
-        time_ctype t = {std::get<0>(ftime), ts_to_double(std::get<1>(ftime))};
-        uint64_t freq_ind = freq_id_map.at(frame.freq_id);
-
-        // acq.file_bundle->add_sample(t, freq_ind, frame); then does the writing to disk/buffer
-
-
-        // class called frame_id in visutil -> does all the cyclic
-
         // Check whether the next value written is within the buffer bounds
         if (i * access_record_size + access_record_size > ntime * access_record_size) {
             INFO("Setting back to 0!");
             i = 0;
         }
 
-
-        CHECK(sem_wait(sem));
-        memcpy(record_addr + i, &in_progress, access_record_size);
-        CHECK(sem_post(sem));
-
-        memcpy(buf_addr + i * frame_size, &ONE, sizeof(uint8_t));
-        memcpy(buf_addr + i * frame_size + 1, frame.metadata(), metadata_size);
-        memcpy(buf_addr + i * frame_size + metadata_size + 1, frame.data(), data_size);
-
-        gettimeofday(&timestamp, nullptr);
-        time_us = timestamp.tv_sec * 1000000 + timestamp.tv_usec;
-        INFO("Data written to location at {} us", time_us);
-
-        CHECK(sem_wait(sem));
-        memcpy(record_addr + i, &time_us, access_record_size);
-        CHECK(sem_post(sem));
+        write_to_memory(frame, i);
 
         ++i;
 

--- a/lib/stages/visSharedMemWriter.cpp
+++ b/lib/stages/visSharedMemWriter.cpp
@@ -1,0 +1,159 @@
+#include "visSharedMemWriter.hpp"
+
+#include "errors.h"
+
+#include "fmt.hpp"
+
+
+using kotekan::bufferContainer;
+using kotekan::Config;
+using kotekan::Stage;
+
+
+REGISTER_KOTEKAN_STAGE(visSharedMemWriter);
+
+visSharedMemWriter::visSharedMemWriter(Config& config, const std::string& unique_name, bufferContainer& buffer_container) :
+    Stage(config, unique_name, buffer_container, std::bind(&visSharedMemWriter::main_thread, this)) {
+
+        // Fetch any simple configuration
+        root_path = config.get_default<std::string>(unique_name, "root_path", "/dev/shm/");
+        sem_name = config.get_default<std::string>(unique_name, "sem_name", "kotekan");
+        fname_met = config.get_default<std::string>(unique_name, "fname_met", "calBufferMetadata");
+        fname_buf = config.get_default<std::string>(unique_name, "fname_buf", "calBuffer");
+        nsamples = config.get_default<size_t>(unique_name, "nsamples", 4096);
+
+        // Setup the input vector
+        in_buf = get_buffer("in_buf");
+        register_consumer(in_buf, unique_name.c_str());
+
+        // Check if any of the old buffer files exist
+        DEBUG("Checking for and removing old buffer files...");
+        check_remove(root_path + "sem." + sem_name);
+        check_remove(root_path + fname_met);
+        check_remove(root_path + fname_buf);
+
+        // Create the semaphore, and gain first access to it
+        sem = sem_open(
+                sem_name.c_str(),
+                (O_CREAT | O_EXCL),
+                (S_IRUSR | S_IWUSR),
+                1
+            );
+
+        if (sem == SEM_FAILED) {
+            perror("sem_open");
+            exit(errno);
+        }
+
+        INFO("Semaphore created.\n");
+
+        // memory_size should be ntime * nfreq * file_frame_size (data + metadata)
+        met_addr = assign_memory<uint64_t*>(fname_met, nsamples * 64, met_addr);
+        buf_addr = assign_memory<uint8_t*>(fname_buf, nsamples * 8, buf_addr);
+        INFO("Created the shared memory segments\n");
+
+}
+
+// make a deconstructor in which to deconstruct semaphores and shared memory
+visSharedMemWriter::~visSharedMemWriter() {
+    // make sure to unlink the semaphore and unmap the mappings
+}
+
+// takes the name of a shared memory address opens it, and maps the memory to the provided address pointer
+template <typename T>
+T visSharedMemWriter::assign_memory(std::string shm_name, int shm_size, T addr) {
+        int fd = shm_open(shm_name.c_str(), (O_CREAT | O_RDWR), (S_IRUSR | S_IWUSR));
+
+        if (fd == -1) {
+            throw std::runtime_error(
+                fmt::format(fmt("Cannot open shared memory named {:s}: {:s}"), shm_name, strerror(errno)));
+        }
+
+        // Resize object to hold buffer
+        CHECK(ftruncate(fd, shm_size));
+        INFO("Resized to %ld bytes\n", (long) shm_size);
+
+        addr = (T) mmap(nullptr, shm_size, (PROT_READ | PROT_WRITE), MAP_SHARED, fd, 0);
+        if (addr == MAP_FAILED) {
+            throw std::runtime_error(
+                fmt::format(fmt("Failed to map shm {:s} to memory: {:s}."), shm_name, strerror(errno)));
+        }
+
+        // fd is no longer needed
+        CHECK(close(fd));
+
+        return addr;
+}
+
+
+void visSharedMemWriter::main_thread() {
+    INFO("Reached main thread");
+
+    frameID frame_id(in_buf);
+
+    size_t i = 0;
+    struct timeval timestamp;
+    uint64_t time_us;
+    const uint64_t in_progress = -1;
+
+    // gets called once when kotekan is running
+    while (!stop_thread) {
+
+
+        // Wait for the buffer to be filled with data
+        if (wait_for_full_frame(in_buf, unique_name.c_str(), frame_id) == nullptr) {
+            break;
+        }
+
+        // Get a view of the current frame
+        auto frame = visFrameView(in_buf, frame_id);
+
+        // dset_id_t ds_id -> frame.dataset_id
+        // Frequency IDs that we are expecting
+        /*std::map<uint64_t, uint64_t> freq_id_map;
+        auto& dm = datasetManager::instance();
+        auto fstate_fut = std::async(&datasetManager::dataset_state<freqState>, &dm, frame.dataset_id);
+        const freqState* fstate = fstate_fut.get();
+
+        uint ind = 0;
+        for (auto& f : fstate->get_freqs())
+            freq_id_map[f.first] = ind++;
+
+        // Get the time and frequency of the frame
+        auto ftime = frame.time;
+        time_ctype t = {std::get<0>(ftime), ts_to_double(std::get<1>(ftime))};
+        uint64_t freq_ind = freq_id_map.at(frame.freq_id); */
+
+        // acq.file_bundle->add_sample(t, freq_ind, frame); then does the writing to disk/buffer
+
+
+        // class called frame_id in visutil -> does all the cyclic
+
+        // Check whether the next value written is within the buffer bounds
+        if (i * sizeof(uint64_t) + sizeof(uint64_t) > nsamples * 64) {
+            INFO("Setting back to 0!");
+            i = 0;
+        }
+
+
+        CHECK(sem_wait(sem));
+        memcpy(met_addr + i, &in_progress, sizeof(uint64_t));
+        CHECK(sem_post(sem));
+
+        memcpy(buf_addr + i, frame.data(), sizeof(uint8_t));
+
+        gettimeofday(&timestamp, nullptr);
+        time_us = timestamp.tv_sec * 1000000 + timestamp.tv_usec;
+        INFO("Data written to location at {} us", time_us);
+
+        CHECK(sem_wait(sem));
+        memcpy(met_addr + i, &time_us, sizeof(uint64_t));
+        CHECK(sem_post(sem));
+
+        i += 1;
+
+        // marks the buffer and moves on
+        mark_frame_empty(in_buf, unique_name.c_str(), frame_id++);
+
+    }
+}

--- a/lib/stages/visSharedMemWriter.cpp
+++ b/lib/stages/visSharedMemWriter.cpp
@@ -1,9 +1,31 @@
 #include "visSharedMemWriter.hpp"
 
-#include "errors.h"
-
-#include "fmt.hpp"
-
+#include "visSharedMemWriter.hpp"
+#include <cxxabi.h>            // for __forced_unwind
+#include <fcntl.h>             // for O_CREAT
+#include <string.h>            // for memcpy, strerror
+#include <sys/mman.h>          // for mmap, shm_open, MAP_FAILED, MAP_SHARED, PROT_READ, PROT_WRITE
+#include <sys/stat.h>          // for S_IRUSR, S_IWUSR
+#include <sys/time.h>          // for gettimeofday, timeval
+#include <sys/types.h>         // for uint
+#include <atomic>              // for atomic_bool
+#include <exception>           // for exception
+#include <functional>          // for _Bind_helper<>::type, bind, function
+#include <future>              // for async, future
+#include <map>                 // for map
+#include <regex>               // for match_results<>::_Base_type
+#include <system_error>        // for system_error
+#include <tuple>               // for get
+#include <utility>             // for pair
+#include <vector>              // for vector
+#include "Hash.hpp"            // for Hash
+#include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE, StageMakerTemplate
+#include "datasetManager.hpp"  // for datasetManager
+#include "datasetState.hpp"    // for freqState
+#include "fmt.hpp"             // for format, fmt
+#include "kotekanLogging.hpp"  // for INFO, DEBUG
+#include "visBuffer.hpp"       // for visFrameView, visMetadata
+#include "visUtil.hpp"         // for frameID
 
 using kotekan::bufferContainer;
 using kotekan::Config;

--- a/lib/stages/visSharedMemWriter.hpp
+++ b/lib/stages/visSharedMemWriter.hpp
@@ -1,0 +1,84 @@
+#ifndef VISSHAREDMEMWRITER_HPP
+#define VISSHAREDMEMWRITER_HPP
+
+#include "Config.hpp"               // for Config
+#include "StageFactory.hpp"         // for REGISTER_KOTEKAN_STAGE, StageMakerTemplate
+#include "Stage.hpp"                // for Stage
+#include <future>                   // for async
+#include "datasetManager.hpp"       // for dset_id_t, datasetManager
+#include "datasetState.hpp"         // for freqState
+#include "buffer.h"                 // for mark_frame_empty, register_consumer, wait_for_full_frame
+#include "bufferContainer.hpp"      // for bufferContainer
+#include "visBuffer.hpp"            // for visFrameView
+#include "kotekanLogging.hpp"       // for INFO, ERROR, WARN, FATAL_ERROR, DEBUG, logLevel
+
+#include <cstdint>
+#include <map>                      // for map
+#include <string>                   // for string, operator+
+#include <errno.h>                  // for ENOENT, errno
+
+#include <semaphore.h>              // for sem_open, sem_wait, SEM_FAILED, sem_post
+#include <sys/types.h>              // Type definitions
+#include <sys/time.h>               // Time-related functions
+#include <fcntl.h>
+#include <unistd.h>                 // System calls, access, F_OK
+#include <stdio.h>                  // size_t, remove
+#include <sys/stat.h>
+
+#include <sys/mman.h>               //mmap
+
+#define CHECK(EXPR) ({ \
+    int _r = EXPR; \
+    if (_r == -1) { \
+        perror(#EXPR); \
+        exit(EXIT_FAILURE); \
+    } \
+    _r; \
+})
+
+
+
+class visSharedMemWriter : public kotekan::Stage {
+
+public:
+    visSharedMemWriter(kotekan::Config& config, const std::string& unique_name,
+             kotekan::bufferContainer& buffer_container);
+
+    ~visSharedMemWriter();
+
+    void main_thread() override;
+
+
+protected:
+    // Input buffer to read from
+    Buffer* in_buf;
+
+    // Output every set number of frames
+    int _output_period;
+
+    // Semaphore for updating metadata
+    sem_t *sem;
+
+    // Pointers to shared memory addresses for metadata and ringBuffer
+    uint64_t *met_addr;
+    uint8_t *buf_addr;
+    size_t nsamples;
+
+    template<typename T>
+    T assign_memory(std::string shm_name, int shm_size, T addr);
+
+    std::string root_path, sem_name, fname_met, fname_buf;
+};
+
+inline void check_remove(std::string fname) {
+    // Check if we need to remove anything
+    if (access(fname.c_str(), F_OK) != 0)
+        return;
+    // Remove
+    if (remove(fname.c_str()) != 0) {
+        if (errno != ENOENT)
+            throw std::runtime_error("Could not remove file " + fname);
+    }
+}
+
+#endif // VISSHAREDMEMWRITER_HPP

--- a/lib/stages/visSharedMemWriter.hpp
+++ b/lib/stages/visSharedMemWriter.hpp
@@ -56,18 +56,18 @@ protected:
     // Output every set number of frames
     int _output_period;
 
-    // Semaphore for updating metadata
+    // Semaphore for updating access record
     sem_t *sem;
 
-    // Pointers to shared memory addresses for metadata and ringBuffer
-    uint64_t *met_addr;
+    // Pointers to shared memory addresses for access record and ringBuffer
+    uint64_t *record_addr;
     uint8_t *buf_addr;
-    size_t nsamples;
+    size_t ntime;
 
     template<typename T>
     T assign_memory(std::string shm_name, int shm_size, T addr);
 
-    std::string root_path, sem_name, fname_met, fname_buf;
+    std::string root_path, sem_name, fname_access_record, fname_buf;
 };
 
 inline void check_remove(std::string fname) {

--- a/lib/stages/visSharedMemWriter.hpp
+++ b/lib/stages/visSharedMemWriter.hpp
@@ -1,31 +1,19 @@
 #ifndef VISSHAREDMEMWRITER_HPP
 #define VISSHAREDMEMWRITER_HPP
 
-#include "Config.hpp"               // for Config
-#include "StageFactory.hpp"         // for REGISTER_KOTEKAN_STAGE, StageMakerTemplate
-#include "Stage.hpp"                // for Stage
-#include <future>                   // for async
-#include "datasetManager.hpp"       // for dset_id_t, datasetManager
-#include "datasetState.hpp"         // for freqState
-#include "buffer.h"                 // for mark_frame_empty, register_consumer, wait_for_full_frame
-#include "bufferContainer.hpp"      // for bufferContainer
-#include "visBuffer.hpp"            // for visFrameView
-#include "kotekanLogging.hpp"       // for INFO, ERROR, WARN, FATAL_ERROR, DEBUG, logLevel
-
-#include <cstdint>
-#include <map>                      // for map
-#include <string>                   // for string, operator+
-#include <errno.h>                  // for ENOENT, errno
-
-#include <semaphore.h>              // for sem_open, sem_wait, SEM_FAILED, sem_post
-#include <sys/types.h>              // Type definitions
-#include <sys/time.h>               // Time-related functions
-#include <fcntl.h>
-#include <unistd.h>                 // System calls, access, F_OK
-#include <stdio.h>                  // size_t, remove
-#include <sys/stat.h>
-
-#include <sys/mman.h>               //mmap
+#include <errno.h>              // for ENOENT, errno
+#include <semaphore.h>          // for sem_t
+#include <stdio.h>              // for perror, remove, size_t
+#include <stdlib.h>             // for exit, EXIT_FAILURE
+#include <unistd.h>             // for access, F_OK
+#include <cstdint>              // for uint64_t, uint8_t
+#include <stdexcept>            // for runtime_error
+#include <string>               // for string, operator+
+#include "Config.hpp"           // for Config
+#include "visBuffer.hpp"        // for visFrameView
+#include "Stage.hpp"            // for Stage
+#include "buffer.h"             // for Buffer
+#include "bufferContainer.hpp"  // for bufferContainer
 
 #define CHECK(EXPR) ({ \
     int _r = EXPR; \

--- a/lib/stages/visSharedMemWriter.hpp
+++ b/lib/stages/visSharedMemWriter.hpp
@@ -64,8 +64,18 @@ protected:
     uint8_t *buf_addr;
     size_t ntime;
 
+    const uint8_t ONE = 1;
+    const uint64_t in_progress = -1;
+
+    size_t access_record_size;
+    size_t metadata_size;
+    size_t data_size;
+    size_t frame_size;
+
     template<typename T>
     T assign_memory(std::string shm_name, int shm_size, T addr);
+
+    void write_to_memory(const visFrameView& frame, size_t index);
 
     std::string root_path, sem_name, fname_access_record, fname_buf;
 };

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -7,3 +7,4 @@ requests
 pyyaml
 tabulate
 comet @ git+ssh://git@github.com/chime-experiment/comet.git
+posix_ipc @ git+https://github.com/osvenskan/posix_ipc.git

--- a/tests/test_vissharedmemwriter.py
+++ b/tests/test_vissharedmemwriter.py
@@ -82,5 +82,7 @@ def test_sharedmem(vis_data, semaphore, mem_map_access_record, memory_map_buf):
     for i in range(0, 100):
         semaphore.acquire()
         print(struct.unpack("<c", memory_map_buf.read(1))[0])
+        print(struct.unpack("<c", memory_map_buf.read(1))[0])
+        print(struct.unpack("<c", memory_map_buf.read(1))[0])
         semaphore.release()
         print(struct.unpack("<Q", mem_map_access_record.read(8))[0])

--- a/tests/test_vissharedmemwriter.py
+++ b/tests/test_vissharedmemwriter.py
@@ -13,7 +13,7 @@ import os
 from kotekan import runner
 
 sem_name = "kotekan"
-fname_met = "calBufferMetadata"
+fname_access_record = "calBufferAccessRecord"
 fname_buf = "calBuffer"
 
 params = {
@@ -56,7 +56,7 @@ def semaphore():
 
 
 @pytest.fixture(scope="module")
-def memory_map_data():
+def memory_map_buf():
     memory = posix_ipc.SharedMemory(fname_buf)
     mapfile = mmap.mmap(memory.fd, memory.size, prot=mmap.PROT_READ)
     os.close(memory.fd)
@@ -65,22 +65,22 @@ def memory_map_data():
     posix_ipc.unlink_shared_memory(fname_buf)
 
 @pytest.fixture(scope="module")
-def memory_map_metadata():
-    memory = posix_ipc.SharedMemory(fname_met)
+def mem_map_access_record():
+    memory = posix_ipc.SharedMemory(fname_access_record)
     mapfile = mmap.mmap(memory.fd, memory.size, prot=mmap.PROT_READ)
     os.close(memory.fd)
     yield mapfile
     mapfile.close()
-    posix_ipc.unlink_shared_memory(fname_met)
+    posix_ipc.unlink_shared_memory(fname_access_record)
 
 
-def test_sharedmem(vis_data, semaphore, memory_map_metadata, memory_map_data):
-    for memory_map in [memory_map_metadata, memory_map_data]:
+def test_sharedmem(vis_data, semaphore, mem_map_access_record, memory_map_buf):
+    for memory_map in [mem_map_access_record, memory_map_buf]:
         memory_map.seek(0)
     import struct
 
     for i in range(0, 100):
         semaphore.acquire()
-        print(struct.unpack("<c", memory_map_data.read(1))[0])
+        print(struct.unpack("<c", memory_map_buf.read(1))[0])
         semaphore.release()
-        print(struct.unpack("<Q", memory_map_metadata.read(8))[0])
+        print(struct.unpack("<Q", mem_map_access_record.read(8))[0])

--- a/tests/test_vissharedmemwriter.py
+++ b/tests/test_vissharedmemwriter.py
@@ -1,7 +1,7 @@
 # === Start Python 2/3 compatibility
 from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import * #noqa pylint: disable=W0401, W0614
-from future.builtins.disabled import * #noqa pylint: disable=W0401, W0614
+from future.builtins import *  # noqa pylint: disable=W0401, W0614
+from future.builtins.disabled import *  # noqa pylint: disable=W0401, W0614
 
 # == End Python 2/3 compatibility
 
@@ -12,17 +12,19 @@ import os
 
 from kotekan import runner
 
-SEM_NAME = "kotekan"
-MEM_NAME = "ringBufferMetadata"
+sem_name = "kotekan"
+fname_met = "calBufferMetadata"
+fname_buf = "calBuffer"
 
 params = {
-        "num_elements": 7,
-        "num_ev": 0,
-        "total_frames": 128,
-        "cadence": 10.0,
-        "mode": "default",
-        "dataset_manager": {"use_dataset_broker": False},
+    "num_elements": 7,
+    "num_ev": 0,
+    "total_frames": 128,
+    "cadence": 10.0,
+    "mode": "default",
+    "dataset_manager": {"use_dataset_broker": False},
 }
+
 
 @pytest.fixture(scope="module")
 def vis_data(tmpdir_factory):
@@ -30,43 +32,55 @@ def vis_data(tmpdir_factory):
     # keeping all the data this test produced here (probably do not need it)
     # using FakeVisBuffer to produce fake data
     fakevis_buffer = runner.FakeVisBuffer(
-            num_frames=params["total_frames"],
-            mode=params["mode"],
+        num_frames=params["total_frames"], mode=params["mode"]
     )
 
     # KotekanStageTester is used to run kotekan with my config
     test = runner.KotekanStageTester(
-            stage_type="visSharedMemWriter",
-            stage_config={},
-            buffers_in=fakevis_buffer,
-            buffers_out=None,
-            global_config=params
+        stage_type="visSharedMemWriter",
+        stage_config={},
+        buffers_in=fakevis_buffer,
+        buffers_out=None,
+        global_config=params,
     )
 
     test.run()
 
+
 @pytest.fixture(scope="module")
 def semaphore():
-    sem = posix_ipc.Semaphore(SEM_NAME)
-    print("Test is waiting to acquire the semaphore")
-    sem.acquire()
-    print("Acquired!")
+    sem = posix_ipc.Semaphore(sem_name)
     yield sem
     sem.release()
     sem.unlink()
 
+
 @pytest.fixture(scope="module")
-def memory_map():
-    memory = posix_ipc.SharedMemory(MEM_NAME)
+def memory_map_data():
+    memory = posix_ipc.SharedMemory(fname_buf)
     mapfile = mmap.mmap(memory.fd, memory.size, prot=mmap.PROT_READ)
     os.close(memory.fd)
     yield mapfile
     mapfile.close()
-    posix_ipc.unlink_shared_memory(MEM_NAME)
+    posix_ipc.unlink_shared_memory(fname_buf)
 
-def test_sharedmem(vis_data, semaphore, memory_map):
-    memory_map.seek(0)
+@pytest.fixture(scope="module")
+def memory_map_metadata():
+    memory = posix_ipc.SharedMemory(fname_met)
+    mapfile = mmap.mmap(memory.fd, memory.size, prot=mmap.PROT_READ)
+    os.close(memory.fd)
+    yield mapfile
+    mapfile.close()
+    posix_ipc.unlink_shared_memory(fname_met)
+
+
+def test_sharedmem(vis_data, semaphore, memory_map_metadata, memory_map_data):
+    for memory_map in [memory_map_metadata, memory_map_data]:
+        memory_map.seek(0)
     import struct
-    for i in range(0, 800, 8):
-        print(struct.unpack("<Q", memory_map.read(8))[0])
 
+    for i in range(0, 100):
+        semaphore.acquire()
+        print(struct.unpack("<c", memory_map_data.read(1))[0])
+        semaphore.release()
+        print(struct.unpack("<Q", memory_map_metadata.read(8))[0])

--- a/tests/test_vissharedmemwriter.py
+++ b/tests/test_vissharedmemwriter.py
@@ -1,0 +1,72 @@
+# === Start Python 2/3 compatibility
+from __future__ import absolute_import, division, print_function, unicode_literals
+from future.builtins import * #noqa pylint: disable=W0401, W0614
+from future.builtins.disabled import * #noqa pylint: disable=W0401, W0614
+
+# == End Python 2/3 compatibility
+
+import pytest
+import posix_ipc
+import mmap
+import os
+
+from kotekan import runner
+
+SEM_NAME = "kotekan"
+MEM_NAME = "ringBufferMetadata"
+
+params = {
+        "num_elements": 7,
+        "num_ev": 0,
+        "total_frames": 128,
+        "cadence": 10.0,
+        "mode": "default",
+        "dataset_manager": {"use_dataset_broker": False},
+}
+
+@pytest.fixture(scope="module")
+def vis_data(tmpdir_factory):
+
+    # keeping all the data this test produced here (probably do not need it)
+    # using FakeVisBuffer to produce fake data
+    fakevis_buffer = runner.FakeVisBuffer(
+            num_frames=params["total_frames"],
+            mode=params["mode"],
+    )
+
+    # KotekanStageTester is used to run kotekan with my config
+    test = runner.KotekanStageTester(
+            stage_type="visSharedMemWriter",
+            stage_config={},
+            buffers_in=fakevis_buffer,
+            buffers_out=None,
+            global_config=params
+    )
+
+    test.run()
+
+@pytest.fixture(scope="module")
+def semaphore():
+    sem = posix_ipc.Semaphore(SEM_NAME)
+    print("Test is waiting to acquire the semaphore")
+    sem.acquire()
+    print("Acquired!")
+    yield sem
+    sem.release()
+    sem.unlink()
+
+@pytest.fixture(scope="module")
+def memory_map():
+    memory = posix_ipc.SharedMemory(MEM_NAME)
+    mapfile = mmap.mmap(memory.fd, memory.size, prot=mmap.PROT_READ)
+    os.close(memory.fd)
+    yield mapfile
+    mapfile.close()
+    posix_ipc.unlink_shared_memory(MEM_NAME)
+
+def test_sharedmem(vis_data, semaphore, memory_map):
+    memory_map.seek(0)
+    import struct
+    for i in range(0, 800, 8):
+        print(struct.unpack("<Q", memory_map.read(8))[0])
+


### PR DESCRIPTION
This code will create two shared memory regions:
- fname_access_record (of size ntime * uint64_t)
     - keeps a record of fname_buf's access
- fname_buf (of size ntime * frame_size)
      - each region will contain a valid byte, frame metadata, frame data

It will also create a semaphore (sem_name) which will control access to fname_access_record.

The process:

Buffer is writing to index `i`.
`fname_access_record` is locked.  -1 is written to index `i` to represent that that index is invalid. `fname_access_record` is unlocked.
Current frame metadata, and data (along with a 'valid bit') is written to index `i` of `fname_buf`.
`fname_access_record` is locked. The current timestamp is written to index `i` to represent when that region became valid. `fname_access_record` is unlocked.

When the end of the shared memory region is reached, index `i` resets to 0.