### PR TITLE
Exclude 'select' as a backend API for libevent

### DIFF
--- a/lib/core/restServer.cpp
+++ b/lib/core/restServer.cpp
@@ -361,7 +361,7 @@ void restServer::http_server_thread() {
         ERROR_NON_OO("Failed to create config for libevent");
         exit(1);
     }
-    int err = event_config_avoid_method(ev_config, "poll");
+    int err = event_config_avoid_method(ev_config, "select");
     if (err) {
         ERROR_NON_OO("Failed to exclude poll from the libevent options");
         exit(1);

--- a/lib/core/restServer.cpp
+++ b/lib/core/restServer.cpp
@@ -355,7 +355,7 @@ void restServer::http_server_thread() {
     }
 
     // Create the base event for handling requests,
-    // and exclude using `poll` as a backend API
+    // and exclude using `select` as a backend API
     event_config* ev_config = event_config_new();
     if (!ev_config) {
         ERROR_NON_OO("Failed to create config for libevent");
@@ -363,7 +363,7 @@ void restServer::http_server_thread() {
     }
     int err = event_config_avoid_method(ev_config, "select");
     if (err) {
-        ERROR_NON_OO("Failed to exclude poll from the libevent options");
+        ERROR_NON_OO("Failed to exclude select from the libevent options");
         exit(1);
     }
     event_base = event_base_new_with_config(ev_config);

--- a/lib/stages/bufferRecv.cpp
+++ b/lib/stages/bufferRecv.cpp
@@ -212,7 +212,7 @@ void bufferRecv::main_thread() {
         FATAL_ERROR("Failed to create config for libevent");
         return;
     }
-    int err = event_config_avoid_method(ev_config, "poll");
+    int err = event_config_avoid_method(ev_config, "select");
     if (err) {
         FATAL_ERROR("Failed to exclude poll from the libevent options");
         return;

--- a/lib/stages/bufferRecv.cpp
+++ b/lib/stages/bufferRecv.cpp
@@ -205,7 +205,7 @@ void bufferRecv::main_thread() {
         return;
     }
 
-    // Create the base event, and exclude using `poll` as a backend API
+    // Create the base event, and exclude using `select` as a backend API
     event_config* ev_config = event_config_new();
     if (!ev_config) {
         FATAL_ERROR("Failed to create config for libevent");
@@ -213,7 +213,7 @@ void bufferRecv::main_thread() {
     }
     int err = event_config_avoid_method(ev_config, "select");
     if (err) {
-        FATAL_ERROR("Failed to exclude poll from the libevent options");
+        FATAL_ERROR("Failed to exclude select from the libevent options");
         return;
     }
     base = event_base_new_with_config(ev_config);

--- a/lib/stages/bufferRecv.cpp
+++ b/lib/stages/bufferRecv.cpp
@@ -29,7 +29,6 @@
 #include <stdexcept>       // for runtime_error
 #include <stdlib.h>        // for free, malloc
 #include <string>          // for string, allocator, operator+
-#include <sys/select.h>    // for FD_SETSIZE
 #include <sys/socket.h>    // for AF_INET, accept, bind, listen, setsockopt, socket, sock...
 
 namespace kotekan {

--- a/lib/stages/bufferRecv.cpp
+++ b/lib/stages/bufferRecv.cpp
@@ -140,11 +140,6 @@ void bufferRecv::internal_accept_connection(evutil_socket_t listener, short even
         ERROR("Failed to accept connection, error {:d} ({:s}).", errno, std::strerror(errno));
         return;
     }
-    if (fd > FD_SETSIZE) {
-        ERROR("Got invalid FD");
-        close(fd);
-        return;
-    }
 
     struct timeval read_timeout = {connection_timeout, 0};
 
@@ -211,7 +206,18 @@ void bufferRecv::main_thread() {
         return;
     }
 
-    base = event_base_new();
+    // Create the base event, and exclude using `poll` as a backend API
+    event_config* ev_config = event_config_new();
+    if (!ev_config) {
+        FATAL_ERROR("Failed to create config for libevent");
+        return;
+    }
+    int err = event_config_avoid_method(ev_config, "poll");
+    if (err) {
+        FATAL_ERROR("Failed to exclude poll from the libevent options");
+        return;
+    }
+    base = event_base_new_with_config(ev_config);
     if (!base) {
         FATAL_ERROR("Failed to create libevent base");
         return;

--- a/lib/utils/restClient.cpp
+++ b/lib/utils/restClient.cpp
@@ -10,7 +10,6 @@
 #include <event2/bufferevent_struct.h> // for bufferevent
 #include <event2/dns.h>                // for evdns_base_free, evdns_base_new
 #include <event2/event.h>              // for event_base_loopbreak, EV_READ, event_add, event_b...
-#include <event2/event_struct.h>       // for event
 #include <event2/http.h>               // for evhttp_connection_free, evhttp_request_free, evht...
 #include <event2/keyvalq_struct.h>     // for evkeyvalq
 #include <event2/thread.h>             // for evthread_use_pthreads

--- a/lib/utils/restClient.cpp
+++ b/lib/utils/restClient.cpp
@@ -88,7 +88,7 @@ void restClient::event_thread() {
         FATAL_ERROR_NON_OO("Failed to create config for libevent");
         return;
     }
-    int err = event_config_avoid_method(ev_config, "poll");
+    int err = event_config_avoid_method(ev_config, "select");
     if (err) {
         FATAL_ERROR_NON_OO("Failed to exclude poll from the libevent options");
         return;

--- a/lib/utils/restClient.cpp
+++ b/lib/utils/restClient.cpp
@@ -82,7 +82,7 @@ void restClient::event_thread() {
         return;
     }
 
-    // Create the base event, and exclude using `poll` as a backend API
+    // Create the base event, and exclude using `select` as a backend API
     event_config* ev_config = event_config_new();
     if (!ev_config) {
         FATAL_ERROR_NON_OO("Failed to create config for libevent");
@@ -90,7 +90,7 @@ void restClient::event_thread() {
     }
     int err = event_config_avoid_method(ev_config, "select");
     if (err) {
-        FATAL_ERROR_NON_OO("Failed to exclude poll from the libevent options");
+        FATAL_ERROR_NON_OO("Failed to exclude select from the libevent options");
         return;
     }
     _base = event_base_new_with_config(ev_config);

--- a/lib/utils/restClient.hpp
+++ b/lib/utils/restClient.hpp
@@ -188,10 +188,10 @@ private:
 
     /// event base
     /// TODO: use the event base of the restServer
-    struct event_base* _base;
+    struct event_base* _base = nullptr;
 
     /// dns base
-    struct evdns_base* _dns;
+    struct evdns_base* _dns = nullptr;
 
     /// Condition variable to signal that event thread has started
     std::condition_variable _cv_start;
@@ -199,10 +199,13 @@ private:
     std::mutex _mtx_start;
 
     /// Writing socket event to pass requests to the event thread
-    struct bufferevent* bev_req_write;
+    struct bufferevent* bev_req_write = nullptr;
 
     /// Reading socket event to pass requests to the event thread
-    struct bufferevent* bev_req_read;
+    struct bufferevent* bev_req_read = nullptr;
+
+    /// Timer to check for the exit condition
+    struct event* timer_event = nullptr;
 
     /// Lock to protect writing to the bufferevent_pair's output buffer (the datasetManager does
     /// this in threads for example).


### PR DESCRIPTION
* Fixes an issue where if libevent picked `select` as its backend API, we would be limited 1024 file handles.