### PR TITLE
hotfix - fix(receiver config): increase num kept gain/flags updates

### DIFF
--- a/config/chime_science_run_recv.yaml
+++ b/config/chime_science_run_recv.yaml
@@ -168,6 +168,7 @@ receive_flags:
   in_buf: visbuf_10s_all
   out_buf: visbuf_10s_flags
   updatable_config: "/updatable_config/flagging"
+  num_kept_updates: 24
 
 vis_debug:
   n2:
@@ -200,6 +201,7 @@ apply_gains:
   updatable_config: "/updatable_config/gains"
   broker_host: cv0r1
   broker_port: 54328
+  num_kept_updates: 24
 
 stacking:
   num_threads: 3

--- a/lib/utils/updateQueue.hpp
+++ b/lib/utils/updateQueue.hpp
@@ -160,12 +160,9 @@ struct fmt::formatter<updateQueue<T>> {
 
     template<typename FormatContext>
     auto format(const updateQueue<T>& q, FormatContext& ctx) {
-        auto it = q.get_all_updates().begin();
         auto pos = ctx.out();
-        while (it != q.get_all_updates().end()) {
-            pos = format_to(pos, "{:f} ", ts_to_double(it->first));
-            *it++;
-        }
+        for (const auto& item : q.get_all_updates())
+            pos = format_to(pos, "{:f} ", ts_to_double(item.first));
         return pos;
     }
 };

--- a/tests/boost/test_updatequeue.cpp
+++ b/tests/boost/test_updatequeue.cpp
@@ -8,6 +8,7 @@
 #include <algorithm>                         // for copy, copy_backward, max
 #include <boost/test/included/unit_test.hpp> // for BOOST_PP_IIF_1, BOOST_CHECK, BOOST_PP_BOOL_2
 #include <ctime>                             // for timespec
+#include <deque>                             // for deque, _Deque_iterator
 #include <iostream>                          // for cout, ostream, std
 #include <memory>
 #include <string>  // for operator<<
@@ -25,6 +26,31 @@ timespec three = {3, 0};
 timespec four = {4, 0};
 timespec five = {5, 0};
 timespec six = {6, 0};
+
+BOOST_AUTO_TEST_CASE(_updateQueue_return_all) {
+    updateQueue<int> q(3);
+
+    q.insert({1, 0}, 1);
+    auto all_updates = q.get_all_updates();
+    auto it = all_updates.begin();
+
+    BOOST_CHECK(it->first == one);
+    BOOST_CHECK(*(it->second) == 1);
+
+    q.insert({1, 0}, 1);
+    all_updates = q.get_all_updates();
+    it = all_updates.begin();
+    BOOST_CHECK(it->first == one);
+    BOOST_CHECK(*(it->second) == 1);
+
+    q.insert({1, 0}, 1);
+    all_updates = q.get_all_updates();
+    it = all_updates.begin();
+    BOOST_CHECK(it->first == one);
+    BOOST_CHECK(*(it->second) == 1);
+
+    BOOST_CHECK(fmt::format("{}", q) == fmt::format("{}", q));
+}
 
 BOOST_AUTO_TEST_CASE(_updateQueue) {
     updateQueue<int> q(3);
@@ -164,5 +190,5 @@ BOOST_AUTO_TEST_CASE(_updateQueue_out_of_order) {
     BOOST_CHECK(r.first == six);
 
     // A pretty stupid "test" for the fmt formatter:
-    std::cout << fmt::format("This queue should have timestamps 4, 5 and 6 now: {}", q);
+    std::cout << fmt::format("This queue should have timestamps 4, 5 and 6 now: {}\n", q);
 }


### PR DESCRIPTION
PR is against master!

Was at default (5), which allows frames to arrive 50s late when
calbroker sends 1 update in 10s and 150s late when flagging broker sends 1
update in 30s. Increase to num_kept_updates=24 to allow frames 240s late
for gain updates and 720s late for flagging update.

Additionally fixes a bug that is currently worked around by a log level change inserted into the running config. The fix (#727 ) was merged into develop previously.