### PR TITLE
Create a new object to track CPU usage per stage.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,12 @@ option(WITH_TESTS "Compile testing library and boost C++ unit tests" OFF)
 option(IWYU "Enable include-what-you-use and print suggestions to stderr" OFF)
 option(CCACHE "Use ccache to speed up the build" OFF)
 option(WERROR "Warnings are errors" OFF)
+option(CPU_MONITOR "Enable CPU usage tracking for each stage" OFF)
+
+if(${CPU_MONITOR})
+    add_definitions(-DCPU_MONITOR)
+    message("Enabled CPU monitor")
+endif()
 
 if(${CCACHE})
     find_program(CCACHE_PROGRAM ccache)

--- a/kotekan/kotekan.cpp
+++ b/kotekan/kotekan.cpp
@@ -83,6 +83,7 @@ sys.stdout.write(json.dumps(config_json))
 )";
 
 kotekanMode* kotekan_mode = nullptr;
+CpuMonitor* cpu_monitor = nullptr;
 bool running = false;
 std::mutex kotekan_state_lock;
 volatile std::sig_atomic_t sig_value = 0;
@@ -251,6 +252,9 @@ void start_new_kotekan_mode(Config& config, bool dump_config) {
     kotekan_mode->initalize_stages();
     kotekan_mode->start_stages();
     running = true;
+
+    cpu_monitor = new CpuMonitor();
+    cpu_monitor.start();
 }
 
 int main(int argc, char** argv) {

--- a/kotekan/kotekan.cpp
+++ b/kotekan/kotekan.cpp
@@ -83,7 +83,6 @@ sys.stdout.write(json.dumps(config_json))
 )";
 
 kotekanMode* kotekan_mode = nullptr;
-CpuMonitor* cpu_monitor = nullptr;
 bool running = false;
 std::mutex kotekan_state_lock;
 volatile std::sig_atomic_t sig_value = 0;
