### PR TITLE
Change metrics from references to smart pointers.

### DIFF
--- a/kotekan/kotekan.cpp
+++ b/kotekan/kotekan.cpp
@@ -462,8 +462,8 @@ int main(int argc, char** argv) {
 
     auto& metrics = prometheus::Metrics::instance();
     metrics.register_with_server(&rest_server);
-    auto& kotekan_running_metric = metrics.add_gauge("kotekan_running", "main");
-    kotekan_running_metric.set(running);
+    auto kotekan_running_metric = metrics.add_gauge("kotekan_running", "main", {});
+    kotekan_running_metric->labels({}).set(running);
 
     basebandApiManager& baseband = basebandApiManager::instance();
     baseband.register_with_server(&rest_server);
@@ -473,7 +473,7 @@ int main(int argc, char** argv) {
         // Update running state
         {
             std::lock_guard<std::mutex> lock(kotekan_state_lock);
-            kotekan_running_metric.set(running);
+            kotekan_running_metric->labels({}).set(running);
         }
 
         if (sig_value == SIGINT) {

--- a/lib/core/basebandApiManager.cpp
+++ b/lib/core/basebandApiManager.cpp
@@ -101,7 +101,7 @@ basebandApiManager::basebandApiManager() :
     // clang-format off
     request_counter(
         prometheus::Metrics::instance()
-        .add_counter("kotekan_baseband_requests_total", "baseband")
+        .add_counter("kotekan_baseband_requests_total", "baseband", {})
         ) // clang-format on
 {}
 
@@ -241,7 +241,7 @@ void basebandApiManager::handle_request_callback(connectionInstance& conn, json&
                                                      {"length_fpga", readout_slice.length_fpga}};
         }
 
-        request_counter.inc();
+        request_counter->labels({}).inc();
 
         conn.send_json_reply(response);
     } catch (const std::exception& ex) {

--- a/lib/core/basebandApiManager.hpp
+++ b/lib/core/basebandApiManager.hpp
@@ -226,7 +226,7 @@ private:
     /// Map of registered readout stages, indexed by `freq_id`
     basebandReadoutRegistry readout_registry;
 
-    prometheus::Counter& request_counter;
+    prometheus::prometheus_counter_ptr_t request_counter;
 };
 
 } // namespace kotekan

--- a/lib/core/prometheusMetrics.cpp
+++ b/lib/core/prometheusMetrics.cpp
@@ -183,6 +183,10 @@ prometheus_gauge_ptr_t Metrics::add_gauge(const std::string& name, const std::st
                                           const std::vector<std::string>& label_names) {
     auto gauge = std::make_shared<MetricFamily<Gauge>>(name, stage_name, label_names,
                                                        MetricFamily<Gauge>::MetricType::Gauge);
+    // If this gauge has no labels, then generate the one (and only) metric in this family.
+    if (label_names.empty()) {
+        gauge->labels({});
+    }
     add(name, stage_name, gauge);
     return gauge;
 }
@@ -192,6 +196,10 @@ prometheus_counter_ptr_t Metrics::add_counter(const std::string& name,
                                               const std::vector<std::string>& label_names) {
     auto counter = std::shared_ptr<MetricFamily<Counter>>(new MetricFamily<Counter>(
         name, stage_name, label_names, MetricFamily<Counter>::MetricType::Counter));
+    // If this counter has no labels, then generate the one (and only) metric in this family.
+    if (label_names.empty()) {
+        counter->labels({});
+    }
     add(name, stage_name, counter);
     return counter;
 }

--- a/lib/core/prometheusMetrics.cpp
+++ b/lib/core/prometheusMetrics.cpp
@@ -179,38 +179,22 @@ void Metrics::add(const string name, const string stage_name,
     families[key] = metric;
 }
 
