### PR TITLE
ci(github): repair docker_build step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,14 +30,23 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
-    - name: Build docker images
+    - name: Pull docker images
       run: |
         SECONDS=0
         docker login docker.pkg.github.com -u ${GITHUB_REPOSITORY} -p "${{ secrets.GITHUB_TOKEN }}" | while read line ; do echo "$SECONDS s | $line";  done;
         docker pull --disable-content-trust ${IMG_CORE} | while read line ; do echo "$SECONDS s | $line";  done;
         docker pull --disable-content-trust ${IMG_IWYU} | while read line ; do echo "$SECONDS s | $line";  done;
+    - name: Build core docker image
+      run: |
+        SECONDS=0
         docker build --cache-from=rocm/dev-ubuntu-18.04,${IMG_CORE} -t ${IMG_CORE} - < tools/docker/Dockerfile | while read line ; do echo "$SECONDS s | $line";  done;
+    - name: Build iwyu docker image
+      run: |
+        SECONDS=0
         docker build --cache-from=rocm/dev-ubuntu-18.04,${IMG_CORE},${IMG_IWYU} -t ${IMG_IWYU} - < tools/iwyu/docker/Dockerfile | while read line ; do echo "$SECONDS s | $line";  done;
+    - name: Push docker images
+      run: |
+        SECONDS=0
         docker push ${IMG_CORE} | while read line ; do echo "$SECONDS s| $line";  done;
         docker push ${IMG_IWYU} | while read line ; do echo "$SECONDS s| $line";  done;
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,23 +32,19 @@ jobs:
 
     - name: Pull docker images
       run: |
-        SECONDS=0
-        docker login docker.pkg.github.com -u ${GITHUB_REPOSITORY} -p "${{ secrets.GITHUB_TOKEN }}" | while read line ; do echo "$SECONDS s | $line";  done;
-        docker pull --disable-content-trust ${IMG_CORE} | while read line ; do echo "$SECONDS s | $line";  done;
-        docker pull --disable-content-trust ${IMG_IWYU} | while read line ; do echo "$SECONDS s | $line";  done;
+        docker login docker.pkg.github.com -u ${GITHUB_REPOSITORY} -p "${{ secrets.GITHUB_TOKEN }}"
+        docker pull --disable-content-trust ${IMG_CORE}
+        docker pull --disable-content-trust ${IMG_IWYU}
     - name: Build core docker image
       run: |
-        SECONDS=0
-        docker build --cache-from=rocm/dev-ubuntu-18.04,${IMG_CORE} -t ${IMG_CORE} - < tools/docker/Dockerfile | while read line ; do echo "$SECONDS s | $line";  done;
+        docker build --cache-from=rocm/dev-ubuntu-18.04,${IMG_CORE} -t ${IMG_CORE} - < tools/docker/Dockerfile
     - name: Build iwyu docker image
       run: |
-        SECONDS=0
-        docker build --cache-from=rocm/dev-ubuntu-18.04,${IMG_CORE},${IMG_IWYU} -t ${IMG_IWYU} - < tools/iwyu/docker/Dockerfile | while read line ; do echo "$SECONDS s | $line";  done;
+        docker build --cache-from=rocm/dev-ubuntu-18.04,${IMG_CORE},${IMG_IWYU} -t ${IMG_IWYU} - < tools/iwyu/docker/Dockerfile
     - name: Push docker images
       run: |
-        SECONDS=0
-        docker push ${IMG_CORE} | while read line ; do echo "$SECONDS s| $line";  done;
-        docker push ${IMG_IWYU} | while read line ; do echo "$SECONDS s| $line";  done;
+        docker push ${IMG_CORE}
+        docker push ${IMG_IWYU}
 
 
   # Build a basic version of kotekan

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -45,7 +45,8 @@ RUN git clone https://github.com/kiyo-masui/bitshuffle.git bitshuffle && \
     python3.7 setup.py install --h5plugin --h5plugin-dir=/usr/local/hdf5/lib/plugin
 
 # Install OpenBLAS and clone Blaze for the eigenvalue processes
-RUN apt-get -y install libopenblas-dev liblapack-dev liblapacke-dev && \
+RUN apt-get update && \
+    apt-get -y install libopenblas-dev liblapack-dev liblapacke-dev && \
     apt-get clean && apt-get autoclean && \
     git clone https://bitbucket.org/blaze-lib/blaze.git blaze
 
@@ -53,16 +54,19 @@ RUN apt-get -y install libopenblas-dev liblapack-dev liblapacke-dev && \
 RUN python3.7 -m pip install "msgpack>=0.6.1" click future requests pyyaml tabulate \
                              pytest==5.3.0 pytest-xdist pytest-cpp pytest-localserver flask \
                              posix_ipc && \
+    apt-get update && \
     apt-get install -y mysql-client libmysqlclient-dev && \
     apt-get clean && apt-get autoclean && \
     python3.7 -m pip install git+https://github.com/chime-experiment/comet.git
 
 # Install redis for comet tests
-RUN apt-get install -y redis && \
+RUN apt-get update && \
+    apt-get install -y redis && \
     apt-get clean && apt-get autoclean
 
 # Install documentation dependencies
-RUN apt-get -y install doxygen graphviz python-sphinx default-jre && \
+RUN apt-get update && \
+    apt-get -y install doxygen graphviz python-sphinx default-jre && \
     apt-get clean && apt-get autoclean && \
     python3.7 -m pip install --no-cache-dir breathe sphinx_rtd_theme sphinxcontrib-plantuml && \
     wget https://phoenixnap.dl.sourceforge.net/project/plantuml/plantuml.jar -P plantuml


### PR DESCRIPTION
Closes #730 

Do an `apt-get update` every time we use `apt-get install`.
Also chops the build_docker step into 4 steps so the output is easier to read and removes the pipes in the docker_build steps commands because they lead to the exit codes being ignored.