@@ -252,9 +251,6 @@ void start_new_kotekan_mode(Config& config, bool dump_config) {
     kotekan_mode->initalize_stages();
     kotekan_mode->start_stages();
     running = true;
-
-    cpu_monitor = new CpuMonitor();
-    cpu_monitor->start();
 }
 
 int main(int argc, char** argv) {

--- a/kotekan/kotekan.cpp
+++ b/kotekan/kotekan.cpp
@@ -254,7 +254,7 @@ void start_new_kotekan_mode(Config& config, bool dump_config) {
     running = true;
 
     cpu_monitor = new CpuMonitor();
-    cpu_monitor.start();
+    cpu_monitor->start();
 }
 
 int main(int argc, char** argv) {

--- a/lib/core/CMakeLists.txt
+++ b/lib/core/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library(
     bufferFactory.cpp
     Config.cpp
     configUpdater.cpp
+    cpuMonitor.cpp
     errors.c
     kotekanLogging.cpp
     kotekanMode.cpp

--- a/lib/core/Stage.cpp
+++ b/lib/core/Stage.cpp
@@ -22,6 +22,8 @@
 
 namespace kotekan {
 
+extern std::map<std::string, pthread_t> thread_list;
+
 Stage::Stage(Config& config, const std::string& unique_name, bufferContainer& buffer_container_,
              std::function<void(const Stage&)> main_thread_ref) :
     stop_thread(false),
@@ -101,6 +103,9 @@ void Stage::set_cpu_affinity(const std::vector<int>& cpu_affinity_) {
 
 void Stage::start() {
     this_thread = std::thread(main_thread_fn, std::ref(*this));
+
+    // Add stage to the thread list for CPU usage tracking
+    thread_list[unique_name] = this_thread.native_handle();
 
     apply_cpu_affinity();
 }

--- a/lib/core/Stage.cpp
+++ b/lib/core/Stage.cpp
@@ -4,6 +4,7 @@
 #include "buffer.h"            // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
 #include "util.h"              // for string_tail
+#include "kotekanMode.hpp"
 
 #include "fmt.hpp" // for format
 

--- a/lib/core/Stage.hpp
+++ b/lib/core/Stage.hpp
@@ -5,13 +5,16 @@
 #include "bufferContainer.hpp" // for bufferContainer
 #include "kotekanLogging.hpp"  // for kotekanLogging
 
-#include <atomic>     // for atomic_bool
-#include <functional> // for function
-#include <mutex>      // for mutex
-#include <stdint.h>   // for uint32_t
-#include <string>     // for string
-#include <thread>     // for thread
-#include <vector>     // for vector
+#include <atomic>      // for atomic_bool
+#include <functional>  // for function
+#include <map>         // for map
+#include <mutex>       // for mutex
+#include <pthread.h>   // for pthread_t
+#include <stdint.h>    // for uint32_t
+#include <string>      // for string
+#include <sys/types.h> // for pid_t
+#include <thread>      // for thread
+#include <vector>      // for vector
 
 #ifdef MAC_OSX
 #include "osxBindCPU.hpp"
@@ -50,6 +53,23 @@ public:
      * @return "dot" style graph description for this stage.
      */
     virtual std::string dot_string(const std::string& prefix) const;
+
+    /**
+     * @brief Add newly created stage tid to thread_list for cpu usage tracking.
+     */
+    void register_tid(pthread_t ptr);
+
+    /**
+     * @brief Remove the current stage tid from thread_list.
+     */
+    void unregister_tid();
+
+    /**
+     * @brief Get the list of all registered tid.
+     *
+     * @return the copy of the thread list.
+     */
+    static std::map<std::string, pid_t> get_thread_list();
 
 protected:
     std::atomic_bool stop_thread;
@@ -98,6 +118,9 @@ private:
     /// The number of seconds to wait for a kotekan stage thread to be
     /// joined after the exit signal has been given before exiting ungracefully.
     uint32_t join_timeout;
+
+    // List of all stage tid used for CPU usage tracking
+    static std::map<std::string, pid_t> thread_list;
 };
 
 } // namespace kotekan

--- a/lib/core/cpuMonitor.cpp
+++ b/lib/core/cpuMonitor.cpp
@@ -1,0 +1,114 @@
+#include "cpuMonitor.hpp"
+
+#include "Stage.hpp" // for Stage
+
+#include "json.hpp" // for basic_json<>::object_t, json, basic_json<>::value_type
+
+#include <chrono>      // for operator""ms, chrono_literals
+#include <functional>  // for _Bind_helper<>::type, _Placeholder, bind, _1, placeholders
+#include <math.h>      // for floor
+#include <pthread.h>   // for pthread_detach
+#include <stdio.h>     // for fclose, fopen, fscanf, snprintf, FILE
+#include <sys/types.h> // for pid_t
+#include <utility>     // for pair
+
+using namespace std::chrono_literals;
+using namespace std::placeholders;
+
+namespace kotekan {
+
+CpuMonitor::CpuMonitor() {
+    // Register CPU usage callback
+    restServer::instance().register_get_callback(
+        "/cpu_ult", std::bind(&CpuMonitor::cpu_ult_call_back, this, _1));
+}
+
+CpuMonitor::~CpuMonitor() {
+    restServer::instance().remove_get_callback("/cpu_ult");
+    ult_list.clear();
+}
+
+void CpuMonitor::start() {
+    this_thread = std::thread(&CpuMonitor::track_cpu, this);
+    pthread_detach(this_thread.native_handle());
+}
+
+void CpuMonitor::stop() {
+    stop_thread = true;
+}
+
+void CpuMonitor::track_cpu() {
+    while (!stop_thread) {
+        uint32_t cpu_times[10];
+        uint32_t cpu_time = 0;
+
+        // Read CPU stats from /proc/stat first line
+        std::string stat;
+        FILE* cpu_fp = fopen("/proc/stat", "r");
+        int ret = fscanf(cpu_fp, "%*s %u %u %u %u %u %u %u %u %u %u", &cpu_times[0], &cpu_times[1],
+                         &cpu_times[2], &cpu_times[3], &cpu_times[4], &cpu_times[5], &cpu_times[6],
+                         &cpu_times[7], &cpu_times[8], &cpu_times[9]);
+        fclose(cpu_fp);
+
+        // Compute total cpu time
+        if (ret == 10) {
+            for (int i = 0; i < 10; i++) {
+                cpu_time += cpu_times[i];
+            }
+        }
+
+        // Read each thread stats based on tid
+        std::map<std::string, pid_t> thread_list = Stage::get_thread_list();
+        for (auto element : thread_list) {
+            char fname[40];
+            snprintf(fname, sizeof(fname), "/proc/self/task/%d/stat", element.second);
+            FILE* thread_fp = fopen(fname, "r");
+
+            if (thread_fp) {
+                // Get the 14th (utime) and the 15th (stime) stats
+                uint32_t utime = 0, stime = 0;
+                ret = fscanf(thread_fp, "%*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %u %u",
+                             &utime, &stime);
+
+                auto itr = ult_list.find(element.first);
+                if (itr != ult_list.end() && ret == 2) {
+                    // Compute usr and sys CPU usage
+                    itr->second.utime_usage.add_sample(100 * (utime - itr->second.prev_utime)
+                                                       / (cpu_time - prev_cpu_time));
+                    itr->second.stime_usage.add_sample(100 * (stime - itr->second.prev_stime)
+                                                       / (cpu_time - prev_cpu_time));
+                    // Update thread usr and sys time
+                    itr->second.prev_utime = utime;
+                    itr->second.prev_stime = stime;
+                } else {
+                    // Add new thead to ult_list
+                    ult_list[element.first].prev_utime = utime;
+                    ult_list[element.first].prev_stime = stime;
+                }
+            }
+            fclose(thread_fp);
+        }
+        // Update cpu time
+        prev_cpu_time = cpu_time;
+
+        // Wait for next check
+        std::this_thread::sleep_for(1000ms);
+    }
+}
+
+void CpuMonitor::cpu_ult_call_back(connectionInstance& conn) {
+    nlohmann::json cpu_ult_json = {};
+
+    for (auto& element : ult_list) {
+        nlohmann::json thread_cpu_ult = {};
+        // Limit outputs to two digits
+        thread_cpu_ult["usr_cpu_ult"] = floor(element.second.utime_usage.get_avg() * 100) / 100;
+        thread_cpu_ult["sys_cpu_ult"] = floor(element.second.stime_usage.get_avg() * 100) / 100;
+
+        cpu_ult_json[element.first] = thread_cpu_ult;
+    }
+
+    conn.send_json_reply(cpu_ult_json);
+}
+
+} // namespace kotekan

--- a/lib/core/cpuMonitor.hpp
+++ b/lib/core/cpuMonitor.hpp
@@ -1,0 +1,62 @@
+#ifndef CPU_MONITOR_HPP
+#define CPU_MONITOR_HPP
+
+#include "restServer.hpp" // for connectionInstance
+#include "visUtil.hpp"    // for StatTracker
+
+#include <cstdint> // for uint32_t
+#include <map>     // for map
+#include <string>  // for string
+#include <thread>  // for thread
+
+namespace kotekan {
+
+// Store thread CPU stats
+struct CpuStat {
+    // StatTracker object is used to get average usage.
+    StatTracker utime_usage = StatTracker(120);
+    StatTracker stime_usage = StatTracker(120);
+
+    uint32_t prev_utime = 0;
+    uint32_t prev_stime = 0;
+};
+
+/**
+ * @class CpuMonitor
+ *
+ * @brief Create a new thread to keep tracking all stage cpu usage.
+ * This implementation is only applicable on Linux.
+ **/
+class CpuMonitor {
+public:
+    CpuMonitor();
+    ~CpuMonitor();
+
+    /**
+     * @brief Create a new thread and start tracking.
+     **/
+    void start();
+    void stop();
+
+    /**
+     * @brief Give stage CPU usage in json format.
+     **/
+    void cpu_ult_call_back(connectionInstance& conn);
+
+    /**
+     * @brief Compute stage CPU usage periodically (thread entry function).
+     * Get CPU stat from /proc/stat and stage stat from /proc/self/tid/stat.
+     * Thread list maintained and passed by Stage class.
+     **/
+    void track_cpu();
+
+private:
+    std::thread this_thread;
+    bool stop_thread;
+    std::map<std::string, CpuStat> ult_list;
+    uint32_t prev_cpu_time;
+};
+
+} // namespace kotekan
+
+#endif /* CHIME_HPP */

--- a/lib/core/kotekanMode.cpp
+++ b/lib/core/kotekanMode.cpp
@@ -20,11 +20,8 @@
 #include <functional> // for _Bind_helper<>::type, _Placeholder, bind, _1, placeholders
 #include <stdlib.h>   // for free
 #include <utility>    // for pair
-#include <pthread.h>
-#include <fstream>
 
 using namespace std::placeholders;
-using namespace std::chrono_literals;
 
 namespace kotekan {
 
@@ -123,9 +120,15 @@ void kotekanMode::start_stages() {
         INFO_NON_OO("Starting kotekan_stage: {:s}...", stage.first);
         stage.second->start();
     }
+#if defined(CPU_MONITOR) && !defined(MAC_OSX)
+    cpu_monitor->start();
+#endif
 }
 
 void kotekanMode::stop_stages() {
+#if defined(CPU_MONITOR) && !defined(MAC_OSX)
+    cpu_monitor->stop();
+#endif
     // First set the shutdown variable on all stages
     for (auto const& stage : stages)
         stage.second->stop();
@@ -228,84 +231,5 @@ void kotekanMode::pipeline_dot_graph_callback(connectionInstance& conn) {
     dot += "}\n";
     conn.send_text_reply(dot);
 }
-
-CpuMonitor::CpuMonitor() {};
-
-void CpuMonitor::start() {
-    pthread_t pid;
-    pthread_create(&pid, NULL, CpuMonitor::track_cpu, NULL);
-    pthread_detach(pid);
-
-    ERROR_NON_OO("After pthread_creat");
-
-    // Register CPU usage callback
-    restServer::instance().register_get_callback(
-        "/cpu_ult", std::bind(&CpuMonitor::cpu_ult_call_back, this, _1));
-}
-
-void* CpuMonitor::track_cpu(void *) {
-    ERROR_NON_OO("entered track_cpu");
-
-    // Read total CPU stat from /proc/stat first line
-    std::string stat;
-    std::ifstream cpu_stat("./proc/stat", std::ifstream::in);
-    getline(cpu_stat, stat);
-    std::istringstream iss(stat);
-
-    // Parse and get total cpu time
-    char prefix[10];
-    iss >> prefix;
-    uint32_t num = 0;
-    uint32_t cpu_time = 0;
-    for (int i = 0; i < 10; i++) {
-        iss >> num;
-        cpu_time += num;
-    }
-
-    // Read CPU stat for each thread
-    for(auto element : thread_list) {
-        char fname[100];
-        snprintf(fname, sizeof(fname), "/proc/self/task/%d/stat", element.second);
-        FILE *fp = fopen(fname, "r");
-
-        if (fp) {
-            // Get the 14th (utime) and the 15th (stime) numbers
-            uint32_t utime = 0, stime = 0;
-            fscanf(fp, "%*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %d %d", &utime, &stime);
-
-            auto itr = ult_list.find(element.first);
-            if (itr != ult_list.end()) {
-                // Compute usr and sys CPU usage
-                itr->second.utime_usage =
-                    100 * (utime - itr->second.prev_utime) / (cpu_time - prev_cpu_time);
-                itr->second.stime_usage =
-                    100 * (stime - itr->second.prev_stime) / (cpu_time - prev_cpu_time);
-            }
-
-            // Update thread usr and sys time
-            itr->second.prev_utime = utime;
-            itr->second.prev_stime = stime;
-        }
-    }
-    prev_cpu_time = cpu_time;
-
-    // Check each stage periodically
-    std::this_thread::sleep_for(2000ms);
-}
-
-void CpuMonitor::cpu_ult_call_back(connectionInstance& conn) {
-    nlohmann::json cpu_ult_json = {};
-
-    for (auto element : ult_list) {
-        nlohmann::json thread_cpu_ult = {};
-        thread_cpu_ult["usr_cpu_ult"] = element.second.utime_usage;
-        thread_cpu_ult["sys_cpu_ult"] = element.second.stime_usage;
-
-        cpu_ult_json[element.first] = thread_cpu_ult;
-    }
-
-    conn.send_json_reply(cpu_ult_json);
-}
-
 
 } // namespace kotekan

--- a/lib/core/kotekanMode.cpp
+++ b/lib/core/kotekanMode.cpp
@@ -20,8 +20,11 @@
 #include <functional> // for _Bind_helper<>::type, _Placeholder, bind, _1, placeholders
 #include <stdlib.h>   // for free
 #include <utility>    // for pair
+#include <pthread.h>
+#include <fstream>
 
 using namespace std::placeholders;
+using namespace std::chrono_literals;
 
 namespace kotekan {
 
@@ -225,5 +228,84 @@ void kotekanMode::pipeline_dot_graph_callback(connectionInstance& conn) {
     dot += "}\n";
     conn.send_text_reply(dot);
 }
+
+CpuMonitor::CpuMonitor() {};
+
+void CpuMonitor::start() {
+    pthread_t pid;
+    pthread_create(&pid, NULL, CpuMonitor::track_cpu, NULL);
+    pthread_detach(pid);
+
+    ERROR_NON_OO("After pthread_creat");
+
+    // Register CPU usage callback
+    restServer::instance().register_get_callback(
+        "/cpu_ult", std::bind(&CpuMonitor::cpu_ult_call_back, this, _1));
+}
+
+void* CpuMonitor::track_cpu(void *) {
+    ERROR_NON_OO("entered track_cpu");
+
+    // Read total CPU stat from /proc/stat first line
+    std::string stat;
+    std::ifstream cpu_stat("./proc/stat", std::ifstream::in);
+    getline(cpu_stat, stat);
+    std::istringstream iss(stat);
+
+    // Parse and get total cpu time
+    char prefix[10];
+    iss >> prefix;
+    uint32_t num = 0;
+    uint32_t cpu_time = 0;
+    for (int i = 0; i < 10; i++) {
+        iss >> num;
+        cpu_time += num;
+    }
+
+    // Read CPU stat for each thread
+    for(auto element : thread_list) {
+        char fname[100];
+        snprintf(fname, sizeof(fname), "/proc/self/task/%d/stat", element.second);
+        FILE *fp = fopen(fname, "r");
+
+        if (fp) {
+            // Get the 14th (utime) and the 15th (stime) numbers
+            uint32_t utime = 0, stime = 0;
+            fscanf(fp, "%*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %d %d", &utime, &stime);
+
+            auto itr = ult_list.find(element.first);
+            if (itr != ult_list.end()) {
+                // Compute usr and sys CPU usage
+                itr->second.utime_usage =
+                    100 * (utime - itr->second.prev_utime) / (cpu_time - prev_cpu_time);
+                itr->second.stime_usage =
+                    100 * (stime - itr->second.prev_stime) / (cpu_time - prev_cpu_time);
+            }
+
+            // Update thread usr and sys time
+            itr->second.prev_utime = utime;
+            itr->second.prev_stime = stime;
+        }
+    }
+    prev_cpu_time = cpu_time;
+
+    // Check each stage periodically
+    std::this_thread::sleep_for(2000ms);
+}
+
+void CpuMonitor::cpu_ult_call_back(connectionInstance& conn) {
+    nlohmann::json cpu_ult_json = {};
+
+    for (auto element : ult_list) {
+        nlohmann::json thread_cpu_ult = {};
+        thread_cpu_ult["usr_cpu_ult"] = element.second.utime_usage;
+        thread_cpu_ult["sys_cpu_ult"] = element.second.stime_usage;
+
+        cpu_ult_json[element.first] = thread_cpu_ult;
+    }
+
+    conn.send_json_reply(cpu_ult_json);
+}
+
 
 } // namespace kotekan

--- a/lib/core/kotekanMode.hpp
+++ b/lib/core/kotekanMode.hpp
@@ -51,6 +51,34 @@ private:
     std::map<std::string, struct Buffer*> buffers;
 };
 
+// List of thread ids <stage_name, thread_id>
+std::map<std::string, pthread_t> thread_list;
+
+struct CpuStat {
+    double utime_usage = 0;
+    double stime_usage = 0;
+    uint32_t prev_utime = 0;
+    uint32_t prev_stime = 0;
+};
+
+class CpuMonitor {
+public:
+    CpuMonitor();
+
+    void start();
+
+    void cpu_ult_call_back(connectionInstance& conn);
+
+private:
+    static void* track_cpu(void *);
+
+    // List of CPU usage data <stage_name, CPU_stat>
+    static std::map<std::string, CpuStat> ult_list;
+
+    static uint32_t prev_cpu_time;
+};
+
+
 } // namespace kotekan
 
 /*! @} End of Doxygen Groups*/

--- a/lib/core/kotekanMode.hpp
+++ b/lib/core/kotekanMode.hpp
@@ -51,15 +51,20 @@ private:
     std::map<std::string, struct Buffer*> buffers;
 };
 
