### PR TITLE
config: change to explicit notation to avoid config parsing issues

### DIFF
--- a/config/chime_science_run_gpu.yaml
+++ b/config/chime_science_run_gpu.yaml
@@ -1513,8 +1513,8 @@ eigcalc:
   out_buf: visbuf_eig_10s_merge
 
   # Convergence config
-  tol_eval: 1.0e-5
-  tol_evec: 1.0e-4
+  tol_eval: 0.00001
+  tol_evec: 0.0001
   max_iterations: 19
   num_ev_conv: 2
   krylov: 2

--- a/config/chime_science_run_gpu_no_output.yaml
+++ b/config/chime_science_run_gpu_no_output.yaml
@@ -1512,8 +1512,8 @@ eigcalc:
   out_buf: visbuf_eig_10s_merge
 
   # Convergence config
-  tol_eval: 1.0e-5
-  tol_evec: 1.0e-4
+  tol_eval: 0.00001
+  tol_evec: 0.0001
   max_iterations: 19
   num_ev_conv: 2
   krylov: 2


### PR DESCRIPTION
For some completely inexplicable reason, coco has decided that the value of `tol_eval` is not the floating point `0.00001` but is the string `"1e-05"`. It didn't used to, this is a recent decision it's made, I can only presume it missed lunch yesterday and got angry, because this only started to happen when the correlator came back online at 4pm yesterday.

Now you'd think this would be a big issue, right? After all the `EigenVisIter` process knows it's expecting a `double` and there's no way of converting a JSON string to a float, so it should just error out. Oh, but there is! Don't you remember the ridiculous in built arithmetic expression parsing logic that will attempt to turn any string into an arithmetic type? Indeed, it sees that string, ignores the fact it's scientific notation, isn't phased by the errant `e` in the middle, and decided you definitely want that value to be `-4`. Yes folks, `1.0e-5 == -4` in the wise eyes of coco and kotekan.

Anyway, it's not wise to argue with such wisdom so I'm taking the easy way out and just specifying the values in exact decimals. Surely it can't mess that up.