### PR TITLE
Fix configEval parsing issues

### DIFF
--- a/lib/core/Config.hpp
+++ b/lib/core/Config.hpp
@@ -315,9 +315,9 @@ Config::configEval<Type>::configEval(const Config& _config, const std::string& b
     }
     const std::string& expression = value.get<std::string>();
 
-    static const std::regex re(R"((-?(?:0|[1-9]\d*)(?:\.\d*)?(?:[eE][+\-]?\d+)?"
-                               "|\+|\*|\-|\/|\)|\(|[a-zA-Z][a-zA-Z0-9_]*))",
-                               std::regex::ECMAScript);
+    static const std::regex re(
+        R"((-?(?:0|[1-9]\d*)(?:\.\d*)?(?:[eE][+\-]?\d+)?|\+|\*|\-|\/|\)|\(|[a-zA-Z][a-zA-Z0-9_]*))",
+        std::regex::ECMAScript);
 
     tokens = {std::sregex_token_iterator(expression.begin(), expression.end(), re, 1),
               std::sregex_token_iterator()};

--- a/lib/core/Config.hpp
+++ b/lib/core/Config.hpp
@@ -316,7 +316,7 @@ Config::configEval<Type>::configEval(const Config& _config, const std::string& b
     const std::string& expression = value.get<std::string>();
 
     static const std::regex re(
-        R"((-?(?:0|[1-9]\d*)(?:\.\d*)?(?:[eE][+\-]?\d+)?|\+|\*|\-|\/|\)|\(|[a-zA-Z][a-zA-Z0-9_]*))",
+        R"((-?(?:0|[1-9][0-9]*)(?:\.[0-9]*)?(?:[eE][+\-]?[0-9]+)?|\+|\*|\-|\/|\)|\(|[a-zA-Z][a-zA-Z0-9_]*))",
         std::regex::ECMAScript);
 
     tokens = {std::sregex_token_iterator(expression.begin(), expression.end(), re, 1),
@@ -352,7 +352,8 @@ void Config::configEval<Type>::next() {
 
 template<class Type>
 bool Config::configEval<Type>::isNumber() {
-    std::regex re(R"(-?(?:0|[1-9]\d*)(?:\.\d*)?(?:[eE][+\-]?\d+)?)", std::regex::ECMAScript);
+    std::regex re(R"(-?(?:0|[1-9][0-9]*)(?:\.[0-9]*)?(?:[eE][+\-]?[0-9]+)?)",
+                  std::regex::ECMAScript);
     std::cmatch m;
     return std::regex_match(tokens.front().c_str(), m, re);
 }

--- a/lib/core/Config.hpp
+++ b/lib/core/Config.hpp
@@ -315,7 +315,8 @@ Config::configEval<Type>::configEval(const Config& _config, const std::string& b
     }
     const std::string& expression = value.get<std::string>();
 
-    static const std::regex re(R"(([0-9]*\.?[0-9]+|\+|\*|\-|\/|\)|\(|[a-zA-Z][a-zA-Z0-9_]+))",
+    static const std::regex re(R"((-?(?:0|[1-9]\d*)(?:\.\d*)?(?:[eE][+\-]?\d+)?"
+                               "|\+|\*|\-|\/|\)|\(|[a-zA-Z][a-zA-Z0-9_]*))",
                                std::regex::ECMAScript);
 
     tokens = {std::sregex_token_iterator(expression.begin(), expression.end(), re, 1),
@@ -330,7 +331,13 @@ Config::configEval<Type>::~configEval() {}
 
 template<class Type>
 Type Config::configEval<Type>::compute_result() {
-    return exp();
+    Type result = exp();
+    if (current_token != "") {
+        std::string error_msg = fmt::format("Unexpected symbol: {:s}", current_token);
+        ERROR_NON_OO("{:s}", error_msg);
+        throw std::runtime_error(error_msg);
+    }
+    return result;
 }
 
 template<class Type>
@@ -345,14 +352,14 @@ void Config::configEval<Type>::next() {
 
 template<class Type>
 bool Config::configEval<Type>::isNumber() {
-    std::regex re(R"([0-9]*\.?[0-9]+)", std::regex::ECMAScript);
+    std::regex re(R"(-?(?:0|[1-9]\d*)(?:\.\d*)?(?:[eE][+\-]?\d+)?)", std::regex::ECMAScript);
     std::cmatch m;
     return std::regex_match(tokens.front().c_str(), m, re);
 }
 
 template<class Type>
 bool Config::configEval<Type>::isVar() {
-    std::regex re(R"([a-zA-Z][a-zA-Z0-9_]+)", std::regex::ECMAScript);
+    std::regex re(R"([a-zA-Z][a-zA-Z0-9_]*)", std::regex::ECMAScript);
     std::cmatch m;
     return std::regex_match(tokens.front().c_str(), m, re);
 }

--- a/lib/core/Config.hpp
+++ b/lib/core/Config.hpp
@@ -421,7 +421,10 @@ template<class Type>
 Type Config::configEval<Type>::factor() {
     Type ret;
 
-    if (isVar()) {
+    if (current_token == "") {
+        ERROR_NON_OO("Expected another value/symbol in expression but found none");
+        throw std::runtime_error("Expected another value/symbol in expression but found none");
+    } else if (isVar()) {
         ret = config.get<Type>(unique_name, current_token);
         next();
     } else if (isNumber()) {

--- a/lib/stages/pulsarPostProcess.cpp
+++ b/lib/stages/pulsarPostProcess.cpp
@@ -189,8 +189,8 @@ void pulsarPostProcess::main_thread() {
             return;
 
         for (uint32_t i = 0; i < _num_gpus; ++i) {
+            psr_coord[i] = get_psr_coord(in_buf[i], in_buffer_ID[i]);
             if (_timesamples_per_pulsar_packet == 3125) {
-                psr_coord[i] = get_psr_coord(in_buf[i], in_buffer_ID[i]);
                 thread_ids[i] = tel.to_freq_id(in_buf[i], in_buffer_ID[i]);
             } else if (_timesamples_per_pulsar_packet == 625) {
                 // In the case of 4 frequencies per packet we convert the stream_id into a

--- a/python/kotekan/runner.py
+++ b/python/kotekan/runner.py
@@ -1097,7 +1097,7 @@ main_pool:
 vis_pool:
     kotekan_metadata_pool: VisMetadata
     num_metadata_objects: 30 * buffer_depth
-    "int_frames": 64,
+    int_frames: 64
 """
 
 

--- a/tests/boost/test_config.cpp
+++ b/tests/boost/test_config.cpp
@@ -40,6 +40,7 @@ BOOST_AUTO_TEST_CASE(_get_value_recursive) {
         {"scientific2", "-0.5e2 + -0.5e+4 + 1.2E-1 - 5.32e-2"},
         {"scientific3", "1.22e20"},
         {"scientific4", "1.258e-20"},
+        {"scientific5", "190.2508e+0"},
         {"broken", "5 + e3"},
         {"broken2", "5 +"},
         {"broken3", "5 +* 8"},
@@ -106,6 +107,7 @@ BOOST_AUTO_TEST_CASE(_get_value_recursive) {
     BOOST_CHECK_EQUAL(config.get<double>("/", "scientific2"), -0.5e2 + -0.5e+4 + 1.2E-1 - 5.32e-2);
     BOOST_CHECK_EQUAL(config.get<double>("/", "scientific3"), 1.22e20);
     BOOST_CHECK_EQUAL(config.get<double>("/", "scientific4"), 1.258e-20);
+    BOOST_CHECK_EQUAL(config.get<double>("/", "scientific5"), 190.2508e+0);
     BOOST_CHECK_THROW(config.get<double>("/", "broken"), std::runtime_error);
     BOOST_CHECK_THROW(config.get<double>("/", "broken2"), std::runtime_error);
     BOOST_CHECK_THROW(config.get<double>("/", "broken3"), std::runtime_error);

--- a/tests/boost/test_config.cpp
+++ b/tests/boost/test_config.cpp
@@ -37,7 +37,7 @@ BOOST_AUTO_TEST_CASE(_get_value_recursive) {
         {"subtract", "25.5 - 0.5"},
         {"divide", "10 / 4"},
         {"scientific", "-0.5e2"},
-        {"scientific2", "-0.5e2 + -0.5e+4 + 1.2e-1 - 5.32e-2"},
+        {"scientific2", "-0.5e2 + -0.5e+4 + 1.2E-1 - 5.32e-2"},
         {"scientific3", "1.22e20"},
         {"scientific4", "1.258e-20"},
         {"broken", "5 + e3"},
@@ -103,7 +103,7 @@ BOOST_AUTO_TEST_CASE(_get_value_recursive) {
     BOOST_CHECK_EQUAL(config.get<double>("/", "subtract"), 25);
     BOOST_CHECK_EQUAL(config.get<double>("/", "divide"), 2.5);
     BOOST_CHECK_EQUAL(config.get<double>("/", "scientific"), -0.5e2);
-    BOOST_CHECK_EQUAL(config.get<double>("/", "scientific2"), -0.5e2 + -0.5e+4 + 1.2e-1 - 5.32e-2);
+    BOOST_CHECK_EQUAL(config.get<double>("/", "scientific2"), -0.5e2 + -0.5e+4 + 1.2E-1 - 5.32e-2);
     BOOST_CHECK_EQUAL(config.get<double>("/", "scientific3"), 1.22e20);
     BOOST_CHECK_EQUAL(config.get<double>("/", "scientific4"), 1.258e-20);
     BOOST_CHECK_THROW(config.get<double>("/", "broken"), std::runtime_error);

--- a/tests/boost/test_config.cpp
+++ b/tests/boost/test_config.cpp
@@ -27,7 +27,26 @@ BOOST_AUTO_TEST_CASE(_get_value_recursive) {
         {"nothing", nullptr},
         {"answer", {{"everything", 42}}},
         {"list", {1, 0, 2}},
-        {"object", {{"currency", "USD"}, {"value", 42.99}, {"hidden", {{"treasure", "found"}}}}}};
+        {"object", {{"currency", "USD"}, {"value", 42.99}, {"hidden", {{"treasure", "found"}}}}},
+        {"add", "2 + pi"},
+        {"one_var", "pi"},
+        {"num_as_string", "-5.01"},
+        {"int_as_string", "50"},
+        {"int_as_string2", "-50"},
+        {"multiply", "2 * pi"},
+        {"subtract", "25.5 - 0.5"},
+        {"divide", "10 / 4"},
+        {"scientific", "-0.5e2"},
+        {"scientific2", "-0.5e2 + -0.5e+4 + 1.2e-1 - 5.32e-2"},
+        {"scientific3", "1.22e20"},
+        {"scientific4", "1.258e-20"},
+        {"broken", "5 + e3"},
+        {"broken2", "5 +"},
+        {"broken3", "5 +* 8"},
+        {"broken4", "5 + (8"},
+        {"broken5", "*5"},
+        {"missing", "5 + not_set"},
+        {"complicated", "1e4 + divide * 10 /(4 + 1) - 20 * (6-pi) + -1.2e2"}};
     Config config;
     config.update_config(json_config);
 
@@ -74,6 +93,28 @@ BOOST_AUTO_TEST_CASE(_get_value_recursive) {
     results.clear();
     results.push_back(j);
     BOOST_CHECK_EQUAL(config.get_value("everything"), results);
+
+    // Check the arithmetic parser
+    BOOST_CHECK_EQUAL(config.get<double>("/", "add"), 5.141);
+    BOOST_CHECK_EQUAL(config.get<double>("/", "one_var"), 3.141);
+    BOOST_CHECK_EQUAL(config.get<double>("/", "num_as_string"), -5.01);
+    BOOST_CHECK_EQUAL(config.get<int32_t>("/", "int_as_string"), 50);
+    BOOST_CHECK_EQUAL(config.get<int32_t>("/", "int_as_string2"), -50);
+    BOOST_CHECK_EQUAL(config.get<double>("/", "subtract"), 25);
+    BOOST_CHECK_EQUAL(config.get<double>("/", "divide"), 2.5);
+    BOOST_CHECK_EQUAL(config.get<double>("/", "scientific"), -0.5e2);
+    BOOST_CHECK_EQUAL(config.get<double>("/", "scientific2"), -0.5e2 + -0.5e+4 + 1.2e-1 - 5.32e-2);
+    BOOST_CHECK_EQUAL(config.get<double>("/", "scientific3"), 1.22e20);
+    BOOST_CHECK_EQUAL(config.get<double>("/", "scientific4"), 1.258e-20);
+    BOOST_CHECK_THROW(config.get<double>("/", "broken"), std::runtime_error);
+    BOOST_CHECK_THROW(config.get<double>("/", "broken2"), std::runtime_error);
+    BOOST_CHECK_THROW(config.get<double>("/", "broken3"), std::runtime_error);
+    BOOST_CHECK_THROW(config.get<double>("/", "broken4"), std::runtime_error);
+    BOOST_CHECK_THROW(config.get<double>("/", "broken5"), std::runtime_error);
+    BOOST_CHECK_THROW(config.get<double>("/", "missing"), std::runtime_error);
+    BOOST_CHECK_EQUAL(config.get<double>("/", "complicated"),
+                      1e4 + (2.5) * 10 / (4 + 1) - 20 * (6 - 3.141) + -1.2e2);
+
 
     BOOST_CHECK(config.get_value("Niels").empty());
     BOOST_CHECK(config.get_value("found").empty());


### PR DESCRIPTION
This change adds the following fixes:

- Check for unexpected tokens after exp()
- Allow isNumber regex to parse numbers in scientific notation
- Variable regex now accepts single characters so they don't get dropped from the token list
- Throw exception for incomplete expressions (i.e. `5 + `). 

Closes: #378 