### PR TITLE
Correctly mask lost samples in sum_hfb kernel.

### DIFF
--- a/config/tests/chime_frb_verification.yaml
+++ b/config/tests/chime_frb_verification.yaml
@@ -16,7 +16,7 @@ log_level: info
 num_elements: 2048
 num_local_freq: 1
 num_data_sets: 1
-samples_per_data_set: 3840
+samples_per_data_set: 49152
 buffer_depth: 2
 baseband_buffer_depth: 120  # 48Gb, 15s buffer.
 vbuffer_depth: 32

--- a/lib/hsa/hsaBeamformHFBSum.cpp
+++ b/lib/hsa/hsaBeamformHFBSum.cpp
@@ -32,8 +32,9 @@ hsaBeamformHFBSum::hsaBeamformHFBSum(Config& config, const std::string& unique_n
     output_frame_len = _num_frb_total_beams * _factor_upchan * sizeof(float);
     compressed_lost_samples_frame_len =
         sizeof(uint32_t) * _samples_per_data_set / _factor_upchan / 3;
- 
-    // Make sure the no. of samples is a multiple of 4 as the kernel relies on vectors with a width of 4.
+
+    // Make sure the no. of samples is a multiple of 4 as the kernel relies on vectors with a width
+    // of 4.
     assert(_num_samples % 4 == 0);
 }
 