-// List of thread ids <stage_name, thread_id>
-std::map<std::string, pthread_t> thread_list;
-
 struct CpuStat {
     double utime_usage = 0;
     double stime_usage = 0;
     uint32_t prev_utime = 0;
     uint32_t prev_stime = 0;
 };
+
+// List of thread ids <stage_name, thread_id>
+std::map<std::string, pthread_t> thread_list;
+
+// List of CPU usage data <stage_name, CPU_stat>
+std::map<std::string, CpuStat> ult_list;
+
+uint32_t prev_cpu_time;
 
 class CpuMonitor {
 public:
@@ -71,11 +76,6 @@ public:
 
 private:
     static void* track_cpu(void *);
-
-    // List of CPU usage data <stage_name, CPU_stat>
-    static std::map<std::string, CpuStat> ult_list;
-
-    static uint32_t prev_cpu_time;
 };
 
 

--- a/lib/core/kotekanMode.hpp
+++ b/lib/core/kotekanMode.hpp
@@ -5,7 +5,7 @@
 #include "Stage.hpp"           // for Stage
 #include "bufferContainer.hpp" // for bufferContainer
 #include "metadata.h"          // for metadataPool  // IWYU pragma: keep
-#include "restServer.hpp"
+#include "restServer.hpp"      // for connectionInstance
 
 #include <map>    // for map
 #include <string> // for string
