### PR TITLE
Run CI on Github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,13 @@
-name: include-what-you-use
+# NOTE:
+# When we build kotekan on the Github VM we need to take into account a few
+# limitations: first we can't lock very much memory so we need to disable
+# mlock the buffers. Second, the VMs run across a range of CPU
+# architectures (from Haswell to Skylake-AVX512 as of 2020/03). Because our
+# use of ccache shares compiled objects we must target our build for the
+# lowest architecture available or we will occasionally crash with SIGILL
+# when a newer instruction is called than is available.
+
+name: kotekan-ci-test
 on:
   pull_request:
     branches:
@@ -9,18 +18,169 @@ on:
     - develop
     - master
 
-jobs:
-  build:
-   runs-on: ubuntu-latest
+env:
+  IMG_CORE: docker.pkg.github.com/kotekan/kotekan/kotekan-core:latest
+  IMG_IWYU: docker.pkg.github.com/kotekan/kotekan/kotekan-iwyu:latest
 
-   steps:
-   - uses: actions/checkout@v1
-   - name: Build docker image
-     run: |
-       docker login docker.pkg.github.com -u ${GITHUB_REPOSITORY} -p "${{ secrets.GITHUB_TOKEN }}"
-       docker pull --disable-content-trust docker.pkg.github.com/kotekan/kotekan/kotekan:latest
-       docker build --cache-from=rocm/dev-ubuntu-18.04,docker.pkg.github.com/kotekan/kotekan/kotekan:latest -f tools/iwyu/docker/Dockerfile -t docker.pkg.github.com/kotekan/kotekan/kotekan:latest .
-       docker push docker.pkg.github.com/kotekan/kotekan/kotekan:latest
-   - name: Run iwyu
-     run: |
-       docker run --rm docker.pkg.github.com/kotekan/kotekan/kotekan:latest /code/tools/iwyu/docker/iwyu.sh
+jobs:
+
+  # Build the docker images
+  build-docker:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Build docker images
+      run: |
+        SECONDS=0
+        docker login docker.pkg.github.com -u ${GITHUB_REPOSITORY} -p "${{ secrets.GITHUB_TOKEN }}" | while read line ; do echo "$SECONDS s | $line";  done;
+        docker pull --disable-content-trust ${IMG_CORE} | while read line ; do echo "$SECONDS s | $line";  done;
+        docker pull --disable-content-trust ${IMG_IWYU} | while read line ; do echo "$SECONDS s | $line";  done;
+        docker build --cache-from=rocm/dev-ubuntu-18.04,${IMG_CORE} -t ${IMG_CORE} - < tools/docker/Dockerfile | while read line ; do echo "$SECONDS s | $line";  done;
+        docker build --cache-from=rocm/dev-ubuntu-18.04,${IMG_CORE},${IMG_IWYU} -t ${IMG_IWYU} - < tools/iwyu/docker/Dockerfile | while read line ; do echo "$SECONDS s | $line";  done;
+        docker push ${IMG_CORE} | while read line ; do echo "$SECONDS s| $line";  done;
+        docker push ${IMG_IWYU} | while read line ; do echo "$SECONDS s| $line";  done;
+
+
+  # Build a basic version of kotekan
+  build-base:
+    runs-on: ubuntu-latest
+    needs: build-docker
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Cache ccache files
+      uses: actions/cache@v1
+      with:
+        path: .ccache
+        key: ccache-base-build-${{ github.sha }}
+        restore-keys: |
+          ccache-base-build
+          ccache-full-build
+
+    - name: Build kotekan
+      run: |
+        OPTS=(--rm --mount type=bind,src=$(pwd),target=/code/kotekan -w /code/kotekan/build/ ${IMG_CORE})
+        docker login docker.pkg.github.com -u ${GITHUB_REPOSITORY} -p "${{ secrets.GITHUB_TOKEN }}"
+        docker run "${OPTS[@]}" ccache -s
+        docker run "${OPTS[@]}" \
+          cmake -DCMAKE_BUILD_TYPE=Debug \
+            -DARCH=haswell \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache ..
+        docker run "${OPTS[@]}" make -j 2
+        docker run "${OPTS[@]}" ccache -s
+
+
+  # Build a full version of kotekan and run the unit tests
+  build-full-test:
+    runs-on: ubuntu-latest
+    needs: build-docker
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Cache ccache files
+      uses: actions/cache@v1
+      with:
+        path: .ccache
+        key: ccache-full-build-${{ github.sha }}
+        restore-keys: |
+          ccache-full-build
+          ccache-base-build
+
+    - name: Build kotekan
+      run: |
+        OPTS=(--rm --mount type=bind,src=$(pwd),target=/code/kotekan -w /code/kotekan/build/ ${IMG_CORE})
+        docker login docker.pkg.github.com -u ${GITHUB_REPOSITORY} -p "${{ secrets.GITHUB_TOKEN }}"
+        docker run "${OPTS[@]}" ccache -s
+        docker run "${OPTS[@]}" \
+          cmake -DCMAKE_BUILD_TYPE=Debug \
+            -DUSE_HDF5=ON -DHIGHFIVE_PATH=/code/build/HighFive \
+            -DUSE_LAPACK=ON -DBLAZE_PATH=/code/build/blaze \
+            -DARCH=haswell \
+            -DNO_MEMLOCK=ON \
+            -DUSE_OMP=ON \
+            -DBOOST_TESTS=ON \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache ..
+        docker run "${OPTS[@]}" make -j 2
+        docker run "${OPTS[@]}" ccache -s
+
+    - name: Run parallel python tests
+      run: |
+        OPTS=(--rm --mount type=bind,src=$(pwd),target=/code/kotekan -w /code/kotekan/tests/ -e PYTHONPATH=/code/kotekan/python/ ${IMG_CORE})
+        docker run "${OPTS[@]}" pytest -v -n auto --dist=loadfile -x -m "not serial"
+
+    - name: Run serial python tests
+      run: |
+        OPTS=(--rm --mount type=bind,src=$(pwd),target=/code/kotekan -w /code/kotekan/tests/ -e PYTHONPATH=/code/kotekan/python/ ${IMG_CORE})
+        docker run "${OPTS[@]}" pytest -v -x -m serial
+
+    - name: Run boost tests
+      run: |
+        OPTS=(--rm --mount type=bind,src=$(pwd),target=/code/kotekan -w /code/kotekan/build/tests/ -e PYTHONPATH=/code/kotekan/python/ ${IMG_CORE})
+        docker run "${OPTS[@]}" pytest -v -x
+
+
+  # Build a full CHIME version of kotekan
+  build-chime:
+    runs-on: ubuntu-latest
+    needs: build-docker
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Cache ccache files
+      uses: actions/cache@v1
+      with:
+        path: .ccache
+        key: ccache-chime-build-${{ github.sha }}
+        restore-keys: |
+          ccache-chime-build
+          ccache-full-build
+
+    - name: Build kotekan
+      run: |
+        OPTS=(--rm --mount type=bind,src=$(pwd),target=/code/kotekan -w /code/kotekan/build/ ${IMG_CORE})
+        docker login docker.pkg.github.com -u ${GITHUB_REPOSITORY} -p "${{ secrets.GITHUB_TOKEN }}"
+        docker run "${OPTS[@]}" ccache -s
+        docker run "${OPTS[@]}" \
+          cmake -DCMAKE_BUILD_TYPE=Debug \
+            -DUSE_DPDK=ON -DRTE_TARGET=x86_64-native-linuxapp-gcc \
+            -DUSE_HDF5=ON -DHIGHFIVE_PATH=/code/build/HighFive \
+            -DUSE_LAPACK=ON -DBLAZE_PATH=/code/build/blaze \
+            -DARCH=haswell \
+            -DNO_MEMLOCK=ON \
+            -DUSE_OMP=ON \
+            -DBOOST_TESTS=OFF \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache ..
+        docker run "${OPTS[@]}" make -j 2
+        docker run "${OPTS[@]}" ccache -s
+
+
+  iwyu:
+    runs-on: ubuntu-latest
+    needs: build-docker
+    if: github.base_ref == 'master'
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Configure kotekan
+      run: |
+        OPTS=(--rm --mount type=bind,src=$(pwd),target=/code/kotekan -w /code/kotekan/build/ ${IMG_IWYU})
+        docker login docker.pkg.github.com -u ${GITHUB_REPOSITORY} -p "${{ secrets.GITHUB_TOKEN }}"
+        docker run "${OPTS[@]}" \
+          cmake -DCMAKE_BUILD_TYPE=Debug \
+            -DUSE_DPDK=ON -DRTE_TARGET=x86_64-native-linuxapp-gcc
+            -DUSE_HDF5=ON -DHIGHFIVE_PATH=/code/build/HighFive \
+            -DUSE_LAPACK=ON -DBLAZE_PATH=/code/build/blaze \
+            -DARCH=haswell \
+            -DNO_MEMLOCK=ON \
+            -DUSE_OMP=ON \
+            -DBOOST_TESTS=OFF \
+
+    - name: Run iwyu
+      run: |
+        OPTS=(--rm --mount type=bind,src=$(pwd),target=/code/kotekan -w /code/kotekan/build/ ${IMG_IWYU})
+        docker run "${OPTS[@]}" /code/tools/iwyu/docker/iwyu.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,12 +109,12 @@ jobs:
     - name: Run parallel python tests
       run: |
         OPTS=(--rm --mount type=bind,src=$(pwd),target=/code/kotekan -w /code/kotekan/tests/ -e PYTHONPATH=/code/kotekan/python/ ${IMG_CORE})
-        docker run "${OPTS[@]}" pytest -v -n auto --dist=loadfile -x -m "not serial"
+        docker run "${OPTS[@]}" pytest -v -n auto --dist=loadfile -x -m 'not serial'
 
     - name: Run serial python tests
       run: |
         OPTS=(--rm --mount type=bind,src=$(pwd),target=/code/kotekan -w /code/kotekan/tests/ -e PYTHONPATH=/code/kotekan/python/ ${IMG_CORE})
-        docker run "${OPTS[@]}" pytest -v -x -m serial
+        docker run "${OPTS[@]}" bash -c "redis-server --daemonize yes; pytest -v -x -m serial"
 
     - name: Run boost tests
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -146,7 +146,7 @@ jobs:
         docker run "${OPTS[@]}" ccache -s
         docker run "${OPTS[@]}" \
           cmake -DCMAKE_BUILD_TYPE=Debug \
-            -DUSE_DPDK=ON -DRTE_TARGET=x86_64-native-linuxapp-gcc \
+            -DUSE_DPDK=ON \
             -DUSE_HDF5=ON -DHIGHFIVE_PATH=/code/build/HighFive \
             -DUSE_LAPACK=ON -DBLAZE_PATH=/code/build/blaze \
             -DARCH=haswell \
