### PR TITLE
Clang and MacOS CI builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -174,6 +174,111 @@ jobs:
         docker run "${OPTS[@]}" ccache -s
 
 
+  # Build a full CHIME version with clang
+  build-clang:
+    runs-on: ubuntu-latest
+    needs: build-docker
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Cache ccache files
+      uses: actions/cache@v1
+      with:
+        path: .ccache
+        key: ccache-clang-build-${{ github.sha }}
+        restore-keys: |
+          ccache-clang-build
+
+    - name: Build kotekan
+      env:
+        CC: clang
+        CXX: clang++
+      run: |
+        OPTS=(--rm --mount type=bind,src=$(pwd),target=/code/kotekan -w /code/kotekan/build/ ${IMG_CORE})
+        docker login docker.pkg.github.com -u ${GITHUB_REPOSITORY} -p "${{ secrets.GITHUB_TOKEN }}"
+        docker run "${OPTS[@]}" ccache -s
+        docker run "${OPTS[@]}" cmake \
+        -DUSE_DPDK=ON \
+        -DCMAKE_BUILD_TYPE=Debug \
+        -DUSE_HDF5=ON \
+        -DHIGHFIVE_PATH=/code/build/HighFive \
+        -DUSE_LAPACK=ON \
+        -DBLAZE_PATH=/code/build/blaze \
+        -DARCH=haswell \
+        -DNO_MEMLOCK=ON \
+        -DUSE_OMP=ON \
+        -DBOOST_TESTS=ON \
+        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+        -DCMAKE_C_COMPILER_LAUNCHER=ccache ..
+        docker run "${OPTS[@]}" make -j 2
+        docker run "${OPTS[@]}" ccache -s
+
+
+  # Build MacOS kotekan
+  build-macos:
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Cache ccache files
+      uses: actions/cache@v1
+      with:
+        path: .ccache
+        key: ccache-macos-build-${{ github.sha }}
+        restore-keys: |
+          ccache-macos-build
+
+    - name: Install ccache and libraries
+      run: |
+        brew install hdf5@1.10 boost libevent ccache airspy fftw
+
+    - name: Build h5py from source
+      run: |
+        git clone https://github.com/h5py/h5py.git h5py && cd h5py
+        python3.7 setup.py configure --hdf5=/usr/local/opt/hdf5@1.10/
+        python3.7 setup.py build
+
+    - name: Install bitshuffle
+      env:
+        HDF5_DIR: /usr/local/opt/hdf5@1.10/
+      run: |
+        git clone https://github.com/kiyo-masui/bitshuffle.git bitshuffle && cd bitshuffle
+        python3.7 setup.py install --h5plugin --h5plugin-dir=/usr/local/opt/hdf5@1.10/lib/plugin
+
+    - name: Clone Blaze and HighFive
+      run: |
+        git clone https://bitbucket.org/blaze-lib/blaze.git blaze
+        git clone --single-branch --branch extensible-datasets https://github.com/jrs65/HighFive.git
+
+    - name: Install OpenBLAS and LAPACK
+      run: brew install openblas lapack
+
+    - name: Build kotekan
+      env:
+        CCACHE_NOHASHDIR: 1
+        CCACHE_BASEDIR: $GITHUB_WORKSPACE
+        CCACHE_DIR: $GITHUB_WORKSPACE/.ccache/
+        CCACHE_COMPRESS: 1
+        CCACHE_MAXSIZE: 1G
+      run: |
+        # adding this to the above env block breaks and results in sh not finding cmake etc
+        export PATH="/usr/local/opt/hdf5@1.10/bin:$PATH"
+        cd build
+        cmake \
+        -DUSE_HDF5=ON \
+        -DUSE_OPENCL=ON \
+        -DUSE_FFTW=ON \
+        -DUSE_AIRSPY=ON \
+        -DUSE_LAPACK=ON \
+        -DCMAKE_PREFIX_PATH=/usr/local/opt/openblas/ \
+        -DLAPACKE_DIR=/usr/local/opt/openblas/ \
+        -DBLAZE_PATH=$GITHUB_WORKSPACE/blaze \
+        -DHIGHFIVE_PATH=$GITHUB_WORKSPACE/HighFive \
+        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+        -DCMAKE_C_COMPILER_LAUNCHER=ccache ..
+        make -j 2
+
   # Build kotekan documentation
   build-docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,7 +70,7 @@ jobs:
         docker login docker.pkg.github.com -u ${GITHUB_REPOSITORY} -p "${{ secrets.GITHUB_TOKEN }}"
         docker run "${OPTS[@]}" ccache -s
         docker run "${OPTS[@]}" \
