### PR TITLE
Revert blaze version to v3.4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -262,7 +262,7 @@ jobs:
     - name: Clone Blaze and HighFive
       run: |
         git clone https://bitbucket.org/blaze-lib/blaze.git blaze
-        cd blaze && git pull && cd ..
+        cd blaze && git checkout v3.4 && cd ..
         git clone --single-branch --branch extensible-datasets https://github.com/jrs65/HighFive.git
         cd HighFive && git pull && cd ..
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -247,7 +247,7 @@ jobs:
 
     - name: Build h5py from source
       run: |
-        git clone https://github.com/h5py/h5py.git h5py && cd h5py && git pull
+        git clone https://github.com/h5py/h5py.git h5py && cd h5py && git checkout 2.9.0
         python3 setup.py configure --hdf5=/usr/local/opt/hdf5@1.10/
         python3 setup.py build
 

--- a/lib/utils/LinearAlgebra.hpp
+++ b/lib/utils/LinearAlgebra.hpp
@@ -43,7 +43,7 @@ template<typename MT, bool SO>
 double rms(const blaze::DenseMatrix<MT, SO>& A) {
     double t = 0.0;
 
-    auto At = *A;
+    auto At = ~A;
     auto* rd = At.data();
     size_t n = At.rows() * At.columns();
 
@@ -56,7 +56,7 @@ template<typename MT, bool TF>
 double rms(const blaze::DenseVector<MT, TF>& A) {
     double t = 0.0;
 
-    auto At = *A;
+    auto At = ~A;
     auto* rd = At.data();
     size_t n = At.size();
 

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -84,7 +84,8 @@ RUN apt-get update && \
                        liblapacke-dev=3.7.1-4ubuntu1 \
                        && \
     apt-get clean && apt-get autoclean && \
-    git clone https://bitbucket.org/blaze-lib/blaze.git blaze && cd blaze && git pull && cd ..
+    git clone https://bitbucket.org/blaze-lib/blaze.git blaze && \
+    cd blaze && git checkout v3.4 && cd ..
 
 # Install kotekan python dependencies
 RUN python3.7 -m pip install msgpack==1.0.0 \

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -64,7 +64,7 @@ ENV CXXFLAGS "-march=haswell"
 
 # Install h5py from source for bitshuffle, and clone HighFive for kotekan build
 RUN git clone https://github.com/h5py/h5py.git h5py && \
-    cd h5py && git pull && \
+    cd h5py && git checkout 2.9.0 && \
     python3.7 setup.py configure --hdf5=/usr/lib/x86_64-linux-gnu/hdf5/serial/ --hdf5-version=1.10.0 && \
     python3.7 setup.py install
 RUN git clone --single-branch --branch extensible-datasets https://github.com/jrs65/HighFive.git && \


### PR DESCRIPTION
When running on site with blaze version `v3.8-12-gf36b481f2` we discovered a regression in the performance of the eigenvalue decomposition.   This change reverts to the `v3.4` API and locks the version in the CI server. 

Also locks `h5py` to `2.9.0` since that broke while I was doing this PR. 