### PR TITLE
Fix docker CI / branches

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -149,7 +149,7 @@ jobs:
             echo "##[set-output name=branch;]$(echo ${GITHUB_HEAD_REF#refs/heads/} | tr / .)";
           fi
         else
-          echo "latest";
+          echo "::set-output name=branch::latest"
         fi
       id: extract_branch
 
@@ -214,7 +214,7 @@ jobs:
             echo "##[set-output name=branch;]$(echo ${GITHUB_HEAD_REF#refs/heads/} | tr / .)";
           fi
         else
-          echo "latest";
+          echo "::set-output name=branch::latest"
         fi
       id: extract_branch
 
@@ -291,7 +291,7 @@ jobs:
             echo "##[set-output name=branch;]$(echo ${GITHUB_HEAD_REF#refs/heads/} | tr / .)";
           fi
         else
-          echo "latest";
+          echo "::set-output name=branch::latest"
         fi
       id: extract_branch
 
@@ -351,7 +351,7 @@ jobs:
             echo "##[set-output name=branch;]$(echo ${GITHUB_HEAD_REF#refs/heads/} | tr / .)";
           fi
         else
-          echo "latest";
+          echo "::set-output name=branch::latest"
         fi
       id: extract_branch
 
@@ -477,7 +477,7 @@ jobs:
             echo "##[set-output name=branch;]$(echo ${GITHUB_HEAD_REF#refs/heads/} | tr / .)";
           fi
         else
-          echo "latest";
+          echo "::set-output name=branch::latest"
         fi
       id: extract_branch
 
@@ -521,7 +521,7 @@ jobs:
             echo "##[set-output name=branch;]$(echo ${GITHUB_HEAD_REF#refs/heads/} | tr / .)";
           fi
         else
-          echo "latest";
+          echo "::set-output name=branch::latest"
         fi
       id: extract_branch
 
@@ -576,7 +576,7 @@ jobs:
             echo "##[set-output name=branch;]$(echo ${GITHUB_HEAD_REF#refs/heads/} | tr / .)";
           fi
         else
-          echo "latest";
+          echo "::set-output name=branch::latest"
         fi
       id: extract_branch
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
       shell: bash
       # Get either branch name of a push or source branch of PR, replace all '/' with '.':
       run: >
-        if [ "${GITHUB_EVENT}" = "push" ]; then
+        if [ "${GITHUB_EVENT_NAME}" = "push" ]; then
           echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/} | tr / .)";
         else
           echo "##[set-output name=branch;]$(echo ${GITHUB_HEAD_REF#refs/heads/} | tr / .)";
@@ -84,7 +84,7 @@ jobs:
       shell: bash
       # Get either branch name of a push or source branch of PR, replace all '/' with '.':
       run: >
-        if [ "${GITHUB_EVENT}" = "push" ]; then
+        if [ "${GITHUB_EVENT_NAME}" = "push" ]; then
           echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/} | tr / .)";
         else
           echo "##[set-output name=branch;]$(echo ${GITHUB_HEAD_REF#refs/heads/} | tr / .)";
@@ -143,7 +143,7 @@ jobs:
       # If Dockerfile didn't change, use 'latest'. TODO: change to 'develop'.
       run: >
         if [ -n "${{ steps.git-diff-docker.outputs.diff }}" ]; then
-          if [ "${GITHUB_EVENT}" = "push" ]; then
+          if [ "${GITHUB_EVENT_NAME}" = "push" ]; then
             echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/} | tr / .)";
           else
             echo "##[set-output name=branch;]$(echo ${GITHUB_HEAD_REF#refs/heads/} | tr / .)";
@@ -208,7 +208,7 @@ jobs:
       # If Dockerfile didn't change, use 'latest'. TODO: change to 'develop'.
       run: >
         if [ -n "${{ steps.git-diff-docker.outputs.diff }}" ]; then
-          if [ "${GITHUB_EVENT}" = "push" ]; then
+          if [ "${GITHUB_EVENT_NAME}" = "push" ]; then
             echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/} | tr / .)";
           else
             echo "##[set-output name=branch;]$(echo ${GITHUB_HEAD_REF#refs/heads/} | tr / .)";
@@ -285,7 +285,7 @@ jobs:
       # If Dockerfile didn't change, use 'latest'. TODO: change to 'develop'.
       run: >
         if [ -n "${{ steps.git-diff-docker.outputs.diff }}" ]; then
-          if [ "${GITHUB_EVENT}" = "push" ]; then
+          if [ "${GITHUB_EVENT_NAME}" = "push" ]; then
             echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/} | tr / .)";
           else
             echo "##[set-output name=branch;]$(echo ${GITHUB_HEAD_REF#refs/heads/} | tr / .)";
@@ -345,7 +345,7 @@ jobs:
       # If Dockerfile didn't change, use 'latest'. TODO: change to 'develop'.
       run: >
         if [ -n "${{ steps.git-diff-docker.outputs.diff }}" ]; then
-          if [ "${GITHUB_EVENT}" = "push" ]; then
+          if [ "${GITHUB_EVENT_NAME}" = "push" ]; then
             echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/} | tr / .)";
           else
             echo "##[set-output name=branch;]$(echo ${GITHUB_HEAD_REF#refs/heads/} | tr / .)";
@@ -471,7 +471,7 @@ jobs:
       # If Dockerfile didn't change, use 'latest'. TODO: change to 'develop'.
       run: >
         if [ -n "${{ steps.git-diff-docker.outputs.diff }}" ]; then
-          if [ "${GITHUB_EVENT}" = "push" ]; then
+          if [ "${GITHUB_EVENT_NAME}" = "push" ]; then
             echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/} | tr / .)";
           else
             echo "##[set-output name=branch;]$(echo ${GITHUB_HEAD_REF#refs/heads/} | tr / .)";
@@ -515,7 +515,7 @@ jobs:
       # If Dockerfile didn't change, use 'latest'. TODO: change to 'develop'.
       run: >
         if [ -n "${{ steps.git-diff-docker-iwyu.outputs.diff }}" ]; then
-          if [ "${GITHUB_EVENT}" = "push" ]; then
+          if [ "${GITHUB_EVENT_NAME}" = "push" ]; then
             echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/} | tr / .)";
           else
             echo "##[set-output name=branch;]$(echo ${GITHUB_HEAD_REF#refs/heads/} | tr / .)";
@@ -570,7 +570,7 @@ jobs:
       # If Dockerfile didn't change, use 'latest'. TODO: change to 'develop'.
       run: >
         if [ -n "${{ steps.git-diff-docker.outputs.diff }}" ]; then
-          if [ "${GITHUB_EVENT}" = "push" ]; then
+          if [ "${GITHUB_EVENT_NAME}" = "push" ]; then
             echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/} | tr / .)";
           else
             echo "##[set-output name=branch;]$(echo ${GITHUB_HEAD_REF#refs/heads/} | tr / .)";


### PR DESCRIPTION
- The name of the environment variable `GITHUB_EVENT` was wrong (should be `GITHUB_EVENT_NAME`), so it always tried to get the branch name in the way to do it in a PR. It then also did it that way when `GITHUB_EVENT_NAME` was `push` and we ended up with a branch name `''`. So it never pushed the docker container with the tag `develop`.
- The fallback tag name had to be set actually, not just echo'd