### PR TITLE
Wconversion Cleanup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -159,6 +159,7 @@ jobs:
         docker run "${OPTS[@]}" \
           cmake -Wdev -Werror=dev -Wdeprecated -Werror=deprecated \
             -DWERROR=ON \
+            -DWFLOAT_CONVERSION=OFF \
             -DCMAKE_LINK_WHAT_YOU_USE=ON \
             -DCMAKE_BUILD_TYPE=Test \
             -DARCH=haswell \
@@ -224,6 +225,7 @@ jobs:
         docker run "${OPTS[@]}" \
           cmake -Wdev -Werror=dev -Wdeprecated -Werror=deprecated \
             -DWERROR=ON \
+            -DWFLOAT_CONVERSION=OFF \
             -DCMAKE_LINK_WHAT_YOU_USE=ON \
             -DCMAKE_BUILD_TYPE=Test \
             -DUSE_HDF5=ON -DHIGHFIVE_PATH=/code/build/HighFive \
@@ -252,6 +254,83 @@ jobs:
       run: |
         OPTS=(--rm --mount type=bind,src=$(pwd),target=/code/kotekan -w /code/kotekan/build/tests/ -e PYTHONPATH=/code/kotekan/python/ ${IMG_CORE}:${{ steps.extract_branch.outputs.branch }})
         docker run "${OPTS[@]}" pytest -v -x --timeout=${PYTEST_TIMEOUT}
+
+
+  # Build the full kotekan with -Wfloat-conversion
+  # All other builds disable this warning. We keep this separate
+  # Wfloat-conversion-build until we cleaned up all warnings, but it's
+  # not required to pass. Once it passes, remove this build build everything
+  # with -Wfloat-conversion.
+  wfloat-conversion:
+    runs-on: ubuntu-latest
+    needs: build-docker
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Free disk space
+      run: |
+          df -h
+          docker rmi $(docker image ls -aq)
+          df -h
+          sudo apt-get clean
+          sudo apt-get autoclean
+          df -h
+
+    - name: Cache ccache files
+      uses: actions/cache@v1
+      with:
+        path: .ccache
+        key: ccache-wfloat-conversion-build-${{ github.sha }}
+        restore-keys: |
+          ccache-wfloat-conversion-build
+          ccache-full-build
+          ccache-base-build
+
+    - name: Check if Dockerfile changed
+      uses: technote-space/get-diff-action@v4
+      id: git-diff-docker
+      with:
+        PATTERNS: tools/docker/Dockerfile
+
+    - name: Extract branch name for docker container
+      shell: bash
+      # Get either branch name of a push or source branch of PR, replace all '/' with '.'.
+      # If Dockerfile didn't change, use 'develop'.
+      run: >
+        if [ -n "${{ steps.git-diff-docker.outputs.diff }}" ]; then
+          if [ "${GITHUB_EVENT_NAME}" = "push" ]; then
+            echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/} | tr / .)";
+          else
+            echo "##[set-output name=branch;]$(echo ${GITHUB_HEAD_REF#refs/heads/} | tr / .)";
+          fi
+        else
+          echo "::set-output name=branch::develop"
+        fi
+      id: extract_branch
+
+    - name: Build kotekan
+      run: |
+        OPTS=(--rm --mount type=bind,src=$(pwd),target=/code/kotekan -w /code/kotekan/build/ ${IMG_CORE}:${{ steps.extract_branch.outputs.branch }})
+        docker login docker.pkg.github.com -u ${GITHUB_REPOSITORY} -p "${{ secrets.GITHUB_TOKEN }}"
+        docker run "${OPTS[@]}" ccache -s
+        docker run "${OPTS[@]}" \
+          cmake -Wdev -Werror=dev -Wdeprecated -Werror=deprecated \
+            -DWERROR=ON \
+            -DWFLOAT_CONVERSION=ON \
+            -DCMAKE_LINK_WHAT_YOU_USE=ON \
+            -DCMAKE_BUILD_TYPE=Test \
+            -DUSE_HDF5=ON -DHIGHFIVE_PATH=/code/build/HighFive \
+            -DUSE_LAPACK=ON -DBLAZE_PATH=/code/build/blaze \
+            -DARCH=haswell \
+            -DNO_MEMLOCK=ON \
+            -DUSE_OMP=ON \
+            -DWITH_TESTS=ON \
+            -DCCACHE=ON ..
+        docker run "${OPTS[@]}" make -j 2
+        docker run "${OPTS[@]}" rm -r lib
+        docker run "${OPTS[@]}" ccache -s
+        df -h
 
 
   # Build a full CHIME version of kotekan
@@ -301,6 +380,7 @@ jobs:
         docker run "${OPTS[@]}" \
           cmake -Wdev -Werror=dev -Wdeprecated -Werror=deprecated \
             -DWERROR=ON \
+            -DWFLOAT_CONVERSION=OFF \
             -DCMAKE_LINK_WHAT_YOU_USE=ON \
             -DCMAKE_BUILD_TYPE=Test \
             -DUSE_DPDK=ON \
@@ -363,6 +443,7 @@ jobs:
         docker run "${OPTS[@]}" ccache -s
         docker run "${OPTS[@]}" cmake -Wdev -Werror=dev -Wdeprecated -Werror=deprecated \
         -DWERROR=ON \
+        -DWFLOAT_CONVERSION=OFF \
         -DCMAKE_LINK_WHAT_YOU_USE=ON \
         -DUSE_DPDK=ON \
         -DCMAKE_BUILD_TYPE=Test \
@@ -439,6 +520,7 @@ jobs:
         cmake -Wdev -Werror=dev -Wdeprecated -Werror=deprecated \
         -DCMAKE_BUILD_TYPE=Test \
         -DWERROR=ON \
+        -DWFLOAT_CONVERSION=OFF \
         -DUSE_HDF5=ON \
         -DUSE_OPENCL=ON \
         -DUSE_FFTW=ON \
@@ -490,6 +572,7 @@ jobs:
           cmake \
             -Wdev -Werror=dev -Wdeprecated -Werror=deprecated \
             -DWERROR=ON \
+            -DWFLOAT_CONVERSION=OFF \
             -DCOMPILE_DOCS=ON \
             -DPLANTUML_PATH=/code/build/plantuml \
             -DWITH_TESTS=OFF ..
@@ -533,6 +616,7 @@ jobs:
         docker run "${OPTS[@]}" \
           cmake -Wdev -Werror=dev -Wdeprecated -Werror=deprecated \
             -DWERROR=ON \
+            -DWFLOAT_CONVERSION=OFF \
             -DCMAKE_LINK_WHAT_YOU_USE=ON \
             -DCMAKE_BUILD_TYPE=Test \
             -DUSE_DPDK=ON \

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,10 @@
 /.vscode/
 /nbproject/
 /cmake-build*/
+kotekan.cflags
+kotekan.config
+kotekan.creator
+kotekan.creator.user
+kotekan.cxxflags
+kotekan.files
+kotekan.includes

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ option(WITH_TESTS "Compile testing library and boost C++ unit tests" OFF)
 option(IWYU "Enable include-what-you-use and print suggestions to stderr" OFF)
 option(CCACHE "Use ccache to speed up the build" OFF)
 option(WERROR "Warnings are errors" OFF)
+option(WFLOAT_CONVERSION "Enable -Wfloat-conversion" ON)
 
 if(${CCACHE})
     find_program(CCACHE_PROGRAM ccache)
@@ -80,9 +81,14 @@ check_cxx_compiler_flag(-Wsuggest-override HAVE_SUGGEST_OVERRIDE)
 if(HAVE_SUGGEST_OVERRIDE AND NOT ${IWYU})
     add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wsuggest-override>)
 endif()
-check_cxx_compiler_flag(-Wfloat-conversion HAVE_FLOAT_CONVERSION)
-if(HAVE_FLOAT_CONVERSION AND NOT ${IWYU})
-    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wfloat-conversion>)
+
+# Separate Wfloat-conversion warning Merge with the block above when there are no such warnings
+# anymore in the whole project
+if(${WFLOAT_CONVERSION})
+    check_cxx_compiler_flag(-Wfloat-conversion HAVE_FLOAT_CONVERSION)
+    if(HAVE_FLOAT_CONVERSION AND NOT ${IWYU})
+        add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wfloat-conversion>)
+    endif()
 endif()
 
 # optimization

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,9 +66,12 @@ if(${WERROR})
 endif()
 # lots of warnings and all warnings as errors
 add_compile_options(-Wall -Wextra)
-add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wzero-as-null-pointer-constant>)
 # Warning about missing override is called differently in clang and gcc
 include(CheckCXXCompilerFlag)
+check_cxx_compiler_flag(-Wzero-as-null-pointer-constant HAVE_ZERO_AS_NULL)
+if(HAVE_ZERO_AS_NULL AND NOT ${IWYU})
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wzero-as-null-pointer-constant>)
+endif()
 check_cxx_compiler_flag(-Winconsistent-missing-override HAVE_INCONSISTANT_MISSING_OVERRIDE)
 if(HAVE_INCONSISTANT_MISSING_OVERRIDE AND NOT ${IWYU})
     add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Winconsistent-missing-override>)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,10 @@ check_cxx_compiler_flag(-Wsuggest-override HAVE_SUGGEST_OVERRIDE)
 if(HAVE_SUGGEST_OVERRIDE AND NOT ${IWYU})
     add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wsuggest-override>)
 endif()
+check_cxx_compiler_flag(-Wfloat-conversion HAVE_FLOAT_CONVERSION)
+if(HAVE_FLOAT_CONVERSION AND NOT ${IWYU})
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wfloat-conversion>)
+endif()
 
 # optimization
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} ${CMAKE_C_FLAGS} -ggdb -O2")

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1,9 +1,9 @@
 project(libexternal)
 add_library(libexternal INTERFACE)
 
-target_include_directories(libexternal INTERFACE fmt)
-target_include_directories(libexternal INTERFACE gsl)
-target_include_directories(libexternal INTERFACE json)
+target_include_directories(libexternal SYSTEM INTERFACE fmt)
+target_include_directories(libexternal SYSTEM INTERFACE gsl)
+target_include_directories(libexternal SYSTEM INTERFACE json)
 
 add_subdirectory(MurmurHash3)
 target_link_libraries(libexternal INTERFACE MurmurHash3)

--- a/external/MurmurHash3/CMakeLists.txt
+++ b/external/MurmurHash3/CMakeLists.txt
@@ -1,4 +1,4 @@
 project(MurmurHash3)
 
 add_library(MurmurHash3 MurmurHash3.cpp)
-target_include_directories(MurmurHash3 INTERFACE .)
+target_include_directories(MurmurHash3 SYSTEM INTERFACE .)

--- a/external/modp_b64/CMakeLists.txt
+++ b/external/modp_b64/CMakeLists.txt
@@ -1,4 +1,4 @@
 project(MurmurHash3)
 
 add_library(modp_b64 modp_b64.cpp)
-target_include_directories(modp_b64 INTERFACE .)
+target_include_directories(modp_b64 SYSTEM INTERFACE .)

--- a/external/modp_b64/CMakeLists.txt
+++ b/external/modp_b64/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(MurmurHash3)
+project(modp_b64)
 
 add_library(modp_b64 modp_b64.cpp)
 target_include_directories(modp_b64 SYSTEM INTERFACE .)

--- a/iwyu.kotekan.imp
+++ b/iwyu.kotekan.imp
@@ -13,8 +13,8 @@
     { include: [ "<bits/types/sig_atomic_t.h>", private, "<csignal>", public ] },
 
     # Use the main fmt header file only
-    { include: [ "\"fmt/core.h\"", private, "\"fmt.hpp\"", public ] },
-    { include: [ "\"fmt/ostream.h\"", private, "\"fmt.hpp\"", public ] },
+    { include: [ "<fmt/core.h>", private, "<fmt.hpp>", public ] },
+    { include: [ "<fmt/ostream.h>", private, "<fmt.hpp>", public ] },
 
     # libevent
     { symbol: [ "evhttp_request", public, "<evhttp.h>", public ] },

--- a/kotekan/kotekan.cpp
+++ b/kotekan/kotekan.cpp
@@ -10,17 +10,16 @@
 #include "version.h"              // for get_kotekan_version, get_cmake_build_options, get_git_...
 #include "visUtil.hpp"            // for regex_split
 
-#include "fmt.hpp"  // for format, fmt
-#include "json.hpp" // for basic_json<>::object_t, basic_json<>::value_type, json
-
 #include <algorithm>   // for max
 #include <array>       // for array
 #include <assert.h>    // for assert
 #include <csignal>     // for signal, SIGINT, sig_atomic_t
 #include <exception>   // for exception
+#include <fmt.hpp>     // for format, fmt
 #include <getopt.h>    // for no_argument, getopt_long, required_argument, option
 #include <iostream>    // for endl, basic_ostream, cout, ostream
 #include <iterator>    // for reverse_iterator
+#include <json.hpp>    // for basic_json<>::object_t, basic_json<>::value_type, json
 #include <map>         // for map
 #include <memory>      // for allocator, shared_ptr
 #include <mutex>       // for mutex, lock_guard

--- a/lib/core/Config.cpp
+++ b/lib/core/Config.cpp
@@ -1,10 +1,9 @@
 #include "Config.hpp"
 
-#include "fmt.hpp"  // for format, fmt
-#include "json.hpp" // for json, iter_impl, basic_json<>::object_t, operator>>, basic_json
-
 #include <cstdint>   // for int32_t
+#include <fmt.hpp>   // for format, fmt
 #include <fstream>   // for ifstream, istream, size_t
+#include <json.hpp>  // for json, iter_impl, basic_json<>::object_t, operator>>, basic_json
 #include <map>       // for map<>::key_type
 #include <stdexcept> // for runtime_error
 #include <stdio.h>   // for sprintf

--- a/lib/core/Config.hpp
+++ b/lib/core/Config.hpp
@@ -8,12 +8,11 @@
 
 #include "kotekanLogging.hpp" // for ERROR_NON_OO
 
-#include "fmt.hpp"  // for format, fmt
-#include "json.hpp" // for json
-
 #include <complex>     // for complex  // IWYU pragma: keep
 #include <cxxabi.h>    // for __cxa_demangle
 #include <exception>   // for exception
+#include <fmt.hpp>     // for format, fmt
+#include <json.hpp>    // for json
 #include <list>        // for list
 #include <regex>       // for regex, cmatch, regex_match, sregex_token_iterator
 #include <stdexcept>   // for runtime_error

--- a/lib/core/Stage.cpp
+++ b/lib/core/Stage.cpp
@@ -5,13 +5,12 @@
 #include "bufferContainer.hpp" // for bufferContainer
 #include "util.h"              // for string_tail
 
-#include "fmt.hpp" // for format
-
 #include <algorithm>    // for copy, max
 #include <chrono>       // for seconds
 #include <cstdlib>      // for abort
 #include <cxxabi.h>     // for __forced_unwind
 #include <exception>    // for exception
+#include <fmt.hpp>      // for format
 #include <future>       // for async, future, future_status, future_status::timeout, launch
 #include <pthread.h>    // for pthread_setaffinity_np, pthread_setname_np
 #include <regex>        // for match_results<>::_Base_type

--- a/lib/core/StageFactory.cpp
+++ b/lib/core/StageFactory.cpp
@@ -3,8 +3,7 @@
 #include "Config.hpp"         // for Config
 #include "kotekanLogging.hpp" // for ERROR_NON_OO
 
-#include "fmt.hpp" // for format, fmt
-
+#include <fmt.hpp>   // for format, fmt
 #include <stdexcept> // for runtime_error
 #include <utility>   // for pair
 

--- a/lib/core/StageFactory.hpp
+++ b/lib/core/StageFactory.hpp
@@ -14,10 +14,9 @@
 #include "Stage.hpp"
 #include "bufferContainer.hpp"
 
