### PR TITLE
Fix failing pytests

### DIFF
--- a/tests/test_accumulate.py
+++ b/tests/test_accumulate.py
@@ -72,6 +72,7 @@ def accumulate_data(tmpdir_factory):
         ),
         dump_buffer,
         accumulate_params,
+        gdb=True,
     )
 
     test.run()

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -5,26 +5,43 @@ MAINTAINER Rick Nitsche <rick@phas.ubc.ca>
 
 # Install any needed packages to run cmake with full CHIME build options
 RUN apt-get update && \
-    apt-get install -y software-properties-common && \
+    apt-get install -y software-properties-common=0.96.24.32.14 && \
     add-apt-repository ppa:deadsnakes/ppa && \
     apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y python3.7 python3-setuptools python3-pip python3.7-distutils python3.7-dev \
-                       build-essential git coreutils ccache pkg-config \
-                       gcc cmake clang-9 clang-format-8 \
-                       dpdk dpdk-dev \
-                       rocm-opencl-dev rocm-opencl \
-                       libhdf5-serial-dev libboost-test-dev libevent-dev libssl-dev \
-                       wget && \
+    apt-get install -y python3.7=3.7.9-1+bionic1 \
+                       python3-setuptools=39.0.1-2 \
+                       python3-pip=9.0.1-2.3~ubuntu1.18.04.2 \
+                       python3.7-distutils \
+                       python3.7-dev=3.7.9-1+bionic1 \
+                       build-essential=12.4ubuntu1 \
+                       git=1:2.17.1-1ubuntu0.7 \
+                       coreutils=8.28-1ubuntu1 \
+                       ccache=3.4.1-1 \
+                       pkg-config=0.29.1-0ubuntu2 \
+                       gcc=4:7.4.0-1ubuntu2.3 \
+                       cmake=3.10.2-1ubuntu2.18.04.1 \
+                       clang-9=1:9-2~ubuntu18.04.2 \
+                       clang-format-8=1:8-3~ubuntu18.04.2 \
+                       dpdk=17.11.10-0ubuntu0.1 \
+                       dpdk-dev=17.11.10-0ubuntu0.1 \
+                       rocm-opencl-dev=2.0.0.293-rocm-rel-3.7-20-3f18143 \
+                       rocm-opencl=2.0.0.293-rocm-rel-3.7-20-3f18143 \
+                       libhdf5-serial-dev=1.10.0-patch1+docs-4 \
+                       libboost-test-dev=1.65.1.0ubuntu1 \
+                       libevent-dev=2.1.8-stable-4build1 \
+                       libssl-dev=1.1.1-1ubuntu2.1~18.04.6 \
+                       wget=1.19.4-1ubuntu2.2 \
+                       && \
     apt-get clean && apt-get autoclean
 
-RUN python3.7 -m pip install --upgrade pip && \
-    python3.7 -m pip install --upgrade --force-reinstall setuptools && \
-    python3.7 -m pip install --upgrade pip setuptools wheel && \
-    python3.7 -m pip install --no-cache-dir "numpy>=1.16.0" && \
-    python3.7 -m pip install --no-cache-dir pkgconfig && \
-    python3.7 -m pip install --no-cache-dir --upgrade cython && \
-    python3.7 -m pip install --no-cache-dir black
+RUN python3.7 -m pip install --upgrade pip==20.2.2 && \
+    python3.7 -m pip install --upgrade --force-reinstall setuptools==49.6.0 && \
+    python3.7 -m pip install --upgrade wheel==0.35.1 && \
+    python3.7 -m pip install --no-cache-dir numpy==1.19.1 && \
+    python3.7 -m pip install --no-cache-dir pkgconfig==1.5.1 && \
+    python3.7 -m pip install --no-cache-dir --upgrade cython==0.29.21 && \
+    python3.7 -m pip install --no-cache-dir black==19.10b0
 
 RUN mkdir -p /code/build
 WORKDIR /code/build
@@ -55,29 +72,51 @@ RUN git clone https://github.com/kiyo-masui/bitshuffle.git bitshuffle && \
 
 # Install OpenBLAS and clone Blaze for the eigenvalue processes
 RUN apt-get update && \
-    apt-get -y install libopenblas-dev liblapack-dev liblapacke-dev && \
+    apt-get -y install libopenblas-dev=0.2.20+ds-4 \
+                       liblapack-dev=3.7.1-4ubuntu1 \
+                       liblapacke-dev=3.7.1-4ubuntu1 \
+                       && \
     apt-get clean && apt-get autoclean && \
     git clone https://bitbucket.org/blaze-lib/blaze.git blaze && cd blaze && git pull && cd ..
 
 # Install kotekan python dependencies
-RUN python3.7 -m pip install "msgpack>=0.6.1" click future requests pyyaml tabulate \
-                             pytest==6.0.1 pytest-xdist pytest-cpp pytest-localserver flask \
-                             pytest-timeout posix_ipc && \
+RUN python3.7 -m pip install msgpack==1.0.0 \
+                             click==7.1.2 \
+                             future==0.18.2 \
+                             requests==2.24.0 \
+                             pyyaml==3.12 \
+                             tabulate==0.8.7 \
+                             pytest==6.0.1 \
+                             pytest-xdist==2.1.0 \
+                             pytest-cpp==1.4.0 \
+                             pytest-localserver==0.5.0 \
+                             flask==1.1.2 \
+                             pytest-timeout==1.4.2 \
+                             posix_ipc==1.0.4 \
+                             && \
     apt-get update && \