@@ -172,7 +172,7 @@ jobs:
         docker login docker.pkg.github.com -u ${GITHUB_REPOSITORY} -p "${{ secrets.GITHUB_TOKEN }}"
         docker run "${OPTS[@]}" \
           cmake -DCMAKE_BUILD_TYPE=Debug \
-            -DUSE_DPDK=ON -DRTE_TARGET=x86_64-native-linuxapp-gcc
+            -DUSE_DPDK=ON \
             -DUSE_HDF5=ON -DHIGHFIVE_PATH=/code/build/HighFive \
             -DUSE_LAPACK=ON -DBLAZE_PATH=/code/build/blaze \
             -DARCH=haswell \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -300,6 +300,12 @@ if (${COMPILE_DOCS})
     add_subdirectory(docs EXCLUDE_FROM_ALL)
 endif()
 
+# Turn off memlocking of buffers. This is useful when running in restricted
+# environments e.g. Docker containers
+if (${NO_MEMLOCK})
+  MESSAGE("Do not lock buffer memory.")
+  add_definitions(-DWITH_NO_MEMLOCK)
+endif ()
 
 # Improve debugging by turning off all optimisations.
 if (${SUPERDEBUG})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,14 +87,13 @@ endif()
 
 include(CheckIncludeFileCXX)
 if (${USE_LAPACK})
-  # Check OpenBLAS is installed
-  if (DEFINED OPENBLAS_PATH)
-    if (NOT EXISTS ${OPENBLAS_PATH})
-      MESSAGE( "OPENBLAS_PATH: \"${OPENBLAS_PATH}\" does not exist" )
-    endif()
-  endif()
-  find_package( OpenBLAS REQUIRED
-                HINTS ${OPENBLAS_PATH})
+
+  find_package( BLAS REQUIRED )
+  MESSAGE("Using BLAS ${BLAS_LIBRARIES}")
+  find_package( LAPACK REQUIRED )
+  MESSAGE("Using LAPACK ${LAPACK_LIBRARIES}")
+  find_package( LAPACKE REQUIRED )
+  MESSAGE("Using LAPACKE ${LAPACKE_LIBRARIES}")
 
   # Check Blaze is installed
   if (DEFINED BLAZE_PATH)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ option(USE_DPDK "Enable DPDK Framework" OFF)
 option(USE_HDF5 "Build HDF5 output stages" OFF)
 option(USE_OMP "Enable OpenMP" OFF)
 option(USE_OLD_ROCM "Build for ROCm versions 2.3 or older" OFF)
+option(NO_MEMLOCK "Do not lock buffer memory (useful when running in Docker)" OFF)
 option(SUPERDEBUG "Enable extra debugging with no optimisation" OFF)
 option(SANITIZE "Enable clang sanitizers for testing" OFF)
 option(COMPILE_DOCS "Use Sphinx to compile documentation" OFF)
@@ -78,6 +79,11 @@ if (${USE_FFTW})
   add_definitions(-DWITH_FFTW)
   include_directories(${FFTW_INCLUDES})
 endif()
+
+if (NOT DEFINED ARCH)
+  set(ARCH "native")
+endif()
+
 
 include(CheckIncludeFileCXX)
 if (${USE_LAPACK})
@@ -233,7 +239,7 @@ if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND NOT CMAKE_CXX_COMPILER_ID MATC
        set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -lrt " )
 endif ()
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99 -O3 -D_GNU_SOURCE -Wall -Wextra -Werror -march=native -mtune=native -I/opt/rocm/include")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99 -O3 -D_GNU_SOURCE -Wall -Wextra -Werror -march=${ARCH} -mtune=${ARCH} -I/opt/rocm/include")
 
 # OpenMP flag
 if(${USE_OMP})
@@ -250,7 +256,7 @@ if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND NOT ${CMAKE_CXX_COMPILER_ID} M
        set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -lrt " )
 endif ()
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GNU_SOURCE -O3 -Wall -Wextra -Werror -Wzero-as-null-pointer-constant -march=native -mtune=native -I/opt/rocm/include")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GNU_SOURCE -O3 -Wall -Wextra -Werror -Wzero-as-null-pointer-constant -march=${ARCH} -mtune=${ARCH} -I/opt/rocm/include")
 
 # dpdk uses the register keyword that got removed in C++17 because it wasn't doing anything
 #TODO remove this line when dpdk people fix this: https://mails.dpdk.org/archives/dev/2018-July/107950.html

--- a/LICENSE
+++ b/LICENSE
@@ -37,8 +37,8 @@ THE SOFTWARE.
 ===== Formatting library for C++ =====
 
 Files:
