### PR TITLE
fix(shared_memory_buffer): upon update, first check if link still exists to shared_mem

### DIFF
--- a/python/kotekan/shared_memory_buffer.py
+++ b/python/kotekan/shared_memory_buffer.py
@@ -84,8 +84,16 @@ class SharedMemoryReader:
         self._time_index_map = {}
 
         self.shared_mem_name = shared_memory_name
-        self.semaphore = posix_ipc.Semaphore(shared_memory_name)
-        self.shared_mem_file = posix_ipc.SharedMemory(shared_memory_name)
+
+        try:
+            self.semaphore = posix_ipc.Semaphore(shared_memory_name)
+            self.shared_mem_file = posix_ipc.SharedMemory(shared_memory_name)
+        except posix_ipc.ExistentialError:
+            raise SharedMemoryError(
+                "The shared memory resources referenced by '{}' were not created yet by the writer.".format(
+                    self.shared_mem_name
+                )
+            )
 
         # 0 means entire file
         self.shared_mem = mmap.mmap(self.shared_mem_file.fd, 0, prot=mmap.PROT_READ)


### PR DESCRIPTION

If kotekan-calbuffer is restarted, then it will write the buffer to a
new location in shared memory, but the calibration broker will continue
to check old location, and will continue to see the same old data, which
it will ignore.

The SharedMemoryReader should check on every .update() call to
see if the file descriptor still has any links.

mmap does not contain a reference to the file descriptor used to create
it, and so we will need to keep the original file descriptor around.

Addresses https://github.com/chime-experiment/ch_cal/issues/2