-Gauge& Metrics::add_gauge(const std::string& name, const std::string& stage_name) {
-    const std::vector<string> empty_labels;
-    auto f = std::make_shared<MetricFamily<Gauge>>(name, stage_name, empty_labels,
-                                                   MetricFamily<Gauge>::MetricType::Gauge);
-    add(name, stage_name, f);
-    return f->labels({});
+prometheus_gauge_ptr_t Metrics::add_gauge(const std::string& name, const std::string& stage_name,
+                                          const std::vector<std::string>& label_names) {
+    auto gauge = std::make_shared<MetricFamily<Gauge>>(name, stage_name, label_names,
+                                                       MetricFamily<Gauge>::MetricType::Gauge);
+    add(name, stage_name, gauge);
+    return gauge;
 }
 
-MetricFamily<Gauge>& Metrics::add_gauge(const std::string& name, const std::string& stage_name,
-                                        const std::vector<std::string>& label_names) {
-    auto f = std::make_shared<MetricFamily<Gauge>>(name, stage_name, label_names,
-                                                   MetricFamily<Gauge>::MetricType::Gauge);
-    add(name, stage_name, f);
-    return *f;
-}
-
-Counter& Metrics::add_counter(const std::string& name, const std::string& stage_name) {
-    const std::vector<string> empty_labels;
-    auto f = std::shared_ptr<MetricFamily<Counter>>(new MetricFamily<Counter>(
-        name, stage_name, empty_labels, MetricFamily<Counter>::MetricType::Counter));
-    add(name, stage_name, f);
-    return f->labels({});
-}
-
-MetricFamily<Counter>& Metrics::add_counter(const std::string& name, const std::string& stage_name,
-                                            const std::vector<std::string>& label_names) {
-    auto f = std::shared_ptr<MetricFamily<Counter>>(new MetricFamily<Counter>(
+prometheus_counter_ptr_t Metrics::add_counter(const std::string& name,
+                                              const std::string& stage_name,
+                                              const std::vector<std::string>& label_names) {
+    auto counter = std::shared_ptr<MetricFamily<Counter>>(new MetricFamily<Counter>(
         name, stage_name, label_names, MetricFamily<Counter>::MetricType::Counter));
-    add(name, stage_name, f);
-    return *f;
+    add(name, stage_name, counter);
+    return counter;
 }
-
 
 void Metrics::remove_stage_metrics(const string& stage_name) {
     std::lock_guard<std::mutex> lock(metrics_lock);

--- a/lib/core/prometheusMetrics.hpp
+++ b/lib/core/prometheusMetrics.hpp
@@ -170,6 +170,11 @@ private:
     std::mutex metrics_lock;
 };
 
+typedef std::shared_ptr<kotekan::prometheus::MetricFamily<kotekan::prometheus::Gauge>>
+    prometheus_gauge_ptr_t;
+typedef std::shared_ptr<kotekan::prometheus::MetricFamily<kotekan::prometheus::Counter>>
+    prometheus_counter_ptr_t;
+
 /**
  * @class Metrics
  * @brief Class for exporting system metrics to a prometheus server
@@ -234,36 +239,16 @@ public:
     std::string serialize();
 
     /**
-     * @brief Adds a new metric of type gauge and no labels
-     *
-     * @param name The name of the metric.
-     * @param stage_name The unique stage name, normally @c unique_name.
-     * @return a reference to the newly created @c Gauge instance
-     * @throw std::runtime_error if the metric with that name is already registered.
-     */
-    Gauge& add_gauge(const std::string& name, const std::string& stage_name);
-
-    /**
      * @brief Adds a new metric family of type gauge
      *
      * @param name The name of the metric.
      * @param stage_name The unique stage name, normally @c unique_name.
      * @param label_names The names of the labels used
-     * @return a reference to the newly created @c MetricFamily<Gauge> instance
+     * @return a shared pointer to the newly created @c MetricFamily<Gauge> object
      * @throw std::runtime_error if the metric with that name is already registered.
      */
-    MetricFamily<Gauge>& add_gauge(const std::string& name, const std::string& stage_name,
-                                   const std::vector<std::string>& label_names);
-
-    /**
-     * @brief Adds a new metric of type counter and no labels
-     *
-     * @param name The name of the metric.
-     * @param stage_name The unique stage name, normally @c unique_name.
-     * @return a reference to the newly created @c Counter instance
-     * @throw std::runtime_error if the metric with that name is already registered.
-     */
-    Counter& add_counter(const std::string& name, const std::string& stage_name);
+    prometheus_gauge_ptr_t add_gauge(const std::string& name, const std::string& stage_name,
+                                     const std::vector<std::string>& label_names);
 
     /**
      * @brief Adds a new metric family of type counter
@@ -271,11 +256,11 @@ public:
      * @param name The name of the metric.
      * @param stage_name The unique stage name, normally @c unique_name.
      * @param label_names The names of the labels used
-     * @return a reference to the newly created @c MetricFamily<Counter> instance
+     * @return a shared pointer to the newly created @c MetricFamily<Counter> object
      * @throw std::runtime_error if the metric with that name is already registered.
      */
-    MetricFamily<Counter>& add_counter(const std::string& name, const std::string& stage_name,
-                                       const std::vector<std::string>& label_names);
+    prometheus_counter_ptr_t add_counter(const std::string& name, const std::string& stage_name,
+                                         const std::vector<std::string>& label_names);
 
     /**
      * @brief Remove all registered stage metrics

--- a/lib/dpdk/iceBoardHandler.hpp
+++ b/lib/dpdk/iceBoardHandler.hpp
@@ -331,19 +331,17 @@ protected:
     int32_t num_local_freq;
 
     /// Prometheus metrics
-    kotekan::prometheus::MetricFamily<kotekan::prometheus::Gauge>& rx_packets_total_metric;
-    kotekan::prometheus::MetricFamily<kotekan::prometheus::Gauge>& rx_samples_total_metric;
-    kotekan::prometheus::MetricFamily<kotekan::prometheus::Gauge>& rx_lost_packets_total_metric;
-    kotekan::prometheus::MetricFamily<kotekan::prometheus::Gauge>& lost_samples_total_metric;
+    kotekan::prometheus::prometheus_gauge_ptr_t rx_packets_total_metric;
+    kotekan::prometheus::prometheus_gauge_ptr_t rx_samples_total_metric;
+    kotekan::prometheus::prometheus_gauge_ptr_t rx_lost_packets_total_metric;
+    kotekan::prometheus::prometheus_gauge_ptr_t lost_samples_total_metric;
 
-    kotekan::prometheus::MetricFamily<kotekan::prometheus::Gauge>& rx_bytes_total_metric;
-    kotekan::prometheus::MetricFamily<kotekan::prometheus::Gauge>& rx_errors_total_metric;
+    kotekan::prometheus::prometheus_gauge_ptr_t rx_bytes_total_metric;
+    kotekan::prometheus::prometheus_gauge_ptr_t rx_errors_total_metric;
 
-    kotekan::prometheus::MetricFamily<kotekan::prometheus::Gauge>& rx_ip_cksum_errors_total_metric;
-    kotekan::prometheus::MetricFamily<kotekan::prometheus::Gauge>&
-        rx_packet_len_errors_total_metric;
-    kotekan::prometheus::MetricFamily<kotekan::prometheus::Gauge>&
-        rx_out_of_order_errors_total_metric;
+    kotekan::prometheus::prometheus_gauge_ptr_t rx_ip_cksum_errors_total_metric;
+    kotekan::prometheus::prometheus_gauge_ptr_t rx_packet_len_errors_total_metric;
+    kotekan::prometheus::prometheus_gauge_ptr_t rx_out_of_order_errors_total_metric;
 
 private:
     // Last time we've printed a status message
@@ -447,18 +445,18 @@ inline void iceBoardHandler::update_stats() {
 
     std::vector<std::string> port_label = {std::to_string(port)};
 
-    rx_packets_total_metric.labels(port_label).set(rx_packets_total);
-    rx_samples_total_metric.labels(port_label).set(rx_packets_total * samples_per_packet);
-    rx_lost_packets_total_metric.labels(port_label)
+    rx_packets_total_metric->labels(port_label).set(rx_packets_total);
+    rx_samples_total_metric->labels(port_label).set(rx_packets_total * samples_per_packet);
+    rx_lost_packets_total_metric->labels(port_label)
         .set((int)(rx_lost_samples_total / samples_per_packet));
-    lost_samples_total_metric.labels(port_label).set(rx_lost_samples_total);
+    lost_samples_total_metric->labels(port_label).set(rx_lost_samples_total);
 
-    rx_bytes_total_metric.labels(port_label).set(rx_bytes_total);
-    rx_errors_total_metric.labels(port_label).set(rx_errors_total);
+    rx_bytes_total_metric->labels(port_label).set(rx_bytes_total);
+    rx_errors_total_metric->labels(port_label).set(rx_errors_total);
 
-    rx_ip_cksum_errors_total_metric.labels(port_label).set(rx_ip_cksum_errors_total);
-    rx_packet_len_errors_total_metric.labels(port_label).set(rx_packet_len_errors_total);
-    rx_out_of_order_errors_total_metric.labels(port_label).set(rx_out_of_order_errors_total);
+    rx_ip_cksum_errors_total_metric->labels(port_label).set(rx_ip_cksum_errors_total);
+    rx_packet_len_errors_total_metric->labels(port_label).set(rx_packet_len_errors_total);
+    rx_out_of_order_errors_total_metric->labels(port_label).set(rx_out_of_order_errors_total);
 
     double time_now = e_time();
     if (status_cadence != 0 && (time_now - last_status_message_time) > (double)status_cadence) {

--- a/lib/dpdk/iceBoardShuffle.hpp
+++ b/lib/dpdk/iceBoardShuffle.hpp
@@ -189,21 +189,17 @@ protected:
     uint64_t rx_shuffle_flags_set = 0;
 
     /// Prometheus metrics
-    kotekan::prometheus::MetricFamily<kotekan::prometheus::Gauge>& third_shuffle_errors_counter;
-    kotekan::prometheus::MetricFamily<kotekan::prometheus::Gauge>& third_crc_errors_counter;
-    kotekan::prometheus::MetricFamily<kotekan::prometheus::Gauge>&
-        third_missing_short_errors_counter;
-    kotekan::prometheus::MetricFamily<kotekan::prometheus::Gauge>& third_long_errors_counter;
-    kotekan::prometheus::MetricFamily<kotekan::prometheus::Gauge>&
-        third_fifo_overflow_errors_counter;
+    kotekan::prometheus::prometheus_gauge_ptr_t third_shuffle_errors_counter;
+    kotekan::prometheus::prometheus_gauge_ptr_t third_crc_errors_counter;
+    kotekan::prometheus::prometheus_gauge_ptr_t third_missing_short_errors_counter;
+    kotekan::prometheus::prometheus_gauge_ptr_t third_long_errors_counter;
+    kotekan::prometheus::prometheus_gauge_ptr_t third_fifo_overflow_errors_counter;
 
-    kotekan::prometheus::MetricFamily<kotekan::prometheus::Gauge>& second_shuffle_errors_counter;
-    kotekan::prometheus::MetricFamily<kotekan::prometheus::Gauge>& second_crc_errors_counter;
-    kotekan::prometheus::MetricFamily<kotekan::prometheus::Gauge>&
-        second_missing_short_errors_counter;
-    kotekan::prometheus::MetricFamily<kotekan::prometheus::Gauge>& second_long_errors_counter;
-    kotekan::prometheus::MetricFamily<kotekan::prometheus::Gauge>&
-        second_fifo_overflow_errors_counter;
+    kotekan::prometheus::prometheus_gauge_ptr_t second_shuffle_errors_counter;
+    kotekan::prometheus::prometheus_gauge_ptr_t second_crc_errors_counter;
+    kotekan::prometheus::prometheus_gauge_ptr_t second_missing_short_errors_counter;
+    kotekan::prometheus::prometheus_gauge_ptr_t second_long_errors_counter;
+    kotekan::prometheus::prometheus_gauge_ptr_t second_fifo_overflow_errors_counter;
 };
 
 iceBoardShuffle::iceBoardShuffle(kotekan::Config& config, const std::string& unique_name,
@@ -609,27 +605,27 @@ void iceBoardShuffle::update_stats() {
     std::string port_str = std::to_string(port);
 
     for (int i = 0; i < 8; ++i) {
-        third_shuffle_errors_counter.labels({port_str, std::to_string(i)})
+        third_shuffle_errors_counter->labels({port_str, std::to_string(i)})
             .set(fpga_third_stage_shuffle_errors[i]);
     }
 
-    third_crc_errors_counter.labels({port_str}).set(fpga_third_stage_crc_errors);
-    third_missing_short_errors_counter.labels({port_str})
+    third_crc_errors_counter->labels({port_str}).set(fpga_third_stage_crc_errors);
+    third_missing_short_errors_counter->labels({port_str})
         .set(fpga_third_stage_missing_short_errors);
-    third_long_errors_counter.labels({port_str}).set(fpga_third_stage_long_errors);
-    third_fifo_overflow_errors_counter.labels({port_str})
+    third_long_errors_counter->labels({port_str}).set(fpga_third_stage_long_errors);
+    third_fifo_overflow_errors_counter->labels({port_str})
         .set(fpga_third_stage_fifo_overflow_errors);
 
     for (int i = 0; i < 16; ++i) {
-        second_shuffle_errors_counter.labels({port_str, std::to_string(i)})
+        second_shuffle_errors_counter->labels({port_str, std::to_string(i)})
             .set(fpga_second_stage_shuffle_errors[i]);
     }
 
-    second_crc_errors_counter.labels({port_str}).set(fpga_second_stage_crc_errors);
-    second_missing_short_errors_counter.labels({port_str})
+    second_crc_errors_counter->labels({port_str}).set(fpga_second_stage_crc_errors);
+    second_missing_short_errors_counter->labels({port_str})
         .set(fpga_second_stage_missing_short_errors);
-    second_long_errors_counter.labels({port_str}).set(fpga_second_stage_long_errors);
-    second_fifo_overflow_errors_counter.labels({port_str})
+    second_long_errors_counter->labels({port_str}).set(fpga_second_stage_long_errors);
+    second_fifo_overflow_errors_counter->labels({port_str})
         .set(fpga_second_stage_fifo_overflow_errors);
 }
 

--- a/lib/dpdk/invalidateVDIFframes.cpp
+++ b/lib/dpdk/invalidateVDIFframes.cpp
@@ -1,14 +1,15 @@
 #include "invalidateVDIFframes.hpp"
 
-#include "StageFactory.hpp"  // for REGISTER_KOTEKAN_STAGE, StageMakerTemplate
-#include "buffer.h"          // for Buffer, mark_frame_empty, mark_frame_full, register_consumer
-#include "chimeMetadata.hpp" // for atomic_add_lost_timesamples
-#include "prometheusMetrics.hpp"
-#include "vdif_functions.h" // for VDIFHeader
+#include "StageFactory.hpp"      // for REGISTER_KOTEKAN_STAGE, StageMakerTemplate
+#include "buffer.h"              // for Buffer, mark_frame_empty, mark_frame_full, register_con...
+#include "chimeMetadata.hpp"     // for atomic_add_lost_timesamples
+#include "prometheusMetrics.hpp" // for Metrics, Counter, MetricFamily
+#include "vdif_functions.h"      // for VDIFHeader
 
 #include <assert.h>   // for assert
 #include <atomic>     // for atomic_bool
 #include <functional> // for _Bind_helper<>::type, bind, function
+#include <memory>     // for __shared_ptr_access, shared_ptr
 
 using kotekan::bufferContainer;
 using kotekan::Config;

--- a/lib/dpdk/invalidateVDIFframes.cpp
+++ b/lib/dpdk/invalidateVDIFframes.cpp
@@ -36,8 +36,8 @@ void invalidateVDIFframes::main_thread() {
     uint32_t frame_location;
     int64_t lost_samples;
 
-    auto& lost_frame_total =
-        Metrics::instance().add_counter("kotekan_vdif_lost_frames_total", unique_name);
+    auto lost_frame_total =
+        Metrics::instance().add_counter("kotekan_vdif_lost_frames_total", unique_name, {});
 
     while (!stop_thread) {
 
@@ -70,7 +70,7 @@ void invalidateVDIFframes::main_thread() {
         }
 
         atomic_add_lost_timesamples(out_buf, out_buf_frame_id, lost_samples);
-        lost_frame_total.inc(lost_samples);
+        lost_frame_total->labels({}).inc(lost_samples);
 
         mark_frame_empty(lost_samples_buf, unique_name.c_str(), lost_samples_buf_frame_id);
         lost_samples_buf_frame_id = (lost_samples_buf_frame_id + 1) % lost_samples_buf->num_frames;

--- a/lib/stages/BadInputFlag.cpp
+++ b/lib/stages/BadInputFlag.cpp
@@ -7,19 +7,18 @@
 #include "bufferContainer.hpp"   // for bufferContainer
 #include "datasetManager.hpp"    // for dset_id_t, datasetManager, fingerprint_t
 #include "kotekanLogging.hpp"    // for FATAL_ERROR
-#include "prometheusMetrics.hpp" // for Counter, MetricFamily, Metrics
+#include "prometheusMetrics.hpp" // for Counter, MetricFamily, Metrics, prometheus_counter_ptr_t
 #include "visBuffer.hpp"         // for VisFrameView
 #include "visUtil.hpp"           // for frameID, modulo
 
 #include "gsl-lite.hpp" // for span
 
-#include <algorithm>  // for copy, copy_backward, equal, max
 #include <assert.h>   // for assert
 #include <atomic>     // for atomic_bool
 #include <cmath>      // for isinf, isnan
-#include <deque>      // for deque
 #include <functional> // for _Bind_helper<>::type, bind, function
 #include <future>     // for future
+#include <memory>     // for __shared_ptr_access
 #include <optional>   // for optional
 #include <stddef.h>   // for size_t
 

--- a/lib/stages/BadInputFlag.cpp
+++ b/lib/stages/BadInputFlag.cpp
@@ -115,12 +115,12 @@ void BadInputFlag::main_thread() {
             // it to Prometheus
             if (frame.flags[i] != 0) {
                 if (std::isinf(frame.weight[auto_ind])) {
-                    bad_input_counter.labels({std::to_string(i), "Inf"}).inc();
+                    bad_input_counter->labels({std::to_string(i), "Inf"}).inc();
                     // TODO: post dataset state changes and turn this on
                     // frame.flags[i] = 0;
 
                 } else if (std::isnan(frame.weight[auto_ind])) {
-                    bad_input_counter.labels({std::to_string(i), "NaN"}).inc();
+                    bad_input_counter->labels({std::to_string(i), "NaN"}).inc();
                     // TODO: post dataset state changes and turn this on
                     // frame.flags[i] = 0;
                 }

--- a/lib/stages/BadInputFlag.hpp
+++ b/lib/stages/BadInputFlag.hpp
@@ -66,7 +66,7 @@ private:
     fingerprint_t fingerprint = fingerprint_t::null;
 
     // Count how often a bad input has been seen
-    kotekan::prometheus::MetricFamily<kotekan::prometheus::Counter>& bad_input_counter;
+    kotekan::prometheus::prometheus_counter_ptr_t bad_input_counter;
 };
 
 

--- a/lib/stages/BaseWriter.cpp
+++ b/lib/stages/BaseWriter.cpp
@@ -16,9 +16,7 @@
 
 #include "fmt.hpp" // for format
 
-#include <algorithm>  // for copy, copy_backward, equal, max
 #include <atomic>     // for atomic_bool
-#include <deque>      // for deque
 #include <exception>  // for exception
 #include <functional> // for _Bind_helper<>::type, bind, function
 #include <regex>      // for match_results<>::_Base_type

--- a/lib/stages/BaseWriter.cpp
+++ b/lib/stages/BaseWriter.cpp
@@ -46,7 +46,7 @@ BaseWriter::BaseWriter(Config& config, const std::string& unique_name,
     bad_dataset_frame_counter(Metrics::instance().add_counter(
         "kotekan_writer_bad_dataset_frame_total", unique_name, {"dataset_id"})),
     write_time_metric(
-        Metrics::instance().add_gauge("kotekan_writer_write_time_seconds", unique_name)) {
+        Metrics::instance().add_gauge("kotekan_writer_write_time_seconds", unique_name, {})) {
 
     // Fetch any simple configuration
     root_path = config.get_default<std::string>(unique_name, "root_path", ".");
@@ -177,7 +177,7 @@ void BaseWriter::write_frame(const FrameView& frame, dset_id_t dataset_id, uint3
 
     // If the dataset is bad, skip the frame and move onto the next
     if (acq.bad_dataset) {
-        bad_dataset_frame_counter.labels({dataset_id.to_string()}).inc();
+        bad_dataset_frame_counter->labels({dataset_id.to_string()}).inc();
 
         // Check if the frequency we are receiving is on the list of frequencies
         // we are processing
@@ -210,12 +210,12 @@ void BaseWriter::write_frame(const FrameView& frame, dset_id_t dataset_id, uint3
 
         // Increase metric count if we dropped a frame at write time
         if (late) {
-            late_frame_counter.labels({std::to_string(freq_id)}).inc();
+            late_frame_counter->labels({std::to_string(freq_id)}).inc();
         }
 
         // Update average write time in prometheus
         write_time.add_sample(elapsed);
-        write_time_metric.set(write_time.average());
+        write_time_metric->labels({}).set(write_time.average());
     }
 }
 

--- a/lib/stages/BaseWriter.hpp
+++ b/lib/stages/BaseWriter.hpp
@@ -202,9 +202,9 @@ private:
     /// Keep track of the average write time
     movingAverage write_time;
 
-    kotekan::prometheus::MetricFamily<kotekan::prometheus::Counter>& late_frame_counter;
-    kotekan::prometheus::MetricFamily<kotekan::prometheus::Counter>& bad_dataset_frame_counter;
-    kotekan::prometheus::Gauge& write_time_metric;
+    kotekan::prometheus::prometheus_counter_ptr_t late_frame_counter;
+    kotekan::prometheus::prometheus_counter_ptr_t bad_dataset_frame_counter;
+    kotekan::prometheus::prometheus_gauge_ptr_t write_time_metric;
 };
 
 #endif

--- a/lib/stages/DataQuality.cpp
+++ b/lib/stages/DataQuality.cpp
@@ -121,7 +121,7 @@ void DataQuality::main_thread() {
         }
 
         std::vector<std::string> labels = {std::to_string(frame.freq_id)};
-        data_quality_metric.labels(labels).set(sensitivity);
+        data_quality_metric->labels(labels).set(sensitivity);
 
         // Finish up iteration.
         mark_frame_empty(in_buf, unique_name.c_str(), input_frame_id++);

--- a/lib/stages/DataQuality.cpp
+++ b/lib/stages/DataQuality.cpp
@@ -6,18 +6,17 @@
 #include "datasetManager.hpp"    // for fingerprint_t, datasetManager, dset_id_t
 #include "datasetState.hpp"      // for stackState
 #include "kotekanLogging.hpp"    // for FATAL_ERROR
-#include "prometheusMetrics.hpp" // for Gauge, Metrics, MetricFamily
+#include "prometheusMetrics.hpp" // for Metrics, Gauge, MetricFamily, prometheus_gauge_ptr_t
 #include "visBuffer.hpp"         // for VisFrameView
 #include "visUtil.hpp"           // for frameID, modulo
 
 #include "gsl-lite.hpp" // for span
 
-#include <algorithm>  // for copy, copy_backward, equal, max
 #include <atomic>     // for atomic_bool
-#include <deque>      // for deque
 #include <exception>  // for exception
 #include <functional> // for _Bind_helper<>::type, bind, function
 #include <math.h>     // for pow
+#include <memory>     // for __shared_ptr_access
 #include <stdexcept>  // for out_of_range
 #include <stdint.h>   // for uint32_t
 #include <string.h>   // for size_t

--- a/lib/stages/DataQuality.hpp
+++ b/lib/stages/DataQuality.hpp
@@ -59,7 +59,7 @@ private:
     std::map<dset_id_t, fingerprint_t> dset_id_map;
 
     /// Prometheus metrics to export
-    kotekan::prometheus::MetricFamily<kotekan::prometheus::Gauge>& data_quality_metric;
+    kotekan::prometheus::prometheus_gauge_ptr_t data_quality_metric;
 };
 
 #endif

--- a/lib/stages/EigenVisIter.cpp
+++ b/lib/stages/EigenVisIter.cpp
@@ -204,18 +204,18 @@ void EigenVisIter::update_metrics(uint32_t freq_id, dset_id_t dset_id, double el
 
     // Output eigenvalues to prometheus
     for (uint32_t i = 0; i < _num_eigenvectors; i++) {
-        eigenvalue_metric.labels({std::to_string(i), std::to_string(freq_id)})
+        eigenvalue_metric->labels({std::to_string(i), std::to_string(freq_id)})
             .set(eigpair.first[_num_eigenvectors - 1 - i]);
     }
 
     // Output RMS to prometheus
-    eigenvalue_metric.labels({"rms", std::to_string(freq_id)}).set(stats.rms);
+    eigenvalue_metric->labels({"rms", std::to_string(freq_id)}).set(stats.rms);
 
     // Output convergence stats
     std::vector<std::string> labels = {std::to_string(freq_id)};
-    iterations_metric.labels(labels).set(stats.iterations);
-    eigenvalue_convergence_metric.labels(labels).set(stats.eps_eval);
-    eigenvector_convergence_metric.labels(labels).set(stats.eps_evec);
+    iterations_metric->labels(labels).set(stats.iterations);
+    eigenvalue_convergence_metric->labels(labels).set(stats.eps_eval);
+    eigenvector_convergence_metric->labels(labels).set(stats.eps_evec);
 }
 
 

--- a/lib/stages/EigenVisIter.cpp
+++ b/lib/stages/EigenVisIter.cpp
@@ -4,27 +4,26 @@
 #include "Hash.hpp"              // for operator!=, operator<
 #include "LinearAlgebra.hpp"     // for EigConvergenceStats, eigen_masked_subspace, to_blaze_herm
 #include "StageFactory.hpp"      // for REGISTER_KOTEKAN_STAGE, StageMakerTemplate
-#include "buffer.h"              // for allocate_new_metadata_object, mark_frame_empty, mark_fr...
+#include "buffer.h"              // for mark_frame_empty, mark_frame_full, register_consumer
 #include "datasetState.hpp"      // for datasetState, eigenvalueState, state_uptr
 #include "kotekanLogging.hpp"    // for DEBUG
-#include "prometheusMetrics.hpp" // for Gauge, Metrics, MetricFamily
+#include "prometheusMetrics.hpp" // for Metrics, Gauge, MetricFamily, prometheus_gauge_ptr_t
 #include "visBuffer.hpp"         // for VisFrameView, VisField, VisField::erms, VisField::eval
 #include "visUtil.hpp"           // for cfloat, frameID, current_time, modulo, movingAverage
 
 #include "fmt.hpp"      // for format, fmt
 #include "gsl-lite.hpp" // for span
 
-#include <algorithm>     // for copy, copy_backward, equal, max, min
+#include <algorithm>     // for min
 #include <atomic>        // for atomic_bool
 #include <blaze/Blaze.h> // for DynamicMatrix, DMatDeclHermExpr, band, HermitianMatrix
 #include <cblas.h>       // for openblas_set_num_threads
 #include <complex>       // for complex
 #include <cstdint>       // for uint32_t, int32_t
-#include <deque>         // for deque
 #include <exception>     // for exception
 #include <functional>    // for _Bind_helper<>::type, bind, function
 #include <iostream>      // for basic_ostream::operator<<, operator<<, basic_ostream<>:...
-#include <memory>        // for make_unique
+#include <memory>        // for __shared_ptr_access, make_unique
 #include <regex>         // for match_results<>::_Base_type
 #include <stdexcept>     // for runtime_error, out_of_range
 #include <tuple>         // for tie, tuple

--- a/lib/stages/EigenVisIter.cpp
+++ b/lib/stages/EigenVisIter.cpp
@@ -40,7 +40,7 @@ EigenVisIter::EigenVisIter(Config& config, const std::string& unique_name,
                            bufferContainer& buffer_container) :
     Stage(config, unique_name, buffer_container, std::bind(&EigenVisIter::main_thread, this)),
     comp_time_seconds_metric(
-        Metrics::instance().add_gauge("kotekan_eigenvisiter_comp_time_seconds", unique_name)),
+        Metrics::instance().add_gauge("kotekan_eigenvisiter_comp_time_seconds", unique_name, {})),
     eigenvalue_metric(Metrics::instance().add_gauge("kotekan_eigenvisiter_eigenvalue", unique_name,
                                                     {"eigenvalue", "freq_id"})),
     iterations_metric(
@@ -200,7 +200,7 @@ void EigenVisIter::update_metrics(uint32_t freq_id, dset_id_t dset_id, double el
     auto key = std::make_pair(freq_id, dset_id);
     auto& calc_time = calc_time_map[key];
     calc_time.add_sample(elapsed_time);
-    comp_time_seconds_metric.set(calc_time.average());
+    comp_time_seconds_metric->labels({}).set(calc_time.average());
 
     // Output eigenvalues to prometheus
     for (uint32_t i = 0; i < _num_eigenvectors; i++) {

--- a/lib/stages/EigenVisIter.hpp
+++ b/lib/stages/EigenVisIter.hpp
@@ -122,11 +122,11 @@ private:
     state_id_t ev_state_id;
     dset_id_t input_dset_id = dset_id_t::null;
 
-    kotekan::prometheus::Gauge& comp_time_seconds_metric;
-    kotekan::prometheus::MetricFamily<kotekan::prometheus::Gauge>& eigenvalue_metric;
-    kotekan::prometheus::MetricFamily<kotekan::prometheus::Gauge>& iterations_metric;
-    kotekan::prometheus::MetricFamily<kotekan::prometheus::Gauge>& eigenvalue_convergence_metric;
-    kotekan::prometheus::MetricFamily<kotekan::prometheus::Gauge>& eigenvector_convergence_metric;
+    kotekan::prometheus::prometheus_gauge_ptr_t comp_time_seconds_metric;
+    kotekan::prometheus::prometheus_gauge_ptr_t eigenvalue_metric;
+    kotekan::prometheus::prometheus_gauge_ptr_t iterations_metric;
+    kotekan::prometheus::prometheus_gauge_ptr_t eigenvalue_convergence_metric;
+    kotekan::prometheus::prometheus_gauge_ptr_t eigenvector_convergence_metric;
 };
 
 #endif

--- a/lib/stages/ReadGain.cpp
+++ b/lib/stages/ReadGain.cpp
@@ -167,7 +167,7 @@ void ReadGain::read_gain_frb() {
     ptr_myfile = fopen(filename, "rb");
     if (ptr_myfile == nullptr) {
         WARN("GPU Cannot open gain file {:s}", filename);
-        gains_last_update_success_metric.labels({"frb"}).set(0);
+        gains_last_update_success_metric->labels({"frb"}).set(0);
         for (uint i = 0; i < _num_elements; i++) {
             out_frame_frb[i * 2] = default_gains[0] * scaling;
             out_frame_frb[i * 2 + 1] = default_gains[1] * scaling;
@@ -177,13 +177,13 @@ void ReadGain::read_gain_frb() {
             WARN("Gain file ({:s}) wasn't long enough! Something went wrong, using default "
                  "gains",
                  filename);
-            gains_last_update_success_metric.labels({"frb"}).set(0);
+            gains_last_update_success_metric->labels({"frb"}).set(0);
             for (uint i = 0; i < _num_elements; i++) {
                 out_frame_frb[i * 2] = default_gains[0] * scaling;
                 out_frame_frb[i * 2 + 1] = default_gains[1] * scaling;
             }
         } else {
-            gains_last_update_success_metric.labels({"frb"}).set(1);
+            gains_last_update_success_metric->labels({"frb"}).set(1);
         }
         fclose(ptr_myfile);
         for (uint i = 0; i < _num_elements; i++) {
@@ -191,7 +191,7 @@ void ReadGain::read_gain_frb() {
             out_frame_frb[i * 2 + 1] = out_frame_frb[i * 2 + 1] * scaling;
         }
     }
-    gains_last_update_timestamp_metric.labels({"frb", ""}).set(start_time);
+    gains_last_update_timestamp_metric->labels({"frb", ""}).set(start_time);
     mark_frame_full(gain_frb_buf, unique_name.c_str(), gain_frb_buf_id);
     DEBUG("Maked gain_frb_buf frame {:d} full", gain_frb_buf_id);
     INFO("Time required to load FRB gains: {:f}", current_time() - start_time);
@@ -223,10 +223,10 @@ void ReadGain::read_gain_tracking() {
         INFO("Tracking Beamformer Loading gains from {:s}", filename);
         ptr_myfile = fopen(filename, "rb");
         std::string beam_label = "tracking_beam_" + std::to_string(beam_id);
-        gains_last_update_success_metric.labels({beam_label}).set(1);
+        gains_last_update_success_metric->labels({beam_label}).set(1);
         if (ptr_myfile == nullptr) {
             WARN("GPU Cannot open gain file {:s}", filename);
-            gains_last_update_success_metric.labels({beam_label}).set(0);
+            gains_last_update_success_metric->labels({beam_label}).set(0);
             for (uint i = 0; i < _num_elements; i++) {
                 tracking_beam_gains[(beam_id * _num_elements + i) * 2] = default_gains[0];
                 tracking_beam_gains[(beam_id * _num_elements + i) * 2 + 1] = default_gains[1];
@@ -238,7 +238,7 @@ void ReadGain::read_gain_tracking() {
                 WARN("Gain file ({:s}) wasn't long enough! Something went wrong, using default "
                      "gains",
                      filename);
-                gains_last_update_success_metric.labels({beam_label}).set(0);
+                gains_last_update_success_metric->labels({beam_label}).set(0);
                 for (uint i = 0; i < _num_elements; i++) {
                     tracking_beam_gains[(beam_id * _num_elements + i) * 2] = default_gains[0];
                     tracking_beam_gains[(beam_id * _num_elements + i) * 2 + 1] = default_gains[1];
@@ -246,7 +246,7 @@ void ReadGain::read_gain_tracking() {
             }
             fclose(ptr_myfile);
         }
-        gains_last_update_timestamp_metric.labels({"tracking", beam_label}).set(start_time);
+        gains_last_update_timestamp_metric->labels({"tracking", beam_label}).set(start_time);
     } // end beam
 
     // Copy the current set of gains to the output buffer frame.

--- a/lib/stages/ReadGain.cpp
+++ b/lib/stages/ReadGain.cpp
@@ -13,7 +13,6 @@
 #include <atomic>      // for atomic_bool
 #include <chrono>      // for seconds
 #include <cstdint>     // for int32_t
-#include <deque>       // for deque
 #include <exception>   // for exception
 #include <functional>  // for _Bind_helper<>::type, bind, _Placeholder, _1, function
 #include <memory>      // for allocator_traits<>::value_type

--- a/lib/stages/ReadGain.hpp
+++ b/lib/stages/ReadGain.hpp
@@ -129,11 +129,10 @@ private:
     float* tracking_beam_gains;
 
     /// implements `kotekan_gains_last_update_success`
-    kotekan::prometheus::MetricFamily<kotekan::prometheus::Gauge>& gains_last_update_success_metric;
+    kotekan::prometheus::prometheus_gauge_ptr_t gains_last_update_success_metric;
 
     /// implements `kotekan_gains_last_update_timestamp`
-    kotekan::prometheus::MetricFamily<kotekan::prometheus::Gauge>&
-        gains_last_update_timestamp_metric;
+    kotekan::prometheus::prometheus_gauge_ptr_t gains_last_update_timestamp_metric;
 };
 
 

--- a/lib/stages/ReceiveFlags.cpp
+++ b/lib/stages/ReceiveFlags.cpp
@@ -44,8 +44,8 @@ ReceiveFlags::ReceiveFlags(Config& config, const std::string& unique_name,
         Metrics::instance().add_counter("kotekan_receiveflags_late_frame_count", unique_name, {})),
     receiveflags_update_age_metric(
         Metrics::instance().add_gauge("kotekan_receiveflags_update_age_seconds", unique_name, {})),
-    late_updates_counter(
-        Metrics::instance().add_counter("kotekan_receiveflags_late_update_count", unique_name, {})) {
+    late_updates_counter(Metrics::instance().add_counter("kotekan_receiveflags_late_update_count",
+                                                         unique_name, {})) {
     // Setup the buffers
     buf_in = get_buffer("in_buf");
     buf_out = get_buffer("out_buf");

--- a/lib/stages/ReceiveFlags.cpp
+++ b/lib/stages/ReceiveFlags.cpp
@@ -41,11 +41,11 @@ ReceiveFlags::ReceiveFlags(Config& config, const std::string& unique_name,
                            bufferContainer& buffer_container) :
     Stage(config, unique_name, buffer_container, std::bind(&ReceiveFlags::main_thread, this)),
     receiveflags_late_frame_counter(
-        Metrics::instance().add_counter("kotekan_receiveflags_late_frame_count", unique_name)),
+        Metrics::instance().add_counter("kotekan_receiveflags_late_frame_count", unique_name, {})),
     receiveflags_update_age_metric(
-        Metrics::instance().add_gauge("kotekan_receiveflags_update_age_seconds", unique_name)),
+        Metrics::instance().add_gauge("kotekan_receiveflags_update_age_seconds", unique_name, {})),
     late_updates_counter(
-        Metrics::instance().add_counter("kotekan_receiveflags_late_update_count", unique_name)) {
+        Metrics::instance().add_counter("kotekan_receiveflags_late_update_count", unique_name, {})) {
     // Setup the buffers
     buf_in = get_buffer("in_buf");
     buf_out = get_buffer("out_buf");
@@ -122,7 +122,7 @@ bool ReceiveFlags::flags_callback(nlohmann::json& json) {
         WARN("Received update with a start_time that is older than the current "
              "frame (The difference is {:f} s).",
              ts_to_double(ts_frame) - ts);
-        late_updates_counter.inc();
+        late_updates_counter->labels({}).inc();
     }
 
     auto& dm = datasetManager::instance();
@@ -144,7 +144,7 @@ void ReceiveFlags::main_thread() {
 
     timespec ts_late = {0, 0};
 
-    receiveflags_update_age_metric.set(-ts_to_double(ts_late));
+    receiveflags_update_age_metric->labels({}).set(-ts_to_double(ts_late));
 
     while (!stop_thread) {
 
@@ -184,13 +184,13 @@ bool ReceiveFlags::copy_flags_into_frame(const VisFrameView& frame_out) {
     const auto& [ts_update, update] = flags.get_update(ts_frame);
 
     // Report how old the flags being applied to the current data are.
-    receiveflags_update_age_metric.set(-ts_to_double(ts_update - ts_frame));
+    receiveflags_update_age_metric->labels({}).set(-ts_to_double(ts_update - ts_frame));
 
     if (update == nullptr) {
         WARN("updateQueue: {}\nFlags for frame with timestamp {:f} are not in memory. Dropping "
              "frame...",
              flags, ts_to_double(ts_frame));
-        receiveflags_late_frame_counter.inc();
+        receiveflags_late_frame_counter->labels({}).inc();
         return false;
     }
 

--- a/lib/stages/ReceiveFlags.hpp
+++ b/lib/stages/ReceiveFlags.hpp
@@ -102,13 +102,13 @@ private:
     timespec ts_frame = {0, 0};
 
     /// Number of frames received late
-    kotekan::prometheus::Counter& receiveflags_late_frame_counter;
+    kotekan::prometheus::prometheus_counter_ptr_t receiveflags_late_frame_counter;
 
     /// Update ages
-    kotekan::prometheus::Gauge& receiveflags_update_age_metric;
+    kotekan::prometheus::prometheus_gauge_ptr_t receiveflags_update_age_metric;
 
     /// Number of updates received too late
-    kotekan::prometheus::Counter& late_updates_counter;
+    kotekan::prometheus::prometheus_counter_ptr_t late_updates_counter;
 
     // config values
     /// Number of elements

--- a/lib/stages/RfiFrameDrop.cpp
+++ b/lib/stages/RfiFrameDrop.cpp
@@ -9,23 +9,22 @@
 #include "bufferContainer.hpp"   // for bufferContainer
 #include "chimeMetadata.hpp"     // for chimeMetadata, get_dataset_id, get_fpga_seq_num, set_da...
 #include "configUpdater.hpp"     // for configUpdater
-#include "datasetManager.hpp"    // for dset_id_t, state_id_t, datasetManager
+#include "datasetManager.hpp"    // for dset_id_t, datasetManager, state_id_t
 #include "kotekanLogging.hpp"    // for WARN, INFO, DEBUG, DEBUG2
-#include "prometheusMetrics.hpp" // for Counter, Metrics, MetricFamily
+#include "prometheusMetrics.hpp" // for Metrics, Counter, MetricFamily, prometheus_counter_ptr_t
 #include "visUtil.hpp"           // for frameID, modulo
 
 #include "fmt.hpp" // for format, fmt
 
-#include <algorithm>  // for copy, max, copy_backward, equal, fill
+#include <algorithm>  // for copy, fill, max
 #include <assert.h>   // for assert
 #include <atomic>     // for atomic_bool
 #include <cmath>      // for sqrt, fabs
 #include <cstring>    // for memcpy
-#include <deque>      // for deque
 #include <exception>  // for exception
 #include <functional> // for _Bind_helper<>::type, function, bind, _Placeholder, _1
 #include <map>        // for map, map<>::mapped_type
-#include <memory>     // for allocator_traits<>::value_type
+#include <memory>     // for allocator_traits<>::value_type, __shared_ptr_access
 #include <regex>      // for match_results<>::_Base_type
 #include <stdexcept>  // for runtime_error
 #include <stdint.h>   // for uint8_t, int64_t, uint32_t

--- a/lib/stages/RfiFrameDrop.cpp
+++ b/lib/stages/RfiFrameDrop.cpp
@@ -197,7 +197,7 @@ void RfiFrameDrop::main_thread() {
                 if (sk_exceeds_copy.at(kk) > num_sk.at(kk)) {
                     skip = true;
                     failing_frame_counter
-                        .labels({std::to_string(freq_id), std::to_string(thresholds.at(kk).first),
+                        ->labels({std::to_string(freq_id), std::to_string(thresholds.at(kk).first),
                                  std::to_string(thresholds.at(kk).second)})
                         .inc();
                 }
@@ -217,11 +217,11 @@ void RfiFrameDrop::main_thread() {
                 set_dataset_id(_buf_out, frame_id_out, dset_id_out);
                 mark_frame_full(_buf_out, unique_name.c_str(), frame_id_out++);
             } else {
-                dropped_frame_counter.labels({std::to_string(freq_id)}).inc();
+                dropped_frame_counter->labels({std::to_string(freq_id)}).inc();
             }
 
             mark_frame_empty(_buf_in_vis, unique_name.c_str(), frame_id_in_vis++);
-            frame_counter.labels({std::to_string(freq_id)}).inc();
+            frame_counter->labels({std::to_string(freq_id)}).inc();
         }
         mark_frame_empty(_buf_in_sk, unique_name.c_str(), frame_id_in_sk++);
     }

--- a/lib/stages/RfiFrameDrop.cpp
+++ b/lib/stages/RfiFrameDrop.cpp
@@ -198,7 +198,7 @@ void RfiFrameDrop::main_thread() {
                     skip = true;
                     failing_frame_counter
                         ->labels({std::to_string(freq_id), std::to_string(thresholds.at(kk).first),
-                                 std::to_string(thresholds.at(kk).second)})
+                                  std::to_string(thresholds.at(kk).second)})
                         .inc();
                 }
                 // Reset counters for the next sub_frame

--- a/lib/stages/RfiFrameDrop.hpp
+++ b/lib/stages/RfiFrameDrop.hpp
@@ -102,9 +102,9 @@ private:
     datasetManager& dm = datasetManager::instance();
 
     /// Prometheus metrics to export
-    kotekan::prometheus::MetricFamily<kotekan::prometheus::Counter>& failing_frame_counter;
-    kotekan::prometheus::MetricFamily<kotekan::prometheus::Counter>& dropped_frame_counter;
-    kotekan::prometheus::MetricFamily<kotekan::prometheus::Counter>& frame_counter;
+    kotekan::prometheus::prometheus_counter_ptr_t failing_frame_counter;
+    kotekan::prometheus::prometheus_counter_ptr_t dropped_frame_counter;
+    kotekan::prometheus::prometheus_counter_ptr_t frame_counter;
 
     size_t num_elements;
     size_t num_sub_frames;

--- a/lib/stages/Transpose.cpp
+++ b/lib/stages/Transpose.cpp
@@ -190,7 +190,7 @@ void Transpose::main_thread() {
             ti = 0;
 
             // export prometheus metric
-            transposed_bytes_metric.labels({}).inc(frame_size);
+            transposed_bytes_metric->labels({}).inc(frame_size);
         }
 
         frames_so_far++;

--- a/lib/stages/Transpose.cpp
+++ b/lib/stages/Transpose.cpp
@@ -120,8 +120,8 @@ void Transpose::main_thread() {
     // Create HDF5 file
     create_hdf5_file();
 
-    auto& transposed_bytes_metric =
-        Metrics::instance().add_counter("kotekan_transpose_data_transposed_bytes", unique_name);
+    auto transposed_bytes_metric =
+        Metrics::instance().add_counter("kotekan_transpose_data_transposed_bytes", unique_name, {});
 
     while (!stop_thread) {
         if (num_empty_skip > 0) {
@@ -190,7 +190,7 @@ void Transpose::main_thread() {
             ti = 0;
 
             // export prometheus metric
-            transposed_bytes_metric.inc(frame_size);
+            transposed_bytes_metric.labels({}).inc(frame_size);
         }
 
         frames_so_far++;

--- a/lib/stages/VisSharedMemWriter.cpp
+++ b/lib/stages/VisSharedMemWriter.cpp
@@ -136,7 +136,7 @@ void VisSharedMemWriter::wait_for_semaphore() {
 
 #endif
     wait_time_average.add_sample(current_time() - start_time);
-    access_record_wait_time_seconds.labels({_name}).set(wait_time_average.average());
+    access_record_wait_time_seconds->labels({_name}).set(wait_time_average.average());
     return;
 }
 
@@ -206,7 +206,7 @@ void VisSharedMemWriter::add_sample(const VisFrameView& frame, time_ctype t, uin
         INFO("Dropping integration as buffer (FPGA count: {:d}) arrived too late (only accepting "
              "new times greater than {:d})",
              t.fpga_count, max_time.fpga_count);
-        dropped_frame_counter.labels({std::to_string(frame.freq_id), "order"}).inc();
+        dropped_frame_counter->labels({std::to_string(frame.freq_id), "order"}).inc();
         return;
     } else if (t < min_time) {
         // this data is older than anything else in the map, so we should
@@ -214,7 +214,7 @@ void VisSharedMemWriter::add_sample(const VisFrameView& frame, time_ctype t, uin
         INFO("Dropping integration as buffer (FPGA count: {:d}) arrived too late (minimum in pool "
              "{:d})",
              t.fpga_count, min_time.fpga_count);
-        dropped_frame_counter.labels({std::to_string(frame.freq_id), "late"}).inc();
+        dropped_frame_counter->labels({std::to_string(frame.freq_id), "late"}).inc();
         return;
     }
 

--- a/lib/stages/VisSharedMemWriter.cpp
+++ b/lib/stages/VisSharedMemWriter.cpp
@@ -6,22 +6,22 @@
 #include "datasetState.hpp"      // for freqState, _factory_aliasdatasetState
 #include "factory.hpp"           // for FACTORY
 #include "kotekanLogging.hpp"    // for FATAL_ERROR, DEBUG, INFO, WARN
-#include "prometheusMetrics.hpp" // for Counter, Gauge, Metrics, MetricFamily
+#include "prometheusMetrics.hpp" // for Metrics, MetricFamily, Counter, prometheus_counter_ptr_t
 #include "visBuffer.hpp"         // for VisFrameView, VisMetadata
 #include "visUtil.hpp"           // for time_ctype, frameID, operator<, modulo, current_time
 
-#include <algorithm>   // for copy, fill_n, copy_backward, equal, max
+#include <algorithm>   // for fill_n
 #include <atomic>      // for atomic_bool
-#include <deque>       // for deque
 #include <errno.h>     // for errno, ENOENT
 #include <exception>   // for exception
 #include <fcntl.h>     // for O_CREAT, O_EXCL, O_RDWR
 #include <functional>  // for _Bind_helper<>::type, bind, function
 #include <iterator>    // for reverse_iterator
 #include <map>         // for map, _Rb_tree_iterator
+#include <memory>      // for __shared_ptr_access
 #include <regex>       // for match_results<>::_Base_type
 #include <stdexcept>   // for runtime_error, out_of_range
-#include <stdio.h>     // for size_t, remove
+#include <stdio.h>     // for remove
 #include <string.h>    // for strerror, memcpy, memset
 #include <sys/mman.h>  // for mmap, shm_open, MAP_FAILED, MAP_SHARED, PROT_READ, PROT...
 #include <sys/stat.h>  // for S_IRUSR, S_IWUSR

--- a/lib/stages/VisSharedMemWriter.hpp
+++ b/lib/stages/VisSharedMemWriter.hpp
@@ -225,10 +225,10 @@ protected:
 
 private:
     // Number of dropped frames
-    kotekan::prometheus::MetricFamily<kotekan::prometheus::Counter>& dropped_frame_counter;
+    kotekan::prometheus::prometheus_counter_ptr_t dropped_frame_counter;
 
     // Time spent waiting for semaphore
-    kotekan::prometheus::MetricFamily<kotekan::prometheus::Gauge>& access_record_wait_time_seconds;
+    kotekan::prometheus::prometheus_gauge_ptr_t access_record_wait_time_seconds;
 
     // Keep track of the average semaphore wait time
     movingAverage wait_time_average;

--- a/lib/stages/applyGains.hpp
+++ b/lib/stages/applyGains.hpp
@@ -155,9 +155,9 @@ private:
     std::mutex m_frame_ids;
 
     // Prometheus metrics
-    kotekan::prometheus::Gauge& update_age_metric;
-    kotekan::prometheus::Counter& late_update_counter;
-    kotekan::prometheus::Counter& late_frames_counter;
+    kotekan::prometheus::prometheus_gauge_ptr_t update_age_metric;
+    kotekan::prometheus::prometheus_counter_ptr_t late_update_counter;
+    kotekan::prometheus::prometheus_counter_ptr_t late_frames_counter;
 
     /// Read the gain file from disk
     std::optional<GainData> read_gain_file(std::string update_id) const;

--- a/lib/stages/basebandReadout.cpp
+++ b/lib/stages/basebandReadout.cpp
@@ -12,7 +12,7 @@
 #include "metadata.h"             // for metadataContainer
 #include "nt_memcpy.h"            // for nt_memcpy
 #include "nt_memset.h"            // for nt_memset
-#include "prometheusMetrics.hpp"  // for Counter, Gauge, MetricFamily, Metrics
+#include "prometheusMetrics.hpp"  // for MetricFamily, prometheus_counter_ptr_t, Counter, Met...
 #include "version.h"              // for get_git_commit_hash
 #include "visFile.hpp"            // for create_lockfile
 #include "visUtil.hpp"            // for input_ctype, ts_to_double, parse_reorder_default
@@ -20,13 +20,12 @@
 #include "fmt.hpp"      // for format, fmt
 #include "gsl-lite.hpp" // for span, operator!=
 
-#include <algorithm>                // for max, copy, copy_backward, min
+#include <algorithm>                // for min, max
 #include <assert.h>                 // for assert
 #include <atomic>                   // for atomic_bool
 #include <chrono>                   // for system_clock::time_point, system_clock, nanoseconds
 #include <cstdint>                  // for uint64_t, uint8_t
 #include <cstdio>                   // for remove, snprintf
-#include <deque>                    // for deque
 #include <exception>                // for exception
 #include <functional>               // for _Bind_helper<>::type, bind, function
 #include <highfive/H5Attribute.hpp> // for Attribute, Attribute::write
@@ -38,7 +37,7 @@
 #include <highfive/H5Group.hpp>     // for Group
 #include <highfive/H5Selection.hpp> // for Selection, SliceTraits::write, SliceTraits::select
 #include <math.h>                   // for fmod
-#include <memory>                   // for unique_ptr, make_shared, make_unique, allocator_trai...
+#include <memory>                   // for unique_ptr, make_shared, __shared_ptr_access, make_u...
 #include <regex>                    // for match_results<>::_Base_type
 #include <stdexcept>                // for runtime_error
 #include <sys/time.h>               // for timeval, timeradd

--- a/lib/stages/basebandReadout.hpp
+++ b/lib/stages/basebandReadout.hpp
@@ -113,8 +113,8 @@ private:
     /// baseband data array
     BipBuffer data_buffer;
 
-    kotekan::prometheus::MetricFamily::prometheus_counter_ptr_t readout_counter;
-    kotekan::prometheus::MetricFamily::prometheus_gauge_ptr_t readout_in_progress_metric;
+    kotekan::prometheus::prometheus_counter_ptr_t readout_counter;
+    kotekan::prometheus::prometheus_gauge_ptr_t readout_in_progress_metric;
 };
 
 #endif

--- a/lib/stages/basebandReadout.hpp
+++ b/lib/stages/basebandReadout.hpp
@@ -113,8 +113,8 @@ private:
     /// baseband data array
     BipBuffer data_buffer;
 
-    kotekan::prometheus::MetricFamily<kotekan::prometheus::Counter>& readout_counter;
-    kotekan::prometheus::MetricFamily<kotekan::prometheus::Gauge>& readout_in_progress_metric;
+    kotekan::prometheus::MetricFamily::prometheus_counter_ptr_t readout_counter;
+    kotekan::prometheus::MetricFamily::prometheus_gauge_ptr_t readout_in_progress_metric;
 };
 
 #endif

--- a/lib/stages/bufferRecv.cpp
+++ b/lib/stages/bufferRecv.cpp
@@ -53,7 +53,7 @@ bufferRecv::bufferRecv(Config& config, const std::string& unique_name,
                        bufferContainer& buffer_container) :
     Stage(config, unique_name, buffer_container, std::bind(&bufferRecv::main_thread, this)),
     dropped_frame_counter(
-        Metrics::instance().add_counter("kotekan_buffer_recv_dropped_frame_total", unique_name)),
+        Metrics::instance().add_counter("kotekan_buffer_recv_dropped_frame_total", unique_name, {})),
     transfer_time_seconds(Metrics::instance().add_gauge("kotekan_buffer_recv_transfer_time_seconds",
                                                         unique_name, {"source"})) {
 
@@ -115,12 +115,12 @@ void bufferRecv::accept_connection(int listener, short event, void* arg) {
 
 void bufferRecv::increment_droped_frame_count() {
     std::lock_guard<mutex> lock(dropped_frame_count_mutex);
-    dropped_frame_counter.inc();
+    dropped_frame_counter->labels({}).inc();
 }
 
 void bufferRecv::set_transfer_time_seconds(const std::string& source_label, const double elapsed) {
     std::lock_guard<mutex> lock(transfer_time_seconds_mutex);
-    transfer_time_seconds.labels({source_label}).set(elapsed);
+    transfer_time_seconds->labels({source_label}).set(elapsed);
 }
 
 void bufferRecv::internal_accept_connection(evutil_socket_t listener, short event, void* arg) {

--- a/lib/stages/bufferRecv.cpp
+++ b/lib/stages/bufferRecv.cpp
@@ -52,8 +52,8 @@ REGISTER_KOTEKAN_STAGE(bufferRecv);
 bufferRecv::bufferRecv(Config& config, const std::string& unique_name,
                        bufferContainer& buffer_container) :
     Stage(config, unique_name, buffer_container, std::bind(&bufferRecv::main_thread, this)),
-    dropped_frame_counter(
-        Metrics::instance().add_counter("kotekan_buffer_recv_dropped_frame_total", unique_name, {})),
+    dropped_frame_counter(Metrics::instance().add_counter("kotekan_buffer_recv_dropped_frame_total",
+                                                          unique_name, {})),
     transfer_time_seconds(Metrics::instance().add_gauge("kotekan_buffer_recv_transfer_time_seconds",
                                                         unique_name, {"source"})) {
 

--- a/lib/stages/bufferRecv.hpp
+++ b/lib/stages/bufferRecv.hpp
@@ -157,14 +157,14 @@ private:
     struct event_base* base;
 
     /// The number of frames dropped
-    kotekan::prometheus::Counter& dropped_frame_counter;
+    kotekan::prometheus::prometheus_counter_ptr_t dropped_frame_counter;
 
     /// A lock on the @c dropped_frame_counter
     // TODO: move locking to prometheusMetrics?
     std::mutex dropped_frame_count_mutex;
 
     /// Time to receive the data
-    kotekan::prometheus::MetricFamily<kotekan::prometheus::Gauge>& transfer_time_seconds;
+    kotekan::prometheus::prometheus_gauge_ptr_t transfer_time_seconds;
 
     /// A lock on the `transfer_time_seconds`
     std::mutex transfer_time_seconds_mutex;

--- a/lib/stages/bufferSend.cpp
+++ b/lib/stages/bufferSend.cpp
@@ -4,18 +4,19 @@
 #include "StageFactory.hpp"      // for REGISTER_KOTEKAN_STAGE, StageMakerTemplate
 #include "buffer.h"              // for Buffer, get_num_full_frames, mark_frame_empty, register...
 #include "bufferContainer.hpp"   // for bufferContainer
-#include "kotekanLogging.hpp"    // for DEBUG2, ERROR, DEBUG, WARN, INFO
+#include "kotekanLogging.hpp"    // for DEBUG2, ERROR, INFO, DEBUG, WARN
 #include "metadata.h"            // for metadataContainer
-#include "prometheusMetrics.hpp" // for Metrics, Counter
+#include "prometheusMetrics.hpp" // for Counter, MetricFamily, Metrics, prometheus_counter_ptr_t
 
 #include "fmt.hpp" // for format, fmt
 
-#include <arpa/inet.h> // for inet_addr
-#include <cerrno>      // for errno
-#include <chrono>
+#include <arpa/inet.h>  // for inet_addr
+#include <cerrno>       // for errno
+#include <chrono>       // for seconds
 #include <cstring>      // for strerror, size_t
 #include <exception>    // for exception
 #include <functional>   // for _Bind_helper<>::type, bind, ref, function
+#include <memory>       // for __shared_ptr_access
 #include <regex>        // for match_results<>::_Base_type
 #include <stdexcept>    // for runtime_error
 #include <strings.h>    // for bzero

--- a/lib/stages/bufferSend.cpp
+++ b/lib/stages/bufferSend.cpp
@@ -40,9 +40,8 @@ REGISTER_KOTEKAN_STAGE(bufferSend);
 bufferSend::bufferSend(Config& config, const std::string& unique_name,
                        bufferContainer& buffer_container) :
     Stage(config, unique_name, buffer_container, std::bind(&bufferSend::main_thread, this)),
-    dropped_frame_counter(
-        Metrics::instance().add_counter("kotekan_buffer_send_dropped_frame_count", unique_name,
-                                        {})) {
+    dropped_frame_counter(Metrics::instance().add_counter("kotekan_buffer_send_dropped_frame_count",
+                                                          unique_name, {})) {
 
     buf = get_buffer("buf");
     register_consumer(buf, unique_name.c_str());

--- a/lib/stages/bufferSend.cpp
+++ b/lib/stages/bufferSend.cpp
@@ -41,7 +41,8 @@ bufferSend::bufferSend(Config& config, const std::string& unique_name,
                        bufferContainer& buffer_container) :
     Stage(config, unique_name, buffer_container, std::bind(&bufferSend::main_thread, this)),
     dropped_frame_counter(
-        Metrics::instance().add_counter("kotekan_buffer_send_dropped_frame_count", unique_name)) {
+        Metrics::instance().add_counter("kotekan_buffer_send_dropped_frame_count", unique_name,
+                                        {})) {
 
     buf = get_buffer("buf");
     register_consumer(buf, unique_name.c_str());
@@ -86,11 +87,11 @@ void bufferSend::main_thread() {
             INFO("Number of full frames in buffer {:s} is {:d} (total frames: {:d}), dropping "
                  "frame_id {:d}",
                  buf->buffer_name, num_full_frames, buf->num_frames, frame_id);
-            dropped_frame_counter.inc();
+            dropped_frame_counter->labels({}).inc();
         } else if (drop_frames && !connected) {
             INFO("Dropping frame {:s}[{:d}], because connection to {:s}:{:d} is down.",
                  buf->buffer_name, frame_id, server_ip, server_port);
-            dropped_frame_counter.inc();
+            dropped_frame_counter->labels({}).inc();
         } else if (connected) {
             // Send header
             struct bufferFrameHeader header;

--- a/lib/stages/bufferSend.hpp
+++ b/lib/stages/bufferSend.hpp
@@ -102,7 +102,7 @@ private:
      * Only counts dropped data from caused by the send being too slow,
      * it does not include the number of frames dropped because the server is down.
      */
-    kotekan::prometheus::Counter& dropped_frame_counter;
+    kotekan::prometheus::prometheus_counter_ptr_t dropped_frame_counter;
 
     /// Set to true if there is an active connection
     std::atomic<bool> connected;

--- a/lib/stages/bufferStatus.cpp
+++ b/lib/stages/bufferStatus.cpp
@@ -11,6 +11,7 @@
 #include <atomic>     // for atomic_bool
 #include <exception>  // for exception
 #include <functional> // for _Bind_helper<>::type, bind, function
+#include <memory>     // for __shared_ptr_access, shared_ptr
 #include <regex>      // for match_results<>::_Base_type
 #include <stdexcept>  // for runtime_error
 #include <stdint.h>   // for uint32_t

--- a/lib/stages/bufferStatus.cpp
+++ b/lib/stages/bufferStatus.cpp
@@ -41,9 +41,9 @@ bufferStatus::~bufferStatus() {}
 void bufferStatus::main_thread() {
 
     Metrics& metrics = Metrics::instance();
-    auto& frames_counter =
+    auto frames_counter =
         metrics.add_gauge("kotekan_bufferstatus_frames_total", unique_name, {"buffer_name"});
-    auto& full_frames_counter =
+    auto full_frames_counter =
         metrics.add_gauge("kotekan_bufferstatus_full_frames_total", unique_name, {"buffer_name"});
 
     double last_print_time = current_time();
@@ -57,8 +57,8 @@ void bufferStatus::main_thread() {
         for (auto& buf_entry : buffers) {
             uint32_t num_full_frames = get_num_full_frames(buf_entry.second);
             std::string buffer_name = buf_entry.first;
-            full_frames_counter.labels({buffer_name}).set(num_full_frames);
-            frames_counter.labels({buffer_name}).set(buf_entry.second->num_frames);
+            full_frames_counter->labels({buffer_name}).set(num_full_frames);
+            frames_counter->labels({buffer_name}).set(buf_entry.second->num_frames);
         }
 
         if (print_status && (now - last_print_time) > ((double)time_delay / 1000000.0)) {

--- a/lib/stages/eigenVis.cpp
+++ b/lib/stages/eigenVis.cpp
@@ -92,14 +92,14 @@ void eigenVis::main_thread() {
 
     openblas_set_num_threads(1);
 
-    auto& eigenvalue_metric = Metrics::instance().add_gauge(
+    auto eigenvalue_metric = Metrics::instance().add_gauge(
         "kotekan_eigenvis_eigenvalue", unique_name, {"eigenvalue", "freq_id", "dataset_id"});
 
-    auto& comp_time_seconds_metric =
-        Metrics::instance().add_gauge("kotekan_eigenvis_comp_time_seconds", unique_name);
+    auto comp_time_seconds_metric =
+        Metrics::instance().add_gauge("kotekan_eigenvis_comp_time_seconds", unique_name, {});
 
     // TODO: this should logically be a Counter
-    auto& lapack_failure_counter = Metrics::instance().add_gauge(
+    auto lapack_failure_counter = Metrics::instance().add_gauge(
         "kotekan_eigenvis_lapack_failure_total", unique_name, {"freq_id", "dataset_id"});
 
     while (!stop_thread) {
@@ -184,7 +184,7 @@ void eigenVis::main_thread() {
 
             // Update prometheus metric about LAPACK failures
             lapack_failure_counter
-                .labels({std::to_string(freq_id), input_frame.dataset_id.to_string()})
+                ->labels({std::to_string(freq_id), input_frame.dataset_id.to_string()})
                 .set(lapack_failure_total);
 
             // Clear frame and advance
@@ -238,19 +238,19 @@ void eigenVis::main_thread() {
 
         // Update average write time in prometheus
         calc_time.add_sample(elapsed_time);
-        comp_time_seconds_metric.set(calc_time.average());
+        comp_time_seconds_metric->labels({}).set(calc_time.average());
 
         // Output eigenvalues to prometheus
         for (uint32_t i = 0; i < num_eigenvectors; i++) {
             eigenvalue_metric
-                .labels({std::to_string(i), std::to_string(freq_id),
+                ->labels({std::to_string(i), std::to_string(freq_id),
                          input_frame.dataset_id.to_string()})
                 .set(evals[num_eigenvectors - 1 - i]);
         }
 
         // Output RMS to prometheus
         eigenvalue_metric
-            .labels({"rms", std::to_string(freq_id), input_frame.dataset_id.to_string()})
+            ->labels({"rms", std::to_string(freq_id), input_frame.dataset_id.to_string()})
             .set(rms);
 
         // Get output buffer for visibilities. Essentially identical to input buffers.

--- a/lib/stages/eigenVis.cpp
+++ b/lib/stages/eigenVis.cpp
@@ -244,7 +244,7 @@ void eigenVis::main_thread() {
         for (uint32_t i = 0; i < num_eigenvectors; i++) {
             eigenvalue_metric
                 ->labels({std::to_string(i), std::to_string(freq_id),
-                         input_frame.dataset_id.to_string()})
+                          input_frame.dataset_id.to_string()})
                 .set(evals[num_eigenvectors - 1 - i]);
         }
 

--- a/lib/stages/frbPostProcess.cpp
+++ b/lib/stages/frbPostProcess.cpp
@@ -17,6 +17,7 @@
 #include <exception>   // for exception
 #include <functional>  // for _Bind_helper<>::type, bind, function
 #include <immintrin.h> // for _mm256_broadcast_ss, __m256, _mm256_load_ps, _mm256_min_ps
+#include <memory>      // for __shared_ptr_access, shared_ptr
 #include <mm_malloc.h> // for posix_memalign
 #include <regex>       // for match_results<>::_Base_type
 #include <stdexcept>   // for runtime_error

--- a/lib/stages/frbPostProcess.cpp
+++ b/lib/stages/frbPostProcess.cpp
@@ -37,7 +37,7 @@ frbPostProcess::frbPostProcess(Config& config_, const std::string& unique_name,
                                bufferContainer& buffer_container) :
     Stage(config_, unique_name, buffer_container, std::bind(&frbPostProcess::main_thread, this)),
     masked_packets_counter(kotekan::prometheus::Metrics::instance().add_counter(
-        "kotekan_frb_masked_packets_total", unique_name)) {
+        "kotekan_frb_masked_packets_total", unique_name, {})) {
     // Apply config.
     _num_gpus = config.get<int32_t>(unique_name, "num_gpus");
     _samples_per_data_set = config.get<int32_t>(unique_name, "samples_per_data_set");
@@ -331,7 +331,7 @@ void frbPostProcess::main_thread() {
                             frb_header_offset[b * _num_gpus + thread_id] = 0.0;
                             scl = 0.0;
                             ofs = 0.0;
-                            masked_packets_counter.inc();
+                            masked_packets_counter->labels({}).inc();
                         } else {
                             // scale to 1-254 (0 and 255 are both error codes)
                             scl = (253.) / (max - min);

--- a/lib/stages/frbPostProcess.hpp
+++ b/lib/stages/frbPostProcess.hpp
@@ -131,7 +131,7 @@ private:
     uint8_t* droppacket;
 
     /// Count of masked packets
-    kotekan::prometheus::Counter& masked_packets_counter;
+    kotekan::prometheus::prometheus_counter_ptr_t masked_packets_counter;
 };
 
 #endif

--- a/lib/stages/rawFileWrite.cpp
+++ b/lib/stages/rawFileWrite.cpp
@@ -15,6 +15,7 @@
 #include <exception>  // for exception
 #include <fcntl.h>    // for open, O_CREAT, O_WRONLY
 #include <functional> // for _Bind_helper<>::type, bind, function
+#include <memory>     // for __shared_ptr_access, shared_ptr
 #include <regex>      // for match_results<>::_Base_type
 #include <stdexcept>  // for runtime_error
 #include <stdint.h>   // for uint32_t, int32_t, uint8_t

--- a/lib/stages/rawFileWrite.cpp
+++ b/lib/stages/rawFileWrite.cpp
@@ -61,8 +61,8 @@ void rawFileWrite::main_thread() {
     const int full_path_len = 200;
     char full_path[full_path_len];
 
-    auto& write_time_metric =
-        Metrics::instance().add_gauge("kotekan_rawfilewrite_write_time_seconds", unique_name);
+    auto write_time_metric =
+        Metrics::instance().add_gauge("kotekan_rawfilewrite_write_time_seconds", unique_name, {});
     while (!stop_thread) {
 
         // This call is blocking.
@@ -136,7 +136,7 @@ void rawFileWrite::main_thread() {
         }
 
         double elapsed = current_time() - st;
-        write_time_metric.set(elapsed);
+        write_time_metric->labels({}).set(elapsed);
 
         mark_frame_empty(buf, unique_name.c_str(), frame_id);
 

--- a/lib/stages/rfiBroadcast.cpp
+++ b/lib/stages/rfiBroadcast.cpp
@@ -231,8 +231,8 @@ void rfiBroadcast::main_thread() {
             // Increment the prometheus metrics for the total number of samples and the total number
             // of flagged samples
             uint32_t current_freq_bin = tel.to_freq_id(StreamIDs[0]);
-            sample_counter.labels({std::to_string(current_freq_bin)}).inc(sk_samples_per_frame);
-            flagged_sample_counter.labels({std::to_string(current_freq_bin)}).inc(mask_total);
+            sample_counter->labels({std::to_string(current_freq_bin)}).inc(sk_samples_per_frame);
+            flagged_sample_counter->labels({std::to_string(current_freq_bin)}).inc(mask_total);
 
             // TODO JSW: Handle num_local_freq > 1
             freq_bins[0] = current_freq_bin;

--- a/lib/stages/rfiBroadcast.cpp
+++ b/lib/stages/rfiBroadcast.cpp
@@ -18,12 +18,11 @@
 
 #include "fmt.hpp" // for format, fmt
 
-#include <algorithm>    // for copy, copy_backward, equal, max
 #include <arpa/inet.h>  // for inet_aton
 #include <atomic>       // for atomic_bool
-#include <deque>        // for deque
 #include <exception>    // for exception
 #include <functional>   // for _Bind_helper<>::type, _Placeholder, bind, _1, _2, function
+#include <memory>       // for __shared_ptr_access
 #include <mutex>        // for mutex, lock_guard
 #include <netinet/in.h> // for sockaddr_in, IPPROTO_UDP, htons
 #include <regex>        // for match_results<>::_Base_type

--- a/lib/stages/rfiBroadcast.hpp
+++ b/lib/stages/rfiBroadcast.hpp
@@ -118,8 +118,8 @@ private:
     /// Moving average of frame zeroing percentage to send to prometheus
     movingAverage perc_zeroed;
     /// Prometheus metrics to export
-    kotekan::prometheus::MetricFamily<kotekan::prometheus::Counter>& sample_counter;
-    kotekan::prometheus::MetricFamily<kotekan::prometheus::Counter>& flagged_sample_counter;
+    kotekan::prometheus::prometheus_counter_ptr_t sample_counter;
+    kotekan::prometheus::prometheus_counter_ptr_t flagged_sample_counter;
 };
 
 #endif

--- a/lib/stages/timeDownsample.cpp
+++ b/lib/stages/timeDownsample.cpp
@@ -15,6 +15,7 @@
 #include <complex>    // for complex
 #include <exception>  // for exception
 #include <functional> // for _Bind_helper<>::type, bind, function
+#include <memory>     // for __shared_ptr_access, shared_ptr
 #include <regex>      // for match_results<>::_Base_type
 #include <stdexcept>  // for runtime_error
 #include <stdint.h>   // for uint32_t, uint64_t, int32_t

--- a/lib/stages/timeDownsample.cpp
+++ b/lib/stages/timeDownsample.cpp
@@ -58,7 +58,7 @@ void timeDownsample::main_thread() {
     uint64_t fpga_seq_start = 0;
     int32_t freq_id = -1; // needs to be set by first frame
 
-    auto& skipped_frame_counter = Metrics::instance().add_counter(
+    auto skipped_frame_counter = Metrics::instance().add_counter(
         "kotekan_timedownsample_skipped_frame_total", unique_name, {"freq_id", "reason"});
 
     while (!stop_thread) {
@@ -96,7 +96,7 @@ void timeDownsample::main_thread() {
         // Don't start accumulating unless at the start of window
         if (nframes == 0 and wdw_pos != 0) {
             // Skip this frame
-            skipped_frame_counter.labels({std::to_string(freq_id), "alignment"}).inc();
+            skipped_frame_counter->labels({std::to_string(freq_id), "alignment"}).inc();
             mark_frame_empty(in_buf, unique_name.c_str(), frame_id++);
             continue;
         } else if (nframes == 0) { // Start accumulating frames
@@ -157,7 +157,7 @@ void timeDownsample::main_thread() {
 
             timespec output_age = std::get<1>(frame.time) - std::get<1>(output_frame.time);
             if (ts_to_double(output_age) > max_age) {
-                skipped_frame_counter.labels({std::to_string(freq_id), "age"}).inc();
+                skipped_frame_counter->labels({std::to_string(freq_id), "age"}).inc();
                 nframes = 0;
                 continue;
             }

--- a/lib/stages/valve.cpp
+++ b/lib/stages/valve.cpp
@@ -1,13 +1,13 @@
 #include "valve.hpp"
 
-#include "Config.hpp"
-#include "Stage.hpp"        // for Stage
-#include "StageFactory.hpp" // for REGISTER_KOTEKAN_STAGE, StageMakerTemplate
-#include "buffer.h"         // for Buffer, allocate_new_metadata_object, get_num_consumers
-#include "bufferContainer.hpp"
+#include "Config.hpp"            // for Config
+#include "Stage.hpp"             // for Stage
+#include "StageFactory.hpp"      // for REGISTER_KOTEKAN_STAGE, StageMakerTemplate
+#include "buffer.h"              // for Buffer, allocate_new_metadata_object, get_num_consumers
+#include "bufferContainer.hpp"   // for bufferContainer
 #include "kotekanLogging.hpp"    // for FATAL_ERROR, WARN
 #include "metadata.h"            // for metadataContainer
-#include "prometheusMetrics.hpp" // for Metrics, Counter
+#include "prometheusMetrics.hpp" // for Metrics, Counter, MetricFamily
 #include "visUtil.hpp"           // for frameID, modulo
 
 #include "fmt.hpp" // for format, fmt
@@ -16,9 +16,10 @@
 #include <cstring>    // for memcpy
 #include <exception>  // for exception
 #include <functional> // for _Bind_helper<>::type, bind, function
+#include <memory>     // for __shared_ptr_access, shared_ptr
 #include <stdexcept>  // for runtime_error
 #include <stdint.h>   // for uint8_t
-#include <string>     // for string, allocator
+#include <string>     // for string
 
 
 using kotekan::bufferContainer;

--- a/lib/stages/valve.cpp
+++ b/lib/stages/valve.cpp
@@ -42,8 +42,8 @@ void Valve::main_thread() {
     frameID frame_id_out(_buf_out);
 
     /// Metric to track the number of dropped frames.
-    auto& dropped_total =
-        Metrics::instance().add_counter("kotekan_valve_dropped_frames_total", unique_name);
+    auto dropped_total =
+        Metrics::instance().add_counter("kotekan_valve_dropped_frames_total", unique_name, {});
 
     while (!stop_thread) {
         // Fetch a new frame and get its sequence id
@@ -66,7 +66,7 @@ void Valve::main_thread() {
             mark_frame_full(_buf_out, unique_name.c_str(), frame_id_out++);
         } else {
             WARN("Output buffer full. Dropping incoming frame {:d}.", frame_id_in);
-            dropped_total.inc();
+            dropped_total->labels({}).inc();
         }
         mark_frame_empty(_buf_in, unique_name.c_str(), frame_id_in++);
     }

--- a/lib/stages/visAccumulate.cpp
+++ b/lib/stages/visAccumulate.cpp
@@ -532,19 +532,19 @@ void visAccumulate::finalise_output(visAccumulate::internalState& state,
         // the following ones must be too. I think this requires the buffer
         // mechanism being rewritten to fix this one.
         if (ts_to_double(std::get<1>(output_frame.time) - newest_frame_time) > max_age) {
-            skipped_frame_counter.labels({std::to_string(output_frame.freq_id), "age"}).inc();
+            skipped_frame_counter->labels({std::to_string(output_frame.freq_id), "age"}).inc();
             blocked = true;
             continue;
         }
         if (output_frame.fpga_seq_total < minimum_samples) {
-            skipped_frame_counter.labels({std::to_string(output_frame.freq_id), "flagged"}).inc();
+            skipped_frame_counter->labels({std::to_string(output_frame.freq_id), "flagged"}).inc();
             blocked = true;
             continue;
         } else if (blocked) {
             // If we are here, an earlier frame was skipped and thus we have to
             // throw this one away too. Mark it as skipped because it was
             // blocked.
-            skipped_frame_counter.labels({std::to_string(output_frame.freq_id), "blocked"}).inc();
+            skipped_frame_counter->labels({std::to_string(output_frame.freq_id), "blocked"}).inc();
             continue;
         }
 

--- a/lib/stages/visAccumulate.hpp
+++ b/lib/stages/visAccumulate.hpp
@@ -236,7 +236,7 @@ private:
 
     // Reference to the prometheus metric that we will use for counting skipped
     // frames
-    kotekan::prometheus::MetricFamily<kotekan::prometheus::Counter>& skipped_frame_counter;
+    kotekan::prometheus::prometheus_counter_ptr_t skipped_frame_counter;
 };
 
 #endif

--- a/lib/stages/visCompression.cpp
+++ b/lib/stages/visCompression.cpp
@@ -19,7 +19,6 @@
 #include <atomic>       // for atomic_bool
 #include <complex>      // for complex, norm
 #include <cxxabi.h>     // for __forced_unwind
-#include <deque>        // for deque
 #include <exception>    // for exception
 #include <functional>   // for _Bind_helper<>::type, bind, function, placeholders
 #include <future>       // for async, future

--- a/lib/stages/visCompression.cpp
+++ b/lib/stages/visCompression.cpp
@@ -290,9 +290,9 @@ void baselineCompression::compress_thread(uint32_t thread_id) {
 
         // Update prometheus metrics
         double elapsed = current_time() - start_time;
-        compression_residuals_metric.labels({std::to_string(output_frame.freq_id)}).set(residual);
-        compression_time_seconds_metric.labels({std::to_string(thread_id)}).set(elapsed);
-        compression_frame_counter.labels({std::to_string(thread_id)}).inc();
+        compression_residuals_metric->labels({std::to_string(output_frame.freq_id)}).set(residual);
+        compression_time_seconds_metric->labels({std::to_string(thread_id)}).set(elapsed);
+        compression_frame_counter->labels({std::to_string(thread_id)}).inc();
 
         // Get the current values of the shared frame IDs and increment them.
         {

--- a/lib/stages/visCompression.hpp
+++ b/lib/stages/visCompression.hpp
@@ -115,9 +115,9 @@ private:
     // Map from the critical incoming states to the correct stackState
     std::map<fingerprint_t, std::tuple<state_id_t, const stackState*, const prodState*>> state_map;
 
-    kotekan::prometheus::MetricFamily<kotekan::prometheus::Gauge>& compression_residuals_metric;
-    kotekan::prometheus::MetricFamily<kotekan::prometheus::Gauge>& compression_time_seconds_metric;
-    kotekan::prometheus::MetricFamily<kotekan::prometheus::Counter>& compression_frame_counter;
+    kotekan::prometheus::prometheus_gauge_ptr_t compression_residuals_metric;
+    kotekan::prometheus::prometheus_gauge_ptr_t compression_time_seconds_metric;
+    kotekan::prometheus::prometheus_counter_ptr_t compression_frame_counter;
 };
 
 

--- a/lib/stages/visDebug.cpp
+++ b/lib/stages/visDebug.cpp
@@ -13,6 +13,7 @@
 #include <cstdint>    // for uint64_t
 #include <exception>  // for exception
 #include <functional> // for _Bind_helper<>::type, bind, function
+#include <memory>     // for __shared_ptr_access, shared_ptr
 #include <regex>      // for match_results<>::_Base_type
 #include <stdexcept>  // for runtime_error
 #include <vector>     // for vector

--- a/lib/stages/visDebug.cpp
+++ b/lib/stages/visDebug.cpp
@@ -43,10 +43,10 @@ void visDebug::main_thread() {
 
     uint64_t num_frames = 0;
 
-    auto& frame_freq_counter = Metrics::instance().add_counter(
+    auto frame_freq_counter = Metrics::instance().add_counter(
         "kotekan_visdebug_frames_by_freq_total", unique_name, {"freq_id"});
 
-    auto& frame_dataset_counter = Metrics::instance().add_counter(
+    auto frame_dataset_counter = Metrics::instance().add_counter(
         "kotekan_visdebug_frames_by_dataset_total", unique_name, {"dataset_id"});
     while (!stop_thread) {
 
@@ -61,8 +61,8 @@ void visDebug::main_thread() {
         auto frame = VisFrameView(in_buf, frame_id);
         DEBUG("{:s}", frame.summary());
 
-        frame_freq_counter.labels({std::to_string(frame.freq_id)}).inc();
-        frame_dataset_counter.labels({frame.dataset_id.to_string()}).inc();
+        frame_freq_counter->labels({std::to_string(frame.freq_id)}).inc();
+        frame_dataset_counter->labels({frame.dataset_id.to_string()}).inc();
 
         // Mark the buffers and move on
         mark_frame_empty(in_buf, unique_name.c_str(), frame_id);

--- a/lib/stages/visTestPattern.cpp
+++ b/lib/stages/visTestPattern.cpp
@@ -144,11 +144,11 @@ void visTestPattern::main_thread() {
     auto bad_values_counter = Metrics::instance().add_gauge(
         "kotekan_vistestpattern_bad_values_total", unique_name, {"name", "freq_id"});
     auto avg_error_metric = Metrics::instance().add_gauge("kotekan_vistestpattern_avg_error",
-                                                           unique_name, {"name", "freq_id"});
+                                                          unique_name, {"name", "freq_id"});
     auto min_error_metric = Metrics::instance().add_gauge("kotekan_vistestpattern_min_error",
-                                                           unique_name, {"name", "freq_id"});
+                                                          unique_name, {"name", "freq_id"});
     auto max_error_metric = Metrics::instance().add_gauge("kotekan_vistestpattern_max_error",
-                                                           unique_name, {"name", "freq_id"});
+                                                          unique_name, {"name", "freq_id"});
     auto fpga_sequence_number_metric = Metrics::instance().add_gauge(
         "kotekan_vistestpattern_fpga_sequence_number", unique_name, {"name", "freq_id"});
     auto ctime_seconds_metric = Metrics::instance().add_gauge(

--- a/lib/stages/visTestPattern.cpp
+++ b/lib/stages/visTestPattern.cpp
@@ -141,17 +141,17 @@ void visTestPattern::main_thread() {
     // Comparisons will be against tolerance^2
     float t2 = _tolerance * _tolerance;
 
-    auto& bad_values_counter = Metrics::instance().add_gauge(
+    auto bad_values_counter = Metrics::instance().add_gauge(
         "kotekan_vistestpattern_bad_values_total", unique_name, {"name", "freq_id"});
-    auto& avg_error_metric = Metrics::instance().add_gauge("kotekan_vistestpattern_avg_error",
+    auto avg_error_metric = Metrics::instance().add_gauge("kotekan_vistestpattern_avg_error",
                                                            unique_name, {"name", "freq_id"});
-    auto& min_error_metric = Metrics::instance().add_gauge("kotekan_vistestpattern_min_error",
+    auto min_error_metric = Metrics::instance().add_gauge("kotekan_vistestpattern_min_error",
                                                            unique_name, {"name", "freq_id"});
-    auto& max_error_metric = Metrics::instance().add_gauge("kotekan_vistestpattern_max_error",
+    auto max_error_metric = Metrics::instance().add_gauge("kotekan_vistestpattern_max_error",
                                                            unique_name, {"name", "freq_id"});
-    auto& fpga_sequence_number_metric = Metrics::instance().add_gauge(
+    auto fpga_sequence_number_metric = Metrics::instance().add_gauge(
         "kotekan_vistestpattern_fpga_sequence_number", unique_name, {"name", "freq_id"});
-    auto& ctime_seconds_metric = Metrics::instance().add_gauge(
+    auto ctime_seconds_metric = Metrics::instance().add_gauge(
         "kotekan_vistestpattern_ctime_seconds", unique_name, {"name", "freq_id"});
 
     while (!stop_thread) {
@@ -230,9 +230,9 @@ void visTestPattern::main_thread() {
 
                 // update Prometheus metrics
                 const std::string freq_id_label = std::to_string(freq_id);
-                bad_values_counter.labels({test_name, freq_id_label}).set(num_bad);
-                fpga_sequence_number_metric.labels({test_name, freq_id_label}).set(fpga_count);
-                ctime_seconds_metric.labels({test_name, freq_id_label}).set(ts_to_double(time));
+                bad_values_counter->labels({test_name, freq_id_label}).set(num_bad);
+                fpga_sequence_number_metric->labels({test_name, freq_id_label}).set(fpga_count);
+                ctime_seconds_metric->labels({test_name, freq_id_label}).set(ts_to_double(time));
 
                 if (num_bad) {
                     avg_err /= (float)num_bad;
@@ -256,9 +256,9 @@ void visTestPattern::main_thread() {
                     DEBUG("freq id: {:d}", freq_id);
 
                     // update error stats
-                    avg_error_metric.labels({test_name, freq_id_label}).set(avg_err);
-                    min_error_metric.labels({test_name, freq_id_label}).set(min_err);
-                    max_error_metric.labels({test_name, freq_id_label}).set(max_err);
+                    avg_error_metric->labels({test_name, freq_id_label}).set(avg_err);
+                    min_error_metric->labels({test_name, freq_id_label}).set(min_err);
+                    max_error_metric->labels({test_name, freq_id_label}).set(max_err);
 
                     // gather data for report after many frames
                     num_bad_tot += num_bad;
@@ -290,9 +290,9 @@ void visTestPattern::main_thread() {
                     // Advance output frame id
                     output_frame_id++;
                 } else {
-                    avg_error_metric.labels({test_name, freq_id_label}).set(0);
-                    min_error_metric.labels({test_name, freq_id_label}).set(0);
-                    max_error_metric.labels({test_name, freq_id_label}).set(0);
+                    avg_error_metric->labels({test_name, freq_id_label}).set(0);
+                    min_error_metric->labels({test_name, freq_id_label}).set(0);
+                    max_error_metric->labels({test_name, freq_id_label}).set(0);
                 }
 
                 // print report some times

--- a/lib/utils/datasetManager.cpp
+++ b/lib/utils/datasetManager.cpp
@@ -23,7 +23,7 @@ datasetManager::datasetManager() :
     _config_applied(false),
     _rest_client(restClient::instance()),
     error_counter(kotekan::prometheus::Metrics::instance().add_gauge(
-        "kotekan_datasetbroker_error_count", DS_UNIQUE_NAME)) {
+        "kotekan_datasetbroker_error_count", DS_UNIQUE_NAME, {})) {
 
     kotekan::restServer::instance().register_get_callback(
         DS_FORCE_UPDATE_ENDPOINT_NAME,
@@ -212,7 +212,7 @@ void datasetManager::request_thread(const json&& request, const std::string&& en
             // Parsing errors are reported by the parsing function.
         } else {
             // Complain and retry...
-            error_counter.set(++_conn_error_count);
+            error_counter->labels({}).set(++_conn_error_count);
             WARN_NON_OO("datasetManager: Failure in connection to broker: {:s}:{:d}/{:s}. Make "
                         "sure the broker is running.",
                         _ds_broker_host, _ds_broker_port, endpoint);
@@ -240,7 +240,7 @@ bool datasetManager::register_state_parser(std::string& reply) {
         WARN_NON_OO("datasetManager: failure parsing reply received from broker after "
                     "registering dataset state (reply: {:s}): {:s}",
                     reply, e.what());
-        error_counter.set(++_conn_error_count);
+        error_counter->labels({}).set(++_conn_error_count);
         return false;
     }
 
@@ -283,7 +283,7 @@ bool datasetManager::register_state_parser(std::string& reply) {
     } catch (std::exception& e) {
         WARN_NON_OO("datasetManager: failure registering dataset state with broker: {:s}",
                     e.what());
-        error_counter.set(++_conn_error_count);
+        error_counter->labels({}).set(++_conn_error_count);
         return false;
     }
     return true;
@@ -302,7 +302,7 @@ bool datasetManager::send_state_parser(std::string& reply) {
         WARN_NON_OO("datasetManager: failure parsing reply received from broker "
                     "after sending dataset state (reply: {:s}): {:s}",
                     reply, e.what());
-        error_counter.set(++_conn_error_count);
+        error_counter->labels({}).set(++_conn_error_count);
         return false;
     }
 }
@@ -339,7 +339,7 @@ bool datasetManager::register_dataset_parser(std::string& reply) {
         WARN_NON_OO("datasetManager: failure parsing reply received from broker "
                     "after registering dataset (reply: {:s}): {:s}",
                     reply, e.what());
-        error_counter.set(++_conn_error_count);
+        error_counter->labels({}).set(++_conn_error_count);
         return false;
     }
 }
@@ -462,7 +462,7 @@ bool datasetManager::parse_reply_dataset_update(restClient::restReply reply) {
     if (!reply.first) {
         WARN_NON_OO("datasetManager: Failure requesting update on datasets from broker: {:s}",
                     reply.second);
-        error_counter.set(++_conn_error_count);
+        error_counter->labels({}).set(++_conn_error_count);
         return false;
     }
 
@@ -489,7 +489,7 @@ bool datasetManager::parse_reply_dataset_update(restClient::restReply reply) {
                             "requesting dataset update: the following exception was thrown when "
                             "parsing dataset {:s} with ID {:s}: {:s}",
                             ds.value().dump(4), ds.key(), e.what());
-                error_counter.set(++_conn_error_count);
+                error_counter->labels({}).set(++_conn_error_count);
                 return false;
             }
         }
@@ -497,7 +497,7 @@ bool datasetManager::parse_reply_dataset_update(restClient::restReply reply) {
         WARN_NON_OO("datasetManager: failure parsing reply received from broker "
                     "after requesting dataset update (reply: {:s}): {:s}",
                     reply.second, e.what());
-        error_counter.set(++_conn_error_count);
+        error_counter->labels({}).set(++_conn_error_count);
         return false;
     }
 

--- a/lib/utils/datasetManager.hpp
+++ b/lib/utils/datasetManager.hpp
@@ -444,7 +444,7 @@ private:
     restClient& _rest_client;
 
     // TODO: this should be a counter, but we don't have it using atomic Ints
-    kotekan::prometheus::Gauge& error_counter;
+    kotekan::prometheus::prometheus_gauge_ptr_t error_counter;
 };
 
 
@@ -568,7 +568,7 @@ inline const T* datasetManager::request_state(state_id_t state_id) {
         PATH_REQUEST_STATE, js_request, _ds_broker_host, _ds_broker_port);
     if (!reply.first) {
         WARN_NON_OO("datasetManager: Failure requesting state from broker: {:s}", reply.second);
-        error_counter.set(++_conn_error_count);
+        error_counter->labels({}).set(++_conn_error_count);
         return nullptr;
     }
 
@@ -622,7 +622,7 @@ inline const T* datasetManager::request_state(state_id_t state_id) {
         WARN_NON_OO("datasetManager: failure parsing reply received from broker after requesting "
                     "state (reply: {:s}): {:s}",
                     reply.second, e.what());
-        error_counter.set(++_conn_error_count);
+        error_counter->labels({}).set(++_conn_error_count);
         return nullptr;
     }
 }

--- a/tests/boost/test_prometheus_metrics.cpp
+++ b/tests/boost/test_prometheus_metrics.cpp
@@ -36,7 +36,7 @@ BOOST_AUTO_TEST_CASE(simple_metrics) {
     auto bazinf = metrics.add_gauge("bazinf_metric", "foos", {}); // a metric with inf
     bazinf->labels({}).set(log(0));
 
-    foo.inc();
+    foo->labels({}).inc();
     auto multi_metrics = metrics.serialize();
 
     // new value
@@ -86,8 +86,8 @@ BOOST_AUTO_TEST_CASE(remove_stage_metrics) {
     BOOST_CHECK(metrics.serialize() == "");
 
     // re-adding metrics from stages that were deleted once is also OK
-    metrics.add_counter("foo_metric", "foo");
-    metrics.add_counter("foo_metric", "foos");
+    metrics.add_counter("foo_metric", "foo", {});
+    metrics.add_counter("foo_metric", "foos", {});
     multi_metrics = metrics.serialize();
     BOOST_CHECK(multi_metrics.find("foo_metric{stage_name=\"foo\"} 0") != std::string::npos);
     BOOST_CHECK(multi_metrics.find("foo_metric{stage_name=\"foos\"} 0") != std::string::npos);

--- a/tests/boost/test_prometheus_metrics.cpp
+++ b/tests/boost/test_prometheus_metrics.cpp
@@ -61,7 +61,7 @@ BOOST_AUTO_TEST_CASE(remove_stage_metrics) {
     metrics.remove_stage_metrics("foos");
     BOOST_CHECK(metrics.serialize() == "");
 
-    metrics.add_counter("foo_metric", "foo",  {});
+    metrics.add_counter("foo_metric", "foo", {});
     metrics.add_counter("foo_metric", "foos", {});
     auto multi_metrics = metrics.serialize();
     BOOST_CHECK(multi_metrics.find("foo_metric{stage_name=\"foo\"} 0") != std::string::npos);
@@ -131,7 +131,7 @@ BOOST_AUTO_TEST_CASE(gauges_with_labels) {
     m1->labels({"baz"}).set(10); // a different label value of the same metric
 
     auto m2 = metrics.add_gauge("bar_with_labels", "foo",
-                                 {"quux"}); // a different label value of the same metric
+                                {"quux"}); // a different label value of the same metric
     m2->labels({"baz"}).set(42);
 
     auto multi_metrics = metrics.serialize();

--- a/tests/boost/test_prometheus_metrics.cpp
+++ b/tests/boost/test_prometheus_metrics.cpp
@@ -103,8 +103,8 @@ BOOST_AUTO_TEST_CASE(counters_with_labels) {
     m1->labels({"GET", "/messages"}).inc();
     std::cout << m1->serialize();
     BOOST_CHECK(m1->serialize().find("# HELP http_requests_total\n# TYPE http_requests_total "
-                                    "counter\nhttp_requests_total{stage_name=\"main\",method="
-                                    "\"POST\",handler=\"/messages\"} 1")
+                                     "counter\nhttp_requests_total{stage_name=\"main\",method="
+                                     "\"POST\",handler=\"/messages\"} 1")
                 != std::string::npos);
     BOOST_CHECK(m1->serialize().find(
         "http_requests_total{stage_name=\"main\",method=\"GET\",handler=\"/messages\"} 2"));

--- a/tests/boost/test_prometheus_metrics.cpp
+++ b/tests/boost/test_prometheus_metrics.cpp
@@ -14,27 +14,27 @@ BOOST_AUTO_TEST_CASE(simple_metrics) {
     Metrics& metrics = Metrics::instance();
     BOOST_CHECK(metrics.serialize() == "");
 
-    auto& foo = metrics.add_counter("foo_metric", "foo");
+    auto foo = metrics.add_counter("foo_metric", "foo", {});
     BOOST_CHECK(
         metrics.serialize().find(
             "# HELP foo_metric\n# TYPE foo_metric counter\nfoo_metric{stage_name=\"foo\"} 0")
         != std::string::npos);
 
-    foo.inc();
+    foo->labels({}).inc();
     BOOST_CHECK(
         metrics.serialize().find(
             "# HELP foo_metric\n# TYPE foo_metric counter\nfoo_metric{stage_name=\"foo\"} 1")
         != std::string::npos);
 
-    auto& foos = metrics.add_gauge("foo_metric", "foos"); // a new stage of the same metric
-    foos.set(10);
-    auto& bar = metrics.add_gauge("bar_metric", "foos"); // a metric for the same stage
-    bar.set(100);
+    auto foos = metrics.add_gauge("foo_metric", "foos", {}); // a new stage of the same metric
+    foos->labels({}).set(10);
+    auto bar = metrics.add_gauge("bar_metric", "foos", {}); // a metric for the same stage
+    bar->labels({}).set(100);
 
-    auto& baznan = metrics.add_gauge("baznan_metric", "foos"); // a metric with NaNs
-    baznan.set(sqrt(-1));
-    auto& bazinf = metrics.add_gauge("bazinf_metric", "foos"); // a metric with inf
-    bazinf.set(log(0));
+    auto baznan = metrics.add_gauge("baznan_metric", "foos", {}); // a metric with NaNs
+    baznan->labels({}).set(sqrt(-1));
+    auto bazinf = metrics.add_gauge("bazinf_metric", "foos", {}); // a metric with inf
+    bazinf->labels({}).set(log(0));
 
     foo.inc();
     auto multi_metrics = metrics.serialize();
@@ -61,8 +61,8 @@ BOOST_AUTO_TEST_CASE(remove_stage_metrics) {
     metrics.remove_stage_metrics("foos");
     BOOST_CHECK(metrics.serialize() == "");
 
-    metrics.add_counter("foo_metric", "foo");
-    metrics.add_counter("foo_metric", "foos");
+    metrics.add_counter("foo_metric", "foo",  {});
+    metrics.add_counter("foo_metric", "foos", {});
     auto multi_metrics = metrics.serialize();
     BOOST_CHECK(multi_metrics.find("foo_metric{stage_name=\"foo\"} 0") != std::string::npos);
     BOOST_CHECK(multi_metrics.find("foo_metric{stage_name=\"foos\"} 0") != std::string::npos);
@@ -97,10 +97,10 @@ BOOST_AUTO_TEST_CASE(remove_stage_metrics) {
 BOOST_AUTO_TEST_CASE(counters_with_labels) {
     Metrics& metrics = Metrics::instance();
 
-    auto& m1 = metrics.add_counter("http_requests_total", "main", {"method", "handler"});
-    m1.labels({"POST", "/messages"}).inc();
-    m1.labels({"GET", "/messages"}).inc();
-    m1.labels({"GET", "/messages"}).inc();
+    auto m1 = metrics.add_counter("http_requests_total", "main", {"method", "handler"});
+    m1->labels({"POST", "/messages"}).inc();
+    m1->labels({"GET", "/messages"}).inc();
+    m1->labels({"GET", "/messages"}).inc();
     std::cout << m1.serialize();
     BOOST_CHECK(m1.serialize().find("# HELP http_requests_total\n# TYPE http_requests_total "
                                     "counter\nhttp_requests_total{stage_name=\"main\",method="
@@ -109,10 +109,10 @@ BOOST_AUTO_TEST_CASE(counters_with_labels) {
     BOOST_CHECK(m1.serialize().find(
         "http_requests_total{stage_name=\"main\",method=\"GET\",handler=\"/messages\"} 2"));
 
-    auto& m2 = metrics.add_counter("total_count", "sidecar");
-    m2.inc();
-    m2.inc();
-    m2.inc();
+    auto m2 = metrics.add_counter("total_count", "sidecar", {});
+    m2->labels({}).inc();
+    m2->labels({}).inc();
+    m2->labels({}).inc();
     BOOST_CHECK(metrics.serialize().find(
         "# HELP total_count\n#TYPE total_count counter\ntotal_count{stage_name=\"sidecar\"} 3"));
 }
@@ -121,18 +121,18 @@ BOOST_AUTO_TEST_CASE(counters_with_labels) {
 BOOST_AUTO_TEST_CASE(gauges_with_labels) {
     Metrics& metrics = Metrics::instance();
 
-    auto& m1 = metrics.add_gauge("foo_with_labels", "foo", {"quux"});
-    m1.labels({"fred"}).set(1);
+    auto m1 = metrics.add_gauge("foo_with_labels", "foo", {"quux"});
+    m1->labels({"fred"}).set(1);
     BOOST_CHECK(metrics.serialize().find("foo_with_labels{stage_name=\"foo\",quux=\"fred\"} 1.0")
                 != std::string::npos);
 
-    m1.labels({"fred"}).set(2);
+    m1->labels({"fred"}).set(2);
 
-    m1.labels({"baz"}).set(10); // a different label value of the same metric
+    m1->labels({"baz"}).set(10); // a different label value of the same metric
 
-    auto& m2 = metrics.add_gauge("bar_with_labels", "foo",
+    auto m2 = metrics.add_gauge("bar_with_labels", "foo",
                                  {"quux"}); // a different label value of the same metric
-    m2.labels({"baz"}).set(42);
+    m2->labels({"baz"}).set(42);
 
     auto multi_metrics = metrics.serialize();
     // std::cout << multi_metrics << "\n";

--- a/tests/boost/test_prometheus_metrics.cpp
+++ b/tests/boost/test_prometheus_metrics.cpp
@@ -101,12 +101,12 @@ BOOST_AUTO_TEST_CASE(counters_with_labels) {
     m1->labels({"POST", "/messages"}).inc();
     m1->labels({"GET", "/messages"}).inc();
     m1->labels({"GET", "/messages"}).inc();
-    std::cout << m1.serialize();
-    BOOST_CHECK(m1.serialize().find("# HELP http_requests_total\n# TYPE http_requests_total "
+    std::cout << m1->serialize();
+    BOOST_CHECK(m1->serialize().find("# HELP http_requests_total\n# TYPE http_requests_total "
                                     "counter\nhttp_requests_total{stage_name=\"main\",method="
                                     "\"POST\",handler=\"/messages\"} 1")
                 != std::string::npos);
-    BOOST_CHECK(m1.serialize().find(
+    BOOST_CHECK(m1->serialize().find(
         "http_requests_total{stage_name=\"main\",method=\"GET\",handler=\"/messages\"} 2"));
 
     auto m2 = metrics.add_counter("total_count", "sidecar", {});

--- a/tests/boost/test_prometheus_metrics.cpp
+++ b/tests/boost/test_prometheus_metrics.cpp
@@ -3,9 +3,10 @@
 #include "prometheusMetrics.hpp" // for Metrics, MetricFamily, Counter, Gauge
 
 #include <boost/test/included/unit_test.hpp> // for BOOST_PP_IIF_1, BOOST_CHECK, BOOST_PP_BOOL_2
-#include <cmath>                             // for sqrt, log
+#include <cmath>                             // for log, sqrt
 #include <iostream>                          // for cout, ostream
-#include <string>                            // for string, allocator, basic_string, operator==
+#include <memory>                            // for __shared_ptr_access, shared_ptr
+#include <string>                            // for string, basic_string, operator==, operator<<
 
 using kotekan::prometheus::Metrics;
 


### PR DESCRIPTION
Fix an issue where the prometheus metrics singleton could be deleted before the objects referencing the individual metrics.   Resolves this by returning smart pointers instead of references. 

Closes #979 