### PR TITLE
Switch to find_package for DPDK

### DIFF
--- a/lib/dpdk/CMakeLists.txt
+++ b/lib/dpdk/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(NUMA REQUIRED)
 add_library(kotekan_dpdk dpdkCore.cpp zeroSamples.cpp invalidateVDIFframes.cpp)
 
 # Link in DPDK
-find_package(dpdk REQUIRED)
+find_package(DPDK REQUIRED)
 message("DPDK include dir: ${DPDK_INCLUDE_DIR}")
 target_include_directories(kotekan_dpdk SYSTEM PRIVATE ${DPDK_INCLUDE_DIR})
 target_link_libraries(kotekan_dpdk PRIVATE ${DPDK_LIBRARIES} ${NUMA_LIBRARY} libexternal

--- a/lib/dpdk/CMakeLists.txt
+++ b/lib/dpdk/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(NUMA REQUIRED)
 add_library(kotekan_dpdk dpdkCore.cpp zeroSamples.cpp invalidateVDIFframes.cpp)
 
 # Link in DPDK
-find_library(dpdk REQUIRED)
+find_package(dpdk REQUIRED)
 message("DPDK include dir: ${DPDK_INCLUDE_DIR}")
 target_include_directories(kotekan_dpdk SYSTEM PRIVATE ${DPDK_INCLUDE_DIR})
 target_link_libraries(kotekan_dpdk PRIVATE ${DPDK_LIBRARIES} ${NUMA_LIBRARY} libexternal


### PR DESCRIPTION
It appears that some versions of `cmake` are particular about `library` vs `package`.   This should work in all versions.