### PR TITLE
ci(github): fix iwyu action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -173,14 +173,16 @@ jobs:
         docker run "${OPTS[@]}" \
           cmake -DCMAKE_BUILD_TYPE=Debug \
             -DUSE_DPDK=ON \
+            -DUSE_HSA=ON \
             -DUSE_HDF5=ON -DHIGHFIVE_PATH=/code/build/HighFive \
             -DUSE_LAPACK=ON -DBLAZE_PATH=/code/build/blaze \
             -DARCH=haswell \
             -DNO_MEMLOCK=ON \
             -DUSE_OMP=ON \
-            -DBOOST_TESTS=OFF \
+            -DBOOST_TESTS=ON \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
 
     - name: Run iwyu
       run: |
         OPTS=(--rm --mount type=bind,src=$(pwd),target=/code/kotekan -w /code/kotekan/build/ ${IMG_IWYU})
-        docker run "${OPTS[@]}" /code/tools/iwyu/docker/iwyu.sh
+        docker run "${OPTS[@]}" /code/kotekan/tools/iwyu/docker/iwyu.sh

--- a/tools/iwyu/docker/iwyu.sh
+++ b/tools/iwyu/docker/iwyu.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-iwyu_tool -j 2 -p . -- -Xiwyu --no_fwd_decls -Xiwyu --mapping_file=/code/iwyu.kotekan.imp -Xiwyu --max_line_length=100 | tee iwyu.out
+iwyu_tool -j 2 -p . -- -Xiwyu --no_fwd_decls -Xiwyu --mapping_file=/code/kotekan/iwyu.kotekan.imp -Xiwyu --max_line_length=100 | tee iwyu.out
 python2 /usr/bin/fix_include --nosafe_headers --comments < iwyu.out


### PR DESCRIPTION
The iqyu action broke in #699 and is fixed here:
- restore iwyu cmake options
- add path (..) to cmake command
- fix path to iwyu.sh
- iwyu.sh: fix path to project .imp