-          cmake -DCMAKE_BUILD_TYPE=Debug \
+          cmake -DCMAKE_BUILD_TYPE=Test \
             -DARCH=haswell \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache ..
         docker run "${OPTS[@]}" make -j 2
@@ -109,7 +109,7 @@ jobs:
         docker login docker.pkg.github.com -u ${GITHUB_REPOSITORY} -p "${{ secrets.GITHUB_TOKEN }}"
         docker run "${OPTS[@]}" ccache -s
         docker run "${OPTS[@]}" \
-          cmake -DCMAKE_BUILD_TYPE=Debug \
+          cmake -DCMAKE_BUILD_TYPE=Test \
             -DUSE_HDF5=ON -DHIGHFIVE_PATH=/code/build/HighFive \
             -DUSE_LAPACK=ON -DBLAZE_PATH=/code/build/blaze \
             -DARCH=haswell \
@@ -161,7 +161,7 @@ jobs:
         docker login docker.pkg.github.com -u ${GITHUB_REPOSITORY} -p "${{ secrets.GITHUB_TOKEN }}"
         docker run "${OPTS[@]}" ccache -s
         docker run "${OPTS[@]}" \
-          cmake -DCMAKE_BUILD_TYPE=Debug \
+          cmake -DCMAKE_BUILD_TYPE=Test \
             -DUSE_DPDK=ON \
             -DUSE_HDF5=ON -DHIGHFIVE_PATH=/code/build/HighFive \
             -DUSE_LAPACK=ON -DBLAZE_PATH=/code/build/blaze \
@@ -200,7 +200,7 @@ jobs:
         docker run "${OPTS[@]}" ccache -s
         docker run "${OPTS[@]}" cmake \
         -DUSE_DPDK=ON \
-        -DCMAKE_BUILD_TYPE=Debug \
+        -DCMAKE_BUILD_TYPE=Test \
         -DUSE_HDF5=ON \
         -DHIGHFIVE_PATH=/code/build/HighFive \
         -DUSE_LAPACK=ON \
@@ -312,7 +312,7 @@ jobs:
         OPTS=(--rm --mount type=bind,src=$(pwd),target=/code/kotekan -w /code/kotekan/build/ ${IMG_IWYU})
         docker login docker.pkg.github.com -u ${GITHUB_REPOSITORY} -p "${{ secrets.GITHUB_TOKEN }}"
         docker run "${OPTS[@]}" \
-          cmake -DCMAKE_BUILD_TYPE=Debug \
+          cmake -DCMAKE_BUILD_TYPE=Test \
             -DUSE_DPDK=ON \
             -DUSE_HSA=ON \
             -DUSE_HDF5=ON -DHIGHFIVE_PATH=/code/build/HighFive \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
   build-docker:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Pull docker images
       run: |
@@ -53,7 +53,7 @@ jobs:
     needs: build-docker
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Cache ccache files
       uses: actions/cache@v1
@@ -83,7 +83,7 @@ jobs:
     needs: build-docker
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Free disk space
       run: |
@@ -144,7 +144,7 @@ jobs:
     needs: build-docker
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Cache ccache files
       uses: actions/cache@v1
@@ -180,7 +180,7 @@ jobs:
     needs: build-docker
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Cache ccache files
       uses: actions/cache@v1
@@ -220,7 +220,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Cache ccache files
       uses: actions/cache@v1
       with:
@@ -285,7 +285,7 @@ jobs:
     needs: build-docker
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Build kotekan docs
       run: |
@@ -305,7 +305,7 @@ jobs:
     if: github.base_ref == 'master'
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Configure kotekan
       run: |
@@ -334,7 +334,7 @@ jobs:
     needs: build-docker
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Run clang-format
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,8 +133,15 @@ else()
  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libgcc -static-libstdc++")
 endif()
 
