### PR TITLE
Fix RFIFrameDrop dataset state registration

### DIFF
--- a/lib/stages/RfiFrameDrop.cpp
+++ b/lib/stages/RfiFrameDrop.cpp
@@ -137,7 +137,6 @@ void RfiFrameDrop::main_thread() {
 
         // Lock update mutex to not allow updates being processed during this critical section
         std::unique_lock<std::mutex> lock(update_mutex);
-        lock.lock();
 
         // Check if we need to register a new dataset
         dset_id_t dset_id_in_new = get_dataset_id(_buf_in_vis, frame_id_in_vis);


### PR DESCRIPTION
If the `enable` endpoint is called befor the `threshold`-one, an uninitialized state_ptr is accessed -> segfault.
Fix: The `enable` endpoint callback uses an empty vector if the state is not available yet.

I would have preferred to create an initial dummy dataset state in the constructor, but it would have to life in the datasetManager and get registered with comet.