@@ -65,7 +66,7 @@ hsa_signal_t hsaBeamformHFBSum::execute(int gpu_frame_id, hsa_signal_t precede_s
     kernelParams params;
     params.workgroup_size_x = 64; // No. of sub-frequencies / 2
     params.workgroup_size_y = 1;
-    params.grid_size_x = 64; // No. of sub-frequencies / 2
+    params.grid_size_x = 64;   // No. of sub-frequencies / 2
     params.grid_size_y = 1024; // No. of FRB beams
     params.num_dims = 2;
 

--- a/lib/hsa/hsaBeamformHFBSum.cpp
+++ b/lib/hsa/hsaBeamformHFBSum.cpp
@@ -32,6 +32,9 @@ hsaBeamformHFBSum::hsaBeamformHFBSum(Config& config, const std::string& unique_n
     output_frame_len = _num_frb_total_beams * _factor_upchan * sizeof(float);
     compressed_lost_samples_frame_len =
         sizeof(uint32_t) * _samples_per_data_set / _factor_upchan / 3;
+ 
+    // Make sure the no. of samples is a multiple of 4 as the kernel relies on vectors with a width of 4.
+    assert(_num_samples % 4 == 0);
 }
 
 hsaBeamformHFBSum::~hsaBeamformHFBSum() {}
@@ -60,9 +63,9 @@ hsa_signal_t hsaBeamformHFBSum::execute(int gpu_frame_id, hsa_signal_t precede_s
     memcpy(kernel_args[gpu_frame_id], &args, sizeof(args));
 
     kernelParams params;
-    params.workgroup_size_x = 64;
+    params.workgroup_size_x = 64; // No. of sub-frequencies / 2
     params.workgroup_size_y = 1;
-    params.grid_size_x = 64;
+    params.grid_size_x = 64; // No. of sub-frequencies / 2
     params.grid_size_y = 1024; // No. of FRB beams
     params.num_dims = 2;
 

--- a/lib/hsa/kernels/sum_hfb.cl
+++ b/lib/hsa/kernels/sum_hfb.cl
@@ -16,27 +16,36 @@ __kernel void sum_hfb(__global float *data, __constant uint *compressed_lost_sam
 
   // Sum data across samples from global memory
   float4 freq_sum_1 = (float4)(0.f, 0.f, 0.f, 0.f), freq_sum_2 = (float4)(0.f, 0.f, 0.f, 0.f);
-  float4 data_1, data_2;
 
   for(int sample=0; sample<num_samples; sample+=4) {
 
-      if(!compressed_lost_samples_buf[sample]) {
+    float4 data_1 = (float4)(0.f, 0.f, 0.f, 0.f), data_2 = (float4)(0.f, 0.f, 0.f, 0.f);
 
-          // Load data into vectors
-          data_1.s0 = data[1024*NUM_SUB_FREQS*sample + beam*NUM_SUB_FREQS + freq];
-          data_1.s1 = data[1024*NUM_SUB_FREQS*(sample + 1) + beam*NUM_SUB_FREQS + freq];
-          data_1.s2 = data[1024*NUM_SUB_FREQS*(sample + 2) + beam*NUM_SUB_FREQS + freq];
-          data_1.s3 = data[1024*NUM_SUB_FREQS*(sample + 3) + beam*NUM_SUB_FREQS + freq];
-          
-          data_2.s0 = data[1024*NUM_SUB_FREQS*sample + beam*NUM_SUB_FREQS + freq + 1];
-          data_2.s1 = data[1024*NUM_SUB_FREQS*(sample + 1) + beam*NUM_SUB_FREQS + freq + 1];
-          data_2.s2 = data[1024*NUM_SUB_FREQS*(sample + 2) + beam*NUM_SUB_FREQS + freq + 1];
-          data_2.s3 = data[1024*NUM_SUB_FREQS*(sample + 3) + beam*NUM_SUB_FREQS + freq + 1];
- 
-          // Add vectors
-          freq_sum_1 += data_1;
-          freq_sum_2 += data_2;
-      }
+    // Load data into vectors if sample is not flagged as lost
+    if(!compressed_lost_samples_buf[sample]) {
+      data_1.s0 = data[1024*NUM_SUB_FREQS*sample + beam*NUM_SUB_FREQS + freq];
+      data_2.s0 = data[1024*NUM_SUB_FREQS*sample + beam*NUM_SUB_FREQS + freq + 1];
+    }
+    
+    if(!compressed_lost_samples_buf[sample + 1]) {
+      data_1.s1 = data[1024*NUM_SUB_FREQS*(sample + 1) + beam*NUM_SUB_FREQS + freq];
+      data_2.s1 = data[1024*NUM_SUB_FREQS*(sample + 1) + beam*NUM_SUB_FREQS + freq + 1];
+    }
+    
+    if(!compressed_lost_samples_buf[sample + 2]) {
+      data_1.s2 = data[1024*NUM_SUB_FREQS*(sample + 2) + beam*NUM_SUB_FREQS + freq];
+      data_2.s2 = data[1024*NUM_SUB_FREQS*(sample + 2) + beam*NUM_SUB_FREQS + freq + 1];
+    }
+    
+    if(!compressed_lost_samples_buf[sample + 3]) {
+      data_1.s3 = data[1024*NUM_SUB_FREQS*(sample + 3) + beam*NUM_SUB_FREQS + freq];
+      data_2.s3 = data[1024*NUM_SUB_FREQS*(sample + 3) + beam*NUM_SUB_FREQS + freq + 1];
+    }
+
+    // Add vectors
+    freq_sum_1 += data_1;
+    freq_sum_2 += data_2;
+
   }
 
   // Write sums back to global

--- a/lib/hsa/kernels/sum_hfb.cl
+++ b/lib/hsa/kernels/sum_hfb.cl
@@ -21,10 +21,10 @@ __kernel void sum_hfb(__global float *data, __constant uint *compressed_lost_sam
   for(int sample=0; sample<num_samples; sample+=4) {
 
      // Mask data from lost samples.
-     const float mask_0 = 1.f - compressed_lost_samples_buf[sample];
-     const float mask_1 = 1.f - compressed_lost_samples_buf[sample + 1];
-     const float mask_2 = 1.f - compressed_lost_samples_buf[sample + 2];
-     const float mask_3 = 1.f - compressed_lost_samples_buf[sample + 3];
+     const int mask_0 = 1 - compressed_lost_samples_buf[sample];
+     const int mask_1 = 1 - compressed_lost_samples_buf[sample + 1];
+     const int mask_2 = 1 - compressed_lost_samples_buf[sample + 2];
+     const int mask_3 = 1 - compressed_lost_samples_buf[sample + 3];
 
      // Load data into vectors
      data_1.s0 = mask_0 * data[1024*NUM_SUB_FREQS*sample + beam*NUM_SUB_FREQS + freq];


### PR DESCRIPTION
I was only checking every 4th element of `compressed_lost_samples_buf` on whether to include the sample in the sum.