-    apt-get install -y mysql-client libmysqlclient-dev && \
+    apt-get install -y mysql-client=5.7.31-0ubuntu0.18.04.1 \
+        libmysqlclient-dev=5.7.31-0ubuntu0.18.04.1 && \
     apt-get clean && apt-get autoclean && \
     python3.7 -m pip install git+https://github.com/chime-experiment/comet.git
 
 # Install redis for comet tests
 RUN apt-get update && \
-    apt-get install -y redis && \
+    apt-get install -y redis=5:4.0.9-1ubuntu0.2 && \
     apt-get clean && apt-get autoclean
 
 # Install documentation dependencies
 RUN apt-get update && \
-    apt-get -y install doxygen graphviz python-sphinx default-jre && \
+    apt-get -y install doxygen=1.8.13-10 \
+                       graphviz=2.40.1-2 \
+                       python-sphinx=1.6.7-1ubuntu1 \
+                       default-jre=2:1.11-68ubuntu1~18.04.1 \
+                       && \
     apt-get clean && apt-get autoclean && \
-    python3.7 -m pip install --no-cache-dir breathe sphinx_rtd_theme sphinxcontrib-plantuml && \
+    python3.7 -m pip install --no-cache-dir breathe==4.20.0 \
+                                            sphinx_rtd_theme==0.5.0 \
+                                            sphinxcontrib-plantuml==0.18 \
+                                            && \
     wget https://phoenixnap.dl.sourceforge.net/project/plantuml/plantuml.jar -P plantuml
 
 

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -61,7 +61,7 @@ RUN apt-get update && \
 
 # Install kotekan python dependencies
 RUN python3.7 -m pip install "msgpack>=0.6.1" click future requests pyyaml tabulate \
-                             pytest==5.3.0 pytest-xdist pytest-cpp pytest-localserver flask \
+                             pytest==6.0.1 pytest-xdist pytest-cpp pytest-localserver flask \
                              pytest-timeout posix_ipc && \
     apt-get update && \
     apt-get install -y mysql-client libmysqlclient-dev && \

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update && \
                        ccache=3.4.1-1 \
                        pkg-config=0.29.1-0ubuntu2 \
                        gcc=4:7.4.0-1ubuntu2.3 \
+                       gdb=8.1-0ubuntu3.2 \
                        cmake=3.10.2-1ubuntu2.18.04.1 \
                        clang-9=1:9-2~ubuntu18.04.2 \
                        clang-format-8=1:8-3~ubuntu18.04.2 \


### PR DESCRIPTION
This is an attempt to fix the failing pytests:

- bump pytest to version 6.0.1 fixes the problem we had:
```
scheduling tests via LoadFileScheduling
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/usr/local/lib/python3.7/dist-packages/_pytest/main.py", line 196, in wrap_session
INTERNALERROR>     session.exitstatus = doit(config, session) or 0
INTERNALERROR>   File "/usr/local/lib/python3.7/dist-packages/_pytest/main.py", line 240, in _main
INTERNALERROR>     config.hook.pytest_runtestloop(session=session)
INTERNALERROR>   File "/usr/local/lib/python3.7/dist-packages/pluggy/hooks.py", line 286, in __call__
INTERNALERROR>     return self._hookexec(self, self.get_hookimpls(), kwargs)
INTERNALERROR>   File "/usr/local/lib/python3.7/dist-packages/pluggy/manager.py", line 93, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook, methods, kwargs)
INTERNALERROR>   File "/usr/local/lib/python3.7/dist-packages/pluggy/manager.py", line 87, in <lambda>
INTERNALERROR>     firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
INTERNALERROR>   File "/usr/local/lib/python3.7/dist-packages/pluggy/callers.py", line 208, in _multicall
INTERNALERROR>     return outcome.get_result()
INTERNALERROR>   File "/usr/local/lib/python3.7/dist-packages/pluggy/callers.py", line 80, in get_result
INTERNALERROR>     raise ex[1].with_traceback(ex[2])
INTERNALERROR>   File "/usr/local/lib/python3.7/dist-packages/pluggy/callers.py", line 187, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File "/usr/local/lib/python3.7/dist-packages/xdist/dsession.py", line 112, in pytest_runtestloop
INTERNALERROR>     self.loop_once()
INTERNALERROR>   File "/usr/local/lib/python3.7/dist-packages/xdist/dsession.py", line 135, in loop_once
INTERNALERROR>     call(**kwargs)
INTERNALERROR>   File "/usr/local/lib/python3.7/dist-packages/xdist/dsession.py", line 174, in worker_workerfinished
INTERNALERROR>     assert not crashitem, (crashitem, node)
INTERNALERROR> AssertionError: ('test_accumulate.py::test_structure', <WorkerController gw1>)
INTERNALERROR> assert not 'test_accumulate.py::test_structure'============================== 1 skipped in 1.60s ==============================
##[error]Process completed with exit code 3.
##[debug]Finishing: Run parallel python tests
```

- freese all packages installed via pip/apt in the dockerfile to prevent future problems