### PR TITLE
ci(docker): freeze base image at rocm/dev-ubuntu-18.04:3.7

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocm/dev-ubuntu-18.04
+FROM rocm/dev-ubuntu-18.04:3.7
 
 ## The maintainer name and email
 MAINTAINER Rick Nitsche <rick@phas.ubc.ca>


### PR DESCRIPTION
In the CI run of #826 the docker image was rebuilt because the base image had a new release. One of the previously version-frozen apt packages was not available anymore and the build failed. To make the version-freezing work, this also freezes the version of the docker base image.