### PR TITLE
Add metric to track invalidated VDIF frames

### DIFF
--- a/lib/dpdk/invalidateVDIFframes.cpp
+++ b/lib/dpdk/invalidateVDIFframes.cpp
@@ -3,6 +3,7 @@
 #include "StageFactory.hpp" // for REGISTER_KOTEKAN_STAGE, StageMakerTemplate
 #include "buffer.h"         // for Buffer, mark_frame_empty, mark_frame_full, register_consumer
 #include "chimeMetadata.h"  // for atomic_add_lost_timesamples
+#include "prometheusMetrics.hpp"
 #include "vdif_functions.h" // for VDIFHeader
 
 #include <assert.h>   // for assert
@@ -12,6 +13,7 @@
 using kotekan::bufferContainer;
 using kotekan::Config;
 using kotekan::Stage;
+using kotekan::prometheus::Metrics;
 
 REGISTER_KOTEKAN_STAGE(invalidateVDIFframes);
 
@@ -33,6 +35,9 @@ void invalidateVDIFframes::main_thread() {
 
     uint32_t frame_location;
     int64_t lost_samples;
+
+    auto& lost_frame_total =
+        Metrics::instance().add_counter("kotekan_vdif_lost_frames_total", unique_name);
 
     while (!stop_thread) {
 
@@ -65,6 +70,7 @@ void invalidateVDIFframes::main_thread() {
         }
 
         atomic_add_lost_timesamples(out_buf, out_buf_frame_id, lost_samples);
+        lost_frame_total.inc(lost_samples);
 
         mark_frame_empty(lost_samples_buf, unique_name.c_str(), lost_samples_buf_frame_id);
         lost_samples_buf_frame_id = (lost_samples_buf_frame_id + 1) % lost_samples_buf->num_frames;

--- a/lib/dpdk/invalidateVDIFframes.hpp
+++ b/lib/dpdk/invalidateVDIFframes.hpp
@@ -32,6 +32,10 @@
  *     @buffer_format Array of flags uint8_t flags which are either 0 (unset) or 1 (set)
  *     @buffer_metadata chimeMetadata
  *
+ * @par Metrics
+ * @metric kotekan_vdif_lost_frames_total
+ *        The number of VDIF frames invalidated because of lost packets.
+ *
  * @author Andre Renard
  */
 class invalidateVDIFframes : public kotekan::Stage {


### PR DESCRIPTION
* Adds the metric `kotekan_vdif_lost_frames_total` to track VDIF frames lost to bad input packets.  