### PR TITLE
Switch to fp16 for intermediate static beam products

### DIFF
--- a/lib/hsa/hsaBeamformKernel.cpp
+++ b/lib/hsa/hsaBeamformKernel.cpp
@@ -63,7 +63,8 @@ hsaBeamformKernel::hsaBeamformKernel(Config& config, const std::string& unique_n
     }
 
     input_frame_len = _num_elements * _num_local_freq * _samples_per_data_set;
-    output_frame_len = _num_elements * _samples_per_data_set * 2 * sizeof(float);
+    // Kernel uses fp16 complex numbers for output which are the same size as sizeof(float)
+    output_frame_len = _num_elements * _samples_per_data_set * sizeof(float);
 
 
     map_len = 256 * sizeof(int);

--- a/lib/hsa/hsaBeamformTranspose.cpp
+++ b/lib/hsa/hsaBeamformTranspose.cpp
@@ -25,8 +25,9 @@ hsaBeamformTranspose::hsaBeamformTranspose(Config& config, const std::string& un
     _num_elements = config.get<int32_t>(unique_name, "num_elements");
     _samples_per_data_set = config.get<int32_t>(unique_name, "samples_per_data_set");
 
-    beamform_frame_len = _num_elements * _samples_per_data_set * 2 * sizeof(float);
-    output_frame_len = _num_elements * (_samples_per_data_set + 32) * 2 * sizeof(float);
+    // Kernel uses fp16 complex numbers which are the same size as sizeof(float)
+    beamform_frame_len = _num_elements * _samples_per_data_set * sizeof(float);
+    output_frame_len = _num_elements * (_samples_per_data_set + 32) * sizeof(float);
 }
 
 hsaBeamformTranspose::~hsaBeamformTranspose() {}

