### PR TITLE
Create a new object to track CPU usage per stage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,12 @@ option(WITH_TESTS "Compile testing library and boost C++ unit tests" OFF)
 option(IWYU "Enable include-what-you-use and print suggestions to stderr" OFF)
 option(CCACHE "Use ccache to speed up the build" OFF)
 option(WERROR "Warnings are errors" OFF)
+option(CPU_MONITOR "Enable CPU usage tracking for each stage" OFF)
+
+if(${CPU_MONITOR})
+    add_definitions(-DCPU_MONITOR)
+    message("Enabled CPU monitor")
+endif()
 
 if(${CCACHE})
     find_program(CCACHE_PROGRAM ccache)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,12 +48,6 @@ option(WITH_TESTS "Compile testing library and boost C++ unit tests" OFF)
 option(IWYU "Enable include-what-you-use and print suggestions to stderr" OFF)
 option(CCACHE "Use ccache to speed up the build" OFF)
 option(WERROR "Warnings are errors" OFF)
-option(CPU_MONITOR "Enable CPU usage tracking for each stage" OFF)
-
-if(${CPU_MONITOR})
-    add_definitions(-DCPU_MONITOR)
-    message("Enabled CPU monitor")
-endif()
 
 if(${CCACHE})
     find_program(CCACHE_PROGRAM ccache)

