### PR TITLE
Create endpoint timer metrics

### DIFF
--- a/lib/core/prometheusMetrics.cpp
+++ b/lib/core/prometheusMetrics.cpp
@@ -103,10 +103,10 @@ std::ostringstream& EndpointTimer::to_string(std::ostringstream& out) {
     double max = stat_tracker.get_max();
     double avg = stat_tracker.get_avg();
 
-    if (std::isnan(max)) {
-        fmt::print(out, fmt("{:f} NaN"), avg);
+    if (std::isnan(avg)) {
+        fmt::print(out, fmt("NaN NaN"));
     } else {
-        fmt::print(out, fmt("{:f} {:f}"), avg, max);
+        fmt::print(out, fmt("{:f}ms {:f}ms"), avg, max);
     }
 
     return out;

--- a/lib/core/prometheusMetrics.cpp
+++ b/lib/core/prometheusMetrics.cpp
@@ -239,16 +239,17 @@ MetricFamily<Gauge>& Metrics::add_gauge(const std::string& name, const std::stri
 
 EndpointTimer& Metrics::add_endpoint(const std::string& name, const std::string& stage_name) {
     const std::vector<string> empty_labels;
-    auto f = std::make_shared<MetricFamily<EndpointTimer>>(name, stage_name, empty_labels,
-                                                   MetricFamily<EndpointTimer>::MetricType::EndpointTimer);
+    auto f = std::make_shared<MetricFamily<EndpointTimer>>(
+        name, stage_name, empty_labels, MetricFamily<EndpointTimer>::MetricType::EndpointTimer);
     add(name, stage_name, f);
     return f->labels({});
 }
 
-MetricFamily<EndpointTimer>& Metrics::add_endpoint(const std::string& name, const std::string& stage_name,
-                                        const std::vector<std::string>& label_names) {
-    auto f = std::make_shared<MetricFamily<EndpointTimer>>(name, stage_name, label_names,
-                                                   MetricFamily<EndpointTimer>::MetricType::EndpointTimer);
+MetricFamily<EndpointTimer>& Metrics::add_endpoint(const std::string& name,
+                                                   const std::string& stage_name,
+                                                   const std::vector<std::string>& label_names) {
+    auto f = std::make_shared<MetricFamily<EndpointTimer>>(
+        name, stage_name, label_names, MetricFamily<EndpointTimer>::MetricType::EndpointTimer);
     add(name, stage_name, f);
     return *f;
 }

--- a/lib/core/prometheusMetrics.hpp
+++ b/lib/core/prometheusMetrics.hpp
@@ -1,7 +1,7 @@
 #ifndef PROMETHEUS_METRICS_HPP
 #define PROMETHEUS_METRICS_HPP
 
-#include "visUtil.hpp"
+#include "visUtil.hpp" // for StatTracker
 
 #include <deque>     // for deque
 #include <iosfwd>    // for ostringstream

--- a/lib/core/prometheusMetrics.hpp
+++ b/lib/core/prometheusMetrics.hpp
@@ -1,7 +1,7 @@
 #ifndef PROMETHEUS_METRICS_HPP
 #define PROMETHEUS_METRICS_HPP
 
-// #include "restServer.hpp"
+#include "visUtil.hpp"
 
 #include <deque>     // for deque
 #include <iosfwd>    // for ostringstream
@@ -13,8 +13,6 @@
 #include <string>    // for string
 #include <tuple>     // for tuple
 #include <vector>    // for vector
-
-#include "visUtil.hpp"
 
 namespace kotekan {
 
@@ -92,7 +90,7 @@ private:
 
 /**
  * @class EndpointTimer
- * @brief Represents a metric that can store timer stats and output avg and max
+ * @brief Represents a metric that can store timer stats and output avg and max reply time
  */
 class EndpointTimer : public Metric {
 public:
@@ -297,8 +295,9 @@ public:
      * @return a reference to the newly created @c MetricFamily<EndpointTimer> instance
      * @throw std::runtime_error if the metric with that name is already registered.
      */
-    MetricFamily<EndpointTimer>& add_endpoint(const std::string& name, const std::string& stage_name,
-                                   const std::vector<std::string>& label_names);
+    MetricFamily<EndpointTimer>& add_endpoint(const std::string& name,
+                                              const std::string& stage_name,
+                                              const std::vector<std::string>& label_names);
 
     /**
      * @brief Adds a new metric of type counter and no labels

--- a/lib/core/prometheusMetrics.hpp
+++ b/lib/core/prometheusMetrics.hpp
@@ -90,6 +90,10 @@ private:
     uint64_t last_update_time_stamp;
 };
 
+/**
+ * @class EndpointTimer
+ * @brief Represents a metric that can store timer stats and output avg and max
+ */
 class EndpointTimer : public Metric {
 public:
     EndpointTimer(const std::vector<std::string>&);
@@ -272,8 +276,25 @@ public:
     MetricFamily<Gauge>& add_gauge(const std::string& name, const std::string& stage_name,
                                    const std::vector<std::string>& label_names);
 
+    /**
+     * @brief Adds a new metric of type endpoint_timer and no labels
+     *
+     * @param name The name of the metric.
+     * @param stage_name The unique stage name, normally @c unique_name.
+     * @return a reference to the newly created @c EndpointTimer instance
+     * @throw std::runtime_error if the metric with that name is already registered.
+     */
     EndpointTimer& add_endpoint(const std::string& name, const std::string& stage_name);
 
+    /**
+     * @brief Adds a new metric family of type endpoint_timer
+     *
+     * @param name The name of the metric.
+     * @param stage_name The unique stage name, normally @c unique_name.
+     * @param label_names The names of the labels used
+     * @return a reference to the newly created @c MetricFamily<EndpointTimer> instance
+     * @throw std::runtime_error if the metric with that name is already registered.
+     */
     MetricFamily<EndpointTimer>& add_endpoint(const std::string& name, const std::string& stage_name,
                                    const std::vector<std::string>& label_names);
 

--- a/lib/core/prometheusMetrics.hpp
+++ b/lib/core/prometheusMetrics.hpp
@@ -100,8 +100,10 @@ public:
     void update(const double);
     std::string to_string() override;
     std::ostringstream& to_string(std::ostringstream& out) override;
+    bool is_slow();
 
 private:
+    /// Structure to store values and compute max and avg.
     StatTracker stat_tracker;
 };
 

--- a/lib/core/prometheusMetrics.hpp
+++ b/lib/core/prometheusMetrics.hpp
@@ -1,7 +1,7 @@
 #ifndef PROMETHEUS_METRICS_HPP
 #define PROMETHEUS_METRICS_HPP
 
-#include "restServer.hpp"
+// #include "restServer.hpp"
 
 #include <deque>     // for deque
 #include <iosfwd>    // for ostringstream
@@ -14,8 +14,13 @@
 #include <tuple>     // for tuple
 #include <vector>    // for vector
 
+#include "visUtil.hpp"
 
 namespace kotekan {
+
+class restServer;
+class connectionInstance;
+
 namespace prometheus {
 
 /**
@@ -85,6 +90,17 @@ private:
     uint64_t last_update_time_stamp;
 };
 
+class EndpointTimer : public Metric {
+public:
+    EndpointTimer(const std::vector<std::string>&);
+    void update(const double);
+    std::string to_string() override;
+    std::ostringstream& to_string(std::ostringstream& out) override;
+
+private:
+    StatTracker stat_tracker;
+};
+
 /**
  * @class Serializable
  * @brief Interface for types that can be represented in Prometheus text format.
@@ -113,6 +129,7 @@ public:
     enum class MetricType {
         Counter,
         Gauge,
+        EndpointTimer,
         Untyped,
     };
 
@@ -253,6 +270,11 @@ public:
      * @throw std::runtime_error if the metric with that name is already registered.
      */
     MetricFamily<Gauge>& add_gauge(const std::string& name, const std::string& stage_name,
+                                   const std::vector<std::string>& label_names);
+
+    EndpointTimer& add_endpoint(const std::string& name, const std::string& stage_name);
+
+    MetricFamily<EndpointTimer>& add_endpoint(const std::string& name, const std::string& stage_name,
                                    const std::vector<std::string>& label_names);
 
     /**

--- a/lib/core/restServer.cpp
+++ b/lib/core/restServer.cpp
@@ -5,9 +5,11 @@
 
 #include "fmt.hpp" // for format, fmt
 
-#include <algorithm>               // for max
-#include <assert.h>                // for assert
-#include <cstdint>                 // for int32_t
+#include <algorithm> // for max
+#include <assert.h>  // for assert
+#include <chrono>
+#include <cstdint> // for int32_t
+#include <ctime>
 #include <event2/buffer.h>         // for evbuffer_add, evbuffer_peek, iovec, evbuffer_free
 #include <event2/event.h>          // for event_add, event_base_dispatch, event_base_free, even...
 #include <event2/http.h>           // for evhttp_send_reply, evhttp_add_header, evhttp_request_...
@@ -26,8 +28,6 @@
 #include <sys/time.h>              // for timeval
 #include <utility>                 // for pair
 #include <vector>                  // for vector
-#include <chrono>
-#include <ctime>
 #ifdef MAC_OSX
 #include "osxBindCPU.hpp"
 #endif
@@ -48,7 +48,8 @@ restServer::restServer() : port(_port), main_thread() {
     stop_thread = false;
 
     // Create a new prometheus metric group for callback timing
-    this->timer_metrics = &(prometheus::Metrics::instance().add_endpoint("endpoint_timers", "/rest_server", {"endpoint"}));
+    this->timer_metrics = &(prometheus::Metrics::instance().add_endpoint(
+        "endpoint_timers", "/rest_server", {"endpoint"}));
 }
 
 restServer::~restServer() {
@@ -109,7 +110,7 @@ void restServer::handle_request(struct evhttp_request* request, void* cb_data) {
 
             // Compute callback reply time and update prometheus metric
             auto t_end = std::chrono::high_resolution_clock::now();
-            double duration = std::chrono::duration<double, std::milli>(t_end-t_start).count();
+            double duration = std::chrono::duration<double, std::milli>(t_end - t_start).count();
             std::string endpoint_name = url + "[GET]";
             server->timer_list[endpoint_name]->update(duration);
             return;
@@ -133,7 +134,7 @@ void restServer::handle_request(struct evhttp_request* request, void* cb_data) {
 
             // Compute callback reply time and update prometheus metric
             auto t_end = std::chrono::high_resolution_clock::now();
-            double duration = std::chrono::duration<double, std::milli>(t_end-t_start).count();
+            double duration = std::chrono::duration<double, std::milli>(t_end - t_start).count();
             std::string endpoint_name = url + "[POST]";
             server->timer_list[endpoint_name]->update(duration);
             return;

--- a/lib/core/restServer.cpp
+++ b/lib/core/restServer.cpp
@@ -5,11 +5,11 @@
 
 #include "fmt.hpp" // for format, fmt
 
-#include <algorithm> // for max
-#include <assert.h>  // for assert
-#include <chrono>
-#include <cstdint> // for int32_t
-#include <ctime>
+#include <algorithm>               // for max, copy, copy_backward, equal
+#include <assert.h>                // for assert
+#include <chrono>                  // for operator-, duration, high_resolution_clock, time_point
+#include <cstdint>                 // for int32_t
+#include <deque>                   // for deque
 #include <event2/buffer.h>         // for evbuffer_add, evbuffer_peek, iovec, evbuffer_free
 #include <event2/event.h>          // for event_add, event_base_dispatch, event_base_free, even...
 #include <event2/http.h>           // for evhttp_send_reply, evhttp_add_header, evhttp_request_...
@@ -20,10 +20,11 @@
 #include <mutex>                   // for unique_lock
 #include <netinet/in.h>            // for sockaddr_in, ntohs
 #include <pthread.h>               // for pthread_setaffinity_np, pthread_setname_np
+#include <ratio>                   // for milli
 #include <sched.h>                 // for cpu_set_t, CPU_SET, CPU_ZERO
 #include <stdexcept>               // for runtime_error
 #include <stdlib.h>                // for exit, free, malloc, size_t
-#include <string>                  // for string, basic_string, allocator, operator!=, operator+
+#include <string>                  // for string, basic_string, operator!=, operator+
 #include <sys/socket.h>            // for getsockname, socklen_t
 #include <sys/time.h>              // for timeval
 #include <utility>                 // for pair

--- a/lib/core/restServer.cpp
+++ b/lib/core/restServer.cpp
@@ -157,7 +157,7 @@ void restServer::register_get_callback(string endpoint,
         } else {
             // Create a new prometheus metric for the new endpoint
             std::string endpoint_name = endpoint + "[GET]";
-            timer_list[endpoint_name] = &(prometheus::Metrics::instance().add_endpoint(endpoint_name + "[GET]", "/rest_server"));
+            timer_list[endpoint_name] = &(prometheus::Metrics::instance().add_endpoint(endpoint_name, "/rest_server"));
         }
         get_callbacks[endpoint] = callback;
     }
@@ -178,7 +178,7 @@ void restServer::register_post_callback(string endpoint,
         } else {
             // Create a new prometheus metric for the new endpoint
             std::string endpoint_name = endpoint + "[POST]";
-            timer_list[endpoint_name] = &(prometheus::Metrics::instance().add_endpoint(endpoint_name + "[POST]", "/rest_server"));
+            timer_list[endpoint_name] = &(prometheus::Metrics::instance().add_endpoint(endpoint_name, "/rest_server"));
         }
         json_callbacks[endpoint] = callback;
     }

--- a/lib/core/restServer.cpp
+++ b/lib/core/restServer.cpp
@@ -46,6 +46,9 @@ restServer& restServer::instance() {
 
 restServer::restServer() : port(_port), main_thread() {
     stop_thread = false;
+
+    // Create a new prometheus metric group for callback timing
+    this->timer_metrics = &(prometheus::Metrics::instance().add_endpoint("endpoint_timers", "/rest_server", {"endpoint"}));
 }
 
 restServer::~restServer() {
@@ -157,7 +160,7 @@ void restServer::register_get_callback(string endpoint,
         } else {
             // Create a new prometheus metric for the new endpoint
             std::string endpoint_name = endpoint + "[GET]";
-            timer_list[endpoint_name] = &(prometheus::Metrics::instance().add_endpoint(endpoint_name, "/rest_server"));
+            timer_list[endpoint_name] = &(timer_metrics->labels({endpoint_name}));
         }
         get_callbacks[endpoint] = callback;
     }
@@ -178,7 +181,7 @@ void restServer::register_post_callback(string endpoint,
         } else {
             // Create a new prometheus metric for the new endpoint
             std::string endpoint_name = endpoint + "[POST]";
-            timer_list[endpoint_name] = &(prometheus::Metrics::instance().add_endpoint(endpoint_name, "/rest_server"));
+            timer_list[endpoint_name] = &(timer_metrics->labels({endpoint_name}));
         }
         json_callbacks[endpoint] = callback;
     }

--- a/lib/core/restServer.hpp
+++ b/lib/core/restServer.hpp
@@ -324,6 +324,7 @@ private:
     /// Alias map
     std::map<std::string, std::string> aliases;
 
+    /// A list to save all endpoint prometheus metrics
     std::map<std::string, prometheus::EndpointTimer*> timer_list;
 
     /// Mutex to lock changes to the maps while a request is in progress

--- a/lib/core/restServer.hpp
+++ b/lib/core/restServer.hpp
@@ -2,6 +2,7 @@
 #define REST_SERVER_HPP
 
 #include "Config.hpp" // for Config
+#include "prometheusMetrics.hpp"
 
 #include "json.hpp" // for json
 
@@ -18,6 +19,7 @@
 
 namespace kotekan {
 
+// class prometheus::EndpointTimer;
 
 enum class HTTP_RESPONSE {
     OK = 200,
@@ -321,6 +323,8 @@ private:
 
     /// Alias map
     std::map<std::string, std::string> aliases;
+
+    std::map<std::string, prometheus::EndpointTimer*> timer_list;
 
     /// Mutex to lock changes to the maps while a request is in progress
     std::shared_timed_mutex callback_map_lock;

--- a/lib/core/restServer.hpp
+++ b/lib/core/restServer.hpp
@@ -327,6 +327,9 @@ private:
     /// A list to save all endpoint prometheus metrics
     std::map<std::string, prometheus::EndpointTimer*> timer_list;
 
+    /// A group of all endpoints
+    prometheus::MetricFamily<kotekan::prometheus::EndpointTimer>* timer_metrics;
+
     /// Mutex to lock changes to the maps while a request is in progress
     std::shared_timed_mutex callback_map_lock;
 

--- a/lib/core/restServer.hpp
+++ b/lib/core/restServer.hpp
@@ -19,8 +19,6 @@
 
 namespace kotekan {
 
-// class prometheus::EndpointTimer;
-
 enum class HTTP_RESPONSE {
     OK = 200,
     BAD_REQUEST = 400,

--- a/tests/boost/CMakeLists.txt
+++ b/tests/boost/CMakeLists.txt
@@ -43,7 +43,7 @@ target_link_libraries(test_bip_buffer PRIVATE libexternal kotekan_utils kotekan_
 
 # test_prometheus_metrics needs fmt and prometheusMetrics
 add_executable(test_prometheus_metrics test_prometheus_metrics.cpp)
-target_link_libraries(test_prometheus_metrics PRIVATE libexternal kotekan_core)
+target_link_libraries(test_prometheus_metrics PRIVATE libexternal kotekan_core kotekan_utils)
 
 # test_config needs fmt
 add_executable(test_config test_config.cpp)


### PR DESCRIPTION
- Create a group of endpoint metrics in the REST server with the label "endpoint"
- Add StatTracker to get avg and max reply time
- Use a threshold of 1.0 to max reply time