-  include/ftm.hpp
-  include/ftm/*
+  include/fmt.hpp
+  include/fmt/*
 
 ===
 Formatting library for C++
@@ -172,7 +172,7 @@ DEALINGS WITH THE SOFTWARE.
 ===== FindHCC.cmake =====
 
 Files:
-  camke/FindHCC.cmake
+  cmake/FindHCC.cmake
 
 ===
 Copyright (C) 2016 Advanced Micro Devices, Inc. All rights reserved.
@@ -195,3 +195,17 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNE-
 CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ===
 
+
+===== FindLAPACKE.cmake =====
+
+Files:
+    cmake/FindLAPACKE.cmake
+
+===
+Copyright 2016 Hans J. Johnson <hans-johnson@uiowa.edu>
+
+Distributed under the OSI-approved BSD License (the "License")
+
+This software is distributed WITHOUT ANY WARRANTY; without even the
+implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+===

--- a/cmake/FindLAPACKE.cmake
+++ b/cmake/FindLAPACKE.cmake
@@ -1,0 +1,380 @@
+###
+#
+# @copyright (c) 2009-2014 The University of Tennessee and The University
+#                          of Tennessee Research Foundation.
+#                          All rights reserved.
+# @copyright (c) 2012-2016 Inria. All rights reserved.
+# @copyright (c) 2012-2014 Bordeaux INP, CNRS (LaBRI UMR 5800), Inria, Univ. Bordeaux. All rights reserved.
+#
+###
+#
+# - Find LAPACKE include dirs and libraries
+# Use this module by invoking find_package with the form:
+#  find_package(LAPACKE
+#               [REQUIRED] # Fail with error if lapacke is not found
+#               [COMPONENTS <comp1> <comp2> ...] # dependencies
+#              )
+#
+#  LAPACKE depends on the following libraries:
+#   - LAPACK
+#
+# This module finds headers and lapacke library.
+# Results are reported in variables:
+#  LAPACKE_FOUND            - True if headers and requested libraries were found
+#  LAPACKE_LINKER_FLAGS     - list of required linker flags (excluding -l and -L)
+#  LAPACKE_INCLUDE_DIRS     - lapacke include directories
+#  LAPACKE_LIBRARY_DIRS     - Link directories for lapacke libraries
+#  LAPACKE_LIBRARIES        - lapacke component libraries to be linked
+#  LAPACKE_INCLUDE_DIRS_DEP - lapacke + dependencies include directories
+#  LAPACKE_LIBRARY_DIRS_DEP - lapacke + dependencies link directories
+#  LAPACKE_LIBRARIES_DEP    - lapacke libraries + dependencies
+#
+# The user can give specific paths where to find the libraries adding cmake
+# options at configure (ex: cmake path/to/project -DLAPACKE_DIR=path/to/lapacke):
+#  LAPACKE_DIR             - Where to find the base directory of lapacke
+#  LAPACKE_INCDIR          - Where to find the header files
+#  LAPACKE_LIBDIR          - Where to find the library files
+# The module can also look for the following environment variables if paths
+# are not given as cmake variable: LAPACKE_DIR, LAPACKE_INCDIR, LAPACKE_LIBDIR
+#
+# LAPACKE could be directly embedded in LAPACK library (ex: Intel MKL) so that
+# we test a lapacke function with the lapack libraries found and set LAPACKE
+# variables to LAPACK ones if test is successful. To skip this feature and
+# look for a stand alone lapacke, please add the following in your
+# CMakeLists.txt before to call find_package(LAPACKE):
+# set(LAPACKE_STANDALONE TRUE)
+
+#=============================================================================
+# Copyright 2012-2013 Inria
+# Copyright 2012-2013 Emmanuel Agullo
+# Copyright 2012-2013 Mathieu Faverge
+# Copyright 2012      Cedric Castagnede
+# Copyright 2013-2016 Florent Pruvost
+#
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file MORSE-Copyright.txt for details.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# (To distribute this file outside of Morse, substitute the full
+#  License text for the above reference.)
+
+if (NOT LAPACKE_FOUND)
+  set(LAPACKE_DIR "" CACHE PATH "Installation directory of LAPACKE library")
+  if (NOT LAPACKE_FIND_QUIETLY)
+    message(STATUS "A cache variable, namely LAPACKE_DIR, has been set to specify the install directory of LAPACKE")
+  endif()
+endif()
+
+# LAPACKE depends on LAPACK anyway, try to find it
+if (NOT LAPACK_FOUND)
+  if(LAPACKE_FIND_REQUIRED)
+    find_package(LAPACKEXT REQUIRED)
+  else()
+    find_package(LAPACKEXT)
+  endif()
+endif()
+
+# LAPACKE depends on LAPACK
+if (LAPACK_FOUND)
+
+  if (NOT LAPACKE_STANDALONE)
+    # check if a lapacke function exists in the LAPACK lib
+    include(CheckFunctionExists)
+    set(CMAKE_REQUIRED_LIBRARIES "${LAPACK_LINKER_FLAGS};${LAPACK_LIBRARIES}")
+    unset(LAPACKE_WORKS CACHE)
+    check_function_exists(LAPACKE_dgeqrf LAPACKE_WORKS)
+    mark_as_advanced(LAPACKE_WORKS)
+    set(CMAKE_REQUIRED_LIBRARIES)
+
+    if(LAPACKE_WORKS)
+      if(NOT LAPACKE_FIND_QUIETLY)
+        message(STATUS "Looking for lapacke: test with lapack succeeds")
+      endif()
+      # test succeeds: LAPACKE is in LAPACK
+      set(LAPACKE_LIBRARIES "${LAPACK_LIBRARIES}")
+      set(LAPACKE_LIBRARIES_DEP "${LAPACK_LIBRARIES}")
+      if (LAPACK_LIBRARY_DIRS)
+        set(LAPACKE_LIBRARY_DIRS "${LAPACK_LIBRARY_DIRS}")
+      endif()
+      if(LAPACK_INCLUDE_DIRS)
+        set(LAPACKE_INCLUDE_DIRS "${LAPACK_INCLUDE_DIRS}")
+        set(LAPACKE_INCLUDE_DIRS_DEP "${LAPACK_INCLUDE_DIRS}")
+      endif()
+      if (LAPACK_LINKER_FLAGS)
+        set(LAPACKE_LINKER_FLAGS "${LAPACK_LINKER_FLAGS}")
+      endif()
+    endif()
+  endif (NOT LAPACKE_STANDALONE)
+
+  if (LAPACKE_STANDALONE OR NOT LAPACKE_WORKS)
+
+    if(NOT LAPACKE_WORKS AND NOT LAPACKE_FIND_QUIETLY)
+      message(STATUS "Looking for lapacke : test with lapack fails")
+    endif()
+    # test fails: try to find LAPACKE lib exterior to LAPACK
+
+    # Try to find LAPACKE lib
+    #######################
+
+    # Looking for include
+    # -------------------
+
+    # Add system include paths to search include
+    # ------------------------------------------
+    unset(_inc_env)
+    set(ENV_LAPACKE_DIR "$ENV{LAPACKE_DIR}")
+    set(ENV_LAPACKE_INCDIR "$ENV{LAPACKE_INCDIR}")
+    if(ENV_LAPACKE_INCDIR)
+      list(APPEND _inc_env "${ENV_LAPACKE_INCDIR}")
+    elseif(ENV_LAPACKE_DIR)
+      list(APPEND _inc_env "${ENV_LAPACKE_DIR}")
+      list(APPEND _inc_env "${ENV_LAPACKE_DIR}/include")
+      list(APPEND _inc_env "${ENV_LAPACKE_DIR}/include/lapacke")
+    else()
+      if(WIN32)
+        string(REPLACE ":" ";" _inc_env "$ENV{INCLUDE}")
+      else()
+        string(REPLACE ":" ";" _path_env "$ENV{INCLUDE}")
+        list(APPEND _inc_env "${_path_env}")
+        string(REPLACE ":" ";" _path_env "$ENV{C_INCLUDE_PATH}")
+        list(APPEND _inc_env "${_path_env}")
+        string(REPLACE ":" ";" _path_env "$ENV{CPATH}")
+        list(APPEND _inc_env "${_path_env}")
+        string(REPLACE ":" ";" _path_env "$ENV{INCLUDE_PATH}")
+        list(APPEND _inc_env "${_path_env}")
+      endif()
+    endif()
+    list(APPEND _inc_env "${CMAKE_PLATFORM_IMPLICIT_INCLUDE_DIRECTORIES}")
+    list(APPEND _inc_env "${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES}")
+    list(REMOVE_DUPLICATES _inc_env)
+
+
+    # Try to find the lapacke header in the given paths
+    # -------------------------------------------------
+    # call cmake macro to find the header path
+    if(LAPACKE_INCDIR)
+      set(LAPACKE_lapacke.h_DIRS "LAPACKE_lapacke.h_DIRS-NOTFOUND")
+      find_path(LAPACKE_lapacke.h_DIRS
+        NAMES lapacke.h
+        HINTS ${LAPACKE_INCDIR})
+    else()
+      if(LAPACKE_DIR)
+        set(LAPACKE_lapacke.h_DIRS "LAPACKE_lapacke.h_DIRS-NOTFOUND")
+        find_path(LAPACKE_lapacke.h_DIRS
+          NAMES lapacke.h
+          HINTS ${LAPACKE_DIR}
+          PATH_SUFFIXES "include" "include/lapacke")
+      else()
+        set(LAPACKE_lapacke.h_DIRS "LAPACKE_lapacke.h_DIRS-NOTFOUND")
+        find_path(LAPACKE_lapacke.h_DIRS
+          NAMES lapacke.h
+          HINTS ${_inc_env})
+      endif()
+    endif()
+    mark_as_advanced(LAPACKE_lapacke.h_DIRS)
+
+    # If found, add path to cmake variable
+    # ------------------------------------
+    if (LAPACKE_lapacke.h_DIRS)
+      set(LAPACKE_INCLUDE_DIRS "${LAPACKE_lapacke.h_DIRS}")
+    else ()
+      set(LAPACKE_INCLUDE_DIRS "LAPACKE_INCLUDE_DIRS-NOTFOUND")
+      if(NOT LAPACKE_FIND_QUIETLY)
+        message(STATUS "Looking for lapacke -- lapacke.h not found")
+      endif()
+    endif()
+
+
+    # Looking for lib
+    # ---------------
+
+    # Add system library paths to search lib
+    # --------------------------------------
+    unset(_lib_env)
+    set(ENV_LAPACKE_LIBDIR "$ENV{LAPACKE_LIBDIR}")
+    if(ENV_LAPACKE_LIBDIR)
+      list(APPEND _lib_env "${ENV_LAPACKE_LIBDIR}")
+    elseif(ENV_LAPACKE_DIR)
+      list(APPEND _lib_env "${ENV_LAPACKE_DIR}")
+      list(APPEND _lib_env "${ENV_LAPACKE_DIR}/lib")
+    else()
+      if(WIN32)
+        string(REPLACE ":" ";" _lib_env "$ENV{LIB}")
+      else()
+        if(APPLE)
+          string(REPLACE ":" ";" _lib_env "$ENV{DYLD_LIBRARY_PATH}")
+        else()
+          string(REPLACE ":" ";" _lib_env "$ENV{LD_LIBRARY_PATH}")
+        endif()
+        list(APPEND _lib_env "${CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES}")
+        list(APPEND _lib_env "${CMAKE_C_IMPLICIT_LINK_DIRECTORIES}")
+      endif()
+    endif()
+    list(REMOVE_DUPLICATES _lib_env)
+
+    # Try to find the lapacke lib in the given paths
+    # ----------------------------------------------
+
+    # call cmake macro to find the lib path
+    if(LAPACKE_LIBDIR)
+      set(LAPACKE_lapacke_LIBRARY "LAPACKE_lapacke_LIBRARY-NOTFOUND")
+      find_library(LAPACKE_lapacke_LIBRARY
+        NAMES lapacke
+        HINTS ${LAPACKE_LIBDIR})
+    else()
+      if(LAPACKE_DIR)
+        set(LAPACKE_lapacke_LIBRARY "LAPACKE_lapacke_LIBRARY-NOTFOUND")
+        find_library(LAPACKE_lapacke_LIBRARY
+          NAMES lapacke
+          HINTS ${LAPACKE_DIR}
+          PATH_SUFFIXES lib lib32 lib64)
+      else()
+        set(LAPACKE_lapacke_LIBRARY "LAPACKE_lapacke_LIBRARY-NOTFOUND")
+        find_library(LAPACKE_lapacke_LIBRARY
+          NAMES lapacke
+          HINTS ${_lib_env})
+      endif()
+    endif()
+    mark_as_advanced(LAPACKE_lapacke_LIBRARY)
+
+    # If found, add path to cmake variable
+    # ------------------------------------
+    if (LAPACKE_lapacke_LIBRARY)
+      get_filename_component(lapacke_lib_path "${LAPACKE_lapacke_LIBRARY}" PATH)
+      # set cmake variables
+      set(LAPACKE_LIBRARIES    "${LAPACKE_lapacke_LIBRARY}")
+      set(LAPACKE_LIBRARY_DIRS "${lapacke_lib_path}")
+    else ()
+      set(LAPACKE_LIBRARIES    "LAPACKE_LIBRARIES-NOTFOUND")
+      set(LAPACKE_LIBRARY_DIRS "LAPACKE_LIBRARY_DIRS-NOTFOUND")
+      if (NOT LAPACKE_FIND_QUIETLY)
+        message(STATUS "Looking for lapacke -- lib lapacke not found")
+      endif()
+    endif ()
+
+    # check a function to validate the find
+    if(LAPACKE_LIBRARIES)
+
+      set(REQUIRED_LDFLAGS)
+      set(REQUIRED_INCDIRS)
+      set(REQUIRED_LIBDIRS)
+      set(REQUIRED_LIBS)
+
+      # LAPACKE
+      if (LAPACKE_INCLUDE_DIRS)
+        set(REQUIRED_INCDIRS "${LAPACKE_INCLUDE_DIRS}")
+      endif()
+      if (LAPACKE_LIBRARY_DIRS)
+        set(REQUIRED_LIBDIRS "${LAPACKE_LIBRARY_DIRS}")
+      endif()
+      set(REQUIRED_LIBS "${LAPACKE_LIBRARIES}")
+      # LAPACK
+      if (LAPACK_INCLUDE_DIRS)
+        list(APPEND REQUIRED_INCDIRS "${LAPACK_INCLUDE_DIRS}")
+      endif()
+      if (LAPACK_LIBRARY_DIRS)
+        list(APPEND REQUIRED_LIBDIRS "${LAPACK_LIBRARY_DIRS}")
+      endif()
+      list(APPEND REQUIRED_LIBS "${LAPACK_LIBRARIES}")
+      if (LAPACK_LINKER_FLAGS)
+        list(APPEND REQUIRED_LDFLAGS "${LAPACK_LINKER_FLAGS}")
+      endif()
+      # Fortran
+      if (CMAKE_C_COMPILER_ID MATCHES "GNU")
+        find_library(
+          FORTRAN_gfortran_LIBRARY
+          NAMES gfortran
+          HINTS ${_lib_env}
+          )
+        mark_as_advanced(FORTRAN_gfortran_LIBRARY)
+        if (FORTRAN_gfortran_LIBRARY)
+          list(APPEND REQUIRED_LIBS "${FORTRAN_gfortran_LIBRARY}")
+        endif()
+      elseif (CMAKE_C_COMPILER_ID MATCHES "Intel")
+        find_library(
+          FORTRAN_ifcore_LIBRARY
+          NAMES ifcore
+          HINTS ${_lib_env}
+          )
+        mark_as_advanced(FORTRAN_ifcore_LIBRARY)
+        if (FORTRAN_ifcore_LIBRARY)
+          list(APPEND REQUIRED_LIBS "${FORTRAN_ifcore_LIBRARY}")
+        endif()
+      endif()
+      # m
+      find_library(M_LIBRARY NAMES m HINTS ${_lib_env})
+      mark_as_advanced(M_LIBRARY)
+      if(M_LIBRARY)
+        list(APPEND REQUIRED_LIBS "-lm")
+      endif()
+      # set required libraries for link
+      set(CMAKE_REQUIRED_INCLUDES "${REQUIRED_INCDIRS}")
+      set(CMAKE_REQUIRED_LIBRARIES)
+      list(APPEND CMAKE_REQUIRED_LIBRARIES "${REQUIRED_LDFLAGS}")
+      foreach(lib_dir ${REQUIRED_LIBDIRS})
+        list(APPEND CMAKE_REQUIRED_LIBRARIES "-L${lib_dir}")
+      endforeach()
+      list(APPEND CMAKE_REQUIRED_LIBRARIES "${REQUIRED_LIBS}")
+      string(REGEX REPLACE "^ -" "-" CMAKE_REQUIRED_LIBRARIES "${CMAKE_REQUIRED_LIBRARIES}")
+
+      # test link
+      unset(LAPACKE_WORKS CACHE)
+      include(CheckFunctionExists)
+      check_function_exists(LAPACKE_dgeqrf LAPACKE_WORKS)
+      mark_as_advanced(LAPACKE_WORKS)
+
+      if(LAPACKE_WORKS)
+        # save link with dependencies
+        set(LAPACKE_LIBRARIES_DEP "${REQUIRED_LIBS}")
+        set(LAPACKE_LIBRARY_DIRS_DEP "${REQUIRED_LIBDIRS}")
+        set(LAPACKE_INCLUDE_DIRS_DEP "${REQUIRED_INCDIRS}")
+        set(LAPACKE_LINKER_FLAGS "${REQUIRED_LDFLAGS}")
+        list(REMOVE_DUPLICATES LAPACKE_LIBRARY_DIRS_DEP)
+        list(REMOVE_DUPLICATES LAPACKE_INCLUDE_DIRS_DEP)
+        list(REMOVE_DUPLICATES LAPACKE_LINKER_FLAGS)
+      else()
+        if(NOT LAPACKE_FIND_QUIETLY)
+          message(STATUS "Looking for lapacke: test of LAPACKE_dgeqrf with lapacke and lapack libraries fails")
+          message(STATUS "CMAKE_REQUIRED_LIBRARIES: ${CMAKE_REQUIRED_LIBRARIES}")
+          message(STATUS "CMAKE_REQUIRED_INCLUDES: ${CMAKE_REQUIRED_INCLUDES}")
+          message(STATUS "Check in CMakeFiles/CMakeError.log to figure out why it fails")
+        endif()
+      endif()
+      set(CMAKE_REQUIRED_INCLUDES)
+      set(CMAKE_REQUIRED_FLAGS)
+      set(CMAKE_REQUIRED_LIBRARIES)
+    endif(LAPACKE_LIBRARIES)
+
+  endif (LAPACKE_STANDALONE OR NOT LAPACKE_WORKS)
+
+else(LAPACK_FOUND)
+
+  if (NOT LAPACKE_FIND_QUIETLY)
+    message(STATUS "LAPACKE requires LAPACK but LAPACK has not been found."
+      "Please look for LAPACK first.")
+  endif()
+
+endif(LAPACK_FOUND)
+
+if (LAPACKE_LIBRARIES)
+  list(GET LAPACKE_LIBRARIES 0 first_lib)
+  get_filename_component(first_lib_path "${first_lib}" PATH)
+  if (${first_lib_path} MATCHES "(/lib(32|64)?$)|(/lib/intel64$|/lib/ia32$)")
+    string(REGEX REPLACE "(/lib(32|64)?$)|(/lib/intel64$|/lib/ia32$)" "" not_cached_dir "${first_lib_path}")
+    set(LAPACKE_DIR_FOUND "${not_cached_dir}" CACHE PATH "Installation directory of LAPACKE library" FORCE)
+  else()
+    set(LAPACKE_DIR_FOUND "${first_lib_path}" CACHE PATH "Installation directory of LAPACKE library" FORCE)
+  endif()
+endif()
+mark_as_advanced(LAPACKE_DIR)
+mark_as_advanced(LAPACKE_DIR_FOUND)
+
+# check that LAPACKE has been found
+# ---------------------------------
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(LAPACKE DEFAULT_MSG
+  LAPACKE_LIBRARIES
+  LAPACKE_WORKS)

--- a/cmake/FindLAPACKE.cmake
+++ b/cmake/FindLAPACKE.cmake
@@ -1,380 +1,191 @@
-###
+# FindLAPACKE
+# -------------
 #
-# @copyright (c) 2009-2014 The University of Tennessee and The University
-#                          of Tennessee Research Foundation.
-#                          All rights reserved.
-# @copyright (c) 2012-2016 Inria. All rights reserved.
-# @copyright (c) 2012-2014 Bordeaux INP, CNRS (LaBRI UMR 5800), Inria, Univ. Bordeaux. All rights reserved.
+# Find the LAPACKE library
 #
-###
+# Using LAPACKE:
 #
-# - Find LAPACKE include dirs and libraries
-# Use this module by invoking find_package with the form:
-#  find_package(LAPACKE
-#               [REQUIRED] # Fail with error if lapacke is not found
-#               [COMPONENTS <comp1> <comp2> ...] # dependencies
-#              )
+# ::
 #
-#  LAPACKE depends on the following libraries:
-#   - LAPACK
+#   find_package(LAPACKE REQUIRED)
+#   include_directories(${LAPACKE_INCLUDE_DIRS})
+#   add_executable(foo foo.cc)
+#   target_link_libraries(foo ${LAPACKE_LIBRARIES})
 #
-# This module finds headers and lapacke library.
-# Results are reported in variables:
-#  LAPACKE_FOUND            - True if headers and requested libraries were found
-#  LAPACKE_LINKER_FLAGS     - list of required linker flags (excluding -l and -L)
-#  LAPACKE_INCLUDE_DIRS     - lapacke include directories
-#  LAPACKE_LIBRARY_DIRS     - Link directories for lapacke libraries
-#  LAPACKE_LIBRARIES        - lapacke component libraries to be linked
-#  LAPACKE_INCLUDE_DIRS_DEP - lapacke + dependencies include directories
-#  LAPACKE_LIBRARY_DIRS_DEP - lapacke + dependencies link directories
-#  LAPACKE_LIBRARIES_DEP    - lapacke libraries + dependencies
+# This module sets the following variables:
 #
-# The user can give specific paths where to find the libraries adding cmake
-# options at configure (ex: cmake path/to/project -DLAPACKE_DIR=path/to/lapacke):
-#  LAPACKE_DIR             - Where to find the base directory of lapacke
-#  LAPACKE_INCDIR          - Where to find the header files
-#  LAPACKE_LIBDIR          - Where to find the library files
-# The module can also look for the following environment variables if paths
-# are not given as cmake variable: LAPACKE_DIR, LAPACKE_INCDIR, LAPACKE_LIBDIR
+# ::
 #
-# LAPACKE could be directly embedded in LAPACK library (ex: Intel MKL) so that
-# we test a lapacke function with the lapack libraries found and set LAPACKE
-# variables to LAPACK ones if test is successful. To skip this feature and
-# look for a stand alone lapacke, please add the following in your
-# CMakeLists.txt before to call find_package(LAPACKE):
-# set(LAPACKE_STANDALONE TRUE)
+#   LAPACKE_FOUND - set to true if the library is found
+#   LAPACKE_INCLUDE_DIRS - list of required include directories
+#   LAPACKE_LIBRARIES - list of libraries to be linked
+#   LAPACKE_VERSION_MAJOR - major version number
+#   LAPACKE_VERSION_MINOR - minor version number
+#   LAPACKE_VERSION_PATCH - patch version number
+#   LAPACKE_VERSION_STRING - version number as a string (ex: "0.2.18")
 
 #=============================================================================
-# Copyright 2012-2013 Inria
-# Copyright 2012-2013 Emmanuel Agullo
-# Copyright 2012-2013 Mathieu Faverge
-# Copyright 2012      Cedric Castagnede
-# Copyright 2013-2016 Florent Pruvost
+# Copyright 2016 Hans J. Johnson <hans-johnson@uiowa.edu>
 #
-# Distributed under the OSI-approved BSD License (the "License");
-# see accompanying file MORSE-Copyright.txt for details.
+# Distributed under the OSI-approved BSD License (the "License")
 #
 # This software is distributed WITHOUT ANY WARRANTY; without even the
 # implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-# See the License for more information.
 #=============================================================================
-# (To distribute this file outside of Morse, substitute the full
-#  License text for the above reference.)
+#
+set(LAPACKE_SEARCH_PATHS
+  ${LAPACKE_DIR}
+  $ENV{LAPACKE_DIR}
+  $ENV{CMAKE_PREFIX_PATH}
+  ${CMAKE_PREFIX_PATH}
+  /usr
+  /usr/openblas
+  /usr/local
+  /usr/local/opt/lapack  ## Mac Homebrew install path
+  /opt/local
+  /opt/LAPACKE
+)
+message(STATUS "LAPACKE_SEARCH_PATHS: ${LAPACKE_SEARCH_PATHS}")
 
-if (NOT LAPACKE_FOUND)
-  set(LAPACKE_DIR "" CACHE PATH "Installation directory of LAPACKE library")
-  if (NOT LAPACKE_FIND_QUIETLY)
-    message(STATUS "A cache variable, namely LAPACKE_DIR, has been set to specify the install directory of LAPACKE")
+set(CMAKE_PREFIX_PATH ${LAPACKE_SEARCH_PATHS})
+list(REMOVE_DUPLICATES CMAKE_PREFIX_PATH)
+
+## First try to find LAPACKE with NO_MODULE,
+## As of 20160706 version 0.2.18 there is limited cmake support for LAPACKE
+## that is not as complete as this version, if found, use it
+## to identify the LAPACKE_VERSION_STRING and improve searching.
+find_package(LAPACKE NO_MODULE QUIET)
+if(LAPACKE_FOUND)
+  if(EXISTS ${LAPACKE_DIR}/lapacke-config-version.cmake)
+    include(${LAPACKE_DIR}/lapacke-config-version.cmake)
+    set(LAPACKE_VERSION_STRING ${PACKAGE_VERSION})
+    unset(PACKAGE_VERSION) # Use cmake conventional naming
   endif()
+  find_package(LAPACK NO_MODULE QUIET) #Require matching versions here!
+  find_package(BLAS NO_MODULE QUIET)   #Require matching versions here!
 endif()
 
-# LAPACKE depends on LAPACK anyway, try to find it
-if (NOT LAPACK_FOUND)
-  if(LAPACKE_FIND_REQUIRED)
-    find_package(LAPACKEXT REQUIRED)
-  else()
-    find_package(LAPACKEXT)
-  endif()
+##################################################################################################
+### First search for headers
+MESSAGE(" MESSAGES " ${LAPACKE_SEARCH_PATHS})
+find_path(LAPACKE_CBLAS_INCLUDE_DIR 
+             NAMES cblas.h 
+             PATHS ${LAPACKE_SEARCH_PATHS} 
+             PATH_SUFFIXES include include/lapack include/openblas include/lapacke)
+find_path(LAPACKE_LAPACKE_INCLUDE_DIR 
+             NAMES lapacke.h 
+             PATHS ${LAPACKE_SEARCH_PATHS} 
+             PATH_SUFFIXES include include/lapack include/lapacke include/openblas)
+
+##################################################################################################
+### Second, search for libraries
+set(PATH_SUFFIXES_LIST
+  lib64
+  lib
+  lib/lapack
+)
+find_library(LAPACKE_LIB 
+                 NAMES lapacke
+                 PATHS ${LAPACKE_SEARCH_PATHS}
+                 PATH_SUFFIXES ${PATH_SUFFIXES_LIST})
+find_library(CBLAS_LIB 
+                 NAMES cblas
+                 PATHS ${LAPACKE_SEARCH_PATHS}
+                 PATH_SUFFIXES ${PATH_SUFFIXES_LIST})
+find_library(LAPACK_LIB 
+                 NAMES lapack
+                 PATHS ${LAPACKE_SEARCH_PATHS}
+                 PATH_SUFFIXES ${PATH_SUFFIXES_LIST})
+find_library(BLAS_LIB 
+                 NAMES blas
+                 PATHS ${LAPACKE_SEARCH_PATHS}
+                 PATH_SUFFIXES ${PATH_SUFFIXES_LIST})
+
+## TODO: Get version components
+# ------------------------------------------------------------------------
+#  Extract version information
+# ------------------------------------------------------------------------
+
+# WARNING: We may not be able to determine the version of some LAPACKE
+set(LAPACKE_VERSION_MAJOR 0)
+set(LAPACKE_VERSION_MINOR 0)
+set(LAPACKE_VERSION_PATCH 0)
+if(LAPACKE_VERSION_STRING)
+  string(REGEX REPLACE "([0-9]+).([0-9]+).([0-9]+)" "\\1" LAPACKE_VERSION_MAJOR "${LAPACKE_VERSION_STRING}")
+  string(REGEX REPLACE "([0-9]+).([0-9]+).([0-9]+)" "\\2" LAPACKE_VERSION_MINOR "${LAPACKE_VERSION_STRING}")
+  string(REGEX REPLACE "([0-9]+).([0-9]+).([0-9]+)" "\\3" LAPACKE_VERSION_PATCH "${LAPACKE_VERSION_STRING}")
 endif()
 
-# LAPACKE depends on LAPACK
-if (LAPACK_FOUND)
-
-  if (NOT LAPACKE_STANDALONE)
-    # check if a lapacke function exists in the LAPACK lib
-    include(CheckFunctionExists)
-    set(CMAKE_REQUIRED_LIBRARIES "${LAPACK_LINKER_FLAGS};${LAPACK_LIBRARIES}")
-    unset(LAPACKE_WORKS CACHE)
-    check_function_exists(LAPACKE_dgeqrf LAPACKE_WORKS)
-    mark_as_advanced(LAPACKE_WORKS)
-    set(CMAKE_REQUIRED_LIBRARIES)
-
-    if(LAPACKE_WORKS)
-      if(NOT LAPACKE_FIND_QUIETLY)
-        message(STATUS "Looking for lapacke: test with lapack succeeds")
-      endif()
-      # test succeeds: LAPACKE is in LAPACK
-      set(LAPACKE_LIBRARIES "${LAPACK_LIBRARIES}")
-      set(LAPACKE_LIBRARIES_DEP "${LAPACK_LIBRARIES}")
-      if (LAPACK_LIBRARY_DIRS)
-        set(LAPACKE_LIBRARY_DIRS "${LAPACK_LIBRARY_DIRS}")
-      endif()
-      if(LAPACK_INCLUDE_DIRS)
-        set(LAPACKE_INCLUDE_DIRS "${LAPACK_INCLUDE_DIRS}")
-        set(LAPACKE_INCLUDE_DIRS_DEP "${LAPACK_INCLUDE_DIRS}")
-      endif()
-      if (LAPACK_LINKER_FLAGS)
-        set(LAPACKE_LINKER_FLAGS "${LAPACK_LINKER_FLAGS}")
-      endif()
-    endif()
-  endif (NOT LAPACKE_STANDALONE)
-
-  if (LAPACKE_STANDALONE OR NOT LAPACKE_WORKS)
-
-    if(NOT LAPACKE_WORKS AND NOT LAPACKE_FIND_QUIETLY)
-      message(STATUS "Looking for lapacke : test with lapack fails")
-    endif()
-    # test fails: try to find LAPACKE lib exterior to LAPACK
-
-    # Try to find LAPACKE lib
-    #######################
-
-    # Looking for include
-    # -------------------
-
-    # Add system include paths to search include
-    # ------------------------------------------
-    unset(_inc_env)
-    set(ENV_LAPACKE_DIR "$ENV{LAPACKE_DIR}")
-    set(ENV_LAPACKE_INCDIR "$ENV{LAPACKE_INCDIR}")
-    if(ENV_LAPACKE_INCDIR)
-      list(APPEND _inc_env "${ENV_LAPACKE_INCDIR}")
-    elseif(ENV_LAPACKE_DIR)
-      list(APPEND _inc_env "${ENV_LAPACKE_DIR}")
-      list(APPEND _inc_env "${ENV_LAPACKE_DIR}/include")
-      list(APPEND _inc_env "${ENV_LAPACKE_DIR}/include/lapacke")
-    else()
-      if(WIN32)
-        string(REPLACE ":" ";" _inc_env "$ENV{INCLUDE}")
-      else()
-        string(REPLACE ":" ";" _path_env "$ENV{INCLUDE}")
-        list(APPEND _inc_env "${_path_env}")
-        string(REPLACE ":" ";" _path_env "$ENV{C_INCLUDE_PATH}")
-        list(APPEND _inc_env "${_path_env}")
-        string(REPLACE ":" ";" _path_env "$ENV{CPATH}")
-        list(APPEND _inc_env "${_path_env}")
-        string(REPLACE ":" ";" _path_env "$ENV{INCLUDE_PATH}")
-        list(APPEND _inc_env "${_path_env}")
-      endif()
-    endif()
-    list(APPEND _inc_env "${CMAKE_PLATFORM_IMPLICIT_INCLUDE_DIRECTORIES}")
-    list(APPEND _inc_env "${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES}")
-    list(REMOVE_DUPLICATES _inc_env)
-
-
-    # Try to find the lapacke header in the given paths
-    # -------------------------------------------------
-    # call cmake macro to find the header path
-    if(LAPACKE_INCDIR)
-      set(LAPACKE_lapacke.h_DIRS "LAPACKE_lapacke.h_DIRS-NOTFOUND")
-      find_path(LAPACKE_lapacke.h_DIRS
-        NAMES lapacke.h
-        HINTS ${LAPACKE_INCDIR})
-    else()
-      if(LAPACKE_DIR)
-        set(LAPACKE_lapacke.h_DIRS "LAPACKE_lapacke.h_DIRS-NOTFOUND")
-        find_path(LAPACKE_lapacke.h_DIRS
-          NAMES lapacke.h
-          HINTS ${LAPACKE_DIR}
-          PATH_SUFFIXES "include" "include/lapacke")
-      else()
-        set(LAPACKE_lapacke.h_DIRS "LAPACKE_lapacke.h_DIRS-NOTFOUND")
-        find_path(LAPACKE_lapacke.h_DIRS
-          NAMES lapacke.h
-          HINTS ${_inc_env})
-      endif()
-    endif()
-    mark_as_advanced(LAPACKE_lapacke.h_DIRS)
-
-    # If found, add path to cmake variable
-    # ------------------------------------
-    if (LAPACKE_lapacke.h_DIRS)
-      set(LAPACKE_INCLUDE_DIRS "${LAPACKE_lapacke.h_DIRS}")
-    else ()
-      set(LAPACKE_INCLUDE_DIRS "LAPACKE_INCLUDE_DIRS-NOTFOUND")
-      if(NOT LAPACKE_FIND_QUIETLY)
-        message(STATUS "Looking for lapacke -- lapacke.h not found")
-      endif()
-    endif()
-
-
-    # Looking for lib
-    # ---------------
-
-    # Add system library paths to search lib
-    # --------------------------------------
-    unset(_lib_env)
-    set(ENV_LAPACKE_LIBDIR "$ENV{LAPACKE_LIBDIR}")
-    if(ENV_LAPACKE_LIBDIR)
-      list(APPEND _lib_env "${ENV_LAPACKE_LIBDIR}")
-    elseif(ENV_LAPACKE_DIR)
-      list(APPEND _lib_env "${ENV_LAPACKE_DIR}")
-      list(APPEND _lib_env "${ENV_LAPACKE_DIR}/lib")
-    else()
-      if(WIN32)
-        string(REPLACE ":" ";" _lib_env "$ENV{LIB}")
-      else()
-        if(APPLE)
-          string(REPLACE ":" ";" _lib_env "$ENV{DYLD_LIBRARY_PATH}")
-        else()
-          string(REPLACE ":" ";" _lib_env "$ENV{LD_LIBRARY_PATH}")
-        endif()
-        list(APPEND _lib_env "${CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES}")
-        list(APPEND _lib_env "${CMAKE_C_IMPLICIT_LINK_DIRECTORIES}")
-      endif()
-    endif()
-    list(REMOVE_DUPLICATES _lib_env)
-
-    # Try to find the lapacke lib in the given paths
-    # ----------------------------------------------
-
-    # call cmake macro to find the lib path
-    if(LAPACKE_LIBDIR)
-      set(LAPACKE_lapacke_LIBRARY "LAPACKE_lapacke_LIBRARY-NOTFOUND")
-      find_library(LAPACKE_lapacke_LIBRARY
-        NAMES lapacke
-        HINTS ${LAPACKE_LIBDIR})
-    else()
-      if(LAPACKE_DIR)
-        set(LAPACKE_lapacke_LIBRARY "LAPACKE_lapacke_LIBRARY-NOTFOUND")
-        find_library(LAPACKE_lapacke_LIBRARY
-          NAMES lapacke
-          HINTS ${LAPACKE_DIR}
-          PATH_SUFFIXES lib lib32 lib64)
-      else()
-        set(LAPACKE_lapacke_LIBRARY "LAPACKE_lapacke_LIBRARY-NOTFOUND")
-        find_library(LAPACKE_lapacke_LIBRARY
-          NAMES lapacke
-          HINTS ${_lib_env})
-      endif()
-    endif()
-    mark_as_advanced(LAPACKE_lapacke_LIBRARY)
-
-    # If found, add path to cmake variable
-    # ------------------------------------
-    if (LAPACKE_lapacke_LIBRARY)
-      get_filename_component(lapacke_lib_path "${LAPACKE_lapacke_LIBRARY}" PATH)
-      # set cmake variables
-      set(LAPACKE_LIBRARIES    "${LAPACKE_lapacke_LIBRARY}")
-      set(LAPACKE_LIBRARY_DIRS "${lapacke_lib_path}")
-    else ()
-      set(LAPACKE_LIBRARIES    "LAPACKE_LIBRARIES-NOTFOUND")
-      set(LAPACKE_LIBRARY_DIRS "LAPACKE_LIBRARY_DIRS-NOTFOUND")
-      if (NOT LAPACKE_FIND_QUIETLY)
-        message(STATUS "Looking for lapacke -- lib lapacke not found")
-      endif()
-    endif ()
-
-    # check a function to validate the find
-    if(LAPACKE_LIBRARIES)
-
-      set(REQUIRED_LDFLAGS)
-      set(REQUIRED_INCDIRS)
-      set(REQUIRED_LIBDIRS)
-      set(REQUIRED_LIBS)
-
-      # LAPACKE
-      if (LAPACKE_INCLUDE_DIRS)
-        set(REQUIRED_INCDIRS "${LAPACKE_INCLUDE_DIRS}")
-      endif()
-      if (LAPACKE_LIBRARY_DIRS)
-        set(REQUIRED_LIBDIRS "${LAPACKE_LIBRARY_DIRS}")
-      endif()
-      set(REQUIRED_LIBS "${LAPACKE_LIBRARIES}")
-      # LAPACK
-      if (LAPACK_INCLUDE_DIRS)
-        list(APPEND REQUIRED_INCDIRS "${LAPACK_INCLUDE_DIRS}")
-      endif()
-      if (LAPACK_LIBRARY_DIRS)
-        list(APPEND REQUIRED_LIBDIRS "${LAPACK_LIBRARY_DIRS}")
-      endif()
-      list(APPEND REQUIRED_LIBS "${LAPACK_LIBRARIES}")
-      if (LAPACK_LINKER_FLAGS)
-        list(APPEND REQUIRED_LDFLAGS "${LAPACK_LINKER_FLAGS}")
-      endif()
-      # Fortran
-      if (CMAKE_C_COMPILER_ID MATCHES "GNU")
-        find_library(
-          FORTRAN_gfortran_LIBRARY
-          NAMES gfortran
-          HINTS ${_lib_env}
-          )
-        mark_as_advanced(FORTRAN_gfortran_LIBRARY)
-        if (FORTRAN_gfortran_LIBRARY)
-          list(APPEND REQUIRED_LIBS "${FORTRAN_gfortran_LIBRARY}")
-        endif()
-      elseif (CMAKE_C_COMPILER_ID MATCHES "Intel")
-        find_library(
-          FORTRAN_ifcore_LIBRARY
-          NAMES ifcore
-          HINTS ${_lib_env}
-          )
-        mark_as_advanced(FORTRAN_ifcore_LIBRARY)
-        if (FORTRAN_ifcore_LIBRARY)
-          list(APPEND REQUIRED_LIBS "${FORTRAN_ifcore_LIBRARY}")
-        endif()
-      endif()
-      # m
-      find_library(M_LIBRARY NAMES m HINTS ${_lib_env})
-      mark_as_advanced(M_LIBRARY)
-      if(M_LIBRARY)
-        list(APPEND REQUIRED_LIBS "-lm")
-      endif()
-      # set required libraries for link
-      set(CMAKE_REQUIRED_INCLUDES "${REQUIRED_INCDIRS}")
-      set(CMAKE_REQUIRED_LIBRARIES)
-      list(APPEND CMAKE_REQUIRED_LIBRARIES "${REQUIRED_LDFLAGS}")
-      foreach(lib_dir ${REQUIRED_LIBDIRS})
-        list(APPEND CMAKE_REQUIRED_LIBRARIES "-L${lib_dir}")
-      endforeach()
-      list(APPEND CMAKE_REQUIRED_LIBRARIES "${REQUIRED_LIBS}")
-      string(REGEX REPLACE "^ -" "-" CMAKE_REQUIRED_LIBRARIES "${CMAKE_REQUIRED_LIBRARIES}")
-
-      # test link
-      unset(LAPACKE_WORKS CACHE)
-      include(CheckFunctionExists)
-      check_function_exists(LAPACKE_dgeqrf LAPACKE_WORKS)
-      mark_as_advanced(LAPACKE_WORKS)
-
-      if(LAPACKE_WORKS)
-        # save link with dependencies
-        set(LAPACKE_LIBRARIES_DEP "${REQUIRED_LIBS}")
-        set(LAPACKE_LIBRARY_DIRS_DEP "${REQUIRED_LIBDIRS}")
-        set(LAPACKE_INCLUDE_DIRS_DEP "${REQUIRED_INCDIRS}")
-        set(LAPACKE_LINKER_FLAGS "${REQUIRED_LDFLAGS}")
-        list(REMOVE_DUPLICATES LAPACKE_LIBRARY_DIRS_DEP)
-        list(REMOVE_DUPLICATES LAPACKE_INCLUDE_DIRS_DEP)
-        list(REMOVE_DUPLICATES LAPACKE_LINKER_FLAGS)
-      else()
-        if(NOT LAPACKE_FIND_QUIETLY)
-          message(STATUS "Looking for lapacke: test of LAPACKE_dgeqrf with lapacke and lapack libraries fails")
-          message(STATUS "CMAKE_REQUIRED_LIBRARIES: ${CMAKE_REQUIRED_LIBRARIES}")
-          message(STATUS "CMAKE_REQUIRED_INCLUDES: ${CMAKE_REQUIRED_INCLUDES}")
-          message(STATUS "Check in CMakeFiles/CMakeError.log to figure out why it fails")
-        endif()
-      endif()
-      set(CMAKE_REQUIRED_INCLUDES)
-      set(CMAKE_REQUIRED_FLAGS)
-      set(CMAKE_REQUIRED_LIBRARIES)
-    endif(LAPACKE_LIBRARIES)
-
-  endif (LAPACKE_STANDALONE OR NOT LAPACKE_WORKS)
-
-else(LAPACK_FOUND)
-
-  if (NOT LAPACKE_FIND_QUIETLY)
-    message(STATUS "LAPACKE requires LAPACK but LAPACK has not been found."
-      "Please look for LAPACK first.")
-  endif()
-
-endif(LAPACK_FOUND)
-
-if (LAPACKE_LIBRARIES)
-  list(GET LAPACKE_LIBRARIES 0 first_lib)
-  get_filename_component(first_lib_path "${first_lib}" PATH)
-  if (${first_lib_path} MATCHES "(/lib(32|64)?$)|(/lib/intel64$|/lib/ia32$)")
-    string(REGEX REPLACE "(/lib(32|64)?$)|(/lib/intel64$|/lib/ia32$)" "" not_cached_dir "${first_lib_path}")
-    set(LAPACKE_DIR_FOUND "${not_cached_dir}" CACHE PATH "Installation directory of LAPACKE library" FORCE)
-  else()
-    set(LAPACKE_DIR_FOUND "${first_lib_path}" CACHE PATH "Installation directory of LAPACKE library" FORCE)
-  endif()
-endif()
-mark_as_advanced(LAPACKE_DIR)
-mark_as_advanced(LAPACKE_DIR_FOUND)
-
-# check that LAPACKE has been found
-# ---------------------------------
+#======================
+# Checks 'REQUIRED', 'QUIET' and versions.
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(LAPACKE DEFAULT_MSG
+find_package_handle_standard_args(LAPACKE FOUND_VAR LAPACKE_FOUND
+  REQUIRED_VARS LAPACKE_CBLAS_INCLUDE_DIR
+                LAPACKE_LAPACKE_INCLUDE_DIR
+                LAPACKE_LIB
+                LAPACK_LIB
+  VERSION_VAR LAPACKE_VERSION_STRING
+)
+
+if (LAPACKE_FOUND)
+  set(LAPACKE_INCLUDE_DIRS ${LAPACKE_CBLAS_INCLUDE_DIR} ${LAPACKE_CBLAS_INCLUDE_DIR})
+  list(REMOVE_DUPLICATES LAPACKE_INCLUDE_DIRS)
+  if("${CMAKE_C_COMPILER_ID}" MATCHES ".*Clang.*" OR
+     "${CMAKE_C_COMPILER_ID}" MATCHES ".*GNU.*" OR
+     "${CMAKE_C_COMPILER_ID}" MATCHES ".*Intel.*"
+      ) #NOT MSVC
+    set(MATH_LIB m)
+  endif()
+  list(APPEND LAPACKE_LIBRARIES ${LAPACKE_LIB} ${LAPACK_LIB} ${BLAS_LIB} )
+  # Check for a common combination, and find required gfortran support libraries
+
+  if(1)
+    if("${CMAKE_C_COMPILER_ID}" MATCHES ".*Clang.*" AND "${CMAKE_Fortran_COMPILER_ID}" MATCHES "GNU")
+          message(STATUS "\n\n WARNING: ${CMAKE_C_COMPILER} identified as ${CMAKE_C_COMPILER_ID}\n"
+                                   "AND: ${CMAKE_Fortran_COMPILER} identified as ${CMAKE_Fortran_COMPILER_ID}\n"
+                               "\n"
+                               "may be require special configurations.  The most common is the need to"
+                               "explicitly link C programs against the gfortran support library.")
+                              
+    endif()
+  else()
+    ## This code automated code is hard to determine if it is robust in many different environments.
+    # Check for a common combination, and find required gfortran support libraries
+    if("${CMAKE_C_COMPILER_ID}" MATCHES ".*Clang.*" AND "${CMAKE_Fortran_COMPILER_ID}" MATCHES "GNU")
+       include(FortranCInterface)
+       FortranCInterface_VERIFY() 
+       if(NOT FortranCInterface_VERIFIED_C)
+          message(FATAL_ERROR "C and fortran compilers are not compatible:\n${CMAKE_Fortran_COMPILER}:${CMAKE_C_COMPILER}")
+       endif()
+       
+       execute_process(COMMAND ${CMAKE_Fortran_COMPILER} -print-file-name=libgfortran.a OUTPUT_VARIABLE FORTRANSUPPORTLIB ERROR_QUIET)
+       string(STRIP ${FORTRANSUPPORTLIB} FORTRANSUPPORTLIB)
+       if(EXISTS "${FORTRANSUPPORTLIB}")
+         list(APPEND LAPACKE_LIBRARIES ${FORTRANSUPPORTLIB})
+         message(STATUS "Appending fortran support lib: ${FORTRANSUPPORTLIB}")
+       else()
+         message(FATAL_ERROR "COULD NOT FIND libgfortran.a support library:${FORTRANSUPPORTLIB}:")
+       endif()
+    endif()
+  endif()
+  list(APPEND LAPACKE_LIBRARIES ${MATH_LIB})
+endif()
+
+mark_as_advanced(
+  LAPACKE_FOUND
+  LAPACKE_INCLUDE_DIRS
   LAPACKE_LIBRARIES
-  LAPACKE_WORKS)
+  LAPACKE_VERSION_MAJOR
+  LAPACKE_VERSION_MINOR
+  LAPACKE_VERSION_PATCH
+  LAPACKE_VERSION_STRING
+)
+
+## For debugging
+message(STATUS "LAPACKE_FOUND                  :${LAPACKE_FOUND}:  - set to true if the library is found")
+message(STATUS "LAPACKE_INCLUDE_DIRS           :${LAPACKE_INCLUDE_DIRS}: - list of required include directories")
+message(STATUS "LAPACKE_LIBRARIES              :${LAPACKE_LIBRARIES}: - list of libraries to be linked")
+message(STATUS "LAPACKE_VERSION_MAJOR          :${LAPACKE_VERSION_MAJOR}: - major version number")
+message(STATUS "LAPACKE_VERSION_MINOR          :${LAPACKE_VERSION_MINOR}: - minor version number")
+message(STATUS "LAPACKE_VERSION_PATCH          :${LAPACKE_VERSION_PATCH}: - patch version number")
+message(STATUS "LAPACKE_VERSION_STRING         :${LAPACKE_VERSION_STRING}: - version number as a string")

--- a/lib/core/buffer.c
+++ b/lib/core/buffer.c
@@ -870,6 +870,7 @@ uint8_t* buffer_malloc(ssize_t len, int numa_node) {
     }
 #endif
 
+#ifndef WITH_NO_MEMLOCK
     // Ask that all pages be kept in memory
     err = mlock((void*)frame, len);
 
@@ -878,6 +879,9 @@ uint8_t* buffer_malloc(ssize_t len, int numa_node) {
         free(frame);
         return NULL;
     }
+#else
+    (void)err;
+#endif
 #endif
     // Zero the new frame
     memset(frame, 0x0, len);

--- a/lib/core/configUpdater.cpp
+++ b/lib/core/configUpdater.cpp
@@ -97,8 +97,15 @@ void configUpdater::subscribe(const Stage* subscriber, std::function<bool(json&)
 
 void configUpdater::subscribe(const Stage* subscriber,
                               std::map<std::string, std::function<bool(json&)>> callbacks) {
+
+    // If no callbacks are passed, then we don't need to find any updatable_config blocks
+    if (callbacks.size() == 0) return;
+
+    // Find the nearest updatable config block
     auto updatable_config_paths = _config->get<std::map<std::string, std::string>>(
         subscriber->get_unique_name(), "updatable_config");
+
+    // Extract the paths from that config block, it must contain all callbacks
     for (auto callback : callbacks) {
         std::string path;
         try {

--- a/lib/core/configUpdater.hpp
+++ b/lib/core/configUpdater.hpp
@@ -121,8 +121,9 @@ public:
      * The callback function has to return True on success and False
      * otherwise.
      * The block of the calling stage in the configuration file should have
-     * a key named "updatable_block" that defines the full path to the
-     * updatable block.
+     * a key named "updatable_config" that defines the full path to the
+     * updatable block. As usual if not found at that level, it will search up
+     * the tree.
      *
      * @param subscriber Reference to the subscribing stage.
      * @param callback   Callback function for attribute updates.
@@ -134,10 +135,12 @@ public:
      *
      * The callback functions have to return True on success and False
      * otherwise.
-     * The block of the calling stage in the configuration file should have
-     * an object named "updatable_block" with values that define the full
-     * path to an updatable block, each. The names in the callbacks map refer
-     * to the names of these values.
+     * The block of the calling stage in the configuration file should have an
+     * object named "updatable_config" with values that define the full path to
+     * an updatable block, each. The names in the callbacks map refer to the
+     * names of these values. If an "updatable_config" block is not found in
+     * the current stage it will search up the config tree, but all callback
+     * keys must be contained within this single block.
      *
      * @param subscriber Reference to the subscribing stage.
      * @param callbacks  Map of value names and callback functions.

--- a/lib/stages/CMakeLists.txt
+++ b/lib/stages/CMakeLists.txt
@@ -73,8 +73,6 @@ endif ()
 
 # HDF5 stuff
 if (${USE_HDF5})
-  # Disable for the moment as requires too modern HDF5 not available in most computers
-  #set (KOTEKAN_PROCESS_LIB_SOURCES ${KOTEKAN_PROCESS_LIB_SOURCES} calibration_io.cpp)
   set (KOTEKAN_PROCESS_LIB_SOURCES ${KOTEKAN_PROCESS_LIB_SOURCES} basebandReadout.cpp applyGains.cpp)
 endif ()
 
@@ -112,8 +110,10 @@ if (${USE_EVENT})
 endif ()
 
 if (${USE_LAPACK})
-  include_directories (${OpenBLAS_INCLUDE_DIRS} ${LAPACK_INCLUDE_DIRS})
-  target_link_libraries ( kotekan_stages  ${OpenBLAS_LIBRARIES} ${LAPACK_LIBRARIES})
+  include_directories( ${LAPACKE_INCLUDE_DIRS} )
+  target_link_libraries( kotekan_stages ${BLAS_LIBRARIES} )
+  target_link_libraries( kotekan_stages ${LAPACK_LIBRARIES} )
+  target_link_libraries( kotekan_stages ${LAPACKE_LIBRARIES} )
 endif ()
 
 # Add atomic for building against GCC

--- a/tests/test_baseband_readout.py
+++ b/tests/test_baseband_readout.py
@@ -5,6 +5,7 @@ from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
 
 # === End Python 2/3 compatibility
 
+import os
 import glob
 import random
 import pytest
@@ -14,11 +15,19 @@ import h5py
 
 from kotekan import runner
 
-
 # Skip if HDF5 support not built into kotekan
 if not runner.has_hdf5():
     pytest.skip("HDF5 support not available.", allow_module_level=True)
 
+def is_docker():
+    path = '/proc/self/cgroup'
+    return (
+        os.path.exists('/.dockerenv') or
+        os.path.isfile(path) and any('docker' in line for line in open(path))
+    )
+
+if is_docker():
+    pytest.skip("Does not work in Github Actions docker run.", allow_module_level=True)
 
 default_params = {
     "max_dump_samples": 3500,

--- a/tests/test_dataset_broker.py
+++ b/tests/test_dataset_broker.py
@@ -20,6 +20,19 @@ producer2_path = "../build/tests/boost/dataset_broker_producer2"
 consumer_path = "../build/tests/boost/dataset_broker_consumer"
 
 
+def has_redis(host="localhost", port=6379):
+    """Check if redis is available."""
+
+    try:
+        import redis
+        r = redis.Redis(host, port)
+        return redis.ping()
+
+    except Exception as e:
+        print(e)
+        return False
+
+
 def test_produce_consume():
     broker_path = shutil.which("comet")
     if (
@@ -32,6 +45,8 @@ def test_produce_consume():
         pytest.skip(
             "Make sure PYTHONPATH is set to where the comet dataset broker is installed."
         )
+    if not has_redis():
+        pytest.skip("Redis is not available and so comet will fail.")
 
     with tempfile.NamedTemporaryFile(mode="w") as f_out:
         # Start comet with a random port

--- a/tests/test_dataset_broker.py
+++ b/tests/test_dataset_broker.py
@@ -26,7 +26,7 @@ def has_redis(host="localhost", port=6379):
     try:
         import redis
         r = redis.Redis(host, port)
-        return redis.ping()
+        return r.ping()
 
     except Exception as e:
         print(e)

--- a/tests/test_dataset_broker.py
+++ b/tests/test_dataset_broker.py
@@ -33,6 +33,7 @@ def has_redis(host="localhost", port=6379):
         return False
 
 
+@pytest.mark.serial
 def test_produce_consume():
     broker_path = shutil.which("comet")
     if (

--- a/tests/test_freqslicer_broker.py
+++ b/tests/test_freqslicer_broker.py
@@ -7,6 +7,7 @@ import signal
 
 from kotekan import runner
 
+from test_dataset_broker import has_redis
 
 params = {
     "num_elements": 5,
@@ -43,6 +44,9 @@ def subset_data(tmpdir_factory):
         pytest.skip(
             "Make sure PYTHONPATH is set to where the comet dataset broker is installed."
         )
+    if not has_redis():
+        pytest.skip("Redis is not available and so comet will fail")
+
 
     # run the dataset broker
     broker = Popen([broker_path, "--recover", "False"])

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -1,23 +1,63 @@
-# Use an official Python runtime as a base image
-FROM ubuntu:xenial
+FROM rocm/dev-ubuntu-18.04
 
 ## The maintainer name and email
-MAINTAINER Richard Shaw <richard@phas.ubc.ca>
+MAINTAINER Rick Nitsche <rick@phas.ubc.ca>
 
-# Install any needed packages specified in requirements.txt
-RUN apt-get update
-RUN apt-get install -y gcc
-RUN apt-get install -y cmake
-RUN apt-get install -y libhdf5-10 libhdf5-10-dbg libhdf5-dev h5utils
-RUN apt-get install -y libboost-all-dev
-RUN apt-get install -y python python-setuptools python-pip
-RUN apt-get install -y libevent-dev
-RUN pip install pyyaml
-#RUN apt-get install -y software-properties-common
-#RUN apt-add-repository -y ppa:ubuntu-toolchain-r/test
-#RUN apt-get update
-#RUN apt-get install -y gcc-5 g++-5
+# Install any needed packages to run cmake with full CHIME build options
+RUN apt-get update && \
+    apt-get install -y software-properties-common && \
+    add-apt-repository ppa:deadsnakes/ppa && \
+    apt-get update && \
+    apt-get install -y python3.7 python3-setuptools python3-pip python3.7-distutils python3.7-dev \
+                       build-essential git coreutils ccache pkg-config \
+                       gcc cmake clang-9 clang-format-8 \
+                       rocm-opencl-dev rocm-opencl \
+                       dpdk dpdk-dev \
+                       libhdf5-serial-dev libboost-test-dev libevent-dev libssl-dev \
+                       wget
 
-# Run kotekan when the container launches
-WORKDIR /code/build/kotekan/
-CMD ./kotekan -c $KOTEKAN_CONFIG
+RUN python3.7 -m pip install --upgrade pip && \
+    python3.7 -m pip install --upgrade --force-reinstall setuptools && \
+    python3.7 -m pip install --upgrade pip setuptools wheel && \
+    python3.7 -m pip install "numpy>=1.16.0" && \
+    python3.7 -m pip install pkgconfig && \
+    python3.7 -m pip install --upgrade cython && \
+    python3.7 -m pip install black
+
+RUN mkdir -p /code/build
+WORKDIR /code/build
+
+# Install h5py from source for bitshuffle, and clone HighFive for kotekan build
+RUN git clone https://github.com/h5py/h5py.git h5py && \
+    cd h5py && \
+    python3.7 setup.py configure --hdf5=/usr/lib/x86_64-linux-gnu/hdf5/serial/ --hdf5-version=1.10.0 && \
+    python3.7 setup.py install
+RUN git clone --single-branch --branch extensible-datasets https://github.com/jrs65/HighFive.git
+
+# Install bitshuffle
+RUN git clone https://github.com/kiyo-masui/bitshuffle.git bitshuffle && \
+    cd bitshuffle && \
+    python3.7 setup.py install --h5plugin --h5plugin-dir=/usr/local/hdf5/lib/plugin
+
+# Install OpenBLAS and clone Blaze for the eigenvalue processes
+RUN apt-get -y install libopenblas-dev liblapack-dev liblapacke-dev && \
+    git clone https://bitbucket.org/blaze-lib/blaze.git blaze
+
+# Install kotekan python dependencies
+RUN python3.7 -m pip install "msgpack>=0.6.1" click future requests pyyaml \
+                 tabulate pytest==5.3.0 pytest-xdist pytest-cpp && \
+    apt-get install -y mysql-client libmysqlclient-dev && \
+    python3.7 -m pip install git+https://github.com/chime-experiment/comet.git
+
+# Set ccache to store things sensibly
+ENV CCACHE_NOHASHDIR 1
+ENV CCACHE_BASEDIR /code/kotekan/
+ENV CCACHE_DIR /code/kotekan/.ccache/
+ENV CCACHE_COMPRESS 1
+ENV CCACHE_MAXSIZE 1G
+
+# Set the plugin path so kotekan can find bitshuffle
+ENV HDF5_PLUGIN_PATH /usr/local/hdf5/lib/plugin
+
+# Do nothing when the container launches
+CMD ["/bin/bash"]

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -49,6 +49,9 @@ RUN python3.7 -m pip install "msgpack>=0.6.1" click future requests pyyaml \
     apt-get install -y mysql-client libmysqlclient-dev && \
     python3.7 -m pip install git+https://github.com/chime-experiment/comet.git
 
+# Install redis for comet tests
+RUN apt-get install -y redis
+
 # Set ccache to store things sensibly
 ENV CCACHE_NOHASHDIR 1
 ENV CCACHE_BASEDIR /code/kotekan/

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -15,4 +15,4 @@ service entries for a gpu node and a receiver node that can be used as templates
 additional services (which spawn containers). The kotekan config that will be provided
 to the node is specified by the KOTEKAN_CONFIG environment variable
 3. Start the Docker containers with the command
-`docker-compose -f docker-compose-example.yaml up`, substiting in your own yaml file.
+`docker-compose -f docker-compose-example.yaml up`, substituting in your own yaml file.

--- a/tools/iwyu/docker/Dockerfile
+++ b/tools/iwyu/docker/Dockerfile
@@ -1,92 +1,23 @@
-FROM rocm/dev-ubuntu-18.04
+FROM docker.pkg.github.com/kotekan/kotekan/kotekan-core:latest
 
 ## The maintainer name and email
 MAINTAINER Rick Nitsche <rick@phas.ubc.ca>
 
-# Install any needed packages to run cmake with full CHIME build options
-RUN apt-get update
-RUN apt-get install -y software-properties-common
-RUN add-apt-repository ppa:deadsnakes/ppa
-RUN apt-get update
-RUN apt-get install -y python3.7 python3-setuptools python3-pip python3.7-distutils python3.7-dev
-RUN apt-get install -y gcc
-RUN apt-get install -y cmake
-RUN apt-get install -y libhdf5-serial-dev
-RUN apt-get install -y clang-9
-RUN apt-get install -y clang-format-8
-RUN apt-get install -y wget
-RUN apt-get install -y libssl-dev
-RUN apt-get install -y build-essential
-RUN apt-get install -y git
-RUN apt-get install -y coreutils
-
-WORKDIR /code/build/
-
-# Install h5py from source for bitshuffle
-RUN git clone https://github.com/h5py/h5py.git h5py
-WORKDIR /code/build/h5py
-RUN python3.7 -m pip install --upgrade --force-reinstall setuptools
-RUN python3.7 setup.py configure --hdf5=/usr/lib/x86_64-linux-gnu/hdf5/serial/ --hdf5-version=1.10.0
-
-RUN apt-get install -y libboost-test-dev
-RUN apt-get install -y libevent-dev
-RUN apt-get install -y iwyu
-RUN apt-get install -y gfortran
-RUN apt-get install -y dpdk dpdk-dev # dpdk-igb-uio-dkms
-RUN apt-get install -y libairspy-dev libfftw3-dev
-
-RUN python3.7 -m pip install --upgrade pip
-RUN python3.7 -m pip install --upgrade --force-reinstall setuptools
-RUN python3.7 -m pip install --upgrade pip setuptools wheel
-RUN python3.7 -m pip install numpy
-RUN python3.7 -m pip install pkgconfig
-RUN python3.7 -m pip install --upgrade cython
-RUN python3.7 -m pip install black
-
-#RUN apt-get install -y libevent-2.0-5 libevent-pthreads-2.0-5
-
-RUN mkdir -p /code/build
-WORKDIR /code/build/
-
-# Clone Highfive
-RUN git clone --single-branch --branch extensible-datasets https://github.com/jrs65/HighFive.git
-
-WORKDIR /code/build/
-
-# Install bitshuffle
-RUN git clone https://github.com/kiyo-masui/bitshuffle.git bitshuffle
-WORKDIR /code/build/bitshuffle
-RUN export HDF5_PLUGIN_PATH=/usr/local/hdf5/lib/plugin
-#RUN python3.7 setup.py install --h5plugin --h5plugin-dir=/usr/local/hdf5/lib/plugin
-
-WORKDIR /code/build/
-
-# Build OpenBLAS
-RUN git clone https://github.com/xianyi/OpenBLAS.git OpenBLAS
-WORKDIR /code/build/OpenBLAS
-RUN make
-RUN make PREFIX=/code/build/OpenBLAS install
-
-WORKDIR /code/build/
-
-#Clone Blaze
-RUN git clone https://nickritsche@bitbucket.org/blaze-lib/blaze.git blaze
-
 # Install iwyu for clang 8.0
-RUN wget http://launchpadlibrarian.net/461878080/libstdc++6_9.2.1-25ubuntu1_amd64.deb
-RUN wget http://launchpadlibrarian.net/458626653/iwyu_8.0-3_amd64.deb
-RUN wget http://launchpadlibrarian.net/461877892/gcc-9-base_9.2.1-25ubuntu1_amd64.deb
-RUN wget http://launchpadlibrarian.net/462079080/libllvm9_9.0.1-8build1_amd64.deb
-RUN wget http://launchpadlibrarian.net/453587373/libc6_2.30-0ubuntu3_amd64.deb
-RUN wget http://launchpadlibrarian.net/461284144/libffi7_3.3-3_amd64.deb
-RUN wget http://launchpadlibrarian.net/448587516/libtinfo6_6.1+20191019-1ubuntu1_amd64.deb
-RUN dpkg -i libtinfo6_6.1+20191019-1ubuntu1_amd64.deb
-RUN dpkg -i libffi7_3.3-3_amd64.deb
-RUN dpkg -i libc6_2.30-0ubuntu3_amd64.deb
-RUN dpkg -i gcc-9-base_9.2.1-25ubuntu1_amd64.deb
-RUN dpkg -i libstdc++6_9.2.1-25ubuntu1_amd64.deb
-RUN dpkg -i libllvm9_9.0.1-8build1_amd64.deb
-RUN dpkg -i iwyu_8.0-3_amd64.deb
+RUN wget http://launchpadlibrarian.net/461878080/libstdc++6_9.2.1-25ubuntu1_amd64.deb && \
+    wget http://launchpadlibrarian.net/458626653/iwyu_8.0-3_amd64.deb && \
+    wget http://launchpadlibrarian.net/461877892/gcc-9-base_9.2.1-25ubuntu1_amd64.deb && \
+    wget http://launchpadlibrarian.net/462079080/libllvm9_9.0.1-8build1_amd64.deb && \
+    wget http://launchpadlibrarian.net/453587373/libc6_2.30-0ubuntu3_amd64.deb && \
+    wget http://launchpadlibrarian.net/461284144/libffi7_3.3-3_amd64.deb && \
+    wget http://launchpadlibrarian.net/448587516/libtinfo6_6.1+20191019-1ubuntu1_amd64.deb && \
+    dpkg -i libtinfo6_6.1+20191019-1ubuntu1_amd64.deb && \
+    dpkg -i libffi7_3.3-3_amd64.deb && \
+    dpkg -i libc6_2.30-0ubuntu3_amd64.deb && \
+    dpkg -i gcc-9-base_9.2.1-25ubuntu1_amd64.deb && \
+    dpkg -i libstdc++6_9.2.1-25ubuntu1_amd64.deb && \
+    dpkg -i libllvm9_9.0.1-8build1_amd64.deb && \
+    dpkg -i iwyu_8.0-3_amd64.deb
 
 # Set compiler to clang (to make cmake choose the right flags for iwyu)
 ENV CC clang-9
@@ -95,28 +26,3 @@ ENV CXX clang++-9
 # Help iwyu to find builtin headers
 ENV CFLAGS "-isystem /usr/lib/llvm-9/lib/clang/9.0.0/include/"
 ENV CXXFLAGS "-isystem /usr/lib/llvm-9/lib/clang/9.0.0/include/"
-
-# copy everything we need from kotekan
-WORKDIR /code
-COPY include include/
-COPY tools tools/
-COPY iwyu.kotekan.imp iwyu.kotekan.imp
-COPY CMakeLists.txt CMakeLists.txt
-COPY kotekan kotekan/
-COPY python python/
-COPY tests tests/
-COPY lib lib/
-COPY cmake cmake/
-COPY scripts scripts/
-COPY config config/
-
-# get ready to run cmake
-WORKDIR /code/build
-
-RUN cmake -DRTE_SDK=/opt/dpdk -DRTE_TARGET=x86_64-native-linuxapp-gcc  -DUSE_DPDK=ON -DUSE_HSA=ON \
-    -DCMAKE_BUILD_TYPE=Debug -DUSE_HDF5=ON -DHIGHFIVE_PATH=/code/build/HighFive \
-    -DOPENBLAS_PATH=/code/build/OpenBLAS -DUSE_LAPACK=ON -DBLAZE_PATH=/code/build/blaze \
-    -DUSE_OMP=ON -DBOOST_TESTS=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
-
-# Do nothing when the container launches
-CMD ["/bin/bash"]


### PR DESCRIPTION
Okay this is ready to go. @andrerenard I had to add a few options to the build scripts to make it all work: one to disable mlocking the buffer memory; and one to explicitly set the build architecture, so it would be great if you could look at those. @nritsche if you could check everything else.

Once this is reviewed and merged, I think we can just change the Jenkins webhook status to inactive and it will stop reporting.

There's a few things it doesn't yet do, which we should address in subsequent changes:
- The baseband readout tests are disabled as they didn't work trivially
- All of the tests involving comet are disabled. This should be easy to fix, probably by just installing redis into the container.
- It doesn't built the docs
- It doesn't do a full CHIME kotekan build because of updates to ROCm that need some of @andrerenard's attention.
- It doesn't run the kernel tests (and probably never will).

Additionally there's a few changes that could make things speedier:
- Figure out a way to only run the build-docker job when the Dockerfile's have changed. Although it doesn't actually do anything it pointlessly burns 90s fetching and pushing the images.
- See if there's a way of speeding up the building of the boost_tests. It turns out to add a significant amount of time to the ccache'd build time to build and link the boost tests.