### PR TITLE
Fix problem with tracking beam gain updates

### DIFF
--- a/lib/stages/ReadGain.cpp
+++ b/lib/stages/ReadGain.cpp
@@ -20,6 +20,8 @@
 #include <regex>       // for match_results<>::_Base_type
 #include <stdexcept>   // for runtime_error
 #include <stdio.h>     // for fclose, fopen, fread, snprintf, FILE
+#include <stdlib.h>    // for free, malloc
+#include <string.h>    // for memcpy
 #include <sys/types.h> // for uint
 
 
@@ -250,11 +252,16 @@ void ReadGain::read_gain_tracking() {
     // Copy the current set of gains to the output buffer frame.
     memcpy(out_frame_tracking, tracking_beam_gains, gain_tracking_buf->frame_size);
 
+#ifdef DEBUGGING
+    for (int beam_id = 0; beam_id < _num_beams; ++beam_id)
+        DEBUG("Gain_tracking_buf[{:d}]: {:.2f} {:.2f} ", beam_id,
+              out_frame_tracking[beam_id * _num_elements * 2],
+              out_frame_tracking[beam_id * _num_elements * 2 + 1]);
+#endif
+
     mark_frame_full(gain_tracking_buf, unique_name.c_str(), gain_tracking_buf_id);
     DEBUG("Maked gain_tracking_buf frame {:d} full", gain_tracking_buf_id);
     INFO("Time required to load tracking beamformer gains: {:f}", current_time() - start_time);
-    DEBUG("Gain_tracking_buf: {:.2f} {:.2f} {:.2f} ", out_frame_tracking[0], out_frame_tracking[1],
-          out_frame_tracking[2]);
     gain_tracking_buf_id = (gain_tracking_buf_id + 1) % gain_tracking_buf->num_frames;
 }
 

--- a/lib/stages/ReadGain.hpp
+++ b/lib/stages/ReadGain.hpp
@@ -68,6 +68,9 @@ public:
     ReadGain(kotekan::Config& config_, const std::string& unique_name,
              kotekan::bufferContainer& buffer_container);
 
+    /// Destructor.
+    ~ReadGain();
+
     void main_thread() override;
 
     /// Endpoint for providing new directory path for FRB gain updates
@@ -121,6 +124,9 @@ private:
     uint32_t _num_elements;
     /// Number of pulsar beams, should be 10
     int16_t _num_beams;
+
+    /// Array containing all the current tracking beam gains
+    float* tracking_beam_gains;
 
     /// implements `kotekan_gains_last_update_success`
     kotekan::prometheus::MetricFamily<kotekan::prometheus::Gauge>& gains_last_update_success_metric;


### PR DESCRIPTION
Fixes a logical error introduced by #811.  Basically the code implicitly required all the beams to be updated every time, but #811 changed it so only one beam was updated and the values of the other beams were just whatever was currently in that frame.  Because of the fact there are 10 beams, the buffer depth for the gains was 5, and all gains are loaded at once on startup, this caused the issue to get mostly hidden - the system just ended up using old gains for some beams. 

The hotfix corrects this by keeping a local set of gains and copying them into each new output frame.  

Closes #935   