### PR TITLE
Fix phase center for CHIME tracking beamformer

### DIFF
--- a/config/chime_science_run_gpu.yaml
+++ b/config/chime_science_run_gpu.yaml
@@ -70,6 +70,8 @@ frb_scaling: 0.05 #1.0
 # Tracking beams global options
 feed_sep_NS: 0.3048
 feed_sep_EW: 22.0
+# Latitude and longitude converted from final geocentric (XYZ) position as calculated
+# in https://bao.chimenet.ca/doc/documents/1327 via NGS NOAA website.
 inst_lat: 49.32070922
 inst_long: -119.62367743
 num_beams: 12

--- a/config/chime_science_run_gpu.yaml
+++ b/config/chime_science_run_gpu.yaml
@@ -70,6 +70,8 @@ frb_scaling: 0.05 #1.0
 # Tracking beams global options
 feed_sep_NS: 0.3048
 feed_sep_EW: 22.0
+inst_lat: 49.32070922
+inst_long: -119.62367743
 num_beams: 12
 num_pol: 2
 

--- a/config/chime_science_run_gpu_no_output.yaml
+++ b/config/chime_science_run_gpu_no_output.yaml
@@ -70,6 +70,8 @@ frb_scaling: 0.05 #1.0
 # Tracking beams global options
 feed_sep_NS: 0.3048
 feed_sep_EW: 22.0
+# Latitude and longitude converted from final geocentric (XYZ) position as calculated
+# in https://bao.chimenet.ca/doc/documents/1327 via NGS NOAA website.
 inst_lat: 49.32070922
 inst_long: -119.62367743
 num_beams: 12

--- a/config/chime_science_run_gpu_no_output.yaml
+++ b/config/chime_science_run_gpu_no_output.yaml
@@ -70,6 +70,8 @@ frb_scaling: 0.05 #1.0
 # Tracking beams global options
 feed_sep_NS: 0.3048
 feed_sep_EW: 22.0
+inst_lat: 49.32070922
+inst_long: -119.62367743
 num_beams: 12
 num_pol: 2
 

--- a/lib/hsa/hsaTrackingUpdatePhase.hpp
+++ b/lib/hsa/hsaTrackingUpdatePhase.hpp
@@ -48,15 +48,15 @@
  *     @gpu_mem_format          Array of @c float
  *     @gpu_mem_metadata        none
  *
- * @conf   num_elements         Int (default 2048). Number of elements
- * @conf   num_beams            Int (default 10). Number of beams
- * @conf   feed_sep_NS          Float (default 0.3048). N-S feed separation in m.
- * @conf   feed_sep_EW          Float (default 22.0). E-W feed separation in m.
- * missing
- * @conf   beam_pointing/i/ra       Float - initial RA (in deg) to form beams on for beam_id=i
- * @conf   beam_pointing/i/dec      Float - initial Dec (in deg) to form beams on for beam_id=i
- * @conf   beam_pointing/i/scaling  Int - nominal scaling for beam_id=i
- * beam basis via endpoint)
+ * @conf   num_elements             Int (default 2048). Number of elements
+ * @conf   num_beams                Int (default 10). Number of beams
+ * @conf   feed_sep_NS              Float. N-S feed separation in m.
+ * @conf   feed_sep_EW              Float. E-W feed separation in m.
+ * @conf   inst_lat                 Double. The Instrument latitude
+ * @conf   inst_long                Double. The Instrument longitude
+ * @conf   beam_pointing/i/ra       Float. initial RA (in deg) to form beams on for beam_id=i
+ * @conf   beam_pointing/i/dec      Float. initial Dec (in deg) to form beams on for beam_id=i
+ * @conf   beam_pointing/i/scaling  Int. nominal scaling for beam_id=i
  *
  * @author Cherry Ng
  *
@@ -136,6 +136,10 @@ private:
     float _feed_sep_NS;
     /// E-W feed separation in m
     int32_t _feed_sep_EW;
+    /// The instrument latitude
+    double _inst_lat;
+    /// The instrument longitude
+    double _inst_long;
 
     /// Which phase bank (0 or 1) is used by with gpu_frame_id
     uint* bankID;

--- a/lib/hsa/hsaTrackingUpdatePhase.hpp
+++ b/lib/hsa/hsaTrackingUpdatePhase.hpp
@@ -135,7 +135,7 @@ private:
     /// N-S feed separation in m
     float _feed_sep_NS;
     /// E-W feed separation in m
-    int32_t _feed_sep_EW;
+    float _feed_sep_EW;
     /// The instrument latitude
     double _inst_lat;
     /// The instrument longitude


### PR DESCRIPTION
* Moves the instrument latitude and longitude from define constants into the configuration file. 
* Fixes an issue were a `float` was read as an `int`
* Updates the CHIME phase center to the correct location (appears to have been set to the Pathfinder location)