### PR TITLE
Update Telescope objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.c~
 *.h~
 *.swp
+*.pyc
 /.idea/
 /.vscode/
 /nbproject/

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,7 @@
 *.c~
 *.h~
 *.swp
+/.idea/
 /.vscode/
 /nbproject/
+/cmake-build*/

--- a/config/aro_record.yaml
+++ b/config/aro_record.yaml
@@ -112,9 +112,8 @@ raw_capture:
    note: 10m FRB search
 #Change this if you want to record
    write_to_disk: True
-   gain_files:
-   - /home/arofrb/aro_run/gains/gains_FCC0000.pkl
-   - /home/arofrb/aro_run/gains/gains_noisy_FCC0000.pkl
+   write_metadata_and_gains: False
+   gain_files: Null
    num_disks: 10
    disk_base: /drives
    disk_set: L

--- a/config/aro_record.yaml
+++ b/config/aro_record.yaml
@@ -16,6 +16,12 @@ type: config
 # Note DEBUG and DEBUG2 require a build with (-DCMAKE_BUILD_TYPE=Debug)
 log_level: DEBUG
 
+telescope:
+  name: ICETelescope
+  require_gps: true
+  query_gps: true
+  gps_host: 127.0.0.1 # Set this to the fpga_master host
+
 instrument_name: aro
 
 power_integration_length: 8192

--- a/config/chime_science_run_gpu.yaml
+++ b/config/chime_science_run_gpu.yaml
@@ -85,8 +85,10 @@ trunc_bias_switch: True
 telescope:
   name: CHIMETelescope
   require_gps: true
-  require_frequency_map: true
-  query_frequency_map: true
+  query_gps: false # GPS time is provided via coco
+  query_frequency_map: false # Frequency map is provided via coco
+  require_frequency_map: true # Make sure we have the full frequency map
+  allow_default_frequency_map: false # Don't fall back on default map
 
 ##########################
 #### Dataset manager #####

--- a/config/chime_science_run_gpu.yaml
+++ b/config/chime_science_run_gpu.yaml
@@ -83,9 +83,10 @@ trunc_bias_switch: True
 #### Telescope #####
 ####################
 telescope:
-  name: chime
+  name: CHIMETelescope
   require_gps: true
   require_frequency_map: true
+  query_frequency_map: true
 
 ##########################
 #### Dataset manager #####

--- a/config/chime_science_run_gpu_no_output.yaml
+++ b/config/chime_science_run_gpu_no_output.yaml
@@ -87,8 +87,7 @@ telescope:
   require_gps: true
   query_gps: true
   query_frequency_map: true
-  allow_default_frequency_map: false
-
+  allow_default_frequency_map: true
 
 ##########################
 #### Dataset manager #####

--- a/config/chime_science_run_gpu_no_output.yaml
+++ b/config/chime_science_run_gpu_no_output.yaml
@@ -83,8 +83,12 @@ trunc_bias_switch: True
 #### Telescope #####
 ####################
 telescope:
-  name: chime
+  name: CHIMETelescope
   require_gps: true
+  query_gps: true
+  query_frequency_map: true
+  allow_default_frequency_map: false
+
 
 ##########################
 #### Dataset manager #####

--- a/config/chime_science_run_gpu_no_output.yaml
+++ b/config/chime_science_run_gpu_no_output.yaml
@@ -84,9 +84,10 @@ trunc_bias_switch: True
 ####################
 telescope:
   name: CHIMETelescope
-  require_gps: true
+  require_gps: false # Still run the config if fpga_master is down.
   query_gps: true
   query_frequency_map: true
+  require_frequency_map: false
   allow_default_frequency_map: true
 
 ##########################

--- a/config/chime_science_run_recv.yaml
+++ b/config/chime_science_run_recv.yaml
@@ -29,7 +29,7 @@ num_ev: 4
 cpu_affinity: [7, 11, 14, 15]
 
 telescope:
-  name: chime
+  name: CHIMETelescope
   allow_default_frequency_map: false
 
 dataset_manager:

--- a/kotekan/kotekan.cpp
+++ b/kotekan/kotekan.cpp
@@ -50,9 +50,6 @@ const std::string yaml_to_json = R"(
 import yaml, json, sys, os, subprocess, errno
 
 file_name = sys.argv[1]
-gps_server = ""
-if len(sys.argv) == 3:
-    gps_server = sys.argv[2]
 
 # Lint the YAML file, helpful for finding errors
 try:
@@ -82,36 +79,8 @@ with open(file_name, "r") as stream:
     except yaml.YAMLError as exc:
         sys.stderr.write(exc)
 
-# Get the GPS server time if a server was given
-if gps_server != "":
-    import requests
-    try:
-        gps_request = requests.get(gps_server)
-        gps_request.raise_for_status()
-    except requests.exceptions.HTTPError as rex:
-        config_json["gps_time"] = {}
-        config_json["gps_time"]["error"] = str(rex)
-        sys.stdout.write(json.dumps(config_json))
-        quit()
-    except requests.exceptions.RequestException as rex:
-        config_json["gps_time"] = {}
-        config_json["gps_time"]["error"] = str(rex)
-        sys.stdout.write(json.dumps(config_json))
-        quit()
-
-    try:
-        config_json["gps_time"] = gps_request.json()
-    except:
-        config_json["gps_time"] = {}
-        config_json["gps_time"]["error"] = "Server did not return valid JSON"
-
 sys.stdout.write(json.dumps(config_json))
 )";
-
-// The default location for getting the GPS time reference
-// TODO This entire GPS time system might be moved out of kotekan.cpp entirely
-// since it's a very CHIME specific system.
-const std::string default_gps_source = "http://carillon.chime:54321/get-frame0-time";
 
 kotekanMode* kotekan_mode = nullptr;
 bool running = false;
