### PR TITLE
Check if the new gain update requires a new dataset ID. 

### DIFF
--- a/config/chime_science_run_recv.yaml
+++ b/config/chime_science_run_recv.yaml
@@ -124,6 +124,7 @@ updatable_config:
     start_time: 1575950518.4
     update_id: "zero_gain"
     transition_interval: 300.0
+    new_state: true
   26m_gated:
     kotekan_update_endpoint: "json"
     enabled: false

--- a/lib/stages/applyGains.cpp
+++ b/lib/stages/applyGains.cpp
@@ -118,6 +118,7 @@ bool applyGains::receive_update(json& json) {
     std::string gains_path;
     std::string update_id;
     double transition_interval;
+    bool new_state;
 
     // receive new gains timestamp ("start_time" might move to "start_time")
     try {
@@ -161,8 +162,20 @@ bool applyGains::receive_update(json& json) {
         return false;
     }
 
+    // Should we register a new dataset?
+    try {
+      if (!json.at("new_state").is_boolean())
+        throw std::invalid_argument(fmt::format(fmt("applyGains: received bad gains "
+                "new_state: {:s}"),
+              json.at("new_state").dump()));
+      new_state = json.at("new_state").get<bool>();
+    } catch (std::exception& e) {
+        WARN("Failure reading 'new_state' from update: {:s}", e.what());
+        return false;
+    }
+
     // Signal to fetch thread to get gains from broker
-    update_fetch_queue.put({update_id, transition_interval, new_ts});
+    update_fetch_queue.put({update_id, transition_interval, new_ts, new_state});
 
     INFO("Received gain update with tag {:s}.", update_id);
 
@@ -347,7 +360,7 @@ void applyGains::fetch_thread() {
         if (!update)
             break;
 
-        auto [update_id, transition_interval, new_ts] = *update;
+        auto [update_id, transition_interval, new_ts, new_state] = *update;
 
         std::optional<applyGains::GainData> gain_data;
         if (read_from_file) {
@@ -363,7 +376,15 @@ void applyGains::fetch_thread() {
         }
 
         // update gains
-        state_id_t state_id = dm.create_state<gainState>(update_id, transition_interval).first;
+        state_id_t state_id;
+        if(new_state) {
+          state_id = dm.create_state<gainState>(update_id, transition_interval).first;
+        }
+        // Use the current dataset ID
+        else {
+          const auto update = gains_fifo.get_update(double_to_ts(new_ts)).second;
+          state_id = update->state_id;
+        }
         GainUpdate gain_update{std::move(gain_data.value()), transition_interval, state_id};
 
         {

--- a/lib/stages/applyGains.cpp
+++ b/lib/stages/applyGains.cpp
@@ -164,11 +164,11 @@ bool applyGains::receive_update(json& json) {
 
     // Should we register a new dataset?
     try {
-      if (!json.at("new_state").is_boolean())
-        throw std::invalid_argument(fmt::format(fmt("applyGains: received bad gains "
-                "new_state: {:s}"),
-              json.at("new_state").dump()));
-      new_state = json.at("new_state").get<bool>();
+        if (!json.at("new_state").is_boolean())
+            throw std::invalid_argument(fmt::format(fmt("applyGains: received bad gains "
+                                                        "new_state: {:s}"),
+                                                    json.at("new_state").dump()));
+        new_state = json.at("new_state").get<bool>();
     } catch (std::exception& e) {
         WARN("Failure reading 'new_state' from update: {:s}", e.what());
         return false;
@@ -377,13 +377,13 @@ void applyGains::fetch_thread() {
 
         // update gains
         state_id_t state_id;
-        if(new_state) {
-          state_id = dm.create_state<gainState>(update_id, transition_interval).first;
+        if (new_state) {
+            state_id = dm.create_state<gainState>(update_id, transition_interval).first;
         }
         // Use the current dataset ID
         else {
-          const auto update = gains_fifo.get_update(double_to_ts(new_ts)).second;
-          state_id = update->state_id;
+            const auto update = gains_fifo.get_update(double_to_ts(new_ts)).second;
+            state_id = update->state_id;
         }
         GainUpdate gain_update{std::move(gain_data.value()), transition_interval, state_id};
 

--- a/lib/stages/applyGains.cpp
+++ b/lib/stages/applyGains.cpp
@@ -382,8 +382,11 @@ void applyGains::fetch_thread() {
         }
         // Use the current dataset ID
         else {
-            const auto update = gains_fifo.get_update(double_to_ts(new_ts)).second;
-            state_id = update->state_id;
+            const auto last_update = gains_fifo.get_update(double_to_ts(new_ts)).second;
+            if (last_update == nullptr) {
+                FATAL_ERROR("Failed to retrieve the last update, gains queue empty.");
+            }
+            state_id = last_update->state_id;
         }
         GainUpdate gain_update{std::move(gain_data.value()), transition_interval, state_id};
 

--- a/lib/stages/applyGains.cpp
+++ b/lib/stages/applyGains.cpp
@@ -384,9 +384,12 @@ void applyGains::fetch_thread() {
         else {
             const auto last_update = gains_fifo.get_update(double_to_ts(new_ts)).second;
             if (last_update == nullptr) {
-                FATAL_ERROR("Failed to retrieve the last update, gains queue empty.");
+                WARN("Failed to retrieve the last update, gains queue empty. Creating new gain "
+                     "state.");
+                state_id = dm.create_state<gainState>(update_id, transition_interval).first;
+            } else {
+                state_id = last_update->state_id;
             }
-            state_id = last_update->state_id;
         }
         GainUpdate gain_update{std::move(gain_data.value()), transition_interval, state_id};
 

--- a/lib/stages/applyGains.hpp
+++ b/lib/stages/applyGains.hpp
@@ -170,7 +170,7 @@ private:
     std::atomic<bool> started = false;
 
     /// Queue used to send updates into the fetch thread
-    using update_t = std::tuple<std::string, double, double>;
+    using update_t = std::tuple<std::string, double, double, bool>;
     SynchronizedQueue<update_t> update_fetch_queue;
 
 

--- a/tests/test_applygains.py
+++ b/tests/test_applygains.py
@@ -29,6 +29,7 @@ old_update_id = f"gains{old_timestamp}"
 new_update_id = f"gains{new_timestamp}"
 
 transition_interval = 10.0
+new_state = True
 
 global_params = {
     "num_elements": 16,
@@ -45,6 +46,7 @@ global_params = {
         "start_time": old_timestamp,
         "update_id": old_update_id,
         "transition_interval": transition_interval,
+        "new_state": new_state,
     },
     "wait": True,
     "sleep_before": 2.0,
@@ -170,6 +172,7 @@ def apply_data(request, tmp_path_factory, gain_path, old_gains, new_gains, cal_b
                 "update_id": new_update_id,
                 "start_time": new_timestamp,
                 "transition_interval": transition_interval,
+                "new_state": new_state,
             },
         ]
     ]


### PR DESCRIPTION
If the gain update does not require a dataset ID, this will use the current one. Fixes #740 .