@@ -45,39 +45,14 @@ public:
 private:
     Config& config;
     bufferContainer buffer_container;
+#if defined(CPU_MONITOR) && !defined(MAC_OSX)
+    CpuMonitor cpu_monitor;
+#endif
 
     std::map<std::string, Stage*> stages;
     std::map<std::string, struct metadataPool*> metadata_pools;
     std::map<std::string, struct Buffer*> buffers;
 };
-
-struct CpuStat {
-    double utime_usage = 0;
-    double stime_usage = 0;
-    uint32_t prev_utime = 0;
-    uint32_t prev_stime = 0;
-};
-
-// List of thread ids <stage_name, thread_id>
-std::map<std::string, pthread_t> thread_list;
-
-// List of CPU usage data <stage_name, CPU_stat>
-std::map<std::string, CpuStat> ult_list;
-
-uint32_t prev_cpu_time;
-
-class CpuMonitor {
-public:
-    CpuMonitor();
-
-    void start();
-
-    void cpu_ult_call_back(connectionInstance& conn);
-
-private:
-    static void* track_cpu(void *);
-};
-
 
 } // namespace kotekan
 


### PR DESCRIPTION
New object: CpuMonitor
- Run in a new thread to keep tracking stage CPU usage periodically
- Add a new endpoint /cpu_ult to get the CPU usage message
- Add flags CPU_MONITOR and MAC_OSX to enable CPU tracking
- Start CPU monitor from kotekanMode
- Read thread list from class Stage