@@ -128,14 +97,10 @@ void print_help() {
     printf("    --config (-c) [file]           The local JSON config file to use.\n");
     printf("    --bind-address (-b) [ip:port]  The IP address and port to bind"
            " (default 0.0.0.0:12048)\n");
-    printf("    --gps-time (-g)                Used with -c, try to get GPS time"
-           " (CHIME cmd line runs only).\n");
-    printf("    --gps-time-source (-t)         URL for GPS server (used with -g) default: %s\n",
-           default_gps_source.c_str());
     printf("    --syslog (-s)                  Send a copy of the output to syslog.\n");
     printf("    --no-stderr (-n)               Disables output to std error if syslog (-s) is "
            "enabled.\n");
-    printf("    --version (-v)                 Prints the kotekan version and build details.\n\n");
+    printf("    --version (-v)                 Prints the kotekan version and build details.\n");
     printf("    --print-config (-p)            Prints the config file being used.\n\n");
     printf("If no options are given then kotekan runs in daemon mode and\n");
     printf("expects to get it configuration via the REST endpoint '/start'.\n");
@@ -294,10 +259,8 @@ int main(int argc, char** argv) {
 
     char* config_file_name = (char*)"none";
     int log_options = LOG_CONS | LOG_PID | LOG_NDELAY;
-    bool gps_time = false;
     bool enable_stderr = true;
     bool dump_config = false;
-    std::string gps_time_source = default_gps_source;
     std::string bind_address = "0.0.0.0:12048";
     // We disable syslog to start.
     // If only --config is provided, then we only send messages to stderr
@@ -309,8 +272,6 @@ int main(int argc, char** argv) {
     for (;;) {
         static struct option long_options[] = {{"config", required_argument, nullptr, 'c'},
                                                {"bind-address", required_argument, nullptr, 'b'},
-                                               {"gps-time", no_argument, nullptr, 'g'},
-                                               {"gps-time-source", required_argument, nullptr, 't'},
                                                {"help", no_argument, nullptr, 'h'},
                                                {"syslog", no_argument, nullptr, 's'},
                                                {"no-stderr", no_argument, nullptr, 'n'},
@@ -321,7 +282,7 @@ int main(int argc, char** argv) {
 
         int option_index = 0;
 
-        int opt_val = getopt_long(argc, argv, "gt:hc:b:snvp", long_options, &option_index);
+        int opt_val = getopt_long(argc, argv, "hc:b:snvp", long_options, &option_index);
 
         // End of args
         if (opt_val == -1) {
@@ -338,12 +299,6 @@ int main(int argc, char** argv) {
                 break;
             case 'b':
                 bind_address = string(optarg);
-                break;
-            case 't':
-                gps_time_source = string(optarg);
-                break;
-            case 'g':
-                gps_time = true;
                 break;
             case 's':
                 __enable_syslog = 1;
@@ -404,16 +359,9 @@ int main(int argc, char** argv) {
         std::lock_guard<std::mutex> lock(kotekan_state_lock);
         INFO_NON_OO("Opening config file {:s}", config_file_name);
 
-        std::string exec_command;
-        if (gps_time) {
-            INFO_NON_OO("Getting GPS time from server ({:s}), this might take some time...",
-                        gps_time_source);
-            exec_command = fmt::format(fmt("python -c '{:s}' {:s} {:s}"), yaml_to_json,
-                                       config_file_name, gps_time_source);
-        } else {
-            exec_command =
-                fmt::format(fmt("python -c '{:s}' {:s}"), yaml_to_json, config_file_name);
-        }
+        std::string exec_command =
+            fmt::format(fmt("python -c '{:s}' {:s}"), yaml_to_json, config_file_name);
+
         std::string json_string = exec(exec_command.c_str());
         json config_json = json::parse(json_string);
         config.update_config(config_json);

--- a/lib/dpdk/iceBoardVDIF.hpp
+++ b/lib/dpdk/iceBoardVDIF.hpp
@@ -205,12 +205,14 @@ bool iceBoardVDIF::advance_vdif_frame(uint64_t new_seq, bool first_time) {
         if (tel.gps_time_enabled()) {
             timespec gps_time = tel.to_time(new_seq);
             // Compute the time at fpga_seq_num == 0 in nano seconds
-            // relative to the year 2000 epoch
+            // relative to the 2018 epoch (see above)
             vdif_base_time = gps_time.tv_sec * 1000000000 + gps_time.tv_nsec
                              - new_seq * tel.seq_length_nsec() - ref_epoch_offset * 1000000000;
+            DEBUG("Using GPS based vdif_base_time: {:d}", vdif_base_time);
         } else {
             vdif_base_time = now.tv_sec * 1000000000 + now.tv_usec * 1000
                              - new_seq * tel.seq_length_nsec() - ref_epoch_offset * 1000000000;
+            DEBUG("Using system clock based vdif_base_time: {:d}", vdif_base_time);
         }
     }
 

--- a/lib/hsa/kernels/N2.isa
+++ b/lib/hsa/kernels/N2.isa
@@ -47,6 +47,8 @@ CHIME_X:
 
  .end_amd_kernel_code_t
 
+;enable LDS
+s_mov_b32 m0, -1
 
 ;s[0:1] contains input array
 ;s[10:11] contains the presum buffer
@@ -521,63 +523,321 @@ CHIME_X:
       v_bfe_u32 v3, v9, 28, 4  ;r[3]
       v_mad_u32_u24 v19, s10, v3, v2
 
-      ;LOOP over 8 timesteps, counter in s13
-      s_mov_b32 s13, 0
-      LOOP_INNER8:
+      ;LOOP over 8 timesteps, unrolled
+      ;LOOP_INNER8:
+        ;no s_waitcnt between -- 35 ops ok without bank conflicts
         ;ITERATION 0
-
-        ;wait to proceed -- 35 ops is NOT ENOUGH!
-    ;s_waitcnt lgkmcnt(3)
         v_mad_u32_u24 v20, v10, v16, v20 ;x0y0
         v_mad_u32_u24 v24, v10, v17, v24 ;x0y1
         v_mad_u32_u24 v32, v10, v18, v32 ;x0y2
         v_mad_u32_u24 v36, v10, v19, v36 ;x0y3
           ds_bpermute_b32 v10, v44, v10
-
         v_mad_u32_u24 v21, v11, v16, v21 ;x1y0
         v_mad_u32_u24 v25, v11, v17, v25 ;x1y1
         v_mad_u32_u24 v33, v11, v18, v33 ;x1y2
         v_mad_u32_u24 v37, v11, v19, v37 ;x1y3
           ds_bpermute_b32 v11, v44, v11
-
         v_mad_u32_u24 v22, v12, v16, v22 ;x2y0
         v_mad_u32_u24 v26, v12, v17, v26 ;x2y1
         v_mad_u32_u24 v34, v12, v18, v34 ;x2y2
         v_mad_u32_u24 v38, v12, v19, v38 ;x2y3
           ds_bpermute_b32 v12, v44, v12
-
-    ;s_waitcnt lgkmcnt(3)
         v_mad_u32_u24 v23, v13, v16, v23 ;x3y0
         v_mad_u32_u24 v27, v13, v17, v27 ;x3y1
         v_mad_u32_u24 v35, v13, v18, v35 ;x3y2
         v_mad_u32_u24 v39, v13, v19, v39 ;x3y3
           ds_bpermute_b32 v13, v44, v13
-
         v_bfe_u32 v2, v16, 16, 4
         v_bfe_u32 v3, v17, 16, 4
         v_bfe_u32 v8, v18, 16, 4
         v_bfe_u32 v9, v19, 16, 4
-
         v_mad_u32_u24 v28, v14, v2, v28 ;x01y0
         v_mad_u32_u24 v30, v14, v3, v30 ;x01y1
         v_mad_u32_u24 v40, v14, v8, v40 ;x01y2
         v_mad_u32_u24 v42, v14, v9, v42 ;x01y3
           ds_bpermute_b32 v14, v44, v14
-
         v_mad_u32_u24 v29, v15, v2, v29 ;x23y0
         v_mad_u32_u24 v31, v15, v3, v31 ;x23y1
         v_mad_u32_u24 v41, v15, v8, v41 ;x23y2
         v_mad_u32_u24 v43, v15, v9, v43 ;x23y3
           ds_bpermute_b32 v15, v44, v15
-
         v_mov_b32_dpp v16, v16 row_ror:2
         v_mov_b32_dpp v17, v17 row_ror:2
         v_mov_b32_dpp v18, v18 row_ror:2
         v_mov_b32_dpp v19, v19 row_ror:2
-
-        s_add_u32 s13, 1, s13
-        s_cmp_lt_u32 s13, 8
-      s_cbranch_scc1 LOOP_INNER8
+        ;ITERATION 1
+        v_mad_u32_u24 v20, v10, v16, v20 ;x0y0
+        v_mad_u32_u24 v24, v10, v17, v24 ;x0y1
+        v_mad_u32_u24 v32, v10, v18, v32 ;x0y2
+        v_mad_u32_u24 v36, v10, v19, v36 ;x0y3
+          ds_bpermute_b32 v10, v44, v10
+        v_mad_u32_u24 v21, v11, v16, v21 ;x1y0
+        v_mad_u32_u24 v25, v11, v17, v25 ;x1y1
+        v_mad_u32_u24 v33, v11, v18, v33 ;x1y2
+        v_mad_u32_u24 v37, v11, v19, v37 ;x1y3
+          ds_bpermute_b32 v11, v44, v11
+        v_mad_u32_u24 v22, v12, v16, v22 ;x2y0
+        v_mad_u32_u24 v26, v12, v17, v26 ;x2y1
+        v_mad_u32_u24 v34, v12, v18, v34 ;x2y2
+        v_mad_u32_u24 v38, v12, v19, v38 ;x2y3
+          ds_bpermute_b32 v12, v44, v12
+        v_mad_u32_u24 v23, v13, v16, v23 ;x3y0
+        v_mad_u32_u24 v27, v13, v17, v27 ;x3y1
+        v_mad_u32_u24 v35, v13, v18, v35 ;x3y2
+        v_mad_u32_u24 v39, v13, v19, v39 ;x3y3
+          ds_bpermute_b32 v13, v44, v13
+        v_bfe_u32 v2, v16, 16, 4
+        v_bfe_u32 v3, v17, 16, 4
+        v_bfe_u32 v8, v18, 16, 4
+        v_bfe_u32 v9, v19, 16, 4
+        v_mad_u32_u24 v28, v14, v2, v28 ;x01y0
+        v_mad_u32_u24 v30, v14, v3, v30 ;x01y1
+        v_mad_u32_u24 v40, v14, v8, v40 ;x01y2
+        v_mad_u32_u24 v42, v14, v9, v42 ;x01y3
+          ds_bpermute_b32 v14, v44, v14
+        v_mad_u32_u24 v29, v15, v2, v29 ;x23y0
+        v_mad_u32_u24 v31, v15, v3, v31 ;x23y1
+        v_mad_u32_u24 v41, v15, v8, v41 ;x23y2
+        v_mad_u32_u24 v43, v15, v9, v43 ;x23y3
+          ds_bpermute_b32 v15, v44, v15
+        v_mov_b32_dpp v16, v16 row_ror:2
+        v_mov_b32_dpp v17, v17 row_ror:2
+        v_mov_b32_dpp v18, v18 row_ror:2
+        v_mov_b32_dpp v19, v19 row_ror:2
+        ;ITERATION 2
+        v_mad_u32_u24 v20, v10, v16, v20 ;x0y0
+        v_mad_u32_u24 v24, v10, v17, v24 ;x0y1
+        v_mad_u32_u24 v32, v10, v18, v32 ;x0y2
+        v_mad_u32_u24 v36, v10, v19, v36 ;x0y3
+          ds_bpermute_b32 v10, v44, v10
+        v_mad_u32_u24 v21, v11, v16, v21 ;x1y0
+        v_mad_u32_u24 v25, v11, v17, v25 ;x1y1
+        v_mad_u32_u24 v33, v11, v18, v33 ;x1y2
+        v_mad_u32_u24 v37, v11, v19, v37 ;x1y3
+          ds_bpermute_b32 v11, v44, v11
+        v_mad_u32_u24 v22, v12, v16, v22 ;x2y0
+        v_mad_u32_u24 v26, v12, v17, v26 ;x2y1
+        v_mad_u32_u24 v34, v12, v18, v34 ;x2y2
+        v_mad_u32_u24 v38, v12, v19, v38 ;x2y3
+          ds_bpermute_b32 v12, v44, v12
+        v_mad_u32_u24 v23, v13, v16, v23 ;x3y0
+        v_mad_u32_u24 v27, v13, v17, v27 ;x3y1
+        v_mad_u32_u24 v35, v13, v18, v35 ;x3y2
+        v_mad_u32_u24 v39, v13, v19, v39 ;x3y3
+          ds_bpermute_b32 v13, v44, v13
+        v_bfe_u32 v2, v16, 16, 4
+        v_bfe_u32 v3, v17, 16, 4
+        v_bfe_u32 v8, v18, 16, 4
+        v_bfe_u32 v9, v19, 16, 4
+        v_mad_u32_u24 v28, v14, v2, v28 ;x01y0
+        v_mad_u32_u24 v30, v14, v3, v30 ;x01y1
+        v_mad_u32_u24 v40, v14, v8, v40 ;x01y2
+        v_mad_u32_u24 v42, v14, v9, v42 ;x01y3
+          ds_bpermute_b32 v14, v44, v14
+        v_mad_u32_u24 v29, v15, v2, v29 ;x23y0
+        v_mad_u32_u24 v31, v15, v3, v31 ;x23y1
+        v_mad_u32_u24 v41, v15, v8, v41 ;x23y2
+        v_mad_u32_u24 v43, v15, v9, v43 ;x23y3
+          ds_bpermute_b32 v15, v44, v15
+        v_mov_b32_dpp v16, v16 row_ror:2
+        v_mov_b32_dpp v17, v17 row_ror:2
+        v_mov_b32_dpp v18, v18 row_ror:2
+        v_mov_b32_dpp v19, v19 row_ror:2
+        ;ITERATION 3
+        v_mad_u32_u24 v20, v10, v16, v20 ;x0y0
+        v_mad_u32_u24 v24, v10, v17, v24 ;x0y1
+        v_mad_u32_u24 v32, v10, v18, v32 ;x0y2
+        v_mad_u32_u24 v36, v10, v19, v36 ;x0y3
+          ds_bpermute_b32 v10, v44, v10
+        v_mad_u32_u24 v21, v11, v16, v21 ;x1y0
+        v_mad_u32_u24 v25, v11, v17, v25 ;x1y1
+        v_mad_u32_u24 v33, v11, v18, v33 ;x1y2
+        v_mad_u32_u24 v37, v11, v19, v37 ;x1y3
+          ds_bpermute_b32 v11, v44, v11
+        v_mad_u32_u24 v22, v12, v16, v22 ;x2y0
+        v_mad_u32_u24 v26, v12, v17, v26 ;x2y1
+        v_mad_u32_u24 v34, v12, v18, v34 ;x2y2
+        v_mad_u32_u24 v38, v12, v19, v38 ;x2y3
+          ds_bpermute_b32 v12, v44, v12
+        v_mad_u32_u24 v23, v13, v16, v23 ;x3y0
+        v_mad_u32_u24 v27, v13, v17, v27 ;x3y1
+        v_mad_u32_u24 v35, v13, v18, v35 ;x3y2
+        v_mad_u32_u24 v39, v13, v19, v39 ;x3y3
+          ds_bpermute_b32 v13, v44, v13
+        v_bfe_u32 v2, v16, 16, 4
+        v_bfe_u32 v3, v17, 16, 4
+        v_bfe_u32 v8, v18, 16, 4
+        v_bfe_u32 v9, v19, 16, 4
+        v_mad_u32_u24 v28, v14, v2, v28 ;x01y0
+        v_mad_u32_u24 v30, v14, v3, v30 ;x01y1
+        v_mad_u32_u24 v40, v14, v8, v40 ;x01y2
+        v_mad_u32_u24 v42, v14, v9, v42 ;x01y3
+          ds_bpermute_b32 v14, v44, v14
+        v_mad_u32_u24 v29, v15, v2, v29 ;x23y0
+        v_mad_u32_u24 v31, v15, v3, v31 ;x23y1
+        v_mad_u32_u24 v41, v15, v8, v41 ;x23y2
+        v_mad_u32_u24 v43, v15, v9, v43 ;x23y3
+          ds_bpermute_b32 v15, v44, v15
+        v_mov_b32_dpp v16, v16 row_ror:2
+        v_mov_b32_dpp v17, v17 row_ror:2
+        v_mov_b32_dpp v18, v18 row_ror:2
+        v_mov_b32_dpp v19, v19 row_ror:2
+        ;ITERATION 4
+        v_mad_u32_u24 v20, v10, v16, v20 ;x0y0
+        v_mad_u32_u24 v24, v10, v17, v24 ;x0y1
+        v_mad_u32_u24 v32, v10, v18, v32 ;x0y2
+        v_mad_u32_u24 v36, v10, v19, v36 ;x0y3
+          ds_bpermute_b32 v10, v44, v10
+        v_mad_u32_u24 v21, v11, v16, v21 ;x1y0
+        v_mad_u32_u24 v25, v11, v17, v25 ;x1y1
+        v_mad_u32_u24 v33, v11, v18, v33 ;x1y2
+        v_mad_u32_u24 v37, v11, v19, v37 ;x1y3
+          ds_bpermute_b32 v11, v44, v11
+        v_mad_u32_u24 v22, v12, v16, v22 ;x2y0
+        v_mad_u32_u24 v26, v12, v17, v26 ;x2y1
+        v_mad_u32_u24 v34, v12, v18, v34 ;x2y2
+        v_mad_u32_u24 v38, v12, v19, v38 ;x2y3
+          ds_bpermute_b32 v12, v44, v12
+        v_mad_u32_u24 v23, v13, v16, v23 ;x3y0
+        v_mad_u32_u24 v27, v13, v17, v27 ;x3y1
+        v_mad_u32_u24 v35, v13, v18, v35 ;x3y2
+        v_mad_u32_u24 v39, v13, v19, v39 ;x3y3
+          ds_bpermute_b32 v13, v44, v13
+        v_bfe_u32 v2, v16, 16, 4
+        v_bfe_u32 v3, v17, 16, 4
+        v_bfe_u32 v8, v18, 16, 4
+        v_bfe_u32 v9, v19, 16, 4
+        v_mad_u32_u24 v28, v14, v2, v28 ;x01y0
+        v_mad_u32_u24 v30, v14, v3, v30 ;x01y1
+        v_mad_u32_u24 v40, v14, v8, v40 ;x01y2
+        v_mad_u32_u24 v42, v14, v9, v42 ;x01y3
+          ds_bpermute_b32 v14, v44, v14
+        v_mad_u32_u24 v29, v15, v2, v29 ;x23y0
+        v_mad_u32_u24 v31, v15, v3, v31 ;x23y1
+        v_mad_u32_u24 v41, v15, v8, v41 ;x23y2
+        v_mad_u32_u24 v43, v15, v9, v43 ;x23y3
+          ds_bpermute_b32 v15, v44, v15
+        v_mov_b32_dpp v16, v16 row_ror:2
+        v_mov_b32_dpp v17, v17 row_ror:2
+        v_mov_b32_dpp v18, v18 row_ror:2
+        v_mov_b32_dpp v19, v19 row_ror:2
+        ;ITERATION 5
+        v_mad_u32_u24 v20, v10, v16, v20 ;x0y0
+        v_mad_u32_u24 v24, v10, v17, v24 ;x0y1
+        v_mad_u32_u24 v32, v10, v18, v32 ;x0y2
+        v_mad_u32_u24 v36, v10, v19, v36 ;x0y3
+          ds_bpermute_b32 v10, v44, v10
+        v_mad_u32_u24 v21, v11, v16, v21 ;x1y0
+        v_mad_u32_u24 v25, v11, v17, v25 ;x1y1
+        v_mad_u32_u24 v33, v11, v18, v33 ;x1y2
+        v_mad_u32_u24 v37, v11, v19, v37 ;x1y3
+          ds_bpermute_b32 v11, v44, v11
+        v_mad_u32_u24 v22, v12, v16, v22 ;x2y0
+        v_mad_u32_u24 v26, v12, v17, v26 ;x2y1
+        v_mad_u32_u24 v34, v12, v18, v34 ;x2y2
+        v_mad_u32_u24 v38, v12, v19, v38 ;x2y3
+          ds_bpermute_b32 v12, v44, v12
+        v_mad_u32_u24 v23, v13, v16, v23 ;x3y0
+        v_mad_u32_u24 v27, v13, v17, v27 ;x3y1
+        v_mad_u32_u24 v35, v13, v18, v35 ;x3y2
+        v_mad_u32_u24 v39, v13, v19, v39 ;x3y3
+          ds_bpermute_b32 v13, v44, v13
+        v_bfe_u32 v2, v16, 16, 4
+        v_bfe_u32 v3, v17, 16, 4
+        v_bfe_u32 v8, v18, 16, 4
+        v_bfe_u32 v9, v19, 16, 4
+        v_mad_u32_u24 v28, v14, v2, v28 ;x01y0
+        v_mad_u32_u24 v30, v14, v3, v30 ;x01y1
+        v_mad_u32_u24 v40, v14, v8, v40 ;x01y2
+        v_mad_u32_u24 v42, v14, v9, v42 ;x01y3
+          ds_bpermute_b32 v14, v44, v14
+        v_mad_u32_u24 v29, v15, v2, v29 ;x23y0
+        v_mad_u32_u24 v31, v15, v3, v31 ;x23y1
+        v_mad_u32_u24 v41, v15, v8, v41 ;x23y2
+        v_mad_u32_u24 v43, v15, v9, v43 ;x23y3
+          ds_bpermute_b32 v15, v44, v15
+        v_mov_b32_dpp v16, v16 row_ror:2
+        v_mov_b32_dpp v17, v17 row_ror:2
+        v_mov_b32_dpp v18, v18 row_ror:2
+        v_mov_b32_dpp v19, v19 row_ror:2
+        ;ITERATION 6
+        v_mad_u32_u24 v20, v10, v16, v20 ;x0y0
+        v_mad_u32_u24 v24, v10, v17, v24 ;x0y1
+        v_mad_u32_u24 v32, v10, v18, v32 ;x0y2
+        v_mad_u32_u24 v36, v10, v19, v36 ;x0y3
+          ds_bpermute_b32 v10, v44, v10
+        v_mad_u32_u24 v21, v11, v16, v21 ;x1y0
+        v_mad_u32_u24 v25, v11, v17, v25 ;x1y1
+        v_mad_u32_u24 v33, v11, v18, v33 ;x1y2
+        v_mad_u32_u24 v37, v11, v19, v37 ;x1y3
+          ds_bpermute_b32 v11, v44, v11
+        v_mad_u32_u24 v22, v12, v16, v22 ;x2y0
+        v_mad_u32_u24 v26, v12, v17, v26 ;x2y1
+        v_mad_u32_u24 v34, v12, v18, v34 ;x2y2
+        v_mad_u32_u24 v38, v12, v19, v38 ;x2y3
+          ds_bpermute_b32 v12, v44, v12
+        v_mad_u32_u24 v23, v13, v16, v23 ;x3y0
+        v_mad_u32_u24 v27, v13, v17, v27 ;x3y1
+        v_mad_u32_u24 v35, v13, v18, v35 ;x3y2
+        v_mad_u32_u24 v39, v13, v19, v39 ;x3y3
+          ds_bpermute_b32 v13, v44, v13
+        v_bfe_u32 v2, v16, 16, 4
+        v_bfe_u32 v3, v17, 16, 4
+        v_bfe_u32 v8, v18, 16, 4
+        v_bfe_u32 v9, v19, 16, 4
+        v_mad_u32_u24 v28, v14, v2, v28 ;x01y0
+        v_mad_u32_u24 v30, v14, v3, v30 ;x01y1
+        v_mad_u32_u24 v40, v14, v8, v40 ;x01y2
+        v_mad_u32_u24 v42, v14, v9, v42 ;x01y3
+          ds_bpermute_b32 v14, v44, v14
+        v_mad_u32_u24 v29, v15, v2, v29 ;x23y0
+        v_mad_u32_u24 v31, v15, v3, v31 ;x23y1
+        v_mad_u32_u24 v41, v15, v8, v41 ;x23y2
+        v_mad_u32_u24 v43, v15, v9, v43 ;x23y3
+          ds_bpermute_b32 v15, v44, v15
+        v_mov_b32_dpp v16, v16 row_ror:2
+        v_mov_b32_dpp v17, v17 row_ror:2
+        v_mov_b32_dpp v18, v18 row_ror:2
+        v_mov_b32_dpp v19, v19 row_ror:2
+        ;ITERATION 7 - No need to pass data around!
+        v_mad_u32_u24 v20, v10, v16, v20 ;x0y0
+        v_mad_u32_u24 v24, v10, v17, v24 ;x0y1
+        v_mad_u32_u24 v32, v10, v18, v32 ;x0y2
+        v_mad_u32_u24 v36, v10, v19, v36 ;x0y3
+        ;  ds_bpermute_b32 v10, v44, v10
+        v_mad_u32_u24 v21, v11, v16, v21 ;x1y0
+        v_mad_u32_u24 v25, v11, v17, v25 ;x1y1
+        v_mad_u32_u24 v33, v11, v18, v33 ;x1y2
+        v_mad_u32_u24 v37, v11, v19, v37 ;x1y3
+        ;  ds_bpermute_b32 v11, v44, v11
+        v_mad_u32_u24 v22, v12, v16, v22 ;x2y0
+        v_mad_u32_u24 v26, v12, v17, v26 ;x2y1
+        v_mad_u32_u24 v34, v12, v18, v34 ;x2y2
+        v_mad_u32_u24 v38, v12, v19, v38 ;x2y3
+        ;  ds_bpermute_b32 v12, v44, v12
+        v_mad_u32_u24 v23, v13, v16, v23 ;x3y0
+        v_mad_u32_u24 v27, v13, v17, v27 ;x3y1
+        v_mad_u32_u24 v35, v13, v18, v35 ;x3y2
+        v_mad_u32_u24 v39, v13, v19, v39 ;x3y3
+        ;  ds_bpermute_b32 v13, v44, v13
+        v_bfe_u32 v2, v16, 16, 4
+        v_bfe_u32 v3, v17, 16, 4
+        v_bfe_u32 v8, v18, 16, 4
+        v_bfe_u32 v9, v19, 16, 4
+        v_mad_u32_u24 v28, v14, v2, v28 ;x01y0
+        v_mad_u32_u24 v30, v14, v3, v30 ;x01y1
+        v_mad_u32_u24 v40, v14, v8, v40 ;x01y2
+        v_mad_u32_u24 v42, v14, v9, v42 ;x01y3
+        ;  ds_bpermute_b32 v14, v44, v14
+        v_mad_u32_u24 v29, v15, v2, v29 ;x23y0
+        v_mad_u32_u24 v31, v15, v3, v31 ;x23y1
+        v_mad_u32_u24 v41, v15, v8, v41 ;x23y2
+        v_mad_u32_u24 v43, v15, v9, v43 ;x23y3
+        ;  ds_bpermute_b32 v15, v44, v15
+        ;v_mov_b32_dpp v16, v16 row_ror:2
+        ;v_mov_b32_dpp v17, v17 row_ror:2
+        ;v_mov_b32_dpp v18, v18 row_ror:2
+        ;v_mov_b32_dpp v19, v19 row_ror:2
       ;END OF INNER LOOP
 
       ;increment T by 8

--- a/lib/utils/CHIMETelescope.cpp
+++ b/lib/utils/CHIMETelescope.cpp
@@ -3,6 +3,7 @@
 #include "ICETelescope.hpp"   // for ice_stream_id_t, ice_encode_stream_id, ice_extract_stream_id
 #include "Telescope.hpp"      // for freq_id_t, REGISTER_TELESCOPE, _factory_aliasTelescope
 #include "kotekanLogging.hpp" // for ERROR, DEBUG2, WARN
+#include "restClient.hpp"
 
 #include "fmt.hpp"  // for format
 #include "json.hpp" // for json, basic_json<>::object_t, basic_json
@@ -15,7 +16,7 @@
 #include <vector>    // for vector
 
 
-REGISTER_TELESCOPE(CHIMETelescope, "chime");
+REGISTER_TELESCOPE(CHIMETelescope, "CHIMETelescope");
 
 CHIMETelescope::CHIMETelescope(const kotekan::Config& config, const std::string& path) :
     ICETelescope(config.get<std::string>(path, "log_level")) {
@@ -23,21 +24,64 @@ CHIMETelescope::CHIMETelescope(const kotekan::Config& config, const std::string&
     // This is always 1 for CHIME
     _num_freq_per_stream = 1;
 
+    set_sampling_params(800.0, 2048, 2);
+
+    // Get the GPS time, either from the config or fpga_master
+    bool require_gps = config.get_default<bool>(path, "require_gps", true);
+    _query_gps = config.get_default<bool>(path, "query_gps", false);
+    _gps_host = config.get_default<std::string>(path, "gps_host", "10.1.13.1");
+    _gps_port = config.get_default<uint32_t>(path, "gps_port", 54321);
+    _gps_endpoint = config.get_default<std::string>(path, "gps_endpoint", "/get-frame0-time");
+    if (_query_gps)
+        set_gps(_gps_host, _gps_port, _gps_endpoint);
+    if (!gps_enabled)
+        set_gps(config);
+
     _require_frequency_map = config.get_default<bool>(path, "require_frequency_map", false);
     _allow_default_frequency_map =
         config.get_default<bool>(path, "allow_default_frequency_map", true);
 
-    set_sampling_params(800.0, 2048, 2);
-    set_gps(config, path);
-    set_frequency_map(config, "fpga_frequency_map");
+    // Get the frequency map, either from config or fpga_master
+    _query_frequency_map = config.get_default<bool>(path, "query_frequency_map", false);
+    _frequency_map_host = config.get_default<std::string>(path, "frequency_map_host", "10.1.13.1");
+    _frequency_map_port = config.get_default<uint32_t>(path, "frequency_map_port", 54321);
+    _frequency_map_endpoint = config.get_default<std::string>(path, "frequency_map_endpoint",
+                                                              "/get-frequency-map");
+
+    nlohmann::json fpga_freq_map_json;
+    if (_query_frequency_map)
+        fpga_freq_map_json = get_frequency_map(_frequency_map_host, _frequency_map_port,
+                                               _frequency_map_endpoint);
+    else
+        fpga_freq_map_json = config.get_default<nlohmann::json>("/", "fpga_frequency_map", {});
+
+    set_frequency_map(fpga_freq_map_json);
+
+    if (require_gps && !gps_enabled) {
+        throw std::runtime_error("The system requires a GPS time, but none was found.");
+    }
 }
 
-void CHIMETelescope::set_frequency_map(const kotekan::Config& config, const std::string& path) {
-    nlohmann::json fpga_freq_map_json = config.get_default<nlohmann::json>("/", path, {});
+nlohmann::json CHIMETelescope::get_frequency_map(const std::string& host, const uint32_t port,
+                                                 const std::string& path) {
+    INFO("Requesting frequency map from server: {:s}:{:d}{:s} This might take some time...",
+         host, port, path);
+    auto reply = restClient::instance().make_request_blocking(path, {{"format", "s:b"}},
+                                                              host, port, 0, 30);
 
+    if (!reply.first) {
+        WARN("Failed to get frequency map from {:s}:{:d}{:s}");
+        return nlohmann::json();
+    }
+
+    auto json_reply = nlohmann::json::parse(reply.second);
+    return json_reply;
+}
+
+void CHIMETelescope::set_frequency_map(nlohmann::json &fpga_freq_map_json) {
     if (fpga_freq_map_json.empty()) {
         if (_require_frequency_map) {
-            std::string msg = fmt::format("Frequency map required by not found at /{:s}", path);
+            std::string msg = fmt::format("Frequency map required but not found");
             ERROR("{:s}", msg);
             throw std::runtime_error(msg);
         }
@@ -75,7 +119,7 @@ void CHIMETelescope::set_frequency_map(const kotekan::Config& config, const std:
                 fpga_freq_map_json.at("fmap").get<std::map<std::string, std::vector<int>>>();
         } catch (std::exception const& e) {
             std::string msg =
-                fmt::format("Could not read the fmap table at /{:s}/fmap: {:s}", path, e.what());
+                fmt::format("Could not read the fmap table: {:s}", e.what());
             ERROR("{:s}", msg);
             throw std::runtime_error(msg);
         }
@@ -107,6 +151,7 @@ void CHIMETelescope::set_frequency_map(const kotekan::Config& config, const std:
                 frequency_table[ice_encode_stream_id(post_shuffle_id).id] = bin;
             }
         }
+        INFO("Using custom frequency map.");
     }
 }
 

--- a/lib/utils/CHIMETelescope.cpp
+++ b/lib/utils/CHIMETelescope.cpp
@@ -51,7 +51,7 @@ CHIMETelescope::CHIMETelescope(const kotekan::Config& config, const std::string&
     nlohmann::json fpga_freq_map_json;
     if (_query_frequency_map)
         fpga_freq_map_json =
-            get_frequency_map(_frequency_map_host, _frequency_map_port, _frequency_map_endpoint);
+            fetch_frequency_map(_frequency_map_host, _frequency_map_port, _frequency_map_endpoint);
     else
         fpga_freq_map_json = config.get_default<nlohmann::json>("/", "fpga_frequency_map", {});
 
@@ -62,8 +62,8 @@ CHIMETelescope::CHIMETelescope(const kotekan::Config& config, const std::string&
     }
 }
 
-nlohmann::json CHIMETelescope::get_frequency_map(const std::string& host, const uint32_t port,
-                                                 const std::string& path) {
+nlohmann::json CHIMETelescope::fetch_frequency_map(const std::string& host, const uint32_t port,
+                                                   const std::string& path) {
     INFO("Requesting frequency map from server: {:s}:{:d}{:s} This might take some time...", host,
          port, path);
     auto reply =

--- a/lib/utils/CHIMETelescope.cpp
+++ b/lib/utils/CHIMETelescope.cpp
@@ -45,13 +45,13 @@ CHIMETelescope::CHIMETelescope(const kotekan::Config& config, const std::string&
     _query_frequency_map = config.get_default<bool>(path, "query_frequency_map", false);
     _frequency_map_host = config.get_default<std::string>(path, "frequency_map_host", "10.1.13.1");
     _frequency_map_port = config.get_default<uint32_t>(path, "frequency_map_port", 54321);
-    _frequency_map_endpoint = config.get_default<std::string>(path, "frequency_map_endpoint",
-                                                              "/get-frequency-map");
+    _frequency_map_endpoint =
+        config.get_default<std::string>(path, "frequency_map_endpoint", "/get-frequency-map");
 
     nlohmann::json fpga_freq_map_json;
     if (_query_frequency_map)
-        fpga_freq_map_json = get_frequency_map(_frequency_map_host, _frequency_map_port,
-                                               _frequency_map_endpoint);
+        fpga_freq_map_json =
+            get_frequency_map(_frequency_map_host, _frequency_map_port, _frequency_map_endpoint);
     else
         fpga_freq_map_json = config.get_default<nlohmann::json>("/", "fpga_frequency_map", {});
 
@@ -64,10 +64,10 @@ CHIMETelescope::CHIMETelescope(const kotekan::Config& config, const std::string&
 
 nlohmann::json CHIMETelescope::get_frequency_map(const std::string& host, const uint32_t port,
                                                  const std::string& path) {
-    INFO("Requesting frequency map from server: {:s}:{:d}{:s} This might take some time...",
-         host, port, path);
-    auto reply = restClient::instance().make_request_blocking(path, {{"format", "s:b"}},
-                                                              host, port, 0, 30);
+    INFO("Requesting frequency map from server: {:s}:{:d}{:s} This might take some time...", host,
+         port, path);
+    auto reply =
+        restClient::instance().make_request_blocking(path, {{"format", "s:b"}}, host, port, 0, 30);
 
     if (!reply.first) {
         WARN("Failed to get frequency map from {:s}:{:d}{:s}");
@@ -78,7 +78,7 @@ nlohmann::json CHIMETelescope::get_frequency_map(const std::string& host, const 
     return json_reply;
 }
 
-void CHIMETelescope::set_frequency_map(nlohmann::json &fpga_freq_map_json) {
+void CHIMETelescope::set_frequency_map(nlohmann::json& fpga_freq_map_json) {
     if (fpga_freq_map_json.empty()) {
         if (_require_frequency_map) {
             std::string msg = fmt::format("Frequency map required but not found");
@@ -118,8 +118,7 @@ void CHIMETelescope::set_frequency_map(nlohmann::json &fpga_freq_map_json) {
             fpga_freq_map =
                 fpga_freq_map_json.at("fmap").get<std::map<std::string, std::vector<int>>>();
         } catch (std::exception const& e) {
-            std::string msg =
-                fmt::format("Could not read the fmap table: {:s}", e.what());
+            std::string msg = fmt::format("Could not read the fmap table: {:s}", e.what());
             ERROR("{:s}", msg);
             throw std::runtime_error(msg);
         }

--- a/lib/utils/CHIMETelescope.hpp
+++ b/lib/utils/CHIMETelescope.hpp
@@ -5,6 +5,7 @@
 #include "ICETelescope.hpp" // for ICETelescope
 #include "Telescope.hpp"    // for freq_id_t
 #include "chimeMetadata.h"  // for stream_t
+#include "json.hpp"
 
 #include <map>      // for map
 #include <stdint.h> // for uint64_t, uint32_t
@@ -24,6 +25,10 @@
  *                                       This can be useful for systems not expected to
  *                                       lookup stream_ids. This option has no effect if
  *                                       @c require_frequency_map is set to true.  Default: true
+ * @conf    query_frequency_map  bool.   Should we get the frequency map from a remote source.
+ * @conf    frequency_map_host   string. The frequency map server IP address.
+ * @conf    frequency_map_port   uint.   The port number on the frequency map server.
+ * @conf    frequency_map_endpoint string. The endpoint with the frequency map.
  **/
 class CHIMETelescope : public ICETelescope {
 public:
@@ -39,17 +44,40 @@ private:
     /// Allow a default map to be generated if one isn't aviable in the config.
     bool _allow_default_frequency_map;
 
+    /// Query the frequency map directly from fpga_master (only used for testing)
+    bool _query_frequency_map;
+
+    /// The frequency map server IP address
+    std::string _frequency_map_host;
+
+    /// The port number on the frequency map server.
+    uint32_t _frequency_map_port;
+
+    /// The endpoint with the frequency map.
+    std::string _frequency_map_endpoint;
+
     /// Maps the post-final shuffle stream_ids to frequency bins
     std::map<uint64_t, freq_id_t> frequency_table;
+
+    /**
+     * @brief Get the frequency map from an endpoint
+     *
+     * @param host    String.  The IP address of the server with the map
+     * @param port    Int.     The port of the server
+     * @param path    String   The endpoint name. e.g. (e.g. /get-frequency-map)
+     *
+     * @return json object with frequency map.
+     */
+    nlohmann::json get_frequency_map(const std::string& host, const uint32_t port,
+                                     const std::string& path);
 
     /**
      * @brief Sets the CHIME specific post 4-way CPU shuffle stream ID to
      *        frequency bin mapping table.  Uses the table in the config if one exists
      *        otherwise it generates the FPGA default mapping table.
-     * @param config The current config
-     * @param path The location in the config of the @c fmap table from the FPGAs
+     * @param fpga_freq_map_json  JSON The frequency map from the FPGAs
      */
-    void set_frequency_map(const kotekan::Config& config, const std::string& path);
+    void set_frequency_map(nlohmann::json &fpga_freq_map_json);
 };
 
 

--- a/lib/utils/CHIMETelescope.hpp
+++ b/lib/utils/CHIMETelescope.hpp
@@ -5,6 +5,7 @@
 #include "ICETelescope.hpp" // for ICETelescope
 #include "Telescope.hpp"    // for freq_id_t
 #include "chimeMetadata.h"  // for stream_t
+
 #include "json.hpp"
 
 #include <map>      // for map
@@ -77,7 +78,7 @@ private:
      *        otherwise it generates the FPGA default mapping table.
      * @param fpga_freq_map_json  JSON The frequency map from the FPGAs
      */
-    void set_frequency_map(nlohmann::json &fpga_freq_map_json);
+    void set_frequency_map(nlohmann::json& fpga_freq_map_json);
 };
 
 

--- a/lib/utils/CHIMETelescope.hpp
+++ b/lib/utils/CHIMETelescope.hpp
@@ -61,7 +61,7 @@ private:
     std::map<uint64_t, freq_id_t> frequency_table;
 
     /**
-     * @brief Get the frequency map from an endpoint
+     * @brief Fetch the frequency map from an endpoint
      *
      * @param host    String.  The IP address of the server with the map
      * @param port    Int.     The port of the server
@@ -69,8 +69,8 @@ private:
      *
      * @return json object with frequency map.
      */
-    nlohmann::json get_frequency_map(const std::string& host, const uint32_t port,
-                                     const std::string& path);
+    nlohmann::json fetch_frequency_map(const std::string& host, const uint32_t port,
+                                       const std::string& path);
 
     /**
      * @brief Sets the CHIME specific post 4-way CPU shuffle stream ID to

--- a/lib/utils/ICETelescope.cpp
+++ b/lib/utils/ICETelescope.cpp
@@ -81,11 +81,10 @@ void ICETelescope::set_gps(const kotekan::Config& config) {
     gps_enabled = true;
 }
 
-void ICETelescope::set_gps(const std::string& host, const uint32_t port,
-                           const std::string& path) {
+void ICETelescope::set_gps(const std::string& host, const uint32_t port, const std::string& path) {
 
-    INFO("Requesting GPS time from server: {:s}:{:d}{:s} This might take some time...",
-         host, port, path);
+    INFO("Requesting GPS time from server: {:s}:{:d}{:s} This might take some time...", host, port,
+         path);
     auto reply = restClient::instance().make_request_blocking(path, {}, host, port, 0, 30);
 
     if (!reply.first) {
@@ -124,8 +123,7 @@ freq_id_t ICETelescope::to_freq_id(stream_t stream, uint32_t ind) const {
             return stream_id.crate_id * 16 + stream_id.slot_id + stream_id.link_id * 32
                    + stream_id.unused * 256;
         case 4: // 32 ICEBoards (512 elements) e.g. HIRAX-256
-            return stream_id.slot_id + stream_id.crate_id * 16
-                   + stream_id.link_id * 32 + ind * 256;
+            return stream_id.slot_id + stream_id.crate_id * 16 + stream_id.link_id * 32 + ind * 256;
         case 8: // 16 ICEBoards (256 elements) e.g. Pathfinder/HIRAX-128
             return stream_id.slot_id + stream_id.link_id * 16 + ind * 128;
         case 16: // 8 ICEBoards (128 elements) e.g. Allenby

--- a/lib/utils/ICETelescope.cpp
+++ b/lib/utils/ICETelescope.cpp
@@ -3,6 +3,7 @@
 #include "Telescope.hpp"      // for freq_id_t, REGISTER_TELESCOPE, Telescope, _factory_aliasTe...
 #include "chimeMetadata.h"    // for stream_t
 #include "kotekanLogging.hpp" // for FATAL_ERROR, WARN
+#include "restClient.hpp"
 
 #include "fmt.hpp" // for format
 
@@ -13,7 +14,7 @@
 #include <vector>    // for vector
 
 
-REGISTER_TELESCOPE(ICETelescope, "ice");
+REGISTER_TELESCOPE(ICETelescope, "ICETelescope");
 
 #define GIGA 1000000000
 
@@ -24,62 +25,90 @@ ICETelescope::ICETelescope(const kotekan::Config& config, const std::string& pat
     _num_freq_per_stream = config.get<uint32_t>(path, "num_local_freq");
 
     set_sampling_params(config, path);
-    set_gps(config, path);
+
+    bool require_gps = config.get_default<bool>(path, "require_gps", false);
+    _query_gps = config.get_default<bool>(path, "query_gps", false);
+    _gps_host = config.get_default<std::string>(path, "gps_host", "127.0.0.1");
+    _gps_port = config.get_default<uint32_t>(path, "gps_host", 54321);
+    _gps_endpoint = config.get_default<std::string>(path, "gps_endpoint", "/get-frame0-time");
+    if (_query_gps)
+        set_gps(_gps_host, _gps_port, _gps_endpoint);
+    if (!gps_enabled)
+        set_gps(config);
+
+    if (require_gps && !gps_enabled) {
+        throw std::runtime_error("The system requires a GPS time, but none was found.");
+    }
 }
 
 
 void ICETelescope::set_sampling_params(const kotekan::Config& config, const std::string& path) {
-    set_sampling_params(config.get<double>(path, "sampling_rate"),
-                        config.get<uint32_t>(path, "frame_length"),
-                        config.get<uint8_t>(path, "nyquist_zone"));
+    set_sampling_params(config.get_default<double>(path, "sampling_rate", 800.0),
+                        config.get_default<uint32_t>(path, "fft_length", 2048),
+                        config.get_default<uint8_t>(path, "nyquist_zone", 2));
 }
 
-void ICETelescope::set_sampling_params(double sample_rate, uint32_t length, uint8_t zone) {
+void ICETelescope::set_sampling_params(double sample_rate, uint32_t fft_length, uint8_t zone) {
     // Set the physical frequency of id=0, and the spacing, taking into account
     // the aliasing of each Nyquist zone
     freq0_MHz = (zone / 2) * sample_rate;
-    df_MHz = (zone % 2 ? 1 : -1) * sample_rate / length;
-    nfreq = length / 2;
+    df_MHz = (zone % 2 ? 1 : -1) * sample_rate / fft_length;
+    nfreq = fft_length / 2;
 
     // TODO: revisit this if we think the length might ever not be an integer
     // number of ns
-    dt_ns = 1e3 / sample_rate * length;
+    dt_ns = 1e3 / sample_rate * fft_length;
 }
 
-void ICETelescope::set_gps(const kotekan::Config& config, const std::string& path) {
-
-    auto require_gps = config.get_default<bool>(path, "require_gps", false);
-
+void ICETelescope::set_gps(const kotekan::Config& config) {
     if (!config.exists("/", "gps_time")) {
-        if (require_gps) {
-            FATAL_ERROR("GPS time section is required, but was not found in the config.");
-        } else {
-            WARN("No GPS time section found. Ignoring.");
-        }
+        WARN("No GPS time section found. Ignoring.");
         return;
     }
 
     if (config.exists("/gps_time", "error")) {
         auto error_message = config.get<std::string>("/gps_time", "error");
-
-        if (require_gps) {
-            FATAL_ERROR("Required GPS time lookup failed with reason: \n {:s}\n", error_message);
-        } else {
-            WARN("GPS time lookup failed with reason: \n {:s}\n", error_message);
-        }
+        WARN("GPS time lookup failed with reason: \n {:s}\n", error_message);
         return;
     }
 
     if (!config.exists("/gps_time", "frame0_nano")) {
-        if (require_gps) {
-            FATAL_ERROR("GPS frame0 time is required, but was not found in the config.");
-        } else {
-            WARN("No GPS frame0 time found. Ignoring.");
-        }
+        WARN("No GPS frame0 time found in config.");
         return;
     }
 
     time0_ns = config.get<uint64_t>("/gps_time", "frame0_nano");
+    gps_enabled = true;
+}
+
+void ICETelescope::set_gps(const std::string& host, const uint32_t port,
+                           const std::string& path) {
+
+    INFO("Requesting GPS time from server: {:s}:{:d}{:s} This might take some time...",
+         host, port, path);
+    auto reply = restClient::instance().make_request_blocking(path, {}, host, port, 0, 30);
+
+    if (!reply.first) {
+        WARN("Failed to get GPS time, using system time");
+        return;
+    }
+
+    auto json_reply = nlohmann::json::parse(reply.second);
+
+    if (json_reply.count("error") == 1) {
+        std::string error_message = json_reply["error"];
+        WARN("Error returned by GPS server, error: {:s}", error_message);
+        return;
+    }
+
+    if (json_reply.count("frame0_nano") == 0) {
+        WARN("No `frame0_nano` value returned by GPS server, the server reply was: {:s} - {:s}",
+             reply.second, json_reply.dump());
+        return;
+    }
+
+    time0_ns = json_reply["frame0_nano"].get<uint64_t>();
+    INFO("GPS frame0 time set to {:d}", time0_ns);
     gps_enabled = true;
 }
 
@@ -88,17 +117,26 @@ freq_id_t ICETelescope::to_freq_id(stream_t stream, uint32_t ind) const {
 
     auto stream_id = ice_extract_stream_id(stream);
 
-    // CHIME bin number
-    return stream_id.crate_id * 16 + stream_id.slot_id + stream_id.link_id * 32
-           + stream_id.unused * 256;
-
-    /*
-    // 16 element version
-    return stream_id.link_id + index * 8;
-
-    // Pathfinder version
-    return stream_id.slot_id + stream_id.link_id * 16 + ind * 128;
-    */
+    // The default mapping is directly related to the number of ICEBoards in the system,
+    // and as a result the number of frequencies in each data stream, so we can select on that.
+    switch (_num_freq_per_stream) {
+        case 1: // 128 ICEBoards (2048 elements) e.g. CHIME
+            return stream_id.crate_id * 16 + stream_id.slot_id + stream_id.link_id * 32
+                   + stream_id.unused * 256;
+        case 4: // 32 ICEBoards (512 elements) e.g. HIRAX-256
+            return stream_id.slot_id + stream_id.crate_id * 16
+                   + stream_id.link_id * 32 + ind * 256;
+        case 8: // 16 ICEBoards (256 elements) e.g. Pathfinder/HIRAX-128
+            return stream_id.slot_id + stream_id.link_id * 16 + ind * 128;
+        case 16: // 8 ICEBoards (128 elements) e.g. Allenby
+            // TODO: Check this mapping
+            return stream_id.slot_id + stream_id.link_id * 32 + ind * 64;
+        case 128: // 1 ICEBoard (16 elements) e.g. ARO, Synthesis telescope
+            return stream_id.link_id + ind * 8;
+        default:
+            FATAL_ERROR("No known frequency mapping for num_freq_per_stream = {:d}");
+            return 0;
+    }
 }
 
 

--- a/lib/utils/ICETelescope.hpp
+++ b/lib/utils/ICETelescope.hpp
@@ -75,8 +75,7 @@ protected:
      * @param port   The port of the server with the GPS time information
      * @param path   The endpoint resource name (e.g. /get-frame0-time)
      */
-    void set_gps(const std::string& host, const uint32_t port,
-                 const std::string& path);
+    void set_gps(const std::string& host, const uint32_t port, const std::string& path);
 
     // The number of frequencies per stream
     uint32_t _num_freq_per_stream;

--- a/lib/utils/ICETelescope.hpp
+++ b/lib/utils/ICETelescope.hpp
@@ -13,10 +13,15 @@
 /**
  * @brief Implementation for an ICEboard like telescope with a Casper PFB.
  *
- * @conf  sample_rate   The sampling rate in MHz.
- * @conf  frame_length  The FPGA frame length in samples.
- * @conf  nyquist_zone  The Nyquist zone we are sampling in (zone=1 is standard
- *                      sampling, zone>=2 is alias sampling).
+ * @conf  sample_rate     int.     The sampling rate in MHz.
+ * @conf  frame_length    int.     The FPGA frame length in samples.
+ * @conf  nyquist_zone    int.     The Nyquist zone we are sampling in (zone=1 is standard
+ *                                 sampling, zone>=2 is alias sampling).
+ * @conf  query_gps       bool.    Should the telescope object get the GPS from a remote source
+ *                                 if not available, or false, will try to retrieve from config.
+ * @conf  gps_host        string.  The GPS server IP address
+ * @conf  gps_port        uint.    The port number on the GPS server
+ * @conf  gps_endpoint    string.  The endpoint with the GPS time
  **/
 class ICETelescope : public Telescope {
 public:
@@ -39,12 +44,14 @@ protected:
     /**
      * @brief Set the sampling parameters for the telescope.
      *
-     * @param  sample_rate  The sampling rate in MHz.
-     * @param  length       The length of each frame.
+     * @param  sample_rate  The ADC sampling rate in MHz.
+     * @param  fft_length   The FFT length used in the FPGA.  Note this is the length of a
+     *                      basic FFT, the ICEBoard uses a PFB with a 8096 sample window, but the
+     *                      effective length is 2048 for computing the number of frequency bins.
      * @param  zone         Which Nyquist zone are we sampling in? zone=1 is
      *                      standard sampling, zone>=2 are alias sampling.
      **/
-    void set_sampling_params(double sample_rate, uint32_t length, uint8_t zone);
+    void set_sampling_params(double sample_rate, uint32_t fft_length, uint8_t zone);
 
     /**
      * @brief Set the sampling parameters for the telescope from the config.
@@ -58,9 +65,18 @@ protected:
      * @brief Set the GPS time parameters from the config.
      *
      * @param  config  Kotekan config.
-     * @param  path    Kotekan config path.
      **/
-    void set_gps(const kotekan::Config& config, const std::string& path);
+    void set_gps(const kotekan::Config& config);
+
+    /**
+     * @brief Set the GPS time from a remote server (pychfpga/fpga_master)
+     *
+     * @param host   The host name of the server with the GPS time information
+     * @param port   The port of the server with the GPS time information
+     * @param path   The endpoint resource name (e.g. /get-frame0-time)
+     */
+    void set_gps(const std::string& host, const uint32_t port,
+                 const std::string& path);
 
     // The number of frequencies per stream
     uint32_t _num_freq_per_stream;
@@ -69,6 +85,18 @@ protected:
     double freq0_MHz;
     double df_MHz;
     uint32_t nfreq;
+
+    /// Should we try to get the GPS time from remote server
+    bool _query_gps;
+
+    /// The GPS server IP address
+    std::string _gps_host;
+
+    /// The port number on the GPS server
+    uint32_t _gps_port;
+
+    /// The endpoint with the GPS time
+    std::string _gps_endpoint;
 
     // The time of FPGA frame=0, and the time length of each frame (in ns)
     bool gps_enabled = false;

--- a/lib/utils/ICETelescope.hpp
+++ b/lib/utils/ICETelescope.hpp
@@ -14,7 +14,10 @@
  * @brief Implementation for an ICEboard like telescope with a Casper PFB.
  *
  * @conf  sample_rate     int.     The sampling rate in MHz.
- * @conf  frame_length    int.     The FPGA frame length in samples.
+ * @conf  fft_length      int.     The FFT frame length in samples. Note this is the length of a
+ *                                 basic FFT, the ICEBoard uses a PFB with a 8096 sample window,
+ *                                 but the effective length is 2048 for computing the number
+ *                                 of frequency bins.
  * @conf  nyquist_zone    int.     The Nyquist zone we are sampling in (zone=1 is standard
  *                                 sampling, zone>=2 is alias sampling).
  * @conf  query_gps       bool.    Should the telescope object get the GPS from a remote source

--- a/lib/utils/Telescope.cpp
+++ b/lib/utils/Telescope.cpp
@@ -21,7 +21,7 @@ const Telescope& Telescope::instance() {
 
 const Telescope& Telescope::instance(const kotekan::Config& config) {
 
-    auto telescope_name = config.get_default<std::string>("/telescope", "name", "chime");
+    auto telescope_name = config.get_default<std::string>("/telescope", "name", "ICETelescope");
     if (!FACTORY(Telescope)::exists(telescope_name)) {
         FATAL_ERROR_NON_OO("Requested telescope type {} is not registered", telescope_name);
     }


### PR DESCRIPTION
* Add default frequency mapping for different ICETelescope layouts
* Move query of GPS time to telescope object (and C++ instead of Python)
* Remove CHIME specific GPS references from `kotekan.cpp`
* Allow system to query the FPGA frequency map directly from fpga_master (for testing)
* Change telescope names to match class names (inline with other `kotekan` factory generated objects`)
* (Also sneaks in a change for .gitignore) 
* Adds the metric `kotekan_vdif_lost_frames_total` to track VDIF frames lost to bad input packets.  