### PR TITLE
fix(visRawReader): clear the page cache as well as the memory map

### DIFF
--- a/lib/stages/visRawReader.cpp
+++ b/lib/stages/visRawReader.cpp
@@ -378,14 +378,14 @@ void visRawReader::main_thread() {
 
         // Try and clear out the cached data from the memory map as we don't need it again
         if (madvise(mapped_file + file_ind * file_frame_size, file_frame_size, MADV_DONTNEED) == -1)
-            DEBUG("madvise failed: {:s}", strerror(errno));
+            WARN("madvise failed: {:s}", strerror(errno));
 #ifdef __linux__
         // Try and clear out the cached data from the page cache as we don't need it again
         // NOTE: unless we do this in addition to the above madvise the kernel will try and keep as
         // much of the file in the page cache as possible and it will fill all the available memory
         if (posix_fadvise(fd, file_ind * file_frame_size, file_frame_size, POSIX_FADV_DONTNEED)
             == -1)
-            DEBUG("fadvise failed: {:s}", strerror(errno));
+            WARN("fadvise failed: {:s}", strerror(errno));
 #endif
 
         // Release the frame and advance all the counters


### PR DESCRIPTION
If this is not done, the file will still remain in memory, potentially slowing down other operations
which need to acquire memory.