--- a/lib/hsa/hsaBeamformUpchanHFB.cpp
+++ b/lib/hsa/hsaBeamformUpchanHFB.cpp
@@ -28,7 +28,9 @@ hsaBeamformUpchanHFB::hsaBeamformUpchanHFB(Config& config, const std::string& un
     _num_frb_total_beams = config.get<int32_t>(unique_name, "num_frb_total_beams");
     _factor_upchan = config.get<int32_t>(unique_name, "factor_upchan");
 
-    input_frame_len = _num_elements * (_samples_per_data_set + 32) * 2 * sizeof(float);
+    // Kernel uses fp16 complex numbers for input which are the same size as sizeof(float)
+    input_frame_len = _num_elements * (_samples_per_data_set + 32) * sizeof(float);
+
     output_frame_len = _num_frb_total_beams
                        * (_samples_per_data_set / _downsample_time / _downsample_freq)
                        * sizeof(float);

--- a/lib/hsa/kernels/transpose.cl
+++ b/lib/hsa/kernels/transpose.cl
@@ -2,12 +2,12 @@
 #define BLOCK_ROWS 8
 
 
-__kernel void transpose(__global float2 *input, __global float2 *output) {
+__kernel void transpose(__global float *input, __global float *output) {
   
   uint width1 = get_global_size(0);
   uint width2 = get_global_size(1)*4;
 
-  __local float2 tile[TILE_DIM][TILE_DIM];  //32x32
+  __local float tile[TILE_DIM][TILE_DIM];  //32x32
   uint x  = get_group_id(0) * TILE_DIM + get_local_id(0);
   uint y =  get_group_id(1) * TILE_DIM + get_local_id(1);
 

--- a/lib/hsa/kernels/unpack_shift_beamform_flip.cl
+++ b/lib/hsa/kernels/unpack_shift_beamform_flip.cl
@@ -13,7 +13,7 @@
 
 #define CUSTOM_BIT_REVERSE_9_BITS(index) ((( ( (((index) * 0x0802) & 0x22110) | (((index) * 0x8020)&0x88440) ) * 0x10101 ) >> 15) & 0x1FE)
 
-__kernel void zero_padded_FFT512( __global uint *data, __global uint *mapped,  __global float2 *Co, __global float2 *results_array,  __global float2 *Gain){
+__kernel void zero_padded_FFT512( __global uint *data, __global uint *mapped,  __global float2 *Co, __global float *results_array,  __global float2 *Gain){
 
   __local float2 local_data[2048];//4* 512 float2 * 2 float/float2 * 4 B/float = 16kB
     uint local_address = get_local_id(0);  //0 to 255
@@ -192,7 +192,7 @@ __kernel void zero_padded_FFT512( __global uint *data, __global uint *mapped,  _
     barrier(CLK_LOCAL_MEM_FENCE);
 
     //Clamping
-    index_0= mapped[local_address];  
+    index_0= mapped[local_address];
     index_1 = index_0 + 512;
     index_2 = index_0 + 1024;
     index_3 = index_0 + 1536;
@@ -209,6 +209,7 @@ __kernel void zero_padded_FFT512( __global uint *data, __global uint *mapped,  _
     //change to 255-localadd in order to flip cylinder NS
     uint address = get_global_id(2)*2048 + get_global_id(1)*1024 + (255-local_address);
 
+    float out;
     temp_0.REAL = 4;
     temp_0.IMAG = 4;
     //Beam0
@@ -222,7 +223,12 @@ __kernel void zero_padded_FFT512( __global uint *data, __global uint *mapped,  _
       local_data[index_1].REAL * CoArray[1].IMAG - local_data[index_1].IMAG * CoArray[1].REAL + \
       local_data[index_2].REAL * CoArray[2].IMAG - local_data[index_2].IMAG * CoArray[2].REAL + \
       local_data[index_3].REAL * CoArray[3].IMAG - local_data[index_3].IMAG * CoArray[3].REAL ;
-    results_array[address] = Temp/temp_0;
+    Temp = Temp/temp_0;
+    __asm__ ("V_CVT_PKRTZ_F16_F32 %0, %1, %2" : "=v"(out)
+                                              : "v"(Temp.x),
+                                                "v"(Temp.y));
+    results_array[address] = out;
+//    results_array[address] = Temp/temp_0;
 
     //Beam1
     Temp.REAL =\
@@ -235,7 +241,12 @@ __kernel void zero_padded_FFT512( __global uint *data, __global uint *mapped,  _
       local_data[index_1].REAL * CoArray[5].IMAG - local_data[index_1].IMAG * CoArray[5].REAL + \
       local_data[index_2].REAL * CoArray[6].IMAG - local_data[index_2].IMAG * CoArray[6].REAL + \
       local_data[index_3].REAL * CoArray[7].IMAG - local_data[index_3].IMAG * CoArray[7].REAL ;
-    results_array[address+ 256] = Temp/temp_0;
+    Temp = Temp/temp_0;
+    __asm__ ("V_CVT_PKRTZ_F16_F32 %0, %1, %2" : "=v"(out)
+                                              : "v"(Temp.x),
+                                                "v"(Temp.y));
+    results_array[address + 256] = out;
+//    results_array[address+ 256] = Temp/temp_0;
 
     //Beam2
   Temp.REAL = \
@@ -248,7 +259,12 @@ __kernel void zero_padded_FFT512( __global uint *data, __global uint *mapped,  _
     local_data[index_1].REAL * CoArray[9].IMAG - local_data[index_1].IMAG * CoArray[9].REAL + \
     local_data[index_2].REAL * CoArray[10].IMAG - local_data[index_2].IMAG * CoArray[10].REAL +   \
     local_data[index_3].REAL * CoArray[11].IMAG - local_data[index_3].IMAG * CoArray[11].REAL ;
-  results_array[address + 2*256] = Temp/temp_0;
+    Temp = Temp/temp_0;
+    __asm__ ("V_CVT_PKRTZ_F16_F32 %0, %1, %2" : "=v"(out)
+                                              : "v"(Temp.x),
+                                                "v"(Temp.y));
+    results_array[address + 2*256] = out;
+//  results_array[address + 2*256] = Temp/temp_0;
 
   //Beam3
   Temp.REAL = \
@@ -261,7 +277,12 @@ __kernel void zero_padded_FFT512( __global uint *data, __global uint *mapped,  _
     local_data[index_1].REAL * CoArray[13].IMAG - local_data[index_1].IMAG * CoArray[13].REAL + \
     local_data[index_2].REAL * CoArray[14].IMAG - local_data[index_2].IMAG * CoArray[14].REAL +   \
     local_data[index_3].REAL * CoArray[15].IMAG - local_data[index_3].IMAG * CoArray[15].REAL ;
-  results_array[address+ 3*256] = Temp/temp_0;
+    Temp = Temp/temp_0;
+    __asm__ ("V_CVT_PKRTZ_F16_F32 %0, %1, %2" : "=v"(out)
+                                              : "v"(Temp.x),
+                                                "v"(Temp.y));
+    results_array[address + 3*256] = out;
+//  results_array[address+ 3*256] = Temp/temp_0;
 
   //exit
 


### PR DESCRIPTION
@kvand found out that using an FP16 array instead of FP32 between the FFT Beamformer, transpose, and upchannelization results in a large speed improvement, and lowers the overall utilization on the CHIME nodes by about 2%.   

In theory this slightly increases the quantization noise, but the impact should be very minimal. 

### Typical kernel timing before change: 
```
| -------- GPU[0] Kernel timing --------
| Kernel name         |     time | utilization   |
|---------------------+----------+---------------|
| reorder             | 0.000476 | 0.3783%       |
| zero_padded_FFT512  | 0.010676 | 8.4844%       |
| transpose           | 0.004672 | 3.7127%       |
| upchannelize        | 0.005487 | 4.3609%       |
| sum_hfb             | 0.000223 | 0.1771%       |
| pulsarbf_float      | 0.005896 | 4.6855%       |
| rfi_chime_time_sum  | 0.000865 | 0.6873%       |
| rfi_bad_input       | 0.000159 | 0.1263%       |
| rfi_chime_input_sum | 3.3e-05  | 0.0261%       |
| rfi_chime_zero      | 0.000368 | 0.2928%       |
| CHIME_presum        | 0.000124 | 0.0983%       |
| CHIME_presum        | 0.000129 | 0.1027%       |
| CHIME_presum        | 0.00013  | 0.1034%       |
| CHIME_presum        | 0.000124 | 0.0988%       |
| CHIME_X             | 0.023332 | 18.5425%      |
| CHIME_X             | 0.023341 | 18.5497%      |
| CHIME_X             | 0.023366 | 18.5696%      |
| CHIME_X             | 0.023385 | 18.5848%      |
| Total:              | 0.122786 | 97.5812%      |
```
### Typical kernel timing after change: 
```
| -------- GPU[0] Kernel timing --------
| Kernel name         |     time | utilization   |
|---------------------+----------+---------------|
| reorder             | 0.000476 | 0.3780%       |
| zero_padded_FFT512  | 0.010008 | 7.9537%       |
| transpose           | 0.002517 | 2.0004%       |
| upchannelize        | 0.005417 | 4.3052%       |
| sum_hfb             | 0.000227 | 0.1807%       |
| pulsarbf_float      | 0.005907 | 4.6946%       |
| rfi_chime_time_sum  | 0.000857 | 0.6809%       |
| rfi_bad_input       | 0.000162 | 0.1291%       |
| rfi_chime_input_sum | 3.4e-05  | 0.0267%       |
| rfi_chime_zero      | 0.000303 | 0.2407%       |
| CHIME_presum        | 0.000127 | 0.1006%       |
| CHIME_presum        | 0.000125 | 0.0993%       |
| CHIME_presum        | 0.000108 | 0.0858%       |
| CHIME_presum        | 0.000106 | 0.0844%       |
| CHIME_X             | 0.023367 | 18.5706%      |
| CHIME_X             | 0.023343 | 18.5516%      |
| CHIME_X             | 0.023347 | 18.5547%      |
| CHIME_X             | 0.023389 | 18.5878%      |
| Total:              | 0.11982  | 95.2247%      |
```
 