-#include "json.hpp" // for json
-
-#include <map>    // for map
-#include <string> // for string
+#include <json.hpp> // for json
+#include <map>      // for map
+#include <string>   // for string
 
 namespace kotekan {
 

--- a/lib/core/basebandApiManager.cpp
+++ b/lib/core/basebandApiManager.cpp
@@ -7,12 +7,11 @@
 #include "restServer.hpp"             // for connectionInstance, HTTP_RESPONSE, restServer, HTT...
 #include "visUtil.hpp"
 
-#include "fmt.hpp" // for format, fmt
-
 #include <chrono>      // for milliseconds, duration_cast, system_clock, system_...
 #include <ctime>       // for localtime_r, time_t, tm, timespec
 #include <cxxabi.h>    // for __forced_unwind
 #include <exception>   // for exception
+#include <fmt.hpp>     // for format, fmt
 #include <functional>  // for _Bind_helper<>::type, _Placeholder, bind, _1, _2
 #include <iomanip>     // for operator<<, put_time
 #include <memory>      // for shared_ptr, unique_ptr, __shared_ptr_access

--- a/lib/core/basebandApiManager.hpp
+++ b/lib/core/basebandApiManager.hpp
@@ -11,8 +11,7 @@
 #include "prometheusMetrics.hpp"      // for Counter
 #include "restServer.hpp"             // for connectionInstance, restServer
 
-#include "json.hpp" // for json
-
+#include <json.hpp> // for json
 #include <map>      // for map, map<>::iterator
 #include <math.h>   // for M_PI
 #include <mutex>    // for mutex

--- a/lib/core/basebandReadoutManager.hpp
+++ b/lib/core/basebandReadoutManager.hpp
@@ -11,11 +11,10 @@
 
 #include "SynchronizedQueue.hpp" // for SynchronizedQueue
 
-#include "gsl-lite.hpp" // for span
-
 #include <chrono>       // for system_clock, system_clock::time_point
 #include <forward_list> // for forward_list
 #include <functional>   // for reference_wrapper
+#include <gsl-lite.hpp> // for span
 #include <memory>       // for unique_ptr, shared_ptr, allocator
 #include <mutex>        // for mutex
 #include <stdint.h>     // for uint64_t, int64_t, uint32_t, uint8_t

--- a/lib/core/bufferContainer.cpp
+++ b/lib/core/bufferContainer.cpp
@@ -2,8 +2,7 @@
 
 #include "buffer.h"
 
-#include "fmt.hpp" // for format, fmt
-
+#include <fmt.hpp>   // for format, fmt
 #include <stdexcept> // for runtime_error
 
 using std::map;

--- a/lib/core/bufferFactory.cpp
+++ b/lib/core/bufferFactory.cpp
@@ -7,10 +7,9 @@
 #include "metadata.h"         // for metadataPool // IWYU pragma: keep
 #include "visBuffer.hpp"      // for VisFrameView
 
-#include "fmt.hpp" // for format, fmt
-
 #include <cstdint>   // for int32_t, uint32_t
 #include <exception> // for exception
+#include <fmt.hpp>   // for format, fmt
 #include <regex>     // for match_results<>::_Base_type
 #include <stddef.h>  // for size_t
 #include <stdexcept> // for runtime_error

--- a/lib/core/bufferFactory.hpp
+++ b/lib/core/bufferFactory.hpp
@@ -5,10 +5,9 @@
 #include "buffer.h"   // for Buffer // IWYU pragma: keep
 #include "metadata.h" // for metadataPool // IWYU pragma: keep
 
-#include "json.hpp" // for json
-
-#include <map>    // for map
-#include <string> // for string
+#include <json.hpp> // for json
+#include <map>      // for map
+#include <string>   // for string
 
 namespace kotekan {
 

--- a/lib/core/configUpdater.cpp
+++ b/lib/core/configUpdater.cpp
@@ -6,11 +6,10 @@
 #include "restServer.hpp"     // for connectionInstance, HTTP_RESPONSE, HTTP_RESPONSE::BAD_REQUEST
 #include "visUtil.hpp"        // for json_type_name
 
-#include "fmt.hpp"  // for format, fmt
-#include "json.hpp" // for json, basic_json<>::iterator, basic_json, iter_impl, basic...
-
 #include <algorithm> // for find, count
 #include <exception> // for exception
+#include <fmt.hpp>   // for format, fmt
+#include <json.hpp>  // for json, basic_json<>::iterator, basic_json, iter_impl, basic...
 #include <stdexcept> // for runtime_error
 #include <utility>   // for pair
 

--- a/lib/core/configUpdater.hpp
+++ b/lib/core/configUpdater.hpp
@@ -5,9 +5,8 @@
 #include "Stage.hpp"      // for Stage
 #include "restServer.hpp" // for connectionInstance
 
-#include "json.hpp" // for json
-
 #include <functional> // for function
+#include <json.hpp>   // for json
 #include <map>        // for map, multimap
 #include <string>     // for string
 #include <vector>     // for vector

--- a/lib/core/factory.hpp
+++ b/lib/core/factory.hpp
@@ -45,9 +45,8 @@
 #include "kotekanLogging.hpp"
 #include "type.hpp"
 
-#include "fmt.hpp"
-
 #include <cxxabi.h>
+#include <fmt.hpp>
 #include <functional>
 #include <iostream>
 #include <map>

--- a/lib/core/kotekanLogging.cpp
+++ b/lib/core/kotekanLogging.cpp
@@ -2,8 +2,7 @@
 
 #include "errors.h" // for __enable_syslog, __err_msg, __max_log_msg_len
 
-#include "fmt.hpp" // for basic_string_view, print, vformat, basic_format_context, format_args
-
+#include <fmt.hpp>     // for basic_string_view, print, vformat, basic_format_context, format_args
 #include <stdexcept>   // for runtime_error
 #include <stdio.h>     // for stderr
 #include <strings.h>   // for strcasecmp

--- a/lib/core/kotekanLogging.hpp
+++ b/lib/core/kotekanLogging.hpp
@@ -3,9 +3,8 @@
 
 #include "errors.h" // for _global_log_level  // IWYU pragma: keep
 
-#include "fmt.hpp" // for fmt, basic_string_view, make_format_args, FMT_STRING
-
 #include <errno.h>  // for errno
+#include <fmt.hpp>  // for fmt, basic_string_view, make_format_args, FMT_STRING
 #include <string>   // for string
 #include <syslog.h> // for LOG_ERR, LOG_INFO, LOG_WARNING
 

--- a/lib/core/kotekanMode.cpp
+++ b/lib/core/kotekanMode.cpp
@@ -14,10 +14,9 @@
 #include "prometheusMetrics.hpp" // for Metrics
 #include "restServer.hpp"        // for restServer, connectionInstance
 
-#include "fmt.hpp"  // for format
-#include "json.hpp" // for basic_json<>::object_t, basic_json<>::value_type, json
-
+#include <fmt.hpp>    // for format
 #include <functional> // for _Bind_helper<>::type, _Placeholder, bind, _1, placeholders
+#include <json.hpp>   // for basic_json<>::object_t, basic_json<>::value_type, json
 #include <stdlib.h>   // for free
 #include <utility>    // for pair
 

--- a/lib/core/metadataFactory.cpp
+++ b/lib/core/metadataFactory.cpp
@@ -8,9 +8,8 @@
 #include "metadata.h"         // for create_metadata_pool
 #include "visBuffer.hpp"      // for VisMetadata
 
-#include "fmt.hpp" // for format, fmt
-
 #include <exception> // for exception
+#include <fmt.hpp>   // for format, fmt
 #include <regex>     // for match_results<>::_Base_type
 #include <stdexcept> // for runtime_error
 #include <stdint.h>  // for uint32_t

--- a/lib/core/metadataFactory.hpp
+++ b/lib/core/metadataFactory.hpp
@@ -4,10 +4,9 @@
 #include "Config.hpp" // for Config
 #include "metadata.h" // for metadataPool // IWYU pragma: keep
 
-#include "json.hpp" // for json
-
-#include <map>    // for map
-#include <string> // for string
+#include <json.hpp> // for json
+#include <map>      // for map
+#include <string>   // for string
 
 namespace kotekan {
 

--- a/lib/core/prometheusMetrics.cpp
+++ b/lib/core/prometheusMetrics.cpp
@@ -3,9 +3,8 @@
 #include "kotekanLogging.hpp" // for ERROR_NON_OO
 #include "restServer.hpp"     // for restServer, connectionInstance
 
-#include "fmt.hpp" // for print, format, fmt
-
 #include <cmath>      // for isinf, isnan
+#include <fmt.hpp>    // for print, format, fmt
 #include <functional> // for _Bind_helper<>::type, _Placeholder, bind, _1, placeholders
 #include <iterator>   // for begin, end
 #include <ostream>    // for operator<<, basic_ostream

--- a/lib/core/restServer.cpp
+++ b/lib/core/restServer.cpp
@@ -3,8 +3,6 @@
 #include "Config.hpp"         // for Config
 #include "kotekanLogging.hpp" // for ERROR_NON_OO, WARN_NON_OO, INFO_NON_OO, DEBUG_NON_OO
 
-#include "fmt.hpp" // for format, fmt
-
 #include <algorithm>               // for max
 #include <assert.h>                // for assert
 #include <cstdint>                 // for int32_t
@@ -15,6 +13,7 @@
 #include <event2/thread.h>         // for evthread_use_pthreads
 #include <evhttp.h>                // for evhttp_request
 #include <exception>               // for exception
+#include <fmt.hpp>                 // for format, fmt
 #include <mutex>                   // for unique_lock
 #include <netinet/in.h>            // for sockaddr_in, ntohs
 #include <pthread.h>               // for pthread_setaffinity_np, pthread_setname_np

--- a/lib/core/restServer.hpp
+++ b/lib/core/restServer.hpp
@@ -3,12 +3,11 @@
 
 #include "Config.hpp" // for Config
 
-#include "json.hpp" // for json
-
 #include <atomic>        // for atomic
 #include <event2/util.h> // for evutil_socket_t
 #include <evhttp.h>      // for evhttp  // IWYU pragma: keep
 #include <functional>    // for function
+#include <json.hpp>      // for json
 #include <map>           // for map
 #include <shared_mutex>  // for shared_timed_mutex
 #include <stdint.h>      // for uint8_t

--- a/lib/dpdk/captureHandler.hpp
+++ b/lib/dpdk/captureHandler.hpp
@@ -14,7 +14,7 @@
 #include "packet_copy.h"
 #include "prometheusMetrics.hpp"
 
-#include "json.hpp"
+#include <json.hpp>
 
 /**
  * @brief A simple handler to capture uniformly sized packets into a kotekan buffer

--- a/lib/dpdk/dpdkCore.cpp
+++ b/lib/dpdk/dpdkCore.cpp
@@ -8,12 +8,11 @@
 #include "iceBoardStandard.hpp" // for iceBoardStandard
 #include "iceBoardVDIF.hpp"     // for iceBoardVDIF
 
-#include "fmt.hpp"  // for format, fmt
-#include "json.hpp" // for json, basic_json<>::object_t, basic_json, basic_json<...
-
 #include <algorithm>               // for copy, max
 #include <atomic>                  // for atomic_bool
+#include <fmt.hpp>                 // for format, fmt
 #include <functional>              // for _Bind_helper<>::type, bind, function
+#include <json.hpp>                // for json, basic_json<>::object_t, basic_json, basic_json<...
 #include <numa.h>                  // for numa_node_of_cpu, numa_num_configured_nodes
 #include <regex>                   // for match_results<>::_Base_type
 #include <rte_branch_prediction.h> // for unlikely

--- a/lib/dpdk/iceBoardHandler.hpp
+++ b/lib/dpdk/iceBoardHandler.hpp
@@ -14,8 +14,7 @@
 #include "prometheusMetrics.hpp"
 #include "util.h" // for e_time
 
-#include "json.hpp"
-
+#include <json.hpp>
 #include <mutex>
 
 /**

--- a/lib/dpdk/iceBoardHandler.hpp
+++ b/lib/dpdk/iceBoardHandler.hpp
@@ -413,7 +413,7 @@ nlohmann::json iceBoardHandler::get_json_port_info() {
     info["nic_port"] = this->port;
 
     std::vector<uint32_t> freq_bins;
-    std::vector<float> freq_mhz;
+    std::vector<double> freq_mhz;
     ice_stream_id_t temp_stream_id = port_stream_id;
     temp_stream_id.crate_id = port_stream_id.crate_id % 2;
 

--- a/lib/dpdk/zeroSamples.cpp
+++ b/lib/dpdk/zeroSamples.cpp
@@ -7,13 +7,12 @@
 #include "chimeMetadata.hpp"   // for atomic_add_lost_timesamples
 #include "nt_memset.h"         // for nt_memset
 
-#include "json.hpp" // for json, basic_json, basic_json<>::iterator, iter_impl
-
 #include <algorithm>  // for max
 #include <assert.h>   // for assert
 #include <atomic>     // for atomic_bool
 #include <exception>  // for exception
 #include <functional> // for _Bind_helper<>::type, bind, function
+#include <json.hpp>   // for json, basic_json, basic_json<>::iterator, iter_impl
 #include <regex>      // for match_results<>::_Base_type
 #include <stdexcept>  // for runtime_error
 #include <string.h>   // for memcpy, size_t

--- a/lib/gpu/gpuProcess.cpp
+++ b/lib/gpu/gpuProcess.cpp
@@ -8,14 +8,13 @@
 #include "restServer.hpp"         // for restServer, connectionInstance
 #include "util.h"                 // for e_time
 
-#include "fmt.hpp"  // for format, fmt
-#include "json.hpp" // for json, basic_json<>::object_t, basic_json<>::value_type
-
 #include <algorithm>   // for max
 #include <atomic>      // for atomic_bool
 #include <exception>   // for exception
+#include <fmt.hpp>     // for format, fmt
 #include <functional>  // for _Bind_helper<>::type, _Placeholder, bind, ref, _1, fun...
 #include <iosfwd>      // for std
+#include <json.hpp>    // for json, basic_json<>::object_t, basic_json<>::value_type
 #include <pthread.h>   // for pthread_setaffinity_np
 #include <regex>       // for match_results<>::_Base_type
 #include <sched.h>     // for cpu_set_t, CPU_SET, CPU_ZERO

--- a/lib/hsa/hsaBeamformKernel.cpp
+++ b/lib/hsa/hsaBeamformKernel.cpp
@@ -9,11 +9,10 @@
 #include "hsaDeviceInterface.hpp" // for hsaDeviceInterface, Config
 #include "restServer.hpp"         // for restServer, connectionInstance, HTTP_RESPONSE, HTTP_R...
 
-#include "fmt.hpp" // for format, fmt
-
 #include <cmath>      // for sin, asin, cos, floor
 #include <cstdint>    // for int32_t
 #include <exception>  // for exception
+#include <fmt.hpp>    // for format, fmt
 #include <functional> // for _Bind_helper<>::type, _Placeholder, bind, _1, _2, pla...
 #include <regex>      // for match_results<>::_Base_type
 #include <string.h>   // for memcpy, memset

--- a/lib/hsa/hsaBeamformKernel.hpp
+++ b/lib/hsa/hsaBeamformKernel.hpp
@@ -16,8 +16,7 @@
 #include "hsaDeviceInterface.hpp" // for hsaDeviceInterface
 #include "restServer.hpp"         // for connectionInstance
 
-#include "json.hpp" // for json
-
+#include <json.hpp> // for json
 #include <stdint.h> // for int32_t, uint32_t
 #include <string>   // for string
 #include <vector>   // for vector

--- a/lib/hsa/hsaCorrelatorKernel.cpp
+++ b/lib/hsa/hsaCorrelatorKernel.cpp
@@ -7,10 +7,9 @@
 #include "hsaDeviceInterface.hpp" // for hsaDeviceInterface, Config
 #include "kotekanLogging.hpp"     // for DEBUG2
 
-#include "fmt.hpp" // for format, fmt
-
 #include <cstdint>   // for int32_t
 #include <exception> // for exception
+#include <fmt.hpp>   // for format, fmt
 #include <regex>     // for match_results<>::_Base_type
 #include <string.h>  // for memcpy, memset
 #include <vector>    // for vector

--- a/lib/hsa/hsaOutputData.cpp
+++ b/lib/hsa/hsaOutputData.cpp
@@ -9,8 +9,7 @@
 #include "hsaDeviceInterface.hpp" // for hsaDeviceInterface
 #include "visUtil.hpp"            // for double_to_tv, tv_to_double
 
-#include "fmt.hpp" // for format, fmt
-
+#include <fmt.hpp>    // for format, fmt
 #include <sys/time.h> // for timeval
 #include <time.h>     // for timespec
 

--- a/lib/hsa/hsaOutputDataZero.cpp
+++ b/lib/hsa/hsaOutputDataZero.cpp
@@ -7,9 +7,8 @@
 #include "hsaDeviceInterface.hpp" // for hsaDeviceInterface, Config
 #include "kotekanLogging.hpp"     // for INFO
 
-#include "fmt.hpp" // for format, fmt
-
 #include <exception> // for exception
+#include <fmt.hpp>   // for format, fmt
 #include <regex>     // for match_results<>::_Base_type
 #include <string.h>  // for memset
 #include <vector>    // for vector

--- a/lib/hsa/hsaPresumKernel.cpp
+++ b/lib/hsa/hsaPresumKernel.cpp
@@ -5,10 +5,9 @@
 #include "hsaCommand.hpp"         // for kernelParams, KERNEL_EXT, REGISTER_HSA_COMMAND, _facto...
 #include "hsaDeviceInterface.hpp" // for hsaDeviceInterface, Config
 
-#include "fmt.hpp" // for format, fmt
-
 #include <cstdint>   // for int32_t
 #include <exception> // for exception
+#include <fmt.hpp>   // for format, fmt
 #include <regex>     // for match_results<>::_Base_type
 #include <string.h>  // for memcpy, memset
 #include <vector>    // for vector

--- a/lib/hsa/hsaPresumZero.cpp
+++ b/lib/hsa/hsaPresumZero.cpp
@@ -6,10 +6,9 @@
 #include "hsaCommand.hpp"         // for REGISTER_HSA_COMMAND, _factory_aliashsaCommand
 #include "hsaDeviceInterface.hpp" // for hsaDeviceInterface, Config
 
-#include "fmt.hpp" // for format, fmt
-
 #include <cstdint>   // for int32_t
 #include <exception> // for exception
+#include <fmt.hpp>   // for format, fmt
 #include <regex>     // for match_results<>::_Base_type
 #include <string.h>  // for memset
 #include <vector>    // for vector

--- a/lib/hsa/hsaRfiBadInput.hpp
+++ b/lib/hsa/hsaRfiBadInput.hpp
@@ -13,8 +13,7 @@
 #include "hsaDeviceInterface.hpp" // for hsaDeviceInterface
 #include "restServer.hpp"         // for connectionInstance
 
-#include "json.hpp" // for json
-
+#include <json.hpp> // for json
 #include <stdint.h> // for uint32_t
 #include <string>   // for string
 

--- a/lib/hsa/hsaRfiInputSum.hpp
+++ b/lib/hsa/hsaRfiInputSum.hpp
@@ -14,8 +14,7 @@
 #include "hsaDeviceInterface.hpp" // for hsaDeviceInterface
 #include "restServer.hpp"         // for connectionInstance
 
-#include "json.hpp" // for json
-
+#include <json.hpp> // for json
 #include <stdint.h> // for uint32_t, int32_t
 #include <string>   // for string
 

--- a/lib/hsa/hsaRfiTimeSum.hpp
+++ b/lib/hsa/hsaRfiTimeSum.hpp
@@ -12,8 +12,7 @@
 #include "hsaCommand.hpp"         // for hsaCommand
 #include "hsaDeviceInterface.hpp" // for hsaDeviceInterface
 
-#include "json.hpp" // for json
-
+#include <json.hpp> // for json
 #include <stdint.h> // for uint32_t
 #include <string>   // for string
 #include <vector>   // for vector

--- a/lib/hsa/hsaRfiZeroData.hpp
+++ b/lib/hsa/hsaRfiZeroData.hpp
@@ -13,8 +13,7 @@
 #include "hsaCommand.hpp"         // for hsaCommand
 #include "hsaDeviceInterface.hpp" // for hsaDeviceInterface
 
-#include "json.hpp" // for json
-
+#include <json.hpp> // for json
 #include <mutex>    // for mutex
 #include <stdint.h> // for uint32_t, int32_t
 #include <string>   // for string

--- a/lib/hsa/hsaTrackingBeamform.cpp
+++ b/lib/hsa/hsaTrackingBeamform.cpp
@@ -5,10 +5,9 @@
 #include "gpuCommand.hpp"         // for gpuCommandType, gpuCommandType::KERNEL
 #include "hsaDeviceInterface.hpp" // for hsaDeviceInterface, Config
 
-#include "fmt.hpp" // for format, fmt
-
 #include <cstdint>   // for int32_t
 #include <exception> // for exception
+#include <fmt.hpp>   // for format, fmt
 #include <regex>     // for match_results<>::_Base_type
 #include <stdexcept> // for runtime_error
 #include <string.h>  // for memcpy, memset

--- a/lib/hsa/hsaTrackingUpdatePhase.hpp
+++ b/lib/hsa/hsaTrackingUpdatePhase.hpp
@@ -16,8 +16,7 @@
 #include "hsaCommand.hpp"         // for hsaCommand
 #include "hsaDeviceInterface.hpp" // for hsaDeviceInterface
 
-#include "json.hpp" // for json
-
+#include <json.hpp>    // for json
 #include <mutex>       // for mutex
 #include <stdint.h>    // for int32_t, int16_t, uint32_t, uint8_t
 #include <string>      // for string

--- a/lib/stages/BaseWriter.cpp
+++ b/lib/stages/BaseWriter.cpp
@@ -14,12 +14,11 @@
 #include "version.h"             // for get_git_commit_hash
 #include "visFile.hpp"           // for visFileBundle, _factory_aliasvisFile
 
-#include "fmt.hpp" // for format
-
 #include <algorithm>  // for copy, copy_backward, equal, max
 #include <atomic>     // for atomic_bool
 #include <deque>      // for deque
 #include <exception>  // for exception
+#include <fmt.hpp>    // for format
 #include <functional> // for _Bind_helper<>::type, bind, function
 #include <regex>      // for match_results<>::_Base_type
 #include <stdexcept>  // for runtime_error, out_of_range

--- a/lib/stages/BeamInspect.cpp
+++ b/lib/stages/BeamInspect.cpp
@@ -7,9 +7,8 @@
 #include "kotekanLogging.hpp" // for INFO
 #include "visUtil.hpp"        // for frameID, modulo
 
-#include "fmt.hpp" // for format
-
 #include <atomic>   // for atomic_bool
+#include <fmt.hpp>  // for format
 #include <stdint.h> // for uint8_t, uint32_t
 
 using kotekan::bufferContainer;

--- a/lib/stages/DPDKShuffleSimulate.cpp
+++ b/lib/stages/DPDKShuffleSimulate.cpp
@@ -10,12 +10,11 @@
 #include "kotekanLogging.hpp"  // for DEBUG, INFO
 #include "visUtil.hpp"         // for frameID, current_time, modulo, ts_to_double
 
-#include "fmt.hpp" // for format
-
 #include <assert.h>   // for assert
 #include <atomic>     // for atomic_bool
 #include <cstdint>    // for int32_t
 #include <exception>  // for exception
+#include <fmt.hpp>    // for format
 #include <regex>      // for match_results<>::_Base_type
 #include <sys/time.h> // for gettimeofday, timeval
 #include <unistd.h>   // for sleep, usleep

--- a/lib/stages/DataQuality.cpp
+++ b/lib/stages/DataQuality.cpp
@@ -10,19 +10,18 @@
 #include "visBuffer.hpp"         // for VisFrameView
 #include "visUtil.hpp"           // for frameID, modulo
 
-#include "gsl-lite.hpp" // for span
-
-#include <algorithm>  // for copy, copy_backward, equal, max
-#include <atomic>     // for atomic_bool
-#include <deque>      // for deque
-#include <exception>  // for exception
-#include <functional> // for _Bind_helper<>::type, bind, function
-#include <math.h>     // for pow
-#include <stdexcept>  // for out_of_range
-#include <stdint.h>   // for uint32_t
-#include <string.h>   // for size_t
-#include <string>     // for string, to_string
-#include <vector>     // for vector
+#include <algorithm>    // for copy, copy_backward, equal, max
+#include <atomic>       // for atomic_bool
+#include <deque>        // for deque
+#include <exception>    // for exception
+#include <functional>   // for _Bind_helper<>::type, bind, function
+#include <gsl-lite.hpp> // for span
+#include <math.h>       // for pow
+#include <stdexcept>    // for out_of_range
+#include <stdint.h>     // for uint32_t
+#include <string.h>     // for size_t
+#include <string>       // for string, to_string
+#include <vector>       // for vector
 
 using kotekan::bufferContainer;
 using kotekan::Config;

--- a/lib/stages/EigenVisIter.cpp
+++ b/lib/stages/EigenVisIter.cpp
@@ -11,9 +11,6 @@
 #include "visBuffer.hpp"         // for VisFrameView, VisField, VisField::erms, VisField::eval
 #include "visUtil.hpp"           // for cfloat, frameID, current_time, modulo, movingAverage
 
-#include "fmt.hpp"      // for format, fmt
-#include "gsl-lite.hpp" // for span
-
 #include <algorithm>     // for copy, copy_backward, equal, max, min
 #include <atomic>        // for atomic_bool
 #include <blaze/Blaze.h> // for DynamicMatrix, DMatDeclHermExpr, band, HermitianMatrix
@@ -22,7 +19,9 @@
 #include <cstdint>       // for uint32_t, int32_t
 #include <deque>         // for deque
 #include <exception>     // for exception
+#include <fmt.hpp>       // for format, fmt
 #include <functional>    // for _Bind_helper<>::type, bind, function
+#include <gsl-lite.hpp>  // for span
 #include <iostream>      // for basic_ostream::operator<<, operator<<, basic_ostream<>:...
 #include <memory>        // for make_unique
 #include <regex>         // for match_results<>::_Base_type

--- a/lib/stages/HFBAccumulate.cpp
+++ b/lib/stages/HFBAccumulate.cpp
@@ -12,23 +12,22 @@
 #include "version.h"          // for get_git_commit_hash
 #include "visUtil.hpp"        // for frameID, modulo, freq_ctype
 
-#include "gsl-lite.hpp" // for span
-
-#include <algorithm>  // for max, fill, transform, copy
-#include <atomic>     // for atomic_bool
-#include <cstdint>    // for uint32_t, int32_t
-#include <exception>  // for exception
-#include <functional> // for _Bind_helper<>::type, bind, function
-#include <iterator>   // for back_insert_iterator, begin, end, back_inserter
-#include <math.h>     // for pow
-#include <numeric>    // for iota
-#include <regex>      // for match_results<>::_Base_type
-#include <stdexcept>  // for runtime_error
-#include <string.h>   // for memcpy
-#include <string>     // for string
-#include <time.h>     // for timespec
-#include <utility>    // for pair
-#include <vector>     // for vector, vector<>::iterator
+#include <algorithm>    // for max, fill, transform, copy
+#include <atomic>       // for atomic_bool
+#include <cstdint>      // for uint32_t, int32_t
+#include <exception>    // for exception
+#include <functional>   // for _Bind_helper<>::type, bind, function
+#include <gsl-lite.hpp> // for span
+#include <iterator>     // for back_insert_iterator, begin, end, back_inserter
+#include <math.h>       // for pow
+#include <numeric>      // for iota
+#include <regex>        // for match_results<>::_Base_type
+#include <stdexcept>    // for runtime_error
+#include <string.h>     // for memcpy
+#include <string>       // for string
+#include <time.h>       // for timespec
+#include <utility>      // for pair
+#include <vector>       // for vector, vector<>::iterator
 
 using kotekan::bufferContainer;
 using kotekan::Config;

--- a/lib/stages/HFBAccumulate.hpp
+++ b/lib/stages/HFBAccumulate.hpp
@@ -13,11 +13,10 @@
 #include "bufferContainer.hpp" // for bufferContainer
 #include "datasetManager.hpp"  // for datasetManager, state_id_t, dset_id_t
 
-#include "gsl-lite.hpp" // for span
-
-#include <stdint.h> // for uint32_t, int32_t, int64_t
-#include <string>   // for string
-#include <vector>   // for vector
+#include <gsl-lite.hpp> // for span
+#include <stdint.h>     // for uint32_t, int32_t, int64_t
+#include <string>       // for string
+#include <vector>       // for vector
 
 /**
  * @class HFBAccumulate

--- a/lib/stages/HFBRawReader.cpp
+++ b/lib/stages/HFBRawReader.cpp
@@ -11,12 +11,12 @@
 #include "kotekanLogging.hpp"  // for DEBUG, WARN
 #include "visUtil.hpp"         // for frameID
 
-#include "fmt.hpp"  // for format, fmt
 #include "json.hpp" // for basic_json<>::object_t, json, basic_json, basic_json<>::v...
 
-#include <algorithm> // for fill, max
+#include <algorithm> // for max
 #include <cstdint>   // for uint32_t
-#include <stdexcept> // for runtime_error
+#include <fmt.hpp>   // for format, fmt
+#include <stdexcept> // for runtime_error, out_of_range
 #include <utility>   // for pair
 
 using kotekan::bufferContainer;

--- a/lib/stages/HFBTranspose.cpp
+++ b/lib/stages/HFBTranspose.cpp
@@ -4,26 +4,26 @@
 #include "H5Support.hpp"         // for dset_id_str, DSET_ID_LEN
 #include "HFBFileArchive.hpp"    // for HFBFileArchive
 #include "HFBFrameView.hpp"      // for HFBFrameView
-#include "Hash.hpp"              // for Hash, operator!=
+#include "Hash.hpp"              // for Hash
 #include "Stage.hpp"             // for Stage
 #include "StageFactory.hpp"      // for REGISTER_KOTEKAN_STAGE, StageMakerTemplate
 #include "Telescope.hpp"         // for Telescope
 #include "bufferContainer.hpp"   // for bufferContainer
-#include "datasetManager.hpp"    // for dset_id_t, datasetManager
-#include "datasetState.hpp"      // for metadataState, stackState, acqDatasetIdState, eigenvalu...
-#include "errors.h"              // for exit_kotekan, CLEAN_EXIT, ReturnCode
-#include "kotekanLogging.hpp"    // for DEBUG, FATAL_ERROR, logLevel, INFO
-#include "prometheusMetrics.hpp" // for Metrics, Gauge
+#include "datasetManager.hpp"    // for datasetManager, dset_id_t
+#include "datasetState.hpp"      // for metadataState, beamState, freqState, subfreqState, time...
+#include "errors.h"              // for exit_kotekan, DATASET_MANAGER_FAILURE, ReturnCode
+#include "kotekanLogging.hpp"    // for DEBUG, ERROR, FATAL_ERROR, INFO, logLevel
+#include "prometheusMetrics.hpp" // for Metrics
 
-#include "fmt.hpp"      // for format
-#include "gsl-lite.hpp" // for span
-#include "json.hpp"     // for basic_json<>::object_t, json, basic_json,
+#include "gsl-lite.hpp" // for span<>::pointer, span
+#include "json.hpp"     // for basic_json<>::object_t, json, basic_json<>::value_type
 
-#include <algorithm>    // for max, fill, min
+#include <algorithm>    // for copy, max, fill, min
 #include <cstdint>      // for uint32_t
 #include <cxxabi.h>     // for __forced_unwind
 #include <exception>    // for exception
-#include <future>       // for async, future
+#include <fmt.hpp>      // for format
+#include <future>       // for async, future, future_status, future_status::timeout
 #include <stdexcept>    // for out_of_range, invalid_argument
 #include <stdint.h>     // for uint32_t, uint64_t
 #include <system_error> // for system_error

--- a/lib/stages/InputSubset.cpp
+++ b/lib/stages/InputSubset.cpp
@@ -11,17 +11,16 @@
 #include "visBuffer.hpp"       // for VisFrameView, VisField, VisField::evec, VisField::flags
 #include "visUtil.hpp"         // for prod_ctype, input_ctype, frameID, cfloat, modulo
 
-#include "gsl-lite.hpp" // for span
-
-#include <algorithm>  // for max, copy
-#include <atomic>     // for atomic_bool
-#include <complex>    // for complex
-#include <cstdint>    // for uint32_t, uint16_t
-#include <exception>  // for exception
-#include <functional> // for _Bind_helper<>::type, bind, function
-#include <stddef.h>   // for size_t
-#include <stdexcept>  // for out_of_range
-#include <utility>    // for pair
+#include <algorithm>    // for max, copy
+#include <atomic>       // for atomic_bool
+#include <complex>      // for complex
+#include <cstdint>      // for uint32_t, uint16_t
+#include <exception>    // for exception
+#include <functional>   // for _Bind_helper<>::type, bind, function
+#include <gsl-lite.hpp> // for span
+#include <stddef.h>     // for size_t
+#include <stdexcept>    // for out_of_range
+#include <utility>      // for pair
 
 
 using kotekan::bufferContainer;

--- a/lib/stages/RawReader.hpp
+++ b/lib/stages/RawReader.hpp
@@ -6,36 +6,36 @@
 #ifndef _RAW_READER_HPP
 #define _RAW_READER_HPP
 
-#include "Config.hpp"
-#include "Hash.hpp"      // for Hash, operator<, operator==
-#include "Stage.hpp"     // for Stage
-#include "Telescope.hpp" // for Telescope
-#include "buffer.h"
-#include "bufferContainer.hpp"
-#include "datasetManager.hpp" // for dset_id_t
-#include "datasetState.hpp"   // for freqState, timeState, metadataState
-#include "errors.h"           // for exit_kotekan, CLEAN_EXIT, ReturnCode
-#include "kotekanLogging.hpp" // for INFO, FATAL_ERROR, DEBUG, WARN, ERROR
-#include "metadata.h"         // for metadataContainer
-#include "version.h"          // for get_git_commit_hash
-#include "visUtil.hpp"        // for freq_ctype (ptr only), input_ctype, prod_ctype, rstack_ctype
+#include "Config.hpp"          // for Config
+#include "Hash.hpp"            // for operator==
+#include "Stage.hpp"           // for Stage
+#include "Telescope.hpp"       // for Telescope
+#include "buffer.h"            // for Buffer, allocate_new_metadata_object, mark_frame_full
+#include "bufferContainer.hpp" // for bufferContainer
+#include "datasetManager.hpp"  // for dset_id_t, datasetManager, state_id_t, DS_UNIQUE_NAME
+#include "datasetState.hpp"    // for freqState, metadataState, timeState
+#include "errors.h"            // for exit_kotekan, CLEAN_EXIT, ReturnCode
+#include "kotekanLogging.hpp"  // for INFO, DEBUG, FATAL_ERROR, WARN, DEBUG2
+#include "metadata.h"          // for metadataContainer
+#include "version.h"           // for get_git_commit_hash
+#include "visUtil.hpp"         // for time_ctype, frameID, current_time, double_to_ts, freq_ctype
 
-#include "fmt.hpp"  // for format, fmt
 #include "json.hpp" // for json
 
 #include <cstring>    // for strerror, memcpy
 #include <errno.h>    // for errno
 #include <exception>  // for exception
-#include <fcntl.h>    // for open, posix_fadvise, O_RDONLY, POSIX_FADV_DONTNEED
+#include <fcntl.h>    // for O_RDONLY, POSIX_FADV_DONTNEED, open, posix_fadvise
+#include <fmt.hpp>    // for fmt
 #include <fstream>    // for ifstream, ios_base::failure, ios_base, basic_ios, basic_i...
-#include <functional> // for _Bind_helper<>::type, bind, function
+#include <functional> // for bind
 #include <map>        // for map
 #include <regex>      // for match_results<>::_Base_type
 #include <stddef.h>   // for size_t
-#include <stdexcept>  // for runtime_error, invalid_argument, out_of_range
-#include <stdint.h>   // for uint32_t, uint8_t
-#include <string>     // for string
-#include <sys/mman.h> // for madvise, mmap, munmap, MADV_DONTNEED, MADV_WILLNEED, MAP_...
+#include <stdexcept>  // for runtime_error, invalid_argument
+#include <stdint.h>   // for uint8_t, uint32_t
+#include <string>     // for string, to_string, operator+
+#include <sys/mman.h> // for madvise, MADV_DONTNEED, MADV_WILLNEED, MAP_FAILED, MAP_SH...
 #include <sys/stat.h> // for stat
 #include <time.h>     // for nanosleep, timespec
 #include <unistd.h>   // for close, off_t

--- a/lib/stages/ReadGain.hpp
+++ b/lib/stages/ReadGain.hpp
@@ -14,9 +14,8 @@
 #include "bufferContainer.hpp"   // for bufferContainer
 #include "prometheusMetrics.hpp" // for Gauge, MetricFamily
 
-#include "json.hpp" // for json
-
 #include <condition_variable> // for condition_variable
+#include <json.hpp>           // for json
 #include <mutex>              // for mutex
 #include <queue>              // for queue
 #include <stdint.h>           // for int32_t, uint8_t, int16_t, uint32_t

--- a/lib/stages/ReceiveFlags.cpp
+++ b/lib/stages/ReceiveFlags.cpp
@@ -13,18 +13,17 @@
 #include "visBuffer.hpp"         // for VisFrameView
 #include "visUtil.hpp"           // for frameID, ts_to_double, current_time, double_to_ts, modulo
 
-#include "gsl-lite.hpp" // for span<>::iterator, span
-
-#include <algorithm>   // for copy, fill, copy_backward, max
-#include <atomic>      // for atomic_bool
-#include <exception>   // for exception
-#include <functional>  // for _Bind_helper<>::type, _Placeholder, bind, _1, function
-#include <memory>      // for operator==, __shared_ptr_access
-#include <regex>       // for match_results<>::_Base_type
-#include <stdexcept>   // for invalid_argument, runtime_error
-#include <tuple>       // for get
-#include <type_traits> // for add_const<>::type
-#include <utility>     // for pair, move, tuple_element<>::type
+#include <algorithm>    // for copy, fill, copy_backward, max
+#include <atomic>       // for atomic_bool
+#include <exception>    // for exception
+#include <functional>   // for _Bind_helper<>::type, _Placeholder, bind, _1, function
+#include <gsl-lite.hpp> // for span<>::iterator, span
+#include <memory>       // for operator==, __shared_ptr_access
+#include <regex>        // for match_results<>::_Base_type
+#include <stdexcept>    // for invalid_argument, runtime_error
+#include <tuple>        // for get
+#include <type_traits>  // for add_const<>::type
+#include <utility>      // for pair, move, tuple_element<>::type
 
 using namespace std::placeholders;
 

--- a/lib/stages/ReceiveFlags.hpp
+++ b/lib/stages/ReceiveFlags.hpp
@@ -15,8 +15,7 @@
 #include "updateQueue.hpp"       // for updateQueue
 #include "visBuffer.hpp"         // for VisFrameView
 
-#include "json.hpp" // for json
-
+#include <json.hpp> // for json
 #include <map>      // for map
 #include <mutex>    // for mutex
 #include <stdint.h> // for uint32_t

--- a/lib/stages/RfiFrameDrop.cpp
+++ b/lib/stages/RfiFrameDrop.cpp
@@ -14,8 +14,6 @@
 #include "prometheusMetrics.hpp" // for Counter, Metrics, MetricFamily
 #include "visUtil.hpp"           // for frameID, modulo
 
-#include "fmt.hpp" // for format, fmt
-
 #include <algorithm>  // for copy, max, copy_backward, equal, fill
 #include <assert.h>   // for assert
 #include <atomic>     // for atomic_bool
@@ -23,6 +21,7 @@
 #include <cstring>    // for memcpy
 #include <deque>      // for deque
 #include <exception>  // for exception
+#include <fmt.hpp>    // for format, fmt
 #include <functional> // for _Bind_helper<>::type, function, bind, _Placeholder, _1
 #include <map>        // for map, map<>::mapped_type
 #include <memory>     // for allocator_traits<>::value_type

--- a/lib/stages/RfiFrameDrop.hpp
+++ b/lib/stages/RfiFrameDrop.hpp
@@ -14,8 +14,7 @@
 #include "datasetState.hpp"      // for RFIFrameDropState
 #include "prometheusMetrics.hpp" // for Counter, MetricFamily
 
-#include "json.hpp" // for json
-
+#include <json.hpp> // for json
 #include <mutex>    // for mutex
 #include <stddef.h> // for size_t
 #include <string>   // for string

--- a/lib/stages/RingMapMaker.cpp
+++ b/lib/stages/RingMapMaker.cpp
@@ -10,8 +10,6 @@
 #include "prometheusMetrics.hpp" // for Metrics
 #include "visBuffer.hpp"         // for VisFrameView, VisField, VisField::vis, VisField::weight
 
-#include "gsl-lite.hpp" // for span, span<>::iterator
-
 #include <atomic>       // for atomic_bool
 #include <cblas.h>      // for cblas_cgemv, CblasNoTrans, CblasRowMajor
 #include <complex>      // for operator*, complex, operator/, norm, operator-, operato...
@@ -20,6 +18,7 @@
 #include <exception>    // for exception
 #include <functional>   // for _Bind_helper<>::type, _Placeholder, bind, _1, function, _2
 #include <future>       // for async, future
+#include <gsl-lite.hpp> // for span, span<>::iterator
 #include <iterator>     // for begin, end, back_insert_iterator, back_inserter
 #include <memory>       // for allocator_traits<>::value_type
 #include <numeric>      // for iota

--- a/lib/stages/RingMapMaker.hpp
+++ b/lib/stages/RingMapMaker.hpp
@@ -11,10 +11,9 @@
 #include "restServer.hpp"      // for connectionInstance
 #include "visUtil.hpp"         // for input_ctype, prod_ctype, time_ctype, stack_ctype, cfloat
 
-#include "fmt.hpp"  // for format
-#include "json.hpp" // for json
-
 #include <algorithm> // for copy, max
+#include <fmt.hpp>   // for format
+#include <json.hpp>  // for json
 #include <map>       // for map
 #include <math.h>    // for cos
 #include <mutex>     // for mutex

--- a/lib/stages/Transpose.cpp
+++ b/lib/stages/Transpose.cpp
@@ -1,30 +1,30 @@
 #include "Transpose.hpp"
 
 #include "Config.hpp"            // for Config
-#include "Hash.hpp"              // for Hash, operator!=
+#include "Hash.hpp"              // for Hash, operator==, operator!=, operator<
 #include "SystemInterface.hpp"   // for get_hostname, get_username
-#include "buffer.h"              // for wait_for_full_frame, mark_frame_empty, register_consumer
+#include "buffer.h"              // for mark_frame_empty, wait_for_full_frame, register_consumer
 #include "bufferContainer.hpp"   // for bufferContainer
 #include "dataset.hpp"           // for dataset
 #include "datasetManager.hpp"    // for dset_id_t, datasetManager
-#include "datasetState.hpp"      // for metadataState, stackState, acqDatasetIdState, eigenvalu...
-#include "errors.h"              // for exit_kotekan, CLEAN_EXIT, ReturnCode
-#include "kotekanLogging.hpp"    // for DEBUG, FATAL_ERROR, logLevel, INFO
-#include "prometheusMetrics.hpp" // for Metrics, Gauge
+#include "datasetState.hpp"      // for metadataState
+#include "errors.h"              // for exit_kotekan, ReturnCode, CLEAN_EXIT, DATASET_MANAGER_F...
+#include "kotekanLogging.hpp"    // for DEBUG, FATAL_ERROR, INFO, DEBUG2, ERROR
+#include "prometheusMetrics.hpp" // for Metrics, Counter
 #include "version.h"             // for get_git_commit_hash
 
-#include "fmt.hpp" // for format
-
-#include <algorithm>    // for max, fill, min
+#include <algorithm>    // for copy, fill
 #include <atomic>       // for atomic_bool
 #include <cxxabi.h>     // for __forced_unwind
 #include <exception>    // for exception
+#include <fmt.hpp>      // for format
 #include <functional>   // for _Bind_helper<>::type, bind, function
-#include <future>       // for async, future
+#include <future>       // for async, future, future_status, future_status::timeout
+#include <json.hpp>     // for basic_json<>::object_t, basic_json<>::value_type, json
 #include <map>          // for map
 #include <memory>       // for allocator_traits<>::value_type
 #include <regex>        // for match_results<>::_Base_type
-#include <stdexcept>    // for out_of_range, invalid_argument
+#include <stdexcept>    // for out_of_range, runtime_error
 #include <stdint.h>     // for uint32_t, uint64_t
 #include <system_error> // for system_error
 

--- a/lib/stages/VisRawReader.cpp
+++ b/lib/stages/VisRawReader.cpp
@@ -10,13 +10,13 @@
 #include "visBuffer.hpp"       // for VisFrameView, VisMetadata
 #include "visUtil.hpp"         // for prod_ctype, rstack_ctype, stack_ctype, input_ctype, frameID
 
-#include "fmt.hpp"  // for format, fmt
 #include "json.hpp" // for basic_json<>::object_t, basic_json, json, basic_json<>::v...
 
-#include <algorithm> // for fill, max
+#include <algorithm> // for max
 #include <cstdint>   // for uint32_t
+#include <fmt.hpp>   // for format, fmt
 #include <stddef.h>  // for size_t
-#include <stdexcept> // for runtime_error
+#include <stdexcept> // for runtime_error, out_of_range
 #include <utility>   // for pair, move
 
 using kotekan::bufferContainer;

--- a/lib/stages/VisTranspose.cpp
+++ b/lib/stages/VisTranspose.cpp
@@ -2,28 +2,28 @@
 
 #include "Config.hpp"            // for Config
 #include "H5Support.hpp"         // for dset_id_str, DSET_ID_LEN
-#include "Hash.hpp"              // for Hash, operator!=
+#include "Hash.hpp"              // for Hash
 #include "Stage.hpp"             // for Stage
 #include "StageFactory.hpp"      // for REGISTER_KOTEKAN_STAGE, StageMakerTemplate
 #include "bufferContainer.hpp"   // for bufferContainer
-#include "datasetManager.hpp"    // for dset_id_t, datasetManager
-#include "datasetState.hpp"      // for metadataState, stackState, acqDatasetIdState, eigenvalu...
-#include "errors.h"              // for exit_kotekan, CLEAN_EXIT, ReturnCode
-#include "kotekanLogging.hpp"    // for DEBUG, FATAL_ERROR, logLevel, INFO
-#include "prometheusMetrics.hpp" // for Metrics, Gauge
+#include "datasetManager.hpp"    // for datasetManager, dset_id_t
+#include "datasetState.hpp"      // for metadataState, stackState, eigenvalueState, freqState
+#include "errors.h"              // for exit_kotekan, DATASET_MANAGER_FAILURE, ReturnCode
+#include "kotekanLogging.hpp"    // for DEBUG, logLevel, ERROR, FATAL_ERROR, INFO
+#include "prometheusMetrics.hpp" // for Metrics
 #include "visBuffer.hpp"         // for VisFrameView
 #include "visFileArchive.hpp"    // for visFileArchive
 
-#include "fmt.hpp"      // for format
 #include "gsl-lite.hpp" // for span
-#include "json.hpp"     // for basic_json<>::object_t, json, basic_json,
+#include "json.hpp"     // for basic_json<>::object_t, json, basic_json<>::value_type
 
-#include <algorithm>    // for max, fill, min
+#include <algorithm>    // for copy, fill, max, min
 #include <complex>      // for complex
 #include <cstdint>      // for uint32_t
 #include <cxxabi.h>     // for __forced_unwind
 #include <exception>    // for exception
-#include <future>       // for async, future
+#include <fmt.hpp>      // for format
+#include <future>       // for async, future, future_status, future_status::timeout
 #include <stdexcept>    // for out_of_range, invalid_argument
 #include <stdint.h>     // for uint32_t, uint64_t
 #include <sys/types.h>  // for uint

--- a/lib/stages/applyGains.cpp
+++ b/lib/stages/applyGains.cpp
@@ -16,9 +16,6 @@
 #include "visBuffer.hpp"         // for VisFrameView, VisField, VisField::vis, VisField::we...
 #include "visUtil.hpp"           // for cfloat, modulo, double_to_ts, ts_to_double, frameID
 
-#include "fmt.hpp"      // for format, fmt
-#include "gsl-lite.hpp" // for span
-
 #include <algorithm>                 // for max, copy, copy_backward
 #include <assert.h>                  // for assert
 #include <chrono>                    // for operator""s, chrono_literals
@@ -26,7 +23,9 @@
 #include <complex>                   // for operator*, operator+, complex, operator""if, operat...
 #include <cstdint>                   // for uint64_t, uint32_t, uint8_t
 #include <exception>                 // for exception
+#include <fmt.hpp>                   // for format, fmt
 #include <functional>                // for _Bind_helper<>::type, _Placeholder, bind, _1, function
+#include <gsl-lite.hpp>              // for span
 #include <highfive/H5DataSet.hpp>    // for DataSet
 #include <highfive/H5File.hpp>       // for File, NodeTraits::getDataSet, File::File, File::Rea...
 #include <highfive/H5Object.hpp>     // for HighFive

--- a/lib/stages/applyGains.hpp
+++ b/lib/stages/applyGains.hpp
@@ -13,10 +13,9 @@
 #include "visBuffer.hpp"         // for VisFrameView
 #include "visUtil.hpp"           // for cfloat, frameID
 
-#include "json.hpp" // for json
-
 #include <atomic>       // for atomic
 #include <ctime>        // for timespec, size_t
+#include <json.hpp>     // for json
 #include <map>          // for map
 #include <mutex>        // for mutex
 #include <optional>     // for optional

--- a/lib/stages/basebandReadout.cpp
+++ b/lib/stages/basebandReadout.cpp
@@ -17,9 +17,6 @@
 #include "visFile.hpp"            // for create_lockfile
 #include "visUtil.hpp"            // for input_ctype, ts_to_double, parse_reorder_default
 
-#include "fmt.hpp"      // for format, fmt
-#include "gsl-lite.hpp" // for span, operator!=
-
 #include <algorithm>                // for max, copy, copy_backward, min
 #include <assert.h>                 // for assert
 #include <atomic>                   // for atomic_bool
@@ -28,7 +25,9 @@
 #include <cstdio>                   // for remove, snprintf
 #include <deque>                    // for deque
 #include <exception>                // for exception
+#include <fmt.hpp>                  // for format, fmt
 #include <functional>               // for _Bind_helper<>::type, bind, function
+#include <gsl-lite.hpp>             // for span, operator!=
 #include <highfive/H5Attribute.hpp> // for Attribute, Attribute::write
 #include <highfive/H5DataSet.hpp>   // for AnnotateTraits::createAttribute, DataSet, DataSet::r...
 #include <highfive/H5DataSpace.hpp> // for DataSpace::From, DataSpace, DataSpace::DataSpace

--- a/lib/stages/beamformingPostProcess.cpp
+++ b/lib/stages/beamformingPostProcess.cpp
@@ -9,12 +9,11 @@
 #include "chimeMetadata.hpp"    // for get_fpga_seq_num, get_first_packet_recv_time, get_stream_id
 #include "vdif_functions.h"     // for VDIFHeader
 
-#include "fmt.hpp" // for format, fmt
-
 #include <assert.h>   // for assert
 #include <atomic>     // for atomic_bool
 #include <cstdint>    // for int32_t
 #include <exception>  // for exception
+#include <fmt.hpp>    // for format, fmt
 #include <functional> // for _Bind_helper<>::type, bind, function
 #include <math.h>     // for round
 #include <regex>      // for match_results<>::_Base_type

--- a/lib/stages/bufferBadInputs.hpp
+++ b/lib/stages/bufferBadInputs.hpp
@@ -11,8 +11,7 @@
 #include "Stage.hpp"           // for Stage
 #include "bufferContainer.hpp" // for bufferContainer
 
-#include "json.hpp" // for json
-
+#include <json.hpp> // for json
 #include <stdint.h> // for uint32_t
 #include <string>   // for string
 #include <vector>   // for vector

--- a/lib/stages/bufferCopy.cpp
+++ b/lib/stages/bufferCopy.cpp
@@ -4,17 +4,16 @@
 #include "kotekanLogging.hpp" // for INFO, DEBUG2, FATAL_ERROR
 #include "visUtil.hpp"
 
-#include "fmt.hpp" // for format, fmt
-#include "json.hpp"
-
 #include <algorithm>  // for max
 #include <atomic>     // for atomic_bool
 #include <exception>  // for exception
+#include <fmt.hpp>    // for format, fmt
 #include <functional> // for _Bind_helper<>::type, bind, function
-#include <regex>      // for match_results<>::_Base_type
-#include <stdexcept>  // for runtime_error, invalid_argument
-#include <stdint.h>   // for uint8_t
-#include <string.h>   // for memcpy
+#include <json.hpp>
+#include <regex>     // for match_results<>::_Base_type
+#include <stdexcept> // for runtime_error, invalid_argument
+#include <stdint.h>  // for uint8_t
+#include <string.h>  // for memcpy
 
 
 using nlohmann::json;

--- a/lib/stages/bufferDelay.cpp
+++ b/lib/stages/bufferDelay.cpp
@@ -6,12 +6,11 @@
 #include "metadata.h"         // for metadataContainer
 #include "visUtil.hpp"        // for frameID, modulo
 
-#include "fmt.hpp"  // for format, fmt
-#include "json.hpp" // for json
-
 #include <atomic>     // for atomic_bool
 #include <exception>  // for exception
+#include <fmt.hpp>    // for format, fmt
 #include <functional> // for _Bind_helper<>::type, bind, function
+#include <json.hpp>   // for json
 #include <regex>      // for match_results<>::_Base_type
 #include <stdexcept>  // for runtime_error, invalid_argument
 #include <stdint.h>   // for uint32_t, uint8_t

--- a/lib/stages/bufferMerge.cpp
+++ b/lib/stages/bufferMerge.cpp
@@ -7,15 +7,14 @@
 #include "kotekanLogging.hpp"  // for INFO, DEBUG2, FATAL_ERROR
 #include "visUtil.hpp"         // for frameID, current_time, double_to_ts, modulo
 
-#include "fmt.hpp"  // for format, fmt
-#include "json.hpp" // for json, basic_json<>::iterator, basic_json<>::object_t, bas...
-
 #include <algorithm>  // for max
 #include <assert.h>   // for assert
 #include <atomic>     // for atomic_bool
 #include <cstring>    // for memcpy
 #include <exception>  // for exception
+#include <fmt.hpp>    // for format, fmt
 #include <functional> // for _Bind_helper<>::type, bind, function
+#include <json.hpp>   // for json, basic_json<>::iterator, basic_json<>::object_t, bas...
 #include <regex>      // for match_results<>::_Base_type
 #include <stdexcept>  // for runtime_error, invalid_argument
 

--- a/lib/stages/bufferRecv.cpp
+++ b/lib/stages/bufferRecv.cpp
@@ -10,8 +10,6 @@
 #include "util.h"                // for string_tail
 #include "visUtil.hpp"           // for current_time
 
-#include "fmt.hpp" // for format, fmt
-
 #include <algorithm>       // for copy, max, copy_backward, find, equal
 #include <arpa/inet.h>     // for inet_ntop
 #include <assert.h>        // for assert
@@ -19,6 +17,7 @@
 #include <errno.h>         // for errno
 #include <event2/thread.h> // for evthread_use_pthreads
 #include <exception>       // for exception
+#include <fmt.hpp>         // for format, fmt
 #include <functional>      // for _Bind_helper<>::type, bind, ref, function, placeholders
 #include <memory>          // for allocator_traits<>::value_type
 #include <netinet/in.h>    // for sockaddr_in, htons, in_addr, ntohs

--- a/lib/stages/bufferSend.cpp
+++ b/lib/stages/bufferSend.cpp
@@ -8,13 +8,12 @@
 #include "metadata.h"            // for metadataContainer
 #include "prometheusMetrics.hpp" // for Metrics, Counter
 
-#include "fmt.hpp" // for format, fmt
-
 #include <arpa/inet.h> // for inet_addr
 #include <cerrno>      // for errno
 #include <chrono>
 #include <cstring>      // for strerror, size_t
 #include <exception>    // for exception
+#include <fmt.hpp>      // for format, fmt
 #include <functional>   // for _Bind_helper<>::type, bind, ref, function
 #include <regex>        // for match_results<>::_Base_type
 #include <stdexcept>    // for runtime_error

--- a/lib/stages/bufferSwitch.cpp
+++ b/lib/stages/bufferSwitch.cpp
@@ -8,11 +8,10 @@
 #include "kotekanLogging.hpp"  // for WARN
 #include "visUtil.hpp"         // for frameID  // IWYU pragma: keep
 
-#include "fmt.hpp"  // for format, fmt
-#include "json.hpp" // for json, basic_json<>::iterator, basic_json, iter_impl
-
 #include <exception>  // for exception
+#include <fmt.hpp>    // for format, fmt
 #include <functional> // for _Bind_helper<>::type, _Placeholder, bind, _1, placeholders
+#include <json.hpp>   // for json, basic_json<>::iterator, basic_json, iter_impl
 #include <stdexcept>  // for runtime_error
 #include <tuple>      // for get
 #include <utility>    // for pair

--- a/lib/stages/bufferSwitch.hpp
+++ b/lib/stages/bufferSwitch.hpp
@@ -6,8 +6,7 @@
 #include "bufferContainer.hpp"
 #include "bufferMerge.hpp" // for bufferMerge
 
-#include "json.hpp" // for json
-
+#include <json.hpp> // for json
 #include <map>      // for map
 #include <mutex>    // for mutex
 #include <stdint.h> // for uint32_t

--- a/lib/stages/chrxUplink.cpp
+++ b/lib/stages/chrxUplink.cpp
@@ -6,12 +6,11 @@
 #include "bufferContainer.hpp" // for bufferContainer
 #include "kotekanLogging.hpp"  // for ERROR, INFO
 
-#include "fmt.hpp" // for format, fmt
-
 #include <arpa/inet.h>  // for inet_addr
 #include <atomic>       // for atomic_bool
 #include <errno.h>      // for errno
 #include <exception>    // for exception
+#include <fmt.hpp>      // for format, fmt
 #include <functional>   // for _Bind_helper<>::type, bind, function
 #include <netinet/in.h> // for sockaddr_in, htons, in_addr
 #include <regex>        // for match_results<>::_Base_type

--- a/lib/stages/eigenVis.cpp
+++ b/lib/stages/eigenVis.cpp
@@ -10,26 +10,25 @@
 #include "visBuffer.hpp"         // for VisFrameView, VisField, VisField::erms, VisField::eval
 #include "visUtil.hpp"           // for cfloat, frameID, modulo, current_time, cmap, movingAverage
 
-#include "fmt.hpp"      // for format, fmt
-#include "gsl-lite.hpp" // for span
-
-#include <algorithm>  // for fill, max, lower_bound, remove
-#include <atomic>     // for atomic_bool
-#include <cblas.h>    // for openblas_set_num_threads
-#include <cmath>      // for pow, sqrt
-#include <complex>    // for operator*, norm, complex
-#include <cstdint>    // for uint32_t
-#include <exception>  // for exception
-#include <functional> // for _Bind_helper<>::type, bind, function
-#include <lapacke.h>  // for LAPACKE_cheevr, LAPACK_COL_MAJOR
-#include <map>        // for map, map<>::mapped_type, operator==, map<>::iterator
-#include <memory>     // for make_unique
-#include <numeric>    // for iota
-#include <regex>      // for match_results<>::_Base_type
-#include <stdexcept>  // for runtime_error
-#include <time.h>     // for size_t
-#include <tuple>      // for forward_as_tuple
-#include <utility>    // for move, pair, piecewise_construct
+#include <algorithm>    // for fill, max, lower_bound, remove
+#include <atomic>       // for atomic_bool
+#include <cblas.h>      // for openblas_set_num_threads
+#include <cmath>        // for pow, sqrt
+#include <complex>      // for operator*, norm, complex
+#include <cstdint>      // for uint32_t
+#include <exception>    // for exception
+#include <fmt.hpp>      // for format, fmt
+#include <functional>   // for _Bind_helper<>::type, bind, function
+#include <gsl-lite.hpp> // for span
+#include <lapacke.h>    // for LAPACKE_cheevr, LAPACK_COL_MAJOR
+#include <map>          // for map, map<>::mapped_type, operator==, map<>::iterator
+#include <memory>       // for make_unique
+#include <numeric>      // for iota
+#include <regex>        // for match_results<>::_Base_type
+#include <stdexcept>    // for runtime_error
+#include <time.h>       // for size_t
+#include <tuple>        // for forward_as_tuple
+#include <utility>      // for move, pair, piecewise_construct
 
 using kotekan::bufferContainer;
 using kotekan::Config;

--- a/lib/stages/frbNetworkProcess.cpp
+++ b/lib/stages/frbNetworkProcess.cpp
@@ -11,8 +11,6 @@
 #include "restServer.hpp"        // for restServer, connectionInstance, HTTP_RESPONSE, HTTP_RES...
 #include "tx_utils.hpp"          // for add_nsec, CLOCK_ABS_NANOSLEEP, get_vlan_from_ip, parse_...
 
-#include "fmt.hpp" // for format
-
 #include <algorithm>    // for max, max_element, copy
 #include <arpa/inet.h>  // for inet_pton, inet_ntop
 #include <assert.h>     // for assert
@@ -20,6 +18,7 @@
 #include <cstring>      // for strerror, memset, size_t
 #include <errno.h>      // for errno, EINTR
 #include <exception>    // for exception
+#include <fmt.hpp>      // for format
 #include <map>          // for map, map<>::mapped_type
 #include <memory>       // for allocator_traits<>::value_type
 #include <mutex>        // for mutex, unique_lock

--- a/lib/stages/frbNetworkProcess.hpp
+++ b/lib/stages/frbNetworkProcess.hpp
@@ -12,12 +12,11 @@
 #include "bufferContainer.hpp" // for bufferContainer
 #include "restServer.hpp"      // for connectionInstance
 
-#include "json.hpp" // for json
-
 #include <atomic>             // for atomic_bool
 #include <chrono>             // for seconds
 #include <condition_variable> // for condition_variable
 #include <functional>         // for reference_wrapper
+#include <json.hpp>           // for json
 #include <map>                // for map
 #include <netinet/in.h>       // for sockaddr_in
 #include <stdint.h>           // for uint32_t

--- a/lib/stages/frbPostProcess.cpp
+++ b/lib/stages/frbPostProcess.cpp
@@ -9,12 +9,11 @@
 #include "kotekanLogging.hpp"    // for DEBUG, INFO
 #include "prometheusMetrics.hpp" // for Metrics, Counter
 
-#include "fmt.hpp" // for format, fmt
-
 #include <algorithm>   // for find, max, min
 #include <atomic>      // for atomic_bool
 #include <cstdint>     // for int32_t
 #include <exception>   // for exception
+#include <fmt.hpp>     // for format, fmt
 #include <functional>  // for _Bind_helper<>::type, bind, function
 #include <immintrin.h> // for _mm256_broadcast_ss, __m256, _mm256_load_ps, _mm256_min_ps
 #include <mm_malloc.h> // for posix_memalign

--- a/lib/stages/fullPacketDump.cpp
+++ b/lib/stages/fullPacketDump.cpp
@@ -7,12 +7,11 @@
 #include "kotekanLogging.hpp"  // for ERROR, INFO
 #include "restServer.hpp"      // for connectionInstance, restServer, HTTP_RESPONSE, HTTP_RESPO...
 
-#include "fmt.hpp" // for format, fmt
-
 #include <atomic>     // for atomic_bool
 #include <errno.h>    // for errno
 #include <exception>  // for exception
 #include <fcntl.h>    // for open, O_CREAT, O_WRONLY
+#include <fmt.hpp>    // for format, fmt
 #include <functional> // for _Bind_helper<>::type, _Placeholder, bind, _1, _2, function
 #include <regex>      // for match_results<>::_Base_type
 #include <stdio.h>    // for snprintf

--- a/lib/stages/fullPacketDump.hpp
+++ b/lib/stages/fullPacketDump.hpp
@@ -6,8 +6,7 @@
 #include "bufferContainer.hpp" // for bufferContainer
 #include "restServer.hpp"      // for connectionInstance
 
-#include "json.hpp" // for json
-
+#include <json.hpp> // for json
 #include <mutex>    // for mutex
 #include <stdint.h> // for uint8_t
 #include <string>   // for string

--- a/lib/stages/nDiskFileWrite.cpp
+++ b/lib/stages/nDiskFileWrite.cpp
@@ -8,13 +8,12 @@
 #include "kotekanLogging.hpp"  // for ERROR, INFO
 #include "util.h"              // for cp, make_raw_dirs
 
-#include "fmt.hpp" // for format, fmt
-
 #include <algorithm>  // for max
 #include <atomic>     // for atomic_bool
 #include <errno.h>    // for errno
 #include <exception>  // for exception
 #include <fcntl.h>    // for open, O_CREAT, O_WRONLY
+#include <fmt.hpp>    // for format, fmt
 #include <functional> // for _Bind_helper<>::type, bind, function
 #include <memory>     // for allocator_traits<>::value_type
 #include <pthread.h>  // for pthread_setaffinity_np

--- a/lib/stages/prodSubset.cpp
+++ b/lib/stages/prodSubset.cpp
@@ -11,8 +11,6 @@
 #include "visBuffer.hpp"       // for VisFrameView, VisField, VisField::vis, VisField::weight
 #include "visUtil.hpp"         // for prod_ctype, frameID, cmap, icmap, modulo, cfloat
 
-#include "gsl-lite.hpp" // for span
-
 #include <algorithm>    // for max, binary_search, copy, sort
 #include <atomic>       // for atomic_bool
 #include <complex>      // for complex
@@ -20,6 +18,7 @@
 #include <exception>    // for exception
 #include <functional>   // for _Bind_helper<>::type, bind, function
 #include <future>       // for future, async
+#include <gsl-lite.hpp> // for span
 #include <iterator>     // for back_insert_iterator, back_inserter
 #include <regex>        // for match_results<>::_Base_type
 #include <stdexcept>    // for out_of_range, runtime_error

--- a/lib/stages/pyPlotN2.cpp
+++ b/lib/stages/pyPlotN2.cpp
@@ -6,12 +6,11 @@
 #include "bufferContainer.hpp" // for bufferContainer
 #include "restServer.hpp"      // for restServer, connectionInstance, HTTP_RESPONSE, HTTP_RESPO...
 
-#include "json.hpp" // for json_ref, json
-
 #include <atomic>      // for atomic_bool
 #include <cstdio>      // for fwrite, fflush, popen, FILE
 #include <exception>   // for exception
 #include <functional>  // for _Bind_helper<>::type, _Placeholder, bind, _1, function
+#include <json.hpp>    // for json_ref, json
 #include <regex>       // for match_results<>::_Base_type
 #include <stdint.h>    // for uint32_t, uint8_t
 #include <stdlib.h>    // for free, malloc

--- a/lib/stages/rfiBadInputFinder.hpp
+++ b/lib/stages/rfiBadInputFinder.hpp
@@ -11,8 +11,7 @@
 #include "bufferContainer.hpp" // for bufferContainer
 #include "restServer.hpp"      // for connectionInstance
 
-#include "json.hpp" // for json
-
+#include <json.hpp> // for json
 #include <mutex>    // for mutex
 #include <stdint.h> // for uint32_t
 #include <string>   // for string

--- a/lib/stages/rfiBroadcast.cpp
+++ b/lib/stages/rfiBroadcast.cpp
@@ -16,13 +16,12 @@
 #include "util.h" // for e_time
 #endif
 
-#include "fmt.hpp" // for format, fmt
-
 #include <algorithm>    // for copy, copy_backward, equal, max
 #include <arpa/inet.h>  // for inet_aton
 #include <atomic>       // for atomic_bool
 #include <deque>        // for deque
 #include <exception>    // for exception
+#include <fmt.hpp>      // for format, fmt
 #include <functional>   // for _Bind_helper<>::type, _Placeholder, bind, _1, _2, function
 #include <mutex>        // for mutex, lock_guard
 #include <netinet/in.h> // for sockaddr_in, IPPROTO_UDP, htons

--- a/lib/stages/rfiBroadcast.hpp
+++ b/lib/stages/rfiBroadcast.hpp
@@ -13,8 +13,7 @@
 #include "restServer.hpp"        // for connectionInstance
 #include "visUtil.hpp"           // for movingAverage
 
-#include "json.hpp" // for json
-
+#include <json.hpp> // for json
 #include <mutex>    // for mutex
 #include <stdint.h> // for uint32_t
 #include <string>   // for string

--- a/lib/stages/rfiRecord.hpp
+++ b/lib/stages/rfiRecord.hpp
@@ -11,8 +11,7 @@
 #include "Stage.hpp" // for Stage
 #include "bufferContainer.hpp"
 
-#include "json.hpp" // for json
-
+#include <json.hpp> // for json
 #include <mutex>    // for mutex
 #include <stdint.h> // for uint32_t
 #include <string>   // for string

--- a/lib/stages/testDataGen.cpp
+++ b/lib/stages/testDataGen.cpp
@@ -2,7 +2,7 @@
 
 #include "Config.hpp"          // for Config
 #include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE, StageMakerTemplate
-#include "Telescope.hpp"       // for Telescope
+#include "Telescope.hpp"       // for Telescope, stream_t
 #include "buffer.h"            // for Buffer, allocate_new_metadata_object, mark_frame_full
 #include "bufferContainer.hpp" // for bufferContainer
 #include "chimeMetadata.hpp"   // for set_first_packet_recv_time, set_fpga_seq_num, set_stream_id
@@ -17,6 +17,7 @@
 #include <cstdint>     // for uint64_t
 #include <exception>   // for exception
 #include <functional>  // for _Bind_helper<>::type, _Placeholder, bind, _1, _2, function
+#include <json.hpp>    // for basic_json<>::object_t, json, basic_json, basic_json<>::v...
 #include <regex>       // for match_results<>::_Base_type
 #include <stdexcept>   // for runtime_error
 #include <stdint.h>    // for uint64_t, uint32_t, uint8_t

--- a/lib/stages/timeDownsample.cpp
+++ b/lib/stages/timeDownsample.cpp
@@ -9,18 +9,17 @@
 #include "visBuffer.hpp"         // for VisFrameView
 #include "visUtil.hpp"           // for frameID, modulo, cfloat, operator-, ts_to_double
 
-#include "gsl-lite.hpp" // for span
-
-#include <atomic>     // for atomic_bool
-#include <complex>    // for complex
-#include <exception>  // for exception
-#include <functional> // for _Bind_helper<>::type, bind, function
-#include <regex>      // for match_results<>::_Base_type
-#include <stdexcept>  // for runtime_error
-#include <stdint.h>   // for uint32_t, uint64_t, int32_t
-#include <time.h>     // for timespec
-#include <tuple>      // for get
-#include <vector>     // for vector
+#include <atomic>       // for atomic_bool
+#include <complex>      // for complex
+#include <exception>    // for exception
+#include <functional>   // for _Bind_helper<>::type, bind, function
+#include <gsl-lite.hpp> // for span
+#include <regex>        // for match_results<>::_Base_type
+#include <stdexcept>    // for runtime_error
+#include <stdint.h>     // for uint32_t, uint64_t, int32_t
+#include <time.h>       // for timespec
+#include <tuple>        // for get
+#include <vector>       // for vector
 
 
 using kotekan::bufferContainer;

--- a/lib/stages/valve.cpp
+++ b/lib/stages/valve.cpp
@@ -10,11 +10,10 @@
 #include "prometheusMetrics.hpp" // for Metrics, Counter
 #include "visUtil.hpp"           // for frameID, modulo
 
-#include "fmt.hpp" // for format, fmt
-
 #include <atomic>     // for atomic_bool
 #include <cstring>    // for memcpy
 #include <exception>  // for exception
+#include <fmt.hpp>    // for format, fmt
 #include <functional> // for _Bind_helper<>::type, bind, function
 #include <stdexcept>  // for runtime_error
 #include <stdint.h>   // for uint8_t

--- a/lib/stages/visAccumulate.cpp
+++ b/lib/stages/visAccumulate.cpp
@@ -18,26 +18,25 @@
 #include "visBuffer.hpp"         // for VisFrameView
 #include "visUtil.hpp"           // for prod_ctype, frameID, modulo, input_ctype, operator+
 
-#include "fmt.hpp"      // for format, fmt
-#include "gsl-lite.hpp" // for span<>::iterator, span
-#include "json.hpp"     // for json, basic_json, iteration_proxy_value, basic_json<>::...
-
-#include <algorithm> // for copy, max, fill, copy_backward, equal, transform
-#include <assert.h>  // for assert
-#include <atomic>    // for atomic_bool
-#include <cmath>     // for pow
-#include <complex>   // for operator*, complex
-#include <cstring>   // for memcpy
-#include <exception> // for exception
-#include <iterator>  // for back_insert_iterator, begin, end, back_inserter
-#include <mutex>     // for lock_guard, mutex
-#include <numeric>   // for iota
-#include <optional>  // for optional
-#include <regex>     // for match_results<>::_Base_type
-#include <stdexcept> // for runtime_error, invalid_argument
-#include <time.h>    // for size_t, timespec
-#include <tuple>     // for get
-#include <vector>    // for vector, vector<>::iterator, __alloc_traits<>::value_type
+#include <algorithm>    // for copy, max, fill, copy_backward, equal, transform
+#include <assert.h>     // for assert
+#include <atomic>       // for atomic_bool
+#include <cmath>        // for pow
+#include <complex>      // for operator*, complex
+#include <cstring>      // for memcpy
+#include <exception>    // for exception
+#include <fmt.hpp>      // for format, fmt
+#include <gsl-lite.hpp> // for span<>::iterator, span
+#include <iterator>     // for back_insert_iterator, begin, end, back_inserter
+#include <json.hpp>     // for json, basic_json, iteration_proxy_value, basic_json<>::...
+#include <mutex>        // for lock_guard, mutex
+#include <numeric>      // for iota
+#include <optional>     // for optional
+#include <regex>        // for match_results<>::_Base_type
+#include <stdexcept>    // for runtime_error, invalid_argument
+#include <time.h>       // for size_t, timespec
+#include <tuple>        // for get
+#include <vector>       // for vector, vector<>::iterator, __alloc_traits<>::value_type
 
 
 using namespace std::placeholders;

--- a/lib/stages/visCompression.cpp
+++ b/lib/stages/visCompression.cpp
@@ -253,10 +253,10 @@ void baselineCompression::compress_thread(uint32_t thread_id) {
 
             // Accumulate the weighted *variances*. Normalising and inversion
             // will be done later
-            out_weight[s.stack] += (1.0 / weight);
+            out_weight[s.stack] += ((float)1.0 / weight);
 
             // Accumulate the weights so we can normalize correctly
-            stack_norm[s.stack] += 1.0;
+            stack_norm[s.stack] += (float)1.0;
         }
 
         // Loop over the stacks and normalise (and invert the variances)
@@ -268,10 +268,10 @@ void baselineCompression::compress_thread(uint32_t thread_id) {
             float norm = stack_norm[stack_ind];
 
             // Invert norm if set, otherwise use zero to set data to zero.
-            float inorm = (norm != 0.0) ? (1.0 / norm) : 0.0;
+            float inorm = (norm != 0.0) ? ((float)1.0 / norm) : (float)0.0;
             float iwgt = (output_frame.weight[stack_ind] != 0.0)
-                             ? (1.0 / output_frame.weight[stack_ind])
-                             : 0.0;
+                             ? ((float)1.0 / output_frame.weight[stack_ind])
+                             : (float)0.0;
 
             output_frame.vis[stack_ind] *= inorm;
             output_frame.weight[stack_ind] = norm * norm * iwgt;
@@ -286,7 +286,7 @@ void baselineCompression::compress_thread(uint32_t thread_id) {
         mark_frame_empty(in_buf, unique_name.c_str(), input_frame_id);
 
         // Calculate residuals (return zero if no data for this freq)
-        float residual = (normt != 0.0) ? (vart / normt) : 0.0;
+        float residual = (normt != 0.0) ? (vart / normt) : (float)0.0;
 
         // Update prometheus metrics
         double elapsed = current_time() - start_time;

--- a/lib/stages/visCompression.cpp
+++ b/lib/stages/visCompression.cpp
@@ -13,8 +13,6 @@
 #include "visBuffer.hpp"         // for VisFrameView, VisField, VisField::vis, VisField::weight
 #include "visUtil.hpp"           // for current_time, modulo, rstack_ctype, cfloat, frameID
 
-#include "gsl-lite.hpp" // for span
-
 #include <algorithm>    // for copy, max, fill, copy_backward, equal
 #include <atomic>       // for atomic_bool
 #include <complex>      // for complex, norm
@@ -23,6 +21,7 @@
 #include <exception>    // for exception
 #include <functional>   // for _Bind_helper<>::type, bind, function, placeholders
 #include <future>       // for async, future
+#include <gsl-lite.hpp> // for span
 #include <iterator>     // for begin, end
 #include <memory>       // for allocator_traits<>::value_type
 #include <pthread.h>    // for pthread_setaffinity_np

--- a/lib/stages/visTestPattern.cpp
+++ b/lib/stages/visTestPattern.cpp
@@ -33,11 +33,11 @@
 #include <mutex>        // for mutex, lock_guard, unique_lock
 #include <regex>        // for match_results<>::_Base_type
 #include <stdexcept>    // for runtime_error, invalid_argument, out_of_range
+#include <stdint.h>     // for int8_t
 #include <sys/stat.h>   // for mkdir, S_IRGRP, S_IROTH, S_IRWXU
 #include <system_error> // for system_error
 #include <time.h>       // for timespec
 #include <tuple>        // for get
-
 
 using kotekan::bufferContainer;
 using kotekan::Config;
@@ -67,13 +67,7 @@ visTestPattern::visTestPattern(Config& config, const std::string& unique_name,
                                     + std::to_string(_tolerance) + ").");
 
     // report precision: a bit more than error tolerance
-    precision = log10(1. / _tolerance) + 2;
-
-    if (precision < 0) {
-        throw std::invalid_argument("visCheckTestPattern: invalid value for tolerance: %f "
-                                    "(resultet in negative report precision)"
-                                    + std::to_string(_tolerance));
-    }
+    precision = (int8_t)log10(1. / _tolerance) + 2;
     INFO("Using report precision {:d}", precision);
 
     write_dir = config.get<std::string>(unique_name, "write_dir");
@@ -139,7 +133,7 @@ void visTestPattern::main_thread() {
     get_dataset_state(ds_id);
 
     // Comparisons will be against tolerance^2
-    float t2 = _tolerance * _tolerance;
+    double t2 = _tolerance * _tolerance;
 
     auto& bad_values_counter = Metrics::instance().add_gauge(
         "kotekan_vistestpattern_bad_values_total", unique_name, {"name", "freq_id"});

--- a/lib/stages/visTestPattern.cpp
+++ b/lib/stages/visTestPattern.cpp
@@ -13,9 +13,6 @@
 #include "restServer.hpp"        // for connectionInstance, restServer, HTTP_RESPONSE, HTTP_RES...
 #include "visBuffer.hpp"         // for VisFrameView
 
-#include "fmt.hpp"      // for format, fmt
-#include "gsl-lite.hpp" // for span
-
 #include <algorithm>    // for max
 #include <atomic>       // for atomic_bool
 #include <cmath>        // for log10, sqrt
@@ -26,8 +23,10 @@
 #include <dirent.h>     // for opendir
 #include <errno.h>      // for errno
 #include <exception>    // for exception
+#include <fmt.hpp>      // for format, fmt
 #include <functional>   // for _Bind_helper<>::type, _Placeholder, bind, _1, _2, function
 #include <future>       // for async, future
+#include <gsl-lite.hpp> // for span
 #include <iomanip>      // for operator<<, setprecision
 #include <memory>       // for allocator_traits<>::value_type
 #include <mutex>        // for mutex, lock_guard, unique_lock

--- a/lib/stages/visTestPattern.hpp
+++ b/lib/stages/visTestPattern.hpp
@@ -15,9 +15,8 @@
 #include "restServer.hpp"      // for connectionInstance
 #include "visUtil.hpp"         // for cfloat, input_ctype, prod_ctype, freq_ctype
 
-#include "json.hpp" // for json
-
 #include <fstream>  // for ofstream
+#include <json.hpp> // for json
 #include <map>      // for map
 #include <mutex>    // for mutex
 #include <stddef.h> // for size_t

--- a/lib/stages/visTransform.cpp
+++ b/lib/stages/visTransform.cpp
@@ -14,18 +14,17 @@
 #include "visBuffer.hpp"       // for VisFrameView
 #include "visUtil.hpp"         // for prod_ctype, input_ctype, freq_ctype, copy_vis_triangle
 
-#include "gsl-lite.hpp" // for span<>::iterator, span
-
-#include <algorithm>  // for fill, max, transform
-#include <atomic>     // for atomic_bool
-#include <cstdint>    // for uint32_t
-#include <exception>  // for exception
-#include <functional> // for _Bind_helper<>::type, bind, function
-#include <iterator>   // for back_insert_iterator, begin, end, back_inserter
-#include <numeric>    // for iota
-#include <regex>      // for match_results<>::_Base_type
-#include <stdexcept>  // for runtime_error
-#include <tuple>      // for get, tie, tuple
+#include <algorithm>    // for fill, max, transform
+#include <atomic>       // for atomic_bool
+#include <cstdint>      // for uint32_t
+#include <exception>    // for exception
+#include <functional>   // for _Bind_helper<>::type, bind, function
+#include <gsl-lite.hpp> // for span<>::iterator, span
+#include <iterator>     // for back_insert_iterator, begin, end, back_inserter
+#include <numeric>      // for iota
+#include <regex>        // for match_results<>::_Base_type
+#include <stdexcept>    // for runtime_error
+#include <tuple>        // for get, tie, tuple
 
 
 using kotekan::bufferContainer;

--- a/lib/testing/FakeHFB.cpp
+++ b/lib/testing/FakeHFB.cpp
@@ -15,18 +15,17 @@
 #include "version.h"           // for get_git_commit_hash
 #include "visUtil.hpp"         // for double_to_ts, current_time, freq_ctype, cfloat
 
-#include "gsl-lite.hpp" // for span
-
-#include <algorithm>  // for max, transform
-#include <atomic>     // for atomic_bool
-#include <cstdint>    // for uint32_t, int32_t
-#include <exception>  // for exception
-#include <functional> // for _Bind_helper<>::type, bind, function, placeholders
-#include <iterator>   // for back_insert_iterator, back_inserter, begin, end
-#include <regex>      // for match_results<>::_Base_type
-#include <stdexcept>  // for runtime_error
-#include <time.h>     // for nanosleep, timespec
-#include <utility>    // for pair
+#include <algorithm>    // for max, transform
+#include <atomic>       // for atomic_bool
+#include <cstdint>      // for uint32_t, int32_t
+#include <exception>    // for exception
+#include <functional>   // for _Bind_helper<>::type, bind, function, placeholders
+#include <gsl-lite.hpp> // for span
+#include <iterator>     // for back_insert_iterator, back_inserter, begin, end
+#include <regex>        // for match_results<>::_Base_type
+#include <stdexcept>    // for runtime_error
+#include <time.h>       // for nanosleep, timespec
+#include <utility>      // for pair
 
 
 using namespace std::placeholders;

--- a/lib/testing/FakeVis.cpp
+++ b/lib/testing/FakeVis.cpp
@@ -13,23 +13,22 @@
 #include "visBuffer.hpp"       // for VisFrameView
 #include "visUtil.hpp"         // for prod_ctype, input_ctype, double_to_ts, current_time, freq...
 
-#include "fmt.hpp"      // for format, fmt
-#include "gsl-lite.hpp" // for span<>::iterator, span
-
-#include <algorithm>   // for max, fill, transform
-#include <atomic>      // for atomic_bool
-#include <complex>     // for complex
-#include <cstdint>     // for uint32_t, int32_t
-#include <exception>   // for exception
-#include <functional>  // for _Bind_helper<>::type, bind, function, placeholders
-#include <iterator>    // for back_insert_iterator, back_inserter, begin, end
-#include <memory>      // for allocator, unique_ptr
-#include <regex>       // for match_results<>::_Base_type
-#include <stdexcept>   // for runtime_error
-#include <time.h>      // for nanosleep, timespec
-#include <tuple>       // for get, make_tuple, tuple
-#include <type_traits> // for __decay_and_strip<>::__type
-#include <utility>     // for pair
+#include <algorithm>    // for max, fill, transform
+#include <atomic>       // for atomic_bool
+#include <complex>      // for complex
+#include <cstdint>      // for uint32_t, int32_t
+#include <exception>    // for exception
+#include <fmt.hpp>      // for format, fmt
+#include <functional>   // for _Bind_helper<>::type, bind, function, placeholders
+#include <gsl-lite.hpp> // for span<>::iterator, span
+#include <iterator>     // for back_insert_iterator, back_inserter, begin, end
+#include <memory>       // for allocator, unique_ptr
+#include <regex>        // for match_results<>::_Base_type
+#include <stdexcept>    // for runtime_error
+#include <time.h>       // for nanosleep, timespec
+#include <tuple>        // for get, make_tuple, tuple
+#include <type_traits>  // for __decay_and_strip<>::__type
+#include <utility>      // for pair
 
 
 using namespace std::placeholders;

--- a/lib/testing/FakeVisPattern.cpp
+++ b/lib/testing/FakeVisPattern.cpp
@@ -7,20 +7,19 @@
 #include "visBuffer.hpp"      // for VisFrameView
 #include "visUtil.hpp"        // for cfloat, input_ctype, ts_to_double, cmap
 
-#include "fmt.hpp"      // for format
-#include "gsl-lite.hpp" // for span
-#include "json.hpp"     // for json, basic_json, basic_json<>::object_t
-
-#include <algorithm> // for copy, max, copy_backward
-#include <complex>   // for complex, operator*
-#include <cstdint>   // for uint32_t, uint16_t
-#include <exception> // for exception
-#include <map>       // for map, map<>::mapped_type
-#include <math.h>    // for cosf, sinf
-#include <regex>     // for match_results<>::_Base_type
-#include <stdexcept> // for invalid_argument, runtime_error
-#include <tuple>     // for get
-#include <vector>    // for vector, __alloc_traits<>::value_type
+#include <algorithm>    // for copy, max, copy_backward
+#include <complex>      // for complex, operator*
+#include <cstdint>      // for uint32_t, uint16_t
+#include <exception>    // for exception
+#include <fmt.hpp>      // for format
+#include <gsl-lite.hpp> // for span
+#include <json.hpp>     // for json, basic_json, basic_json<>::object_t
+#include <map>          // for map, map<>::mapped_type
+#include <math.h>       // for cosf, sinf
+#include <regex>        // for match_results<>::_Base_type
+#include <stdexcept>    // for invalid_argument, runtime_error
+#include <tuple>        // for get
+#include <vector>       // for vector, __alloc_traits<>::value_type
 
 
 // Register test patterns

--- a/lib/testing/fakeGpu.cpp
+++ b/lib/testing/fakeGpu.cpp
@@ -12,20 +12,19 @@
 #include "metadata.h"         // for metadataContainer
 #include "visUtil.hpp"        // for frameID, gpu_N2_size, modulo, operator+
 
-#include "gsl-lite.hpp" // for span
-
-#include <atomic>     // for atomic_bool
-#include <csignal>    // for raise, SIGINT
-#include <cstdint>    // for int32_t
-#include <exception>  // for exception
-#include <functional> // for _Bind_helper<>::type, bind, function
-#include <random>     // for mt19937, random_device, uniform_real_distribution
-#include <regex>      // for match_results<>::_Base_type
-#include <stdexcept>  // for runtime_error
-#include <string>     // for string
-#include <sys/time.h> // for CLOCK_REALTIME, TIMESPEC_TO_TIMEVAL, timeval
-#include <time.h>     // for timespec, clock_gettime, nanosleep
-#include <vector>     // for vector
+#include <atomic>       // for atomic_bool
+#include <csignal>      // for raise, SIGINT
+#include <cstdint>      // for int32_t
+#include <exception>    // for exception
+#include <functional>   // for _Bind_helper<>::type, bind, function
+#include <gsl-lite.hpp> // for span
+#include <random>       // for mt19937, random_device, uniform_real_distribution
+#include <regex>        // for match_results<>::_Base_type
+#include <stdexcept>    // for runtime_error
+#include <string>       // for string
+#include <sys/time.h>   // for CLOCK_REALTIME, TIMESPEC_TO_TIMEVAL, timeval
+#include <time.h>       // for timespec, clock_gettime, nanosleep
+#include <vector>       // for vector
 
 
 REGISTER_KOTEKAN_STAGE(FakeGpu);

--- a/lib/testing/fakeGpuPattern.cpp
+++ b/lib/testing/fakeGpuPattern.cpp
@@ -4,15 +4,14 @@
 #include "chimeMetadata.hpp" // for chimeMetadata
 #include "visUtil.hpp"       // for prod_index
 
-#include "gsl-lite.hpp" // for span, span<>::iterator
-
-#include <algorithm> // for fill
-#include <cmath>     // for lroundf, pow
-#include <exception> // for exception
-#include <regex>     // for match_results<>::_Base_type
-#include <stdexcept> // for runtime_error
-#include <time.h>    // for timespec  // IWYU pragma: keep
-#include <vector>    // for vector
+#include <algorithm>    // for fill
+#include <cmath>        // for lroundf, pow
+#include <exception>    // for exception
+#include <gsl-lite.hpp> // for span, span<>::iterator
+#include <regex>        // for match_results<>::_Base_type
+#include <stdexcept>    // for runtime_error
+#include <time.h>       // for timespec  // IWYU pragma: keep
+#include <vector>       // for vector
 
 // Register test patterns
 REGISTER_FAKE_GPU_PATTERN(BlockGpuPattern, "block");

--- a/lib/testing/fakeGpuPattern.cpp
+++ b/lib/testing/fakeGpuPattern.cpp
@@ -159,8 +159,8 @@ void GaussianGpuPattern::fill(gsl::span<int32_t>& data, chimeMetadata* metadata,
     (void)frame_number;
     (void)freq_id;
 
-    float f_auto = pow(_samples_per_data_set, 0.5);
-    float f_cross = pow(_samples_per_data_set / 2, 0.5);
+    float f_auto = (float)pow(_samples_per_data_set, 0.5);
+    float f_cross = (float)pow(_samples_per_data_set / 2, 0.5);
 
     for (size_t i = 0; i < _num_elements; i++) {
         for (size_t j = i; j < _num_elements; j++) {

--- a/lib/testing/fakeGpuPattern.hpp
+++ b/lib/testing/fakeGpuPattern.hpp
@@ -219,7 +219,7 @@ public:
 
 private:
     float _pulse_width; // in s
-    float _rot_freq;    // in Hz
+    double _rot_freq;   // in Hz
     Polyco _polyco;
 };
 

--- a/lib/testing/fakeGpuPattern.hpp
+++ b/lib/testing/fakeGpuPattern.hpp
@@ -18,12 +18,11 @@
 #include "kotekanLogging.hpp" // for kotekanLogging
 #include "pulsarTiming.hpp"   // for Polyco
 
-#include "gsl-lite.hpp" // for span
-
-#include <random>   // for mt19937, normal_distribution, random_device
-#include <stddef.h> // for size_t
-#include <stdint.h> // for int32_t, uint32_t
-#include <string>   // for string
+#include <gsl-lite.hpp> // for span
+#include <random>       // for mt19937, normal_distribution, random_device
+#include <stddef.h>     // for size_t
+#include <stdint.h>     // for int32_t, uint32_t
+#include <string>       // for string
 
 // Create the abstract factory for generating patterns
 class FakeGpuPattern;

--- a/lib/testing/visNoise.cpp
+++ b/lib/testing/visNoise.cpp
@@ -8,17 +8,16 @@
 #include "visBuffer.hpp"       // for VisFrameView
 #include "visUtil.hpp"         // for cfloat
 
-#include "gsl-lite.hpp" // for span
-
-#include <atomic>     // for atomic_bool
-#include <cmath>      // for pow
-#include <complex>    // for complex
-#include <exception>  // for exception
-#include <functional> // for _Bind_helper<>::type, bind, function
-#include <regex>      // for match_results<>::_Base_type
-#include <stdexcept>  // for invalid_argument, runtime_error
-#include <stdint.h>   // for uint32_t
-#include <vector>     // for vector
+#include <atomic>       // for atomic_bool
+#include <cmath>        // for pow
+#include <complex>      // for complex
+#include <exception>    // for exception
+#include <functional>   // for _Bind_helper<>::type, bind, function
+#include <gsl-lite.hpp> // for span
+#include <regex>        // for match_results<>::_Base_type
+#include <stdexcept>    // for invalid_argument, runtime_error
+#include <stdint.h>     // for uint32_t
+#include <vector>       // for vector
 
 
 using kotekan::bufferContainer;

--- a/lib/utils/BipBuffer.hpp
+++ b/lib/utils/BipBuffer.hpp
@@ -10,12 +10,11 @@
 #ifndef BIP_BUFFER_HPP
 #define BIP_BUFFER_HPP
 
-#include "gsl-lite.hpp" // for span
-
-#include <atomic>   // for atomic_size_t
-#include <cstdint>  // for uint8_t
-#include <memory>   // for unique_ptr, make_unique
-#include <stddef.h> // for size_t
+#include <atomic>       // for atomic_size_t
+#include <cstdint>      // for uint8_t
+#include <gsl-lite.hpp> // for span
+#include <memory>       // for unique_ptr, make_unique
+#include <stddef.h>     // for size_t
 
 /**
  * @class BipBuffer

--- a/lib/utils/CHIMETelescope.cpp
+++ b/lib/utils/CHIMETelescope.cpp
@@ -5,11 +5,10 @@
 #include "kotekanLogging.hpp" // for ERROR, DEBUG2, WARN
 #include "restClient.hpp"
 
-#include "fmt.hpp"  // for format
-#include "json.hpp" // for json, basic_json<>::object_t, basic_json
-
 #include <cstdint>   // for uint64_t
 #include <exception> // for exception
+#include <fmt.hpp>   // for format
+#include <json.hpp>  // for json, basic_json<>::object_t, basic_json
 #include <regex>     // for match_results<>::_Base_type
 #include <stdexcept> // for runtime_error
 #include <utility>   // for tuple_element<>::type

--- a/lib/utils/CHIMETelescope.hpp
+++ b/lib/utils/CHIMETelescope.hpp
@@ -5,8 +5,7 @@
 #include "ICETelescope.hpp" // for ICETelescope
 #include "Telescope.hpp"    // for freq_id_t, stream_t
 
-#include "json.hpp" // for json
-
+#include <json.hpp> // for json
 #include <map>      // for map
 #include <stdint.h> // for uint32_t, uint64_t
 #include <string>   // for string

--- a/lib/utils/FrameView.cpp
+++ b/lib/utils/FrameView.cpp
@@ -2,8 +2,7 @@
 
 #include "metadata.h" // for metadataContainer
 
-#include "fmt.hpp" // for format, fmt
-
+#include <fmt.hpp>   // for format, fmt
 #include <stdexcept> // for runtime_error
 #include <string.h>  // for memcpy
 #include <string>    // for string

--- a/lib/utils/FrameView.hpp
+++ b/lib/utils/FrameView.hpp
@@ -8,11 +8,10 @@
 
 #include "buffer.h" // for Buffer
 
-#include "gsl-lite.hpp" // for span
-
-#include <stdint.h> // for uint8_t
-#include <time.h>   // for size_t
-#include <utility>  // for pair
+#include <gsl-lite.hpp> // for span
+#include <stdint.h>     // for uint8_t
+#include <time.h>       // for size_t
+#include <utility>      // for pair
 
 
 /**

--- a/lib/utils/HFBFileArchive.cpp
+++ b/lib/utils/HFBFileArchive.cpp
@@ -3,24 +3,23 @@
 #include "H5Support.hpp" // for AtomicType<>::AtomicType, dset_id_str
 #include "visFile.hpp"   // for create_lockfile
 
-#include "fmt.hpp" // for format, fmt
-
-#include <algorithm>                   // for copy, min
+#include <algorithm>                   // for copy, max
 #include <cstdio>                      // for remove
+#include <fmt.hpp>                     // for format, fmt
 #include <highfive/H5Attribute.hpp>    // for Attribute, Attribute::write
 #include <highfive/H5DataSet.hpp>      // for DataSet, AnnotateTraits::createAttribute, DataSet...
-#include <highfive/H5DataSpace.hpp>    // for DataSpace::From, DataSpace, DataSpace::getDimensions
-#include <highfive/H5DataType.hpp>     // for CompoundType, create_datatype, CompoundType::addM...
+#include <highfive/H5DataSpace.hpp>    // for DataSpace::From, DataSpace, DataSpace::DataSpace
+#include <highfive/H5DataType.hpp>     // for create_datatype, DataType
 #include <highfive/H5Exception.hpp>    // for DataSpaceException, HDF5ErrMapper
-#include <highfive/H5File.hpp>         // for File, NodeTraits::createGroup, File::flush, NodeT...
+#include <highfive/H5File.hpp>         // for File, NodeTraits::createDataSet, File::flush, Nod...
 #include <highfive/H5Group.hpp>        // for Group
-#include <highfive/H5Object.hpp>       // for hid_t
+#include <highfive/H5Object.hpp>       // for hsize_t, H5Z_FLAG_MANDATORY, HighFive, hid_t
 #include <highfive/H5PropertyList.hpp> // for H5Pcreate, H5Pset_chunk, H5Pset_filter, H5P_DATAS...
-#include <highfive/H5Selection.hpp>    // for SliceTraits::select, Selection, SliceTraits::write
+#include <highfive/H5Selection.hpp>    // for SliceTraits::write, SliceTraits::select, Selection
 #include <stdexcept>                   // for invalid_argument
-#include <tuple>                       // for make_tuple, get, tuple
+#include <tuple>                       // for make_tuple, tuple, get
 #include <type_traits>                 // for __decay_and_strip<>::__type
-#include <utility>                     // for move, pair
+#include <utility>                     // for pair
 
 using namespace HighFive;
 

--- a/lib/utils/HFBFrameView.cpp
+++ b/lib/utils/HFBFrameView.cpp
@@ -5,13 +5,12 @@
 #include "metadata.h"    // for metadataContainer
 #include "visUtil.hpp"   // for struct_alignment
 
-#include "fmt.hpp" // for format, fmt
-
 #include <algorithm> // for copy
 #include <complex>   // for complex  // IWYU pragma: keep
 #include <cstdint>   // for uint64_t // IWYU pragma: keep
 #include <ctime>     // for gmtime
 #include <exception> // for exception
+#include <fmt.hpp>   // for format, fmt
 #include <map>       // for map
 #include <regex>     // for match_results<>::_Base_type
 #include <set>       // for set

--- a/lib/utils/HFBFrameView.hpp
+++ b/lib/utils/HFBFrameView.hpp
@@ -15,13 +15,12 @@
 #include "dataset.hpp"     // for dset_id_t
 #include "visUtil.hpp"     // IWYU pragma: keep
 
-#include "gsl-lite.hpp" // for span
-
-#include <set>      // for set
-#include <stdint.h> // for uint32_t, uint64_t, int64_t
-#include <string>   // for string
-#include <time.h>   // for size_t, timespec
-#include <utility>  // for pair
+#include <gsl-lite.hpp> // for span
+#include <set>          // for set
+#include <stdint.h>     // for uint32_t, uint64_t, int64_t
+#include <string>       // for string
+#include <time.h>       // for size_t, timespec
+#include <utility>      // for pair
 
 
 /**

--- a/lib/utils/Hash.cpp
+++ b/lib/utils/Hash.cpp
@@ -1,7 +1,6 @@
 #include "Hash.hpp"
 
-#include "fmt.hpp" // for format
-
+#include <fmt.hpp>    // for format
 #include <inttypes.h> // for SCNx64
 #include <iostream>   // for istream, ostream, basic_istream::read
 #include <stdexcept>  // for invalid_argument

--- a/lib/utils/Hash.hpp
+++ b/lib/utils/Hash.hpp
@@ -3,13 +3,12 @@
 
 #include "MurmurHash3.hpp" // for MurmurHash3_x64_128
 
-#include "fmt.hpp"      // for formatter
-#include "gsl-lite.hpp" // for span
-#include "json.hpp"     // for json
-
-#include <iostream> // for istream, ostream
-#include <stdint.h> // for uint64_t
-#include <string>   // for string
+#include <fmt.hpp>      // for formatter
+#include <gsl-lite.hpp> // for span
+#include <iostream>     // for istream, ostream
+#include <json.hpp>     // for json
+#include <stdint.h>     // for uint64_t
+#include <string>       // for string
 
 // Set a value for the hash seed
 #define _SEED 1420

--- a/lib/utils/ICETelescope.cpp
+++ b/lib/utils/ICETelescope.cpp
@@ -4,11 +4,10 @@
 #include "kotekanLogging.hpp" // for WARN, INFO, FATAL_ERROR
 #include "restClient.hpp"     // for restClient
 
-#include "fmt.hpp"  // for format
-#include "json.hpp" // for basic_json, basic_json<>::object_t, basic_json<>::value_type
-
 #include <cstdint>   // for uint64_t
 #include <exception> // for exception
+#include <fmt.hpp>   // for format
+#include <json.hpp>  // for basic_json, basic_json<>::object_t, basic_json<>::value_type
 #include <math.h>    // for abs
 #include <regex>     // for match_results<>::_Base_type
 #include <stdexcept> // for runtime_error, invalid_argument

--- a/lib/utils/Stack.cpp
+++ b/lib/utils/Stack.cpp
@@ -2,10 +2,9 @@
 
 #include "visUtil.hpp" // for rstack_ctype, prod_ctype, input_ctype
 
-#include "fmt.hpp" // for format, fmt
-
 #include <algorithm>  // for copy, sort, transform, max
 #include <cstdint>    // for uint32_t, int8_t, int16_t
+#include <fmt.hpp>    // for format, fmt
 #include <functional> // for _Bind_helper<>::type, bind, _1, placeholders
 #include <iterator>   // for back_insert_iterator, begin, end, back_inserter
 #include <math.h>     // for abs

--- a/lib/utils/dataset.cpp
+++ b/lib/utils/dataset.cpp
@@ -2,9 +2,8 @@
 
 #include "Hash.hpp" // for operator==
 
-#include "json.hpp" // for json, basic_json<>::value_type, basic_json
-
-#include <string> // for string, operator==
+#include <json.hpp> // for json, basic_json<>::value_type, basic_json
+#include <string>   // for string, operator==
 
 using nlohmann::json;
 

--- a/lib/utils/dataset.hpp
+++ b/lib/utils/dataset.hpp
@@ -3,9 +3,8 @@
 
 #include "Hash.hpp" // for operator==, Hash
 
-#include "json.hpp" // for json
-
-#include <string> // for string
+#include <json.hpp> // for json
+#include <string>   // for string
 
 /// DatasetID
 using dset_id_t = Hash;

--- a/lib/utils/datasetManager.hpp
+++ b/lib/utils/datasetManager.hpp
@@ -11,14 +11,13 @@
 #include "restClient.hpp"        // for restClient::restReply, restClient
 #include "restServer.hpp"        // for connectionInstance
 
-#include "fmt.hpp"  // for fmt
-#include "json.hpp" // for json, basic_json<>::object_t, basic_json, operator!=
-
 #include <atomic>             // for atomic, __atomic_base
 #include <chrono>             // for milliseconds
 #include <condition_variable> // for condition_variable
 #include <exception>          // for exception
+#include <fmt.hpp>            // for fmt
 #include <functional>         // for function
+#include <json.hpp>           // for json, basic_json<>::object_t, basic_json, operator!=
 #include <map>                // for map, _Rb_tree_iterator, operator!=, map<>::iterator
 #include <memory>             // for unique_ptr, allocator, operator==, make_unique
 #include <mutex>              // for mutex, unique_lock, lock_guard

--- a/lib/utils/datasetState.hpp
+++ b/lib/utils/datasetState.hpp
@@ -6,13 +6,12 @@
 #include "gateSpec.hpp" // for gateSpec, _factory_aliasgateSpec
 #include "visUtil.hpp"  // for prod_ctype, rstack_ctype, time_ctype, input_ctype, freq_ctype
 
-#include "fmt.hpp"  // for format, fmt
-#include "json.hpp" // for json, basic_json<>::object_t, json_ref, basic_json, basic_json<>...
-
 #include <algorithm> // for copy
 #include <cstdint>   // for uint32_t
 #include <exception> // for exception
+#include <fmt.hpp>   // for format, fmt
 #include <iosfwd>    // for ostream
+#include <json.hpp>  // for json, basic_json<>::object_t, json_ref, basic_json, basic_json<>...
 #include <memory>    // for allocator, unique_ptr
 #include <numeric>   // for iota
 #include <stddef.h>  // for size_t

--- a/lib/utils/gateSpec.hpp
+++ b/lib/utils/gateSpec.hpp
@@ -9,9 +9,8 @@
 #include "kotekanLogging.hpp" // for logLevel, kotekanLogging
 #include "pulsarTiming.hpp"   // for SegmentedPolyco
 
-#include "json.hpp" // for json
-
 #include <functional> // for function
+#include <json.hpp>   // for json
 #include <memory>     // for unique_ptr
 #include <string>     // for string
 #include <time.h>     // for timespec

--- a/lib/utils/hfbFileRaw.cpp
+++ b/lib/utils/hfbFileRaw.cpp
@@ -7,16 +7,15 @@
 #include "datasetManager.hpp" // for datasetManager, dset_id_t
 #include "datasetState.hpp"   // for beamState, freqState, subfreqState
 
-#include "fmt.hpp"  // for format, fmt
-#include "json.hpp" // for basic_json<>::object_t, basic_json<>::value_type, json
-
 #include <cstdio>       // for remove
 #include <cxxabi.h>     // for __forced_unwind
 #include <errno.h>      // for errno
 #include <exception>    // for exception
 #include <fcntl.h>      // for fallocate, sync_file_range, open, posix_fadvise, FALLOC_FL...
+#include <fmt.hpp>      // for format, fmt
 #include <fstream>      // for ofstream, basic_ostream::write, ios
 #include <future>       // for async, future
+#include <json.hpp>     // for basic_json<>::object_t, basic_json<>::value_type, json
 #include <stdexcept>    // for runtime_error, out_of_range
 #include <string.h>     // for strerror
 #include <sys/stat.h>   // for S_IRGRP, S_IROTH, S_IRUSR, S_IWGRP, S_IWUSR

--- a/lib/utils/hfbFileRaw.hpp
+++ b/lib/utils/hfbFileRaw.hpp
@@ -12,11 +12,10 @@
 #include "visFile.hpp"        // for visFile
 #include "visUtil.hpp"        // for time_ctype
 
-#include "json.hpp" // for json
-
 #include <cstdint>     // for uint32_t
 #include <fcntl.h>     // for O_CREAT, O_EXCL, O_WRONLY
 #include <fstream>     // for ofstream
+#include <json.hpp>    // for json
 #include <map>         // for map
 #include <stddef.h>    // for size_t
 #include <string>      // for string

--- a/lib/utils/pulsarTiming.cpp
+++ b/lib/utils/pulsarTiming.cpp
@@ -34,7 +34,7 @@ double Polyco::unix2phase(timespec t) const {
     return mjd2phase(ts2mjd(t));
 }
 
-double Polyco::next_toa(timespec t, float freq) const {
+double Polyco::next_toa(timespec t, double freq) const {
 
     // Adjust time for dispersion delay
     double dm_delay = -4140. * dm * pow(freq, -2);

--- a/lib/utils/pulsarTiming.cpp
+++ b/lib/utils/pulsarTiming.cpp
@@ -2,9 +2,8 @@
 
 #include "visUtil.hpp" // for add_nsec
 
-#include "fmt.hpp" // for format, fmt
-
 #include <cmath>       // for floor, pow
+#include <fmt.hpp>     // for format, fmt
 #include <memory>      // for allocator_traits<>::value_type
 #include <stdexcept>   // for runtime_error
 #include <sys/types.h> // for uint

--- a/lib/utils/pulsarTiming.hpp
+++ b/lib/utils/pulsarTiming.hpp
@@ -50,7 +50,7 @@ public:
      * @param freq   The frequency (MHz) to use for dispersion delay.
      * @returns      Time after t in seconds.
      **/
-    double next_toa(timespec t, float freq) const;
+    double next_toa(timespec t, double freq) const;
 
 private:
     double tmid;

--- a/lib/utils/restClient.hpp
+++ b/lib/utils/restClient.hpp
@@ -7,14 +7,13 @@
 
 #include "restServer.hpp" // for PORT_REST_SERVER
 
-#include "json.hpp" // for json
-
 #include <atomic>             // for atomic
 #include <condition_variable> // for condition_variable
 #include <event2/buffer.h>    // for evbuffer_iovec
 #include <event2/http.h>      // for evhttp_connection
 #include <event2/util.h>      // for evutil_socket_t
 #include <functional>         // for function
+#include <json.hpp>           // for json
 #include <mutex>              // for mutex
 #include <stddef.h>           // for size_t
 #include <string>             // for string, allocator

--- a/lib/utils/visBuffer.cpp
+++ b/lib/utils/visBuffer.cpp
@@ -6,13 +6,12 @@
 #include "chimeMetadata.hpp" // for chimeMetadata, get_stream_id_from_metadata
 #include "metadata.h"        // for metadataContainer
 
-#include "fmt.hpp" // for format, fmt
-
 #include <algorithm>   // for copy
 #include <complex>     // for complex
 #include <cstdint>     // for uint64_t // IWYU pragma: keep
 #include <ctime>       // for gmtime
 #include <exception>   // for exception
+#include <fmt.hpp>     // for format, fmt
 #include <map>         // for map
 #include <regex>       // for match_results<>::_Base_type
 #include <set>         // for set

--- a/lib/utils/visBuffer.hpp
+++ b/lib/utils/visBuffer.hpp
@@ -15,14 +15,13 @@
 #include "datasetManager.hpp" // for dset_id_t
 #include "visUtil.hpp"        // for cfloat
 
-#include "gsl-lite.hpp" // for span
-
-#include <set>      // for set
-#include <stdint.h> // for uint32_t, uint64_t
-#include <string>   // for string
-#include <time.h>   // for size_t, timespec
-#include <tuple>    // for tuple
-#include <utility>  // for pair
+#include <gsl-lite.hpp> // for span
+#include <set>          // for set
+#include <stdint.h>     // for uint32_t, uint64_t
+#include <string>       // for string
+#include <time.h>       // for size_t, timespec
+#include <tuple>        // for tuple
+#include <utility>      // for pair
 
 
 /**

--- a/lib/utils/visFile.cpp
+++ b/lib/utils/visFile.cpp
@@ -1,9 +1,8 @@
 
 #include "visFile.hpp"
 
-#include "fmt.hpp" // for format, fmt
-
 #include <ctime>      // for gmtime, time_t
+#include <fmt.hpp>    // for format, fmt
 #include <fstream>    // for basic_ostream::operator<<, ofstream, endl, basic_ostream, basic_os...
 #include <iterator>   // for reverse_iterator
 #include <libgen.h>   // for dirname, basename

--- a/lib/utils/visFileArchive.cpp
+++ b/lib/utils/visFileArchive.cpp
@@ -3,11 +3,10 @@
 #include "H5Support.hpp" // for AtomicType<>::AtomicType, dset_id_str
 #include "visFile.hpp"   // for create_lockfile
 
-#include "fmt.hpp" // for format, fmt
-
 #include <algorithm>                   // for copy, max, min
 #include <cstdint>                     // for uint32_t
 #include <cstdio>                      // for remove
+#include <fmt.hpp>                     // for format, fmt
 #include <highfive/H5Attribute.hpp>    // for Attribute, Attribute::write
 #include <highfive/H5DataSet.hpp>      // for DataSet, AnnotateTraits::createAttribute, DataSet...
 #include <highfive/H5DataSpace.hpp>    // for DataSpace::From, DataSpace, DataSpace::DataSpace

--- a/lib/utils/visFileH5.cpp
+++ b/lib/utils/visFileH5.cpp
@@ -8,16 +8,15 @@
 #include "visBuffer.hpp"      // for VisFrameView
 #include "visUtil.hpp"        // for cfloat, time_ctype, freq_ctype, input_ctype, prod_ctype
 
-#include "fmt.hpp"      // for format, fmt
-#include "gsl-lite.hpp" // for span
-
 #include <complex>                  // for complex
 #include <cstdio>                   // for remove
 #include <cxxabi.h>                 // for __forced_unwind
 #include <errno.h>                  // for errno
 #include <exception>                // for exception
 #include <fcntl.h>                  // for sync_file_range, posix_fadvise, posix_fallocate, SYN...
+#include <fmt.hpp>                  // for format, fmt
 #include <future>                   // for async, future
+#include <gsl-lite.hpp>             // for span
 #include <highfive/H5Attribute.hpp> // for Attribute, Attribute::write, Attribute::getSpace
 #include <highfive/H5DataSet.hpp>   // for DataSet, DataSet::resize, AnnotateTraits::createAttr...
 #include <highfive/H5DataSpace.hpp> // for DataSpace, DataSpace::From, DataSpace::DataSpace

--- a/lib/utils/visFileRaw.cpp
+++ b/lib/utils/visFileRaw.cpp
@@ -6,16 +6,15 @@
 #include "datasetState.hpp"   // for stackState, eigenvalueState, freqState, gatingState, input...
 #include "visBuffer.hpp"      // for VisFrameView, VisMetadata
 
-#include "fmt.hpp"  // for format, fmt
-#include "json.hpp" // for basic_json<>::object_t, basic_json<>::value_type, json
-
 #include <cstdio>       // for remove
 #include <cxxabi.h>     // for __forced_unwind
 #include <errno.h>      // for errno
 #include <exception>    // for exception
 #include <fcntl.h>      // for fallocate, sync_file_range, open, posix_fadvise, FALLOC_FL...
+#include <fmt.hpp>      // for format, fmt
 #include <fstream>      // for ofstream, basic_ostream::write, ios
 #include <future>       // for async, future
+#include <json.hpp>     // for basic_json<>::object_t, basic_json<>::value_type, json
 #include <stdexcept>    // for out_of_range, runtime_error
 #include <string.h>     // for strerror
 #include <sys/stat.h>   // for S_IRGRP, S_IROTH, S_IRUSR, S_IWGRP, S_IWUSR

--- a/lib/utils/visFileRaw.hpp
+++ b/lib/utils/visFileRaw.hpp
@@ -12,11 +12,10 @@
 #include "visFile.hpp"        // for visFile
 #include "visUtil.hpp"        // for time_ctype
 
-#include "json.hpp" // for json
-
 #include <cstdint>     // for uint32_t
 #include <fcntl.h>     // for O_CREAT, O_EXCL, O_WRONLY
 #include <fstream>     // for ofstream
+#include <json.hpp>    // for json
 #include <map>         // for map
 #include <stddef.h>    // for size_t
 #include <string>      // for string

--- a/lib/utils/visFileRing.cpp
+++ b/lib/utils/visFileRing.cpp
@@ -3,10 +3,9 @@
 #include "visFile.hpp" // for REGISTER_VIS_FILE, _factory_aliasvisFile
 #include "visUtil.hpp" // for time_ctype
 
-#include "json.hpp" // for basic_json<>::value_type, json
-
 #include <errno.h>     // for errno
 #include <fcntl.h>     // for O_CREAT, O_WRONLY
+#include <json.hpp>    // for basic_json<>::value_type, json
 #include <ostream>     // for ofstream, basic_ostream::flush, basic_ostream::seekp, basi...
 #include <string.h>    // for size_t, strerror
 #include <sys/types.h> // for uint

--- a/lib/utils/visUtil.hpp
+++ b/lib/utils/visUtil.hpp
@@ -15,26 +15,25 @@
 #include "Config.hpp" // for Config
 #include "buffer.h"   // for Buffer
 
-#include "fmt.hpp"      // for format_context, formatter
-#include "gsl-lite.hpp" // for span
-#include "json.hpp"     // for json
-
-#include <algorithm>   // for max
-#include <complex>     // for complex, imag, real
-#include <cstdint>     // for uint32_t, uint16_t, int64_t, int32_t, uint64_t
-#include <cstdlib>     // for size_t, (anonymous), div
-#include <functional>  // for function
-#include <iosfwd>      // for ostream
-#include <map>         // for map
-#include <math.h>      // for fmod
-#include <string>      // for string
-#include <sys/time.h>  // for timeval, CLOCK_REALTIME
-#include <sys/types.h> // for __syscall_slong_t, suseconds_t, time_t
-#include <time.h>      // for timespec, clock_gettime
-#include <tuple>       // for tuple, tie
-#include <type_traits> // for enable_if_t, is_integral, make_unsigned
-#include <utility>     // for pair
-#include <vector>      // for vector
+#include <algorithm>    // for max
+#include <complex>      // for complex, imag, real
+#include <cstdint>      // for uint32_t, uint16_t, int64_t, int32_t, uint64_t
+#include <cstdlib>      // for size_t, (anonymous), div
+#include <fmt.hpp>      // for format_context, formatter
+#include <functional>   // for function
+#include <gsl-lite.hpp> // for span
+#include <iosfwd>       // for ostream
+#include <json.hpp>     // for json
+#include <map>          // for map
+#include <math.h>       // for fmod
+#include <string>       // for string
+#include <sys/time.h>   // for timeval, CLOCK_REALTIME
+#include <sys/types.h>  // for __syscall_slong_t, suseconds_t, time_t
+#include <time.h>       // for timespec, clock_gettime
+#include <tuple>        // for tuple, tie
+#include <type_traits>  // for enable_if_t, is_integral, make_unsigned
+#include <utility>      // for pair
+#include <vector>       // for vector
 
 /// Define an alias for the single precision complex type
 using cfloat = typename std::complex<float>;

--- a/tests/boost/dataset_broker_consumer.cpp
+++ b/tests/boost/dataset_broker_consumer.cpp
@@ -11,12 +11,11 @@
 #include "test_utils.hpp"     // for CompareCTypes
 #include "visUtil.hpp"        // for input_ctype, prod_ctype, freq_ctype
 
-#include "json.hpp" // for basic_json<>::object_t, basic_json<>::value...
-
 #include <algorithm>                         // for max
 #include <boost/test/included/unit_test.hpp> // for master_test_suite, BOOST_PP_IIF_1, BOOST_CHECK
 #include <exception>                         // for exception
 #include <iostream>                          // for operator<<, ostream, endl, basic_ostream, cout
+#include <json.hpp>                          // for basic_json<>::object_t, basic_json<>::value...
 #include <map>                               // for map
 #include <stdexcept>                         // for out_of_range
 #include <stdint.h>                          // for uint32_t

--- a/tests/boost/dataset_broker_producer.cpp
+++ b/tests/boost/dataset_broker_producer.cpp
@@ -10,12 +10,11 @@
 #include "restServer.hpp"     // for restServer
 #include "visUtil.hpp"        // for input_ctype, prod_ctype, freq_ctype
 
-#include "json.hpp" // for basic_json<>::object_t, basic_json<>::value...
-
 #include <algorithm>                         // for max
 #include <boost/test/included/unit_test.hpp> // for master_test_suite, BOOST_PP_IIF_1, BOOST_CHECK
 #include <chrono>                            // for milliseconds
 #include <iostream>                          // for ofstream, operator<<, basic_ostream, ostream
+#include <json.hpp>                          // for basic_json<>::object_t, basic_json<>::value...
 #include <map>                               // for map
 #include <stdint.h>                          // for uint32_t
 #include <stdlib.h>                          // for atoi

--- a/tests/boost/dataset_broker_producer2.cpp
+++ b/tests/boost/dataset_broker_producer2.cpp
@@ -10,12 +10,11 @@
 #include "test_utils.hpp"     // for CompareCTypes
 #include "visUtil.hpp"        // for input_ctype, prod_ctype, freq_ctype
 
-#include "json.hpp" // for basic_json<>::object_t, basic_json<>::value...
-
 #include <algorithm>                         // for copy
 #include <boost/test/included/unit_test.hpp> // for master_test_suite, master_test_suite_t, BOO...
 #include <exception>                         // for exception
 #include <iostream>                          // for operator<<, ostream, endl, basic_ostream, cout
+#include <json.hpp>                          // for basic_json<>::object_t, basic_json<>::value...
 #include <map>                               // for map
 #include <stdexcept>                         // for out_of_range
 #include <stdint.h>                          // for uint32_t

--- a/tests/boost/test_bip_buffer.cpp
+++ b/tests/boost/test_bip_buffer.cpp
@@ -7,12 +7,11 @@
 #include "SynchronizedQueue.hpp" // for SynchronizedQueue
 #include "kotekanLogging.hpp"    // for DEBUG_NON_OO, DEBUG2_NON_OO
 
-#include "gsl-lite.hpp" // for span
-
 #include <algorithm>                         // for min
 #include <atomic>                            // for atomic_size_t
 #include <boost/test/included/unit_test.hpp> // for BOOST_PP_IIF_1, BOOST_CHECK, BOOST_PP_BOOL_2
 #include <chrono>                            // for milliseconds
+#include <gsl-lite.hpp>                      // for span
 #include <memory>                            // for unique_ptr
 #include <optional>                          // for optional
 #include <random>                            // for mt19937, uniform_int_distribution, random_d...

--- a/tests/boost/test_config.cpp
+++ b/tests/boost/test_config.cpp
@@ -11,7 +11,7 @@
 // the code to test:
 #include "Config.hpp" // for Config
 
-#include "json.hpp" // for json_ref, basic_json<>::object_t, json
+#include <json.hpp> // for json_ref, basic_json<>::object_t, json
 
 using kotekan::Config;
 

--- a/tests/boost/test_dataset_manager.cpp
+++ b/tests/boost/test_dataset_manager.cpp
@@ -9,12 +9,11 @@
 #include "test_utils.hpp"     // for CompareCTypes
 #include "visUtil.hpp"        // for input_ctype, prod_ctype, freq_ctype
 
-#include "json.hpp" // for basic_json<>::object_t, basic_json<>::value...
-
 #include <algorithm>                         // for max
 #include <boost/test/included/unit_test.hpp> // for BOOST_PP_IIF_1, BOOST_PP_IIF_0, BOOST_PP_BO...
 #include <exception>                         // for exception
 #include <iostream>                          // for endl, operator<<, ostream, basic_ostream, cout
+#include <json.hpp>                          // for basic_json<>::object_t, basic_json<>::value...
 #include <map>                               // for map
 #include <memory>                            // for allocator, make_unique, unique_ptr
 #include <stdexcept>                         // for out_of_range

--- a/tests/boost/test_dataset_manager_rest.cpp
+++ b/tests/boost/test_dataset_manager_rest.cpp
@@ -11,15 +11,14 @@
 #include "restServer.hpp"     // for restServer, connectionInstance
 #include "visUtil.hpp"        // for input_ctype, prod_ctype, freq_ctype
 
-#include "fmt.hpp"  // for format, fmt
-#include "json.hpp" // for basic_json<>::object_t, basic_json<>::value...
-
 #include <algorithm>                         // for max
 #include <atomic>                            // for atomic, __atomic_base
 #include <boost/test/included/unit_test.hpp> // for BOOST_PP_IIF_1, BOOST_PP_BOOL_2, BOOST_TEST...
 #include <exception>                         // for exception
+#include <fmt.hpp>                           // for format, fmt
 #include <functional>                        // for _Bind_helper<>::type, _Placeholder, bind, _1
 #include <iostream>                          // for operator<<, endl, ostream, basic_ostream, cout
+#include <json.hpp>                          // for basic_json<>::object_t, basic_json<>::value...
 #include <map>                               // for map
 #include <memory>                            // for allocator, make_unique, unique_ptr
 #include <stddef.h>                          // for size_t

--- a/tests/boost/test_hash.cpp
+++ b/tests/boost/test_hash.cpp
@@ -2,10 +2,9 @@
 
 #include "Hash.hpp" // for Hash, hash
 
-#include "fmt.hpp"  // for format
-#include "json.hpp" // for json
-
 #include <boost/test/included/unit_test.hpp> // for BOOST_PP_IIF_1, BOOST_PP_IIF_0, BOOST_PP_BO...
+#include <fmt.hpp>                           // for format
+#include <json.hpp>                          // for json
 #include <stdint.h>                          // for uint64_t
 #include <stdlib.h>                          // for strtoull
 #include <string>                            // for string, allocator

--- a/tests/boost/test_restclient.cpp
+++ b/tests/boost/test_restclient.cpp
@@ -5,14 +5,13 @@
 #include "restClient.hpp"     // for restClient::restReply, restClient
 #include "restServer.hpp"     // for restServer, connectionInstance, HTTP_RESPONSE
 
-#include "fmt.hpp"  // for format, fmt
-#include "json.hpp" // for basic_json, basic_json<>::value_type, opera...
-
 #include <atomic>                            // for atomic, __atomic_base
 #include <boost/test/included/unit_test.hpp> // for BOOST_PP_IIF_1, BOOST_PP_BOOL_2, BOOST_TEST...
 #include <chrono>                            // for milliseconds
 #include <cstdint>                           // for uint32_t
+#include <fmt.hpp>                           // for format, fmt
 #include <functional>                        // for _Placeholder, _Bind_helper<>::type, bind
+#include <json.hpp>                          // for basic_json, basic_json<>::value_type, opera...
 #include <string>                            // for allocator, basic_string, string, operator!=
 #include <thread>                            // for sleep_for
 #include <vector>                            // for vector

--- a/tests/boost/test_updatequeue.cpp
+++ b/tests/boost/test_updatequeue.cpp
@@ -3,12 +3,11 @@
 #include "updateQueue.hpp" // for updateQueue
 #include "visUtil.hpp"     // for operator==
 
-#include "fmt.hpp" // for format
-
 #include <algorithm>                         // for copy, copy_backward, max
 #include <boost/test/included/unit_test.hpp> // for BOOST_PP_IIF_1, BOOST_CHECK, BOOST_PP_BOOL_2
 #include <ctime>                             // for timespec
 #include <deque>                             // for deque, _Deque_iterator
+#include <fmt.hpp>                           // for format
 #include <iostream>                          // for cout, ostream, std
 #include <memory>
 #include <string>  // for operator<<

--- a/tools/iwyu/docker/iwyu.sh
+++ b/tools/iwyu/docker/iwyu.sh
@@ -8,6 +8,7 @@ then
   echo "All good."
   exit 0
 else
+  make clang-format
   git diff
   exit 1
 fi


### PR DESCRIPTION
Let's assign people here who know the code that generates `float-conversion` warnings until they are all cleaned.

If you think someone else knows the code your tagged for better than you, please tag them instead.

- [ ] @cubranic in https://github.com/kotekan/kotekan/blob/096e95ccffb8421f9ca5048213f92cb59f6c3b5e/lib/core/basebandApiManager.cpp#L192
```
../../../lib/core/basebandApiManager.cpp:192:30: error: implicit conversion turns floating-point number into integer: 'double' to 'int64_t' (aka 'long long') [-Werror,-Wfloat-conversion]
    int64_t min_delay_fpga = round(min_delay * fpga_frame_rate);
            ~~~~~~~~~~~~~~   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../../lib/core/basebandApiManager.cpp:193:30: error: implicit conversion turns floating-point number into integer: 'double' to 'int64_t' (aka 'long long') [-Werror,-Wfloat-conversion]
    int64_t max_delay_fpga = round(max_delay * fpga_frame_rate);
            ~~~~~~~~~~~~~~   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
- [x] @jrs65 in https://github.com/kotekan/kotekan/blob/9730a6359be6368edbe33f3c78ff1780b5cdadf6/lib/dpdk/iceBoardHandler.hpp#L435
```
 ../../../lib/dpdk/iceBoardHandler.hpp: In member function 'nlohmann::json iceBoardHandler::get_json_port_info()':
../../../lib/dpdk/iceBoardHandler.hpp:435:47: error: conversion to 'std::vector<float>::value_type {aka float}' from 'double' may alter its value [-Werror=float-conversion]
                 freq_mhz.push_back(tel.to_freq(encoded_id, i));
                                    ~~~~~~~~~~~^~~~~~~~~~~~~~~
```
- [ ] @kvand 
```
kotekan/lib/stages/simpleAutocorr.cpp: In member function ‘virtual void simpleAutocorr::main_thread()’:
kotekan/lib/stages/simpleAutocorr.cpp:74:58: warning: conversion from ‘float’ to ‘uint’ {aka ‘unsigned int’} may change value [-Wfloat-conversion]
   74 |                     out_local[out_loc++] = spectrum_out[i];
      |                                            ~~~~~~~~~~~~~~^
```
- [x] @jrs65 
```
kotekan/lib/testing/fakeGpuPattern.cpp:188: warning: conversion from ‘double’ to ‘float’ may change value [-Wfloat-conversion]
  188 |     _rot_freq = config.get<double>(path, "rot_freq");       // in Hz
      |                 ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
kotekan/lib/testing/fakeGpuPattern.cpp:206: warning: conversion from ‘double’ to ‘float’ may change value [-Wfloat-conversion]
  206 |     double toa = _polyco.next_toa(metadata->gps_time, tel.to_freq(freq_id));
      |                                                       ~~~~~~~~~~~^~~~~~~~~
```

- to be continued...

Feel free to run this locally and fix more warnings in code you know.

Also see https://github.com/kotekan/kotekan/pull/843

Closes #845