### PR TITLE
build(cmake): hsa kernels not generated: variable partly renamed

### DIFF
--- a/lib/hsa/kernels/CMakeLists.txt
+++ b/lib/hsa/kernels/CMakeLists.txt
@@ -77,7 +77,7 @@ file(
     GLOB inCL_FILEs
     RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}"
     "${CMAKE_CURRENT_SOURCE_DIR}/*.cl")
-foreach(clfile ${inCLFiles})
+foreach(clfile ${inCL_FILEs})
     if(${USE_CLOC})
         string(REGEX REPLACE ".cl\$" ".hsaco" HSACO_FILE "${clfile}")
         set(CL_FILE "${CMAKE_CURRENT_SOURCE_DIR}/${clfile}")


### PR DESCRIPTION
A partly rename of the variable inCL_FILEs by cmake-format broke this
cmake file.