### PR TITLE
Remove redundant baseband status locking

### DIFF
--- a/lib/core/basebandReadoutManager.cpp
+++ b/lib/core/basebandReadoutManager.cpp
@@ -119,15 +119,15 @@ std::vector<basebandDumpStatus> basebandReadoutManager::all() {
 std::unique_ptr<basebandDumpStatus> basebandReadoutManager::find(uint64_t event_id) {
     std::lock_guard<std::mutex> lock(requests_mtx);
     for (auto it = requests.begin(); it != requests.end(); it++) {
-        std::unique_lock<std::mutex> readout_lock(readout_mtx, std::defer_lock);
-        std::unique_lock<std::mutex> writeout_lock(writeout_mtx, std::defer_lock);
-        if (&(*it) == readout_current) {
-            readout_lock.lock();
-        }
-        if (&(*it) == writeout_current) {
-            writeout_lock.lock();
-        }
         if (it->request.event_id == event_id) {
+            std::unique_lock<std::mutex> readout_lock(readout_mtx, std::defer_lock);
+            std::unique_lock<std::mutex> writeout_lock(writeout_mtx, std::defer_lock);
+            if (&(*it) == readout_current) {
+                readout_lock.lock();
+            }
+            if (&(*it) == writeout_current) {
+                writeout_lock.lock();
+            }
             return std::make_unique<basebandDumpStatus>(*it);
         }
     }


### PR DESCRIPTION
Baseband API manager needs to acquire a lock on the request currently processed
by either the readout or the writeout thread, in order to see it in a consistent
state. For the endpoint returning only a single event's status, the manager does
not need to acquire this lock if the readout/writeout threads are not processing
this particular event.