-IF(CMAKE_BUILD_TYPE MATCHES Debug)
+# Create custom build type for testing: no debug info, but asserts
+string(REGEX REPLACE "( -DNDEBUG$|-DNDEBUG )" "" CMAKE_CXX_FLAGS_TEST "${CMAKE_CXX_FLAGS_RELEASE}" )
+string(REGEX REPLACE "( -DNDEBUG$|-DNDEBUG )" "" CMAKE_C_FLAGS_TEST "${CMAKE_C_FLAGS_RELEASE}" )
+
+# Enable debug logging for Debug and Test builds
+IF(CMAKE_BUILD_TYPE MATCHES Debug OR CMAKE_BUILD_TYPE MATCHES Test)
   add_definitions(-DDEBUGGING)
+  message("DEBUG logging enabled")
+  message("Asserts enabled")
 endif()
 
 # include-what-you-use: this has to be set before any targets are added

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ To build just the base framework:
 
 Cmake build options:
 
-* `-DCMAKE_BUILD_TYPE=Debug` - Builds the project with debug symbols.
+* `-DCMAKE_BUILD_TYPE=Debug` - Builds the project with asserts, debug logging and debug symbols.
+* `-DCMAKE_BUILD_TYPE=Test` - Builds the project with asserts, debug logging, but without debug
+symbols.
 * `-DUSE_DPDK=ON` - Include DPDK support.  Optional `-DRTE_SDK=<build-location>` and
   `-DRTE_TARGET=x86_64-native-linuxapp-gcc` can be provided for non standard build locations.
 * `-DUSE_HSA=ON` - Build with HSA support if available. On by default.

--- a/docs/sphinx/compiling/general.rst
+++ b/docs/sphinx/compiling/general.rst
@@ -166,7 +166,9 @@ Cmake build options
 -------------------
 
 * ``-DCMAKE_BUILD_TYPE=Debug``
-    Builds the project with debug symbols.
+    Builds the project with asserts, debug logging and debug symbols.
+* ``-DCMAKE_BUILD_TYPE=Test``
+    Builds the project with asserts and debug logging but without debug symbols.
 * ``-DUSE_DPDK=ON``
     Builds with DPDK support, for source installs requires: `-DRTE_SDK=<dir>`
     and `-DRTE_TARGET=x86_64-native-linuxapp-gcc`

--- a/lib/dpdk/iceBoardShuffle.hpp
+++ b/lib/dpdk/iceBoardShuffle.hpp
@@ -532,8 +532,8 @@ inline bool iceBoardShuffle::check_fpga_shuffle_flags(struct rte_mbuf* mbuf) {
 
     int cur_mbuf_len = mbuf->data_len;
     assert(cur_mbuf_len >= flag_len);
-    int flag_location = cur_mbuf_len - flag_len - rounding_factor;
-    assert(2048 * 2 + flag_location == 4922); // Make sure the flag address is correct.
+    assert(2048 * 2 + cur_mbuf_len - flag_len - rounding_factor
+           == 4922); // Make sure the flag address is correct.
     const uint8_t* mbuf_data =
         rte_pktmbuf_mtod_offset(mbuf, uint8_t*, cur_mbuf_len - flag_len - rounding_factor);
 

--- a/lib/stages/RingMapMaker.hpp
+++ b/lib/stages/RingMapMaker.hpp
@@ -147,7 +147,6 @@ private:
     // dataset states and IDs
     dset_id_t output_dset_id;
     dset_id_t input_dset_id;
-    const prodState* prod_state_ptr;
     const stackState* old_stack_state_ptr;
     const stackState* new_stack_state_ptr;
 


### PR DESCRIPTION
Adds 2 builds to github action CI:
- full CHIME build using clang
- macOS build outside of dockerimage: slower because needs to install stuff
  - takes 15min with an empty ccache
  - and 4min after ccache has been filled

This is the compiler the mac build uses:
```
 -- The C compiler identification is AppleClang 11.0.0.11000033
-- The CXX compiler identification is AppleClang 11.0.0.11000033
-- Check for working C compiler: /Applications/Xcode_11.3.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc
-- Check for working C compiler: /Applications/Xcode_11.3.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc - works
```
Let me know if that's what we want.