--- a/lib/core/CMakeLists.txt
+++ b/lib/core/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library(
     bufferFactory.cpp
     Config.cpp
     configUpdater.cpp
+    cpuMonitor.cpp
     errors.c
     kotekanLogging.cpp
     kotekanMode.cpp

--- a/lib/core/Stage.cpp
+++ b/lib/core/Stage.cpp
@@ -17,7 +17,7 @@
 #include <regex>         // for match_results<>::_Base_type
 #include <sched.h>       // for cpu_set_t, CPU_SET, CPU_ZERO
 #include <stdexcept>     // for runtime_error
-#include <sys/syscall.h> // for SYS_gettid
+#include <sys/syscall.h> // for SYS_gettid // IWYU pragma: keep
 // IWYU pragma: no_include <syscall.h>
 #include <system_error> // for system_error
 #include <thread>       // for thread

--- a/lib/core/Stage.cpp
+++ b/lib/core/Stage.cpp
@@ -7,20 +7,20 @@
 
 #include "fmt.hpp" // for format
 
-#include <algorithm>    // for copy, max, find
-#include <chrono>       // for seconds
-#include <cstdlib>      // for abort
-#include <cxxabi.h>     // for __forced_unwind
-#include <exception>    // for exception
-#include <future>       // for async, future, future_status, future_status::timeout, launch
-#include <pthread.h>    // for pthread_setaffinity_np, pthread_setname_np
-#include <regex>        // for match_results<>::_Base_type
-#include <sched.h>      // for cpu_set_t, CPU_SET, CPU_ZERO
-#include <stdexcept>    // for runtime_error
-#include <syscall.h>    // for SYS_gettid
-#include <system_error> // for system_error
-#include <thread>       // for thread
-#include <unistd.h>     // for syscall
+#include <algorithm>     // for copy, max, find
+#include <chrono>        // for seconds
+#include <cstdlib>       // for abort
+#include <cxxabi.h>      // for __forced_unwind
+#include <exception>     // for exception
+#include <future>        // for async, future, future_status, future_status::timeout, launch
+#include <pthread.h>     // for pthread_setaffinity_np, pthread_setname_np
+#include <regex>         // for match_results<>::_Base_type
+#include <sched.h>       // for cpu_set_t, CPU_SET, CPU_ZERO
+#include <stdexcept>     // for runtime_error
+#include <sys/syscall.h> // for SYS_gettid
+#include <system_error>  // for system_error
+#include <thread>        // for thread
+#include <unistd.h>      // for syscall
 
 namespace kotekan {
 

--- a/lib/core/Stage.cpp
+++ b/lib/core/Stage.cpp
@@ -17,7 +17,7 @@
 #include <regex>         // for match_results<>::_Base_type
 #include <sched.h>       // for cpu_set_t, CPU_SET, CPU_ZERO
 #include <stdexcept>     // for runtime_error
-#include <sys/syscall.h> // for SYS_gettid
+#include <sys/syscall.h> // for SYS_gettid // IWYU pragma: keep
 #include <system_error>  // for system_error
 #include <thread>        // for thread
 #include <unistd.h>      // for syscall
@@ -163,7 +163,7 @@ void Stage::unregister_tid(pid_t tid) {
     }
 }
 
-std::vector<pid_t> Stage::get_tids() {
+const std::vector<pid_t>& Stage::get_tids() {
     return thread_list;
 }
 

--- a/lib/core/Stage.cpp
+++ b/lib/core/Stage.cpp
@@ -17,7 +17,8 @@
 #include <regex>         // for match_results<>::_Base_type
 #include <sched.h>       // for cpu_set_t, CPU_SET, CPU_ZERO
 #include <stdexcept>     // for runtime_error
-#include <sys/syscall.h> // for SYS_gettid // IWYU pragma: no_include
+#include <sys/syscall.h> // for SYS_gettid 
+// IWYU pragma: no_include <syscall.h>
 #include <system_error>  // for system_error
 #include <thread>        // for thread
 #include <unistd.h>      // for syscall

--- a/lib/core/Stage.cpp
+++ b/lib/core/Stage.cpp
@@ -7,7 +7,7 @@
 
 #include "fmt.hpp" // for format
 
-#include <algorithm>    // for copy, max
+#include <algorithm>    // for copy, max, find
 #include <chrono>       // for seconds
 #include <cstdlib>      // for abort
 #include <cxxabi.h>     // for __forced_unwind
@@ -17,10 +17,10 @@
 #include <regex>        // for match_results<>::_Base_type
 #include <sched.h>      // for cpu_set_t, CPU_SET, CPU_ZERO
 #include <stdexcept>    // for runtime_error
+#include <syscall.h>    // for SYS_gettid
 #include <system_error> // for system_error
 #include <thread>       // for thread
-#include <unistd.h>
-#include <sys/syscall.h>
+#include <unistd.h>     // for syscall
 
 namespace kotekan {
 
@@ -102,7 +102,7 @@ void Stage::set_cpu_affinity(const std::vector<int>& cpu_affinity_) {
 }
 
 void Stage::start() {
-    this_thread = std::thread([&](){
+    this_thread = std::thread([&]() {
 #if !defined(MAC_OSX)
         pid_t tid = syscall(SYS_gettid);
         register_tid(tid);

--- a/lib/core/Stage.cpp
+++ b/lib/core/Stage.cpp
@@ -17,11 +17,11 @@
 #include <regex>         // for match_results<>::_Base_type
 #include <sched.h>       // for cpu_set_t, CPU_SET, CPU_ZERO
 #include <stdexcept>     // for runtime_error
-#include <sys/syscall.h> // for SYS_gettid 
+#include <sys/syscall.h> // for SYS_gettid
 // IWYU pragma: no_include <syscall.h>
-#include <system_error>  // for system_error
-#include <thread>        // for thread
-#include <unistd.h>      // for syscall
+#include <system_error> // for system_error
+#include <thread>       // for thread
+#include <unistd.h>     // for syscall
 
 namespace kotekan {
 

--- a/lib/core/Stage.cpp
+++ b/lib/core/Stage.cpp
@@ -128,6 +128,7 @@ void Stage::join() {
 
 void Stage::stop() {
     stop_thread = true;
+    unregister_tid(this_thread.native_handle());
 }
 
 void Stage::main_thread() {}
@@ -136,7 +137,6 @@ Stage::~Stage() {
     stop_thread = true;
     if (this_thread.joinable())
         this_thread.join();
-    unregister_tid(this_thread.native_handle());
 }
 
 std::string Stage::dot_string(const std::string& prefix) const {

--- a/lib/core/Stage.cpp
+++ b/lib/core/Stage.cpp
@@ -22,8 +22,6 @@
 
 namespace kotekan {
 
-std::map<std::string, pid_t> Stage::thread_list;
-
 Stage::Stage(Config& config, const std::string& unique_name, bufferContainer& buffer_container_,
              std::function<void(const Stage&)> main_thread_ref) :
     stop_thread(false),
@@ -138,7 +136,7 @@ Stage::~Stage() {
     stop_thread = true;
     if (this_thread.joinable())
         this_thread.join();
-    unregister_tid();
+    unregister_tid(this_thread.native_handle());
 }
 
 std::string Stage::dot_string(const std::string& prefix) const {
@@ -154,17 +152,18 @@ struct pthread_fake {
 
 void Stage::register_tid(pthread_t ptr) {
     pid_t tid = ((pthread_fake*)ptr)->tid;
-    thread_list[unique_name] = tid;
+    thread_list.push_back(tid);
 }
 
-void Stage::unregister_tid() {
-    auto itr = thread_list.find(unique_name);
+void Stage::unregister_tid(pthread_t ptr) {
+    pid_t tid = ((pthread_fake*)ptr)->tid;
+    auto itr = std::find(thread_list.begin(), thread_list.end(), tid);
     if (itr != thread_list.end()) {
         thread_list.erase(itr);
     }
 }
 
-std::map<std::string, pid_t> Stage::get_thread_list() {
+std::vector<pid_t> Stage::get_tids() {
     return thread_list;
 }
 

--- a/lib/core/Stage.cpp
+++ b/lib/core/Stage.cpp
@@ -17,7 +17,7 @@
 #include <regex>         // for match_results<>::_Base_type
 #include <sched.h>       // for cpu_set_t, CPU_SET, CPU_ZERO
 #include <stdexcept>     // for runtime_error
-#include <sys/syscall.h> // for SYS_gettid // IWYU pragma: keep
+#include <sys/syscall.h> // for SYS_gettid // IWYU pragma: no_include
 #include <system_error>  // for system_error
 #include <thread>        // for thread
 #include <unistd.h>      // for syscall

--- a/lib/core/Stage.cpp
+++ b/lib/core/Stage.cpp
@@ -22,6 +22,8 @@
 
 namespace kotekan {
 
+std::map<std::string, pid_t> Stage::thread_list;
+
 Stage::Stage(Config& config, const std::string& unique_name, bufferContainer& buffer_container_,
              std::function<void(const Stage&)> main_thread_ref) :
     stop_thread(false),
@@ -101,6 +103,7 @@ void Stage::set_cpu_affinity(const std::vector<int>& cpu_affinity_) {
 
 void Stage::start() {
     this_thread = std::thread(main_thread_fn, std::ref(*this));
+    register_tid(this_thread.native_handle());
 
     apply_cpu_affinity();
 }
@@ -135,10 +138,34 @@ Stage::~Stage() {
     stop_thread = true;
     if (this_thread.joinable())
         this_thread.join();
+    unregister_tid();
 }
 
 std::string Stage::dot_string(const std::string& prefix) const {
     return fmt::format("{:s}\"{:s}\" [shape=box, color=darkgreen];\n", prefix, get_unique_name());
+}
+
+// Used to get tid from pthread_t
+struct pthread_fake {
+    char offset[720];
+    pid_t tid;
+    void* others;
+};
+
+void Stage::register_tid(pthread_t ptr) {
+    pid_t tid = ((pthread_fake*)ptr)->tid;
+    thread_list[unique_name] = tid;
+}
+
+void Stage::unregister_tid() {
+    auto itr = thread_list.find(unique_name);
+    if (itr != thread_list.end()) {
+        thread_list.erase(itr);
+    }
+}
+
+std::map<std::string, pid_t> Stage::get_thread_list() {
+    return thread_list;
 }
 
 } // namespace kotekan

--- a/lib/core/Stage.hpp
+++ b/lib/core/Stage.hpp
@@ -8,7 +8,6 @@
 #include <atomic>      // for atomic_bool
 #include <functional>  // for function
 #include <mutex>       // for mutex
-#include <pthread.h>   // for pthread_t
 #include <stdint.h>    // for uint32_t
 #include <string>      // for string
 #include <sys/types.h> // for pid_t

--- a/lib/core/Stage.hpp
+++ b/lib/core/Stage.hpp
@@ -56,12 +56,12 @@ public:
     /**
      * @brief Add newly created stage tid to thread_list for cpu usage tracking.
      */
-    void register_tid(pthread_t ptr);
+    void register_tid(pid_t ptr);
 
     /**
      * @brief Remove a tid from thread_list.
      */
-    void unregister_tid(pthread_t ptr);
+    void unregister_tid(pid_t ptr);
 
     /**
      * @brief Get tids from the current stage.

--- a/lib/core/Stage.hpp
+++ b/lib/core/Stage.hpp
@@ -7,7 +7,6 @@
 
 #include <atomic>      // for atomic_bool
 #include <functional>  // for function
-#include <map>         // for map
 #include <mutex>       // for mutex
 #include <pthread.h>   // for pthread_t
 #include <stdint.h>    // for uint32_t

--- a/lib/core/Stage.hpp
+++ b/lib/core/Stage.hpp
@@ -65,7 +65,7 @@ public:
     /**
      * @brief Get tids from the current stage.
      */
-    std::vector<pid_t> get_tids();
+    const std::vector<pid_t>& get_tids();
 
 protected:
     std::atomic_bool stop_thread;

--- a/lib/core/Stage.hpp
+++ b/lib/core/Stage.hpp
@@ -60,16 +60,14 @@ public:
     void register_tid(pthread_t ptr);
 
     /**
-     * @brief Remove the current stage tid from thread_list.
+     * @brief Remove a tid from thread_list.
      */
-    void unregister_tid();
+    void unregister_tid(pthread_t ptr);
 
     /**
-     * @brief Get the list of all registered tid.
-     *
-     * @return the copy of the thread list.
+     * @brief Get tids from the current stage.
      */
-    static std::map<std::string, pid_t> get_thread_list();
+    std::vector<pid_t> get_tids();
 
 protected:
     std::atomic_bool stop_thread;
@@ -119,8 +117,8 @@ private:
     /// joined after the exit signal has been given before exiting ungracefully.
     uint32_t join_timeout;
 
-    // List of all stage tid used for CPU usage tracking
-    static std::map<std::string, pid_t> thread_list;
+    // List of stage tids used for CPU usage tracking
+    std::vector<pid_t> thread_list;
 };
 
 } // namespace kotekan

--- a/lib/core/Stage.hpp
+++ b/lib/core/Stage.hpp
@@ -5,13 +5,16 @@
 #include "bufferContainer.hpp" // for bufferContainer
 #include "kotekanLogging.hpp"  // for kotekanLogging
 
-#include <atomic>     // for atomic_bool
-#include <functional> // for function
-#include <mutex>      // for mutex
-#include <stdint.h>   // for uint32_t
-#include <string>     // for string
-#include <thread>     // for thread
-#include <vector>     // for vector
+#include <atomic>      // for atomic_bool
+#include <functional>  // for function
+#include <map>         // for map
+#include <mutex>       // for mutex
+#include <pthread.h>   // for pthread_t
+#include <stdint.h>    // for uint32_t
+#include <string>      // for string
+#include <sys/types.h> // for pid_t
+#include <thread>      // for thread
+#include <vector>      // for vector
 
 #ifdef MAC_OSX
 #include "osxBindCPU.hpp"
@@ -50,6 +53,23 @@ public:
      * @return "dot" style graph description for this stage.
      */
     virtual std::string dot_string(const std::string& prefix) const;
+
+    /**
+     * @brief Add newly created stage tid to thread_list for cpu usage tracking.
+     */
+    void register_tid(pthread_t ptr);
+
+    /**
+     * @brief Remove the current stage tid from thread_list.
+     */
+    void unregister_tid();
+
+    /**
+     * @brief Get the list of all registered tid.
+     *
+     * @return the copy of the thread list.
+     */
+    static std::map<std::string, pid_t> get_thread_list();
 
 protected:
     std::atomic_bool stop_thread;
@@ -98,6 +118,9 @@ private:
     /// The number of seconds to wait for a kotekan stage thread to be
     /// joined after the exit signal has been given before exiting ungracefully.
     uint32_t join_timeout;
+
+    // List of all stage tid used for CPU usage tracking
+    static std::map<std::string, pid_t> thread_list;
 };
 
 } // namespace kotekan

--- a/lib/core/cpuMonitor.cpp
+++ b/lib/core/cpuMonitor.cpp
@@ -1,0 +1,114 @@
+#include "cpuMonitor.hpp"
+
+#include "Stage.hpp" // for Stage
+
+#include "json.hpp" // for basic_json<>::object_t, json, basic_json<>::value_type
+
+#include <chrono>      // for operator""ms, chrono_literals
+#include <functional>  // for _Bind_helper<>::type, _Placeholder, bind, _1, placeholders
+#include <math.h>      // for floor
+#include <pthread.h>   // for pthread_detach
+#include <stdio.h>     // for fclose, fopen, fscanf, snprintf, FILE
+#include <sys/types.h> // for pid_t
+#include <utility>     // for pair
+
+using namespace std::chrono_literals;
+using namespace std::placeholders;
+
+namespace kotekan {
+
+CpuMonitor::CpuMonitor() {
+    // Register CPU usage callback
+    restServer::instance().register_get_callback(
+        "/cpu_ult", std::bind(&CpuMonitor::cpu_ult_call_back, this, _1));
+}
+
+CpuMonitor::~CpuMonitor() {
+    restServer::instance().remove_get_callback("/cpu_ult");
+    ult_list.clear();
+}
+
+void CpuMonitor::start() {
+    this_thread = std::thread(&CpuMonitor::track_cpu, this);
+    pthread_detach(this_thread.native_handle());
+}
+
+void CpuMonitor::stop() {
+    stop_thread = true;
+}
+
+void CpuMonitor::track_cpu() {
+    while (!stop_thread) {
+        uint32_t cpu_times[10];
+        uint32_t cpu_time = 0;
+
+        // Read CPU stats from /proc/stat first line
+        std::string stat;
+        FILE* cpu_fp = fopen("/proc/stat", "r");
+        int ret = fscanf(cpu_fp, "%*s %u %u %u %u %u %u %u %u %u %u", &cpu_times[0], &cpu_times[1],
+                         &cpu_times[2], &cpu_times[3], &cpu_times[4], &cpu_times[5], &cpu_times[6],
+                         &cpu_times[7], &cpu_times[8], &cpu_times[9]);
+        fclose(cpu_fp);
+
+        // Compute total cpu time
+        if (ret == 10) {
+            for (int i = 0; i < 10; i++) {
+                cpu_time += cpu_times[i];
+            }
+        }
+
+        // Read each thread stats based on tid
+        std::map<std::string, pid_t> thread_list = Stage::get_thread_list();
+        for (auto element : thread_list) {
+            char fname[40];
+            snprintf(fname, sizeof(fname), "/proc/self/task/%d/stat", element.second);
+            FILE* thread_fp = fopen(fname, "r");
+
+            if (thread_fp) {
+                // Get the 14th (utime) and the 15th (stime) stats
+                uint32_t utime = 0, stime = 0;
+                ret = fscanf(thread_fp, "%*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %u %u",
+                             &utime, &stime);
+
+                auto itr = ult_list.find(element.first);
+                if (itr != ult_list.end() && ret == 2) {
+                    // Compute usr and sys CPU usage
+                    itr->second.utime_usage.add_sample(100 * (utime - itr->second.prev_utime)
+                                                       / (cpu_time - prev_cpu_time));
+                    itr->second.stime_usage.add_sample(100 * (stime - itr->second.prev_stime)
+                                                       / (cpu_time - prev_cpu_time));
+                    // Update thread usr and sys time
+                    itr->second.prev_utime = utime;
+                    itr->second.prev_stime = stime;
+                } else {
+                    // Add new thead to ult_list
+                    ult_list[element.first].prev_utime = utime;
+                    ult_list[element.first].prev_stime = stime;
+                }
+            }
+            fclose(thread_fp);
+        }
+        // Update cpu time
+        prev_cpu_time = cpu_time;
+
+        // Wait for next check
+        std::this_thread::sleep_for(1000ms);
+    }
+}
+
+void CpuMonitor::cpu_ult_call_back(connectionInstance& conn) {
+    nlohmann::json cpu_ult_json = {};
+
+    for (auto& element : ult_list) {
+        nlohmann::json thread_cpu_ult = {};
+        // Limit outputs to two digits
+        thread_cpu_ult["usr_cpu_ult"] = floor(element.second.utime_usage.get_avg() * 100) / 100;
+        thread_cpu_ult["sys_cpu_ult"] = floor(element.second.stime_usage.get_avg() * 100) / 100;
+
+        cpu_ult_json[element.first] = thread_cpu_ult;
+    }
+
+    conn.send_json_reply(cpu_ult_json);
+}
+
+} // namespace kotekan

--- a/lib/core/cpuMonitor.cpp
+++ b/lib/core/cpuMonitor.cpp
@@ -1,15 +1,19 @@
 #include "cpuMonitor.hpp"
 
-#include "json.hpp" // for basic_json<>::object_t, json, basic_json<>::value_type
+#include "kotekanLogging.hpp" // for WARN_NON_OO
 
-#include <chrono>      // for operator""ms, chrono_literals
-#include <functional>  // for _Bind_helper<>::type, _Placeholder, bind, _1, placeholders
-#include <math.h>      // for floor
-#include <pthread.h>   // for pthread_detach
-#include <stdio.h>     // for fclose, fopen, fscanf, snprintf, FILE
-#include <sys/types.h> // for pid_t
-#include <unistd.h>
-#include <utility> // for pair
+#include "json.hpp" // for json, basic_json<>::object_t, basic_json<>::value_type
+
+#include <chrono>     // for operator""ms, chrono_literals
+#include <exception>  // for exception
+#include <functional> // for _Bind_helper<>::type, _Placeholder, bind, _1, placeholders
+#include <math.h>     // for floor
+#include <pthread.h>  // for pthread_detach, pthread_setaffinity_np
+#include <sched.h>    // for cpu_set_t, CPU_SET, CPU_ZERO
+#include <stdio.h>    // for fclose, fopen, fscanf, snprintf, FILE
+#include <unistd.h>   // for pid_t, sysconf, _SC_NPROCESSORS_ONLN
+#include <utility>    // for pair
+#include <vector>     // for vector
 
 using namespace std::chrono_literals;
 using namespace std::placeholders;

--- a/lib/core/cpuMonitor.cpp
+++ b/lib/core/cpuMonitor.cpp
@@ -32,7 +32,6 @@ CpuMonitor::~CpuMonitor() {
 
 void CpuMonitor::start() {
     this_thread = std::thread(&CpuMonitor::track_cpu, this);
-    pthread_detach(this_thread.native_handle());
 }
 
 void CpuMonitor::stop() {
@@ -162,6 +161,8 @@ void CpuMonitor::set_affinity(Config& config) {
     for (auto core_id : cpu_affinity)
         CPU_SET(core_id, &cpuset);
     pthread_setaffinity_np(this_thread.native_handle(), sizeof(cpu_set_t), &cpuset);
+
+    this_thread.detach();
 }
 
 } // namespace kotekan

--- a/lib/core/cpuMonitor.cpp
+++ b/lib/core/cpuMonitor.cpp
@@ -1,7 +1,5 @@
 #include "cpuMonitor.hpp"
 
-#include "Stage.hpp" // for Stage
-
 #include "json.hpp" // for basic_json<>::object_t, json, basic_json<>::value_type
 
 #include <chrono>      // for operator""ms, chrono_literals
@@ -10,7 +8,8 @@
 #include <pthread.h>   // for pthread_detach
 #include <stdio.h>     // for fclose, fopen, fscanf, snprintf, FILE
 #include <sys/types.h> // for pid_t
-#include <utility>     // for pair
+#include <unistd.h>
+#include <utility> // for pair
 
 using namespace std::chrono_literals;
 using namespace std::placeholders;
@@ -25,7 +24,6 @@ CpuMonitor::CpuMonitor() {
 
 CpuMonitor::~CpuMonitor() {
     restServer::instance().remove_get_callback("/cpu_ult");
-    ult_list.clear();
 }
 
 void CpuMonitor::start() {
@@ -38,9 +36,16 @@ void CpuMonitor::stop() {
 }
 
 void CpuMonitor::track_cpu() {
+    int core_num = sysconf(_SC_NPROCESSORS_ONLN);
     while (!stop_thread) {
         uint32_t cpu_times[10];
         uint32_t cpu_time = 0;
+
+        // Get tids from all stages
+        std::map<std::string, std::vector<pid_t>> tid_list;
+        for (auto stage : stages) {
+            tid_list[stage.first] = (stage.second)->get_tids();
+        }
 
         // Read CPU stats from /proc/stat first line
         std::string stat;
@@ -55,38 +60,62 @@ void CpuMonitor::track_cpu() {
             for (int i = 0; i < 10; i++) {
                 cpu_time += cpu_times[i];
             }
+        } else {
+            WARN_NON_OO("CPU monitor read insufficient stats from /proc/stat");
         }
 
         // Read each thread stats based on tid
-        std::map<std::string, pid_t> thread_list = Stage::get_thread_list();
-        for (auto element : thread_list) {
-            char fname[40];
-            snprintf(fname, sizeof(fname), "/proc/self/task/%d/stat", element.second);
-            FILE* thread_fp = fopen(fname, "r");
+        for (auto stage : tid_list) {
+            for (auto tid : stage.second) {
+                char fname[40];
+                snprintf(fname, sizeof(fname), "/proc/self/task/%d/stat", tid);
+                FILE* thread_fp = fopen(fname, "r");
 
-            if (thread_fp) {
-                // Get the 14th (utime) and the 15th (stime) stats
-                uint32_t utime = 0, stime = 0;
-                ret = fscanf(thread_fp, "%*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %u %u",
-                             &utime, &stime);
+                if (thread_fp) {
+                    // Get the 14th (utime) and the 15th (stime) stats
+                    uint32_t utime = 0, stime = 0;
+                    ret = fscanf(thread_fp,
+                                 "%*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %u %u",
+                                 &utime, &stime);
 
-                auto itr = ult_list.find(element.first);
-                if (itr != ult_list.end() && ret == 2) {
-                    // Compute usr and sys CPU usage
-                    itr->second.utime_usage.add_sample(100 * (utime - itr->second.prev_utime)
-                                                       / (cpu_time - prev_cpu_time));
-                    itr->second.stime_usage.add_sample(100 * (stime - itr->second.prev_stime)
-                                                       / (cpu_time - prev_cpu_time));
-                    // Update thread usr and sys time
-                    itr->second.prev_utime = utime;
-                    itr->second.prev_stime = stime;
+                    auto stage_itr = ult_list.find(stage.first);
+                    if (stage_itr != ult_list.end()) {
+                        auto thread_itr = (stage_itr->second).find(tid);
+                        if (thread_itr != (stage_itr->second).end()) {
+                            if (ret == 2) {
+                                // Compute usr and sys CPU usage
+                                (thread_itr->second)
+                                    .utime_usage.add_sample(
+                                        core_num * 100 * (utime - (thread_itr->second).prev_utime)
+                                        / (cpu_time - prev_cpu_time));
+                                (thread_itr->second)
+                                    .stime_usage.add_sample(
+                                        core_num * 100 * (stime - (thread_itr->second).prev_stime)
+                                        / (cpu_time - prev_cpu_time));
+                                // Update thread usr and sys time
+                                (thread_itr->second).prev_utime = utime;
+                                (thread_itr->second).prev_stime = stime;
+                            } else {
+                                WARN_NON_OO("CPU monitor read insufficient stats from {:s}", fname);
+                            }
+                        } else {
+                            // Create new thread record
+                            (stage_itr->second)[tid].prev_utime = utime;
+                            (stage_itr->second)[tid].prev_stime = stime;
+                        }
+                    } else {
+                        // Create new stage and thread record
+                        (ult_list[stage.first])[tid].prev_utime = utime;
+                        (ult_list[stage.first])[tid].prev_stime = stime;
+                    }
                 } else {
-                    // Add new thead to ult_list
-                    ult_list[element.first].prev_utime = utime;
-                    ult_list[element.first].prev_stime = stime;
+                    // The thread has been terminated early, add 0 to stats
+                    (ult_list[stage.first])[tid].utime_usage.add_sample(0);
+                    (ult_list[stage.first])[tid].stime_usage.add_sample(0);
+                    WARN_NON_OO("CPU monitor cannot read from {:s}", fname);
                 }
+                fclose(thread_fp);
             }
-            fclose(thread_fp);
         }
         // Update cpu time
         prev_cpu_time = cpu_time;
@@ -99,16 +128,36 @@ void CpuMonitor::track_cpu() {
 void CpuMonitor::cpu_ult_call_back(connectionInstance& conn) {
     nlohmann::json cpu_ult_json = {};
 
-    for (auto& element : ult_list) {
-        nlohmann::json thread_cpu_ult = {};
-        // Limit outputs to two digits
-        thread_cpu_ult["usr_cpu_ult"] = floor(element.second.utime_usage.get_avg() * 100) / 100;
-        thread_cpu_ult["sys_cpu_ult"] = floor(element.second.stime_usage.get_avg() * 100) / 100;
-
-        cpu_ult_json[element.first] = thread_cpu_ult;
+    for (auto& stage : ult_list) {
+        nlohmann::json stage_cpu_ult = {};
+        for (auto& thread : stage.second) {
+            nlohmann::json thread_cpu_ult = {};
+            // Limit outputs to two digits
+            thread_cpu_ult["usr_cpu_ult"] =
+                floor((thread.second).utime_usage.get_avg() * 100) / 100;
+            thread_cpu_ult["sys_cpu_ult"] =
+                floor((thread.second).stime_usage.get_avg() * 100) / 100;
+            stage_cpu_ult[std::to_string(thread.first)] = thread_cpu_ult;
+        }
+        cpu_ult_json[stage.first] = stage_cpu_ult;
     }
 
     conn.send_json_reply(cpu_ult_json);
+}
+
+void CpuMonitor::save_stages(std::map<std::string, Stage*> input_stages) {
+    stages = input_stages;
+}
+
+void CpuMonitor::set_affinity(Config& config) {
+    std::vector<int32_t> cpu_affinity =
+        config.get<std::vector<int32_t>>("/cpu_monitor", "cpu_affinity");
+
+    cpu_set_t cpuset;
+    CPU_ZERO(&cpuset);
+    for (auto core_id : cpu_affinity)
+        CPU_SET(core_id, &cpuset);
+    pthread_setaffinity_np(this_thread.native_handle(), sizeof(cpu_set_t), &cpuset);
 }
 
 } // namespace kotekan

--- a/lib/core/cpuMonitor.cpp
+++ b/lib/core/cpuMonitor.cpp
@@ -62,18 +62,23 @@ void CpuMonitor::track_cpu() {
         // Read CPU stats from /proc/stat first line
         std::string stat;
         FILE* cpu_fp = fopen("/proc/stat", "r");
-        int ret = fscanf(cpu_fp, "%*s %u %u %u %u %u %u %u %u %u %u", &cpu_times[0], &cpu_times[1],
-                         &cpu_times[2], &cpu_times[3], &cpu_times[4], &cpu_times[5], &cpu_times[6],
-                         &cpu_times[7], &cpu_times[8], &cpu_times[9]);
-        fclose(cpu_fp);
+        if (cpu_fp) {
+            int ret =
+                fscanf(cpu_fp, "%*s %u %u %u %u %u %u %u %u %u %u", &cpu_times[0], &cpu_times[1],
+                       &cpu_times[2], &cpu_times[3], &cpu_times[4], &cpu_times[5], &cpu_times[6],
+                       &cpu_times[7], &cpu_times[8], &cpu_times[9]);
+            fclose(cpu_fp);
 
-        // Compute total cpu time
-        if (ret == 10) {
-            for (int i = 0; i < 10; i++) {
-                cpu_time += cpu_times[i];
+            // Compute total cpu time
+            if (ret == 10) {
+                for (int i = 0; i < 10; i++) {
+                    cpu_time += cpu_times[i];
+                }
+            } else {
+                WARN_NON_OO("CPU monitor read insufficient stats from /proc/stat");
             }
         } else {
-            WARN_NON_OO("CPU monitor read insufficient stats from /proc/stat");
+            WARN_NON_OO("CPU monitor cannot read from /proc/stat");
         }
 
         // Read each thread stats based on tid
@@ -86,9 +91,9 @@ void CpuMonitor::track_cpu() {
                 if (thread_fp) {
                     // Get the 14th (utime) and the 15th (stime) stats
                     uint32_t utime = 0, stime = 0;
-                    ret = fscanf(thread_fp,
-                                 "%*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %u %u",
-                                 &utime, &stime);
+                    int ret = fscanf(thread_fp,
+                                     "%*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %u %u",
+                                     &utime, &stime);
 
                     auto stage_itr = ult_list.find(stage.first);
                     if (stage_itr != ult_list.end()) {

--- a/lib/core/cpuMonitor.cpp
+++ b/lib/core/cpuMonitor.cpp
@@ -29,10 +29,13 @@ CpuMonitor::CpuMonitor() {
 CpuMonitor::~CpuMonitor() {
     restServer::instance().remove_get_callback("/cpu_ult");
 
-    try {
-        this_thread.join();
-    } catch (std::exception& e) {
-        WARN_NON_OO("cpuMonitor: Failure when joining thread: {:s}", e.what());
+    if (this_thread.joinable()) {
+        stop();
+        try {
+            this_thread.join();
+        } catch (std::exception& e) {
+            WARN_NON_OO("cpuMonitor: Failure when joining thread: {:s}", e.what());
+        }
     }
 }
 

--- a/lib/core/cpuMonitor.hpp
+++ b/lib/core/cpuMonitor.hpp
@@ -1,14 +1,16 @@
 #ifndef CPU_MONITOR_HPP
 #define CPU_MONITOR_HPP
 
+#include "Config.hpp"     // for Config
 #include "Stage.hpp"      // for Stage
 #include "restServer.hpp" // for connectionInstance
 #include "visUtil.hpp"    // for StatTracker
 
-#include <cstdint> // for uint32_t
-#include <map>     // for map
-#include <string>  // for string
-#include <thread>  // for thread
+#include <cstdint>     // for uint32_t
+#include <map>         // for map
+#include <string>      // for string
+#include <sys/types.h> // for pid_t
+#include <thread>      // for thread
 
 namespace kotekan {
 

--- a/lib/core/cpuMonitor.hpp
+++ b/lib/core/cpuMonitor.hpp
@@ -17,8 +17,8 @@ namespace kotekan {
 // Store thread CPU stats
 struct CpuStat {
     // StatTracker object is used to get average usage.
-    StatTracker utime_usage = StatTracker(120);
-    StatTracker stime_usage = StatTracker(120);
+    StatTracker utime_usage = StatTracker("utime_usage", "percent", 120, true);
+    StatTracker stime_usage = StatTracker("stime_usage", "percent", 120, true);
 
     uint32_t prev_utime = 0;
     uint32_t prev_stime = 0;

--- a/lib/core/cpuMonitor.hpp
+++ b/lib/core/cpuMonitor.hpp
@@ -1,0 +1,62 @@
+#ifndef CPU_MONITOR_HPP
+#define CPU_MONITOR_HPP
+
+#include "restServer.hpp" // for connectionInstance
+#include "visUtil.hpp"    // for StatTracker
+
+#include <cstdint> // for uint32_t
+#include <map>     // for map
+#include <string>  // for string
+#include <thread>  // for thread
+
+namespace kotekan {
+
+// Store thread CPU stats
+struct CpuStat {
+    // StatTracker object is used to get average usage.
+    StatTracker utime_usage = StatTracker(120);
+    StatTracker stime_usage = StatTracker(120);
+
+    uint32_t prev_utime = 0;
+    uint32_t prev_stime = 0;
+};
+
+/**
+ * @class CpuMonitor
+ *
+ * @brief Create a new thread to keep tracking all stage cpu usage.
+ * This implementation is only applicable on Linux.
+ **/
+class CpuMonitor {
+public:
+    CpuMonitor();
+    ~CpuMonitor();
+
+    /**
+     * @brief Create a new thread and start tracking.
+     **/
+    void start();
+    void stop();
+
+    /**
+     * @brief Give stage CPU usage in json format.
+     **/
+    void cpu_ult_call_back(connectionInstance& conn);
+
+    /**
+     * @brief Compute stage CPU usage periodically (thread entry function).
+     * Get CPU stat from /proc/stat and stage stat from /proc/self/tid/stat.
+     * Thread list maintained and passed by Stage class.
+     **/
+    void track_cpu();
+
+private:
+    std::thread this_thread;
+    bool stop_thread;
+    std::map<std::string, CpuStat> ult_list;
+    uint32_t prev_cpu_time;
+};
+
+} // namespace kotekan
+
+#endif /* CHIME_HPP */

--- a/lib/core/cpuMonitor.hpp
+++ b/lib/core/cpuMonitor.hpp
@@ -1,6 +1,7 @@
 #ifndef CPU_MONITOR_HPP
 #define CPU_MONITOR_HPP
 
+#include "Stage.hpp"      // for Stage
 #include "restServer.hpp" // for connectionInstance
 #include "visUtil.hpp"    // for StatTracker
 
@@ -46,14 +47,24 @@ public:
     /**
      * @brief Compute stage CPU usage periodically (thread entry function).
      * Get CPU stat from /proc/stat and stage stat from /proc/self/tid/stat.
-     * Thread list maintained and passed by Stage class.
      **/
     void track_cpu();
+
+    /**
+     * @brief Save all stages. Threads are detched from each stage periodically.
+     **/
+    void save_stages(std::map<std::string, Stage*> input_stages);
+
+    /**
+     * @brief Set cpu affinity based on config file.
+     **/
+    void set_affinity(Config& config);
 
 private:
     std::thread this_thread;
     bool stop_thread;
-    std::map<std::string, CpuStat> ult_list;
+    std::map<std::string, std::map<pid_t, CpuStat>> ult_list; // <stage_name <tid, cpu_stats>>
+    std::map<std::string, Stage*> stages;
     uint32_t prev_cpu_time;
 };
 

--- a/lib/core/kotekanMode.cpp
+++ b/lib/core/kotekanMode.cpp
@@ -120,13 +120,18 @@ void kotekanMode::start_stages() {
         INFO_NON_OO("Starting kotekan_stage: {:s}...", stage.first);
         stage.second->start();
     }
-#if defined(CPU_MONITOR) && !defined(MAC_OSX)
-    cpu_monitor.start();
+
+#if !defined(MAC_OSX)
+    if (config.get_default<bool>("/cpu_monitor", "enabled", false)) {
+        cpu_monitor.save_stages(stages);
+        cpu_monitor.start();
+        cpu_monitor.set_affinity(config);
+    }
 #endif
 }
 
 void kotekanMode::stop_stages() {
-#if defined(CPU_MONITOR) && !defined(MAC_OSX)
+#if !defined(MAC_OSX)
     cpu_monitor.stop();
 #endif
     // First set the shutdown variable on all stages

--- a/lib/core/kotekanMode.cpp
+++ b/lib/core/kotekanMode.cpp
@@ -121,13 +121,13 @@ void kotekanMode::start_stages() {
         stage.second->start();
     }
 #if defined(CPU_MONITOR) && !defined(MAC_OSX)
-    cpu_monitor->start();
+    cpu_monitor.start();
 #endif
 }
 
 void kotekanMode::stop_stages() {
 #if defined(CPU_MONITOR) && !defined(MAC_OSX)
-    cpu_monitor->stop();
+    cpu_monitor.stop();
 #endif
     // First set the shutdown variable on all stages
     for (auto const& stage : stages)

--- a/lib/core/kotekanMode.cpp
+++ b/lib/core/kotekanMode.cpp
@@ -120,9 +120,15 @@ void kotekanMode::start_stages() {
         INFO_NON_OO("Starting kotekan_stage: {:s}...", stage.first);
         stage.second->start();
     }
+#if defined(CPU_MONITOR) && !defined(MAC_OSX)
+    cpu_monitor->start();
+#endif
 }
 
 void kotekanMode::stop_stages() {
+#if defined(CPU_MONITOR) && !defined(MAC_OSX)
+    cpu_monitor->stop();
+#endif
     // First set the shutdown variable on all stages
     for (auto const& stage : stages)
         stage.second->stop();

--- a/lib/core/kotekanMode.cpp
+++ b/lib/core/kotekanMode.cpp
@@ -17,9 +17,13 @@
 #include "fmt.hpp"  // for format
 #include "json.hpp" // for basic_json<>::object_t, basic_json<>::value_type, json
 
+#include <exception>  // for exception
 #include <functional> // for _Bind_helper<>::type, _Placeholder, bind, _1, placeholders
+#include <regex>      // for match_results<>::_Base_type
+#include <stdexcept>  // for runtime_error
 #include <stdlib.h>   // for free
 #include <utility>    // for pair
+#include <vector>     // for vector
 
 using namespace std::placeholders;
 

--- a/lib/core/kotekanMode.hpp
+++ b/lib/core/kotekanMode.hpp
@@ -6,7 +6,7 @@
 #include "bufferContainer.hpp" // for bufferContainer
 #include "metadata.h"          // for metadataPool  // IWYU pragma: keep
 #include "restServer.hpp"      // for connectionInstance
-#if defined(CPU_MONITOR) && !defined(MAC_OSX)
+#if !defined(MAC_OSX)
 #include "cpuMonitor.hpp"
 #endif
 
@@ -48,7 +48,7 @@ public:
 private:
     Config& config;
     bufferContainer buffer_container;
-#if defined(CPU_MONITOR) && !defined(MAC_OSX)
+#if !defined(MAC_OSX)
     CpuMonitor cpu_monitor;
 #endif
 

--- a/lib/core/kotekanMode.hpp
+++ b/lib/core/kotekanMode.hpp
@@ -6,6 +6,9 @@
 #include "bufferContainer.hpp" // for bufferContainer
 #include "metadata.h"          // for metadataPool  // IWYU pragma: keep
 #include "restServer.hpp"      // for connectionInstance
+#if defined(CPU_MONITOR) && !defined(MAC_OSX)
+#include "cpuMonitor.hpp"
+#endif
 
 #include <map>    // for map
 #include <string> // for string

--- a/lib/core/kotekanMode.hpp
+++ b/lib/core/kotekanMode.hpp
@@ -5,7 +5,7 @@
 #include "Stage.hpp"           // for Stage
 #include "bufferContainer.hpp" // for bufferContainer
 #include "metadata.h"          // for metadataPool  // IWYU pragma: keep
-#include "restServer.hpp"
+#include "restServer.hpp"      // for connectionInstance
 
 #include <map>    // for map
 #include <string> // for string
@@ -45,6 +45,9 @@ public:
 private:
     Config& config;
     bufferContainer buffer_container;
+#if defined(CPU_MONITOR) && !defined(MAC_OSX)
+    CpuMonitor cpu_monitor;
+#endif
 
     std::map<std::string, Stage*> stages;
     std::map<std::string, struct metadataPool*> metadata_pools;


### PR DESCRIPTION
New object: CpuMonitor
- Run in a new thread to keep tracking stage CPU usage periodically
- Add a new endpoint /cpu_ult to get the CPU usage message
- Enable CPU monitor by config file
- Only support Linux
- Start CPU monitor from kotekanMode
- Read thread lists from Stages passed by kotekanMode