### PR TITLE
redefinition of station_id attribute for pulsar header

### DIFF
--- a/lib/stages/frbPostProcess.cpp
+++ b/lib/stages/frbPostProcess.cpp
@@ -131,7 +131,7 @@ void frbPostProcess::main_thread() {
     frb_header.data_nbytes = udp_packet_size - udp_header_size;
     frb_header.fpga_counts_per_sample = fpga_counts_per_sample;
     const auto fpga0_ns = tel.to_time(0);
-    frb_header.fpga0_ns = fpga0_ns.tv_sec * 1e9 + fpga0_ns.tv_nsec;
+    frb_header.fpga0_ns = fpga0_ns.tv_sec * 1'000'000'000 + fpga0_ns.tv_nsec;
     frb_header.fpga_count = 0;           // to be updated in fill_header
     frb_header.nbeams = _nbeams;         // 4
     frb_header.nfreq_coarse = _num_gpus; // 4

--- a/lib/stages/pulsarPostProcess.cpp
+++ b/lib/stages/pulsarPostProcess.cpp
@@ -167,11 +167,12 @@ void pulsarPostProcess::main_thread() {
         psr_header.log_num_chan = 3; // ln8
     }
     psr_header.vdif_version = 1;
-    psr_header.station_id = (uint16_t)(stream_id.crate_id * 16
-        + stream_id.slot_id + stream_id.link_id * 32); // effectively a GPU-node identifier.
-    psr_header.thread_id = 0;  // index of first packed frequency.
-    psr_header.bits_depth = 3; // 4+4 bit so 4-1=3
-    psr_header.data_type = 1;  // Complex
+    psr_header.station_id =
+        (uint16_t)(stream_id.crate_id * 16 + stream_id.slot_id
+                   + stream_id.link_id * 32); // effectively a GPU-node identifier.
+    psr_header.thread_id = 0;                 // index of first packed frequency.
+    psr_header.bits_depth = 3;                // 4+4 bit so 4-1=3
+    psr_header.data_type = 1;                 // Complex
     psr_header.edv = 0;
     psr_header.eud1 = 0; // UD: beam number [0 to 9]
     psr_header.eud2 = 0; //_psr_scaling from metadata

--- a/lib/stages/pulsarPostProcess.cpp
+++ b/lib/stages/pulsarPostProcess.cpp
@@ -149,6 +149,7 @@ void pulsarPostProcess::main_thread() {
     }
     uint64_t frame_fpga_seq_num = 0;     // sample starting the current input frame
     uint32_t current_input_location = 0; // goes from 0 to _samples_per_data_set
+    ice_stream_id_t stream_id = ice_get_stream_id_t(in_buf[0], in_buffer_ID[0]);
 
     PSRHeader psr_header;
     psr_header.seconds = 0; // UD
@@ -166,8 +167,8 @@ void pulsarPostProcess::main_thread() {
         psr_header.log_num_chan = 3; // ln8
     }
     psr_header.vdif_version = 1;
-    char si[2] = {'C', 'X'};
-    psr_header.station_id = (si[0] << 8) + si[1];
+    psr_header.station_id = (uint16_t)(stream_id.crate_id * 16
+        + stream_id.slot_id + stream_id.link_id * 32); // effectively a GPU-node identifier.
     psr_header.thread_id = 0;  // index of first packed frequency.
     psr_header.bits_depth = 3; // 4+4 bit so 4-1=3
     psr_header.data_type = 1;  // Complex

--- a/lib/stages/pulsarPostProcess.cpp
+++ b/lib/stages/pulsarPostProcess.cpp
@@ -201,8 +201,7 @@ void pulsarPostProcess::main_thread() {
         // Define station_id as a node identifer in terms of F-engine slot/crate/link data.
         ice_stream_id_t stream_id = ice_get_stream_id_t(in_buf[0], in_buffer_ID[0]);
         psr_header.station_id =
-            (uint16_t)(stream_id.crate_id * 16 + stream_id.slot_id
-                       + stream_id.link_id * 32);
+            (uint16_t)(stream_id.crate_id * 16 + stream_id.slot_id + stream_id.link_id * 32);
 
         bool skipped_frames =
             (new_frame_fpga_seq_num.value() - frame_fpga_seq_num) > _samples_per_data_set;

--- a/lib/utils/pulsar_functions.hpp
+++ b/lib/utils/pulsar_functions.hpp
@@ -12,7 +12,8 @@
  * of frequency channels, each 10-b numbers, are encoded in two places:
  * PSRHeader.thread_id and PSRHeader.eud3, with the latter defined as
  * PSRHeader.eud3 = freq_index[3]<<20 + freq_index[2]<<10 + freq_index[1]
- * Also, position info is encoded into PSRHeader.eud4 as:
+ * Also: a unique node-ID number is stored in PSRHeader.station_id, and
+ * position info is encoded into PSRHeader.eud4 as:
  * PSRHeader.eud4 = (RA << 16) + (DEC)
  *
  * @author Cherry Ng


### PR DESCRIPTION
@andrerenard i made a small change to propagate node-ID info down to the backend, which i forgot to make beforehand. it's been confirmed that the backend get's the right frequency labels, but this new `station_id` has been intended to be used for buffering data on the backend during an observation; again, i just forgot to make this change, my mistake.