### PR TITLE
Improvements to the GPU patient objects

### DIFF
--- a/lib/cuda/cudaCommand.cpp
+++ b/lib/cuda/cudaCommand.cpp
@@ -35,7 +35,9 @@ void cudaCommand::finalize_frame(int gpu_frame_id) {
             float exec_time;
             CHECK_CUDA_ERROR(cudaEventElapsedTime(&exec_time, pre_events[gpu_frame_id],
                                                   post_events[gpu_frame_id]));
-            last_gpu_execution_time = exec_time * 1e-3; // convert ms to s
+            double active_time = exec_time * 1e-3; // convert ms to s
+            excute_time->add_sample(active_time);
+            utilization->add_sample(active_time/frame_arrival_period);
         }
         CHECK_CUDA_ERROR(cudaEventDestroy(pre_events[gpu_frame_id]));
         pre_events[gpu_frame_id] = nullptr;

--- a/lib/cuda/cudaInputData.cpp
+++ b/lib/cuda/cudaInputData.cpp
@@ -69,3 +69,9 @@ void cudaInputData::finalize_frame(int frame_id) {
     mark_frame_empty(in_buf, unique_name.c_str(), in_buffer_finalize_id);
     in_buffer_finalize_id = (in_buffer_finalize_id + 1) % in_buf->num_frames;
 }
+
+std::string cudaInputData::get_performance_metric_string() {
+    double transfer_speed = (double)in_buf->frame_size
+                            / (double)get_last_gpu_execution_time() / 1000000000;
+    return fmt::format("Speed: {:.2f} GB/s ({:.2f} Gb/s)", transfer_speed, transfer_speed * 8);
+}

--- a/lib/cuda/cudaInputData.hpp
+++ b/lib/cuda/cudaInputData.hpp
@@ -33,7 +33,7 @@ public:
     cudaEvent_t execute(int gpu_frame_id, cudaEvent_t pre_event) override;
     void finalize_frame(int frame_id) override;
 
-
+    std::string get_performance_metric_string() override;
 protected:
     cudaEvent_t* data_staged_event;
 

--- a/lib/cuda/cudaOutputData.cpp
+++ b/lib/cuda/cudaOutputData.cpp
@@ -88,3 +88,9 @@ void cudaOutputData::finalize_frame(int frame_id) {
     mark_frame_full(output_buffer, unique_name.c_str(), output_buffer_id);
     output_buffer_id = (output_buffer_id + 1) % output_buffer->num_frames;
 }
+
+std::string cudaOutputData::get_performance_metric_string() {
+    double transfer_speed = (double)output_buffer->frame_size
+                            / (double)get_last_gpu_execution_time() / 1000000000;
+    return fmt::format("Speed: {:.2f} GB/s ({:.2f} Gb/s)", transfer_speed, transfer_speed * 8);
+}

--- a/lib/cuda/cudaOutputData.hpp
+++ b/lib/cuda/cudaOutputData.hpp
@@ -30,6 +30,8 @@ public:
     virtual cudaEvent_t execute(int buf_frame_id, cudaEvent_t pre_event) override;
     void finalize_frame(int frame_id) override;
 
+    std::string get_performance_metric_string() override;
+
 protected:
     int32_t output_buffer_execute_id;
     int32_t output_buffer_precondition_id;

--- a/lib/cuda/cudaProcess.cpp
+++ b/lib/cuda/cudaProcess.cpp
@@ -1,8 +1,10 @@
 #include "cudaProcess.hpp"
 
+#include "StageFactory.hpp"
 #include "cuda_profiler_api.h"
 #include "unistd.h"
 #include "util.h"
+#include "Stage.hpp"
 
 #include <iostream>
 #include <sys/time.h>
@@ -49,4 +51,13 @@ void cudaProcess::queue_commands(int gpu_frame_id) {
     }
     final_signals[gpu_frame_id]->set_signal(signal);
     INFO("Commands executed.");
+}
+
+void cudaProcess::register_host_memory(struct Buffer * host_buffer) {
+    // Register the host memory in in_buf with the OpenCL run time.
+    ERROR("Called register_host_memory: {:s}", host_buffer->buffer_name);
+    for (int i = 0; i < host_buffer->num_frames; i++) {
+        cudaHostRegister(host_buffer->frames[i], host_buffer->aligned_frame_size, cudaHostRegisterDefault);
+        DEBUG("Registered frame: {:s}[{:d}]", host_buffer->buffer_name, i);
+    }
 }

--- a/lib/cuda/cudaProcess.hpp
+++ b/lib/cuda/cudaProcess.hpp
@@ -26,6 +26,8 @@ public:
     gpuEventContainer* create_signal() override;
     void queue_commands(int gpu_frame_id) override;
 
+    void register_host_memory(struct Buffer * host_buffer) override;
+
     cudaDeviceInterface* device;
 };
 

--- a/lib/gpu/gpuCommand.cpp
+++ b/lib/gpu/gpuCommand.cpp
@@ -38,6 +38,14 @@ gpuCommand::gpuCommand(Config& config_, const std::string& unique_name_,
             + config.get_default<string>(unique_name, "kernel", default_kernel_file_name);
         kernel_command = config.get_default<string>(unique_name, "command", default_kernel_command);
     }
+
+    profiling = config.get_default<bool>(unique_name, "profiling", true);
+    if (profiling) {
+        frame_arrival_period = config.get<double>(unique_name, "frame_arrival_period");
+    }
+
+    excute_time = kotekan::KotekanTrackers::instance().add_tracker(unique_name, get_name() + "_execute_time", "seconds");
+    utilization = kotekan::KotekanTrackers::instance().add_tracker(unique_name, get_name() + "_u", "");
 }
 
 gpuCommand::~gpuCommand() {}
@@ -66,7 +74,7 @@ void gpuCommand::pre_execute(int gpu_frame_id) {
 }
 
 double gpuCommand::get_last_gpu_execution_time() {
-    return last_gpu_execution_time;
+    return excute_time->get_current();
 }
 
 gpuCommandType gpuCommand::get_command_type() {

--- a/lib/gpu/gpuProcess.cpp
+++ b/lib/gpu/gpuProcess.cpp
@@ -90,11 +90,13 @@ void gpuProcess::init() {
         std::string command_name = cmd["name"];
         commands.push_back(create_command(command_name, unique_path));
     }
+
+    for (auto &buf : local_buffer_container.get_buffer_map()) {
+        register_host_memory(buf.second);
+    }
 }
 
 void gpuProcess::profile_callback(connectionInstance& conn) {
-    DEBUG(" *** *** *** Profile call made.");
-
     json reply;
 
     reply["copy_in"] = json::array();
@@ -113,12 +115,10 @@ void gpuProcess::profile_callback(connectionInstance& conn) {
                 {{"name", cmd->get_name()}, {"time", time}, {"utilization", utilization}});
             total_kernel_time += cmd->get_last_gpu_execution_time();
         } else if (cmd->get_command_type() == gpuCommandType::COPY_IN) {
-
             reply["copy_in"].push_back(
                 {{"name", cmd->get_name()}, {"time", time}, {"utilization", utilization}});
             total_copy_in_time += cmd->get_last_gpu_execution_time();
         } else if (cmd->get_command_type() == gpuCommandType::COPY_OUT) {
-
             reply["copy_out"].push_back(
                 {{"name", cmd->get_name()}, {"time", time}, {"utilization", utilization}});
             total_copy_out_time += cmd->get_last_gpu_execution_time();
@@ -155,7 +155,7 @@ void gpuProcess::main_thread() {
         // INFO("Waiting on preconditions for GPU[{:d}][{:d}]", gpu_id, gpu_frame_id);
         for (auto& command : commands) {
             if (command->wait_on_precondition(gpu_frame_id) != 0) {
-                INFO("Received exit in GPU command precondition! (Command '{:s}')",
+                INFO("Received exit signal from GPU command precondition (Command '{:s}')",
                      command->get_name());
                 goto exit_loop;
             }
@@ -172,8 +172,8 @@ void gpuProcess::main_thread() {
             // TODO Move to config
             cpu_set_t cpuset;
             CPU_ZERO(&cpuset);
-            for (int j = 4; j < 12; j++)
-                CPU_SET(j, &cpuset);
+            for (auto& i : config.get<std::vector<int>>(unique_name, "cpu_affinity"))
+                CPU_SET(i, &cpuset);
             pthread_setaffinity_np(results_thread_handle.native_handle(), sizeof(cpu_set_t),
                                    &cpuset);
             first_run = false;
@@ -223,11 +223,11 @@ void gpuProcess::results_thread() {
         if (log_profiling) {
             std::string output = "";
             for (uint32_t i = 0; i < commands.size(); ++i) {
-                output = fmt::format(fmt("{:s}kernel: {:s} time: {:f}; \n"), output,
+                output = fmt::format(fmt("{:s}command: {:s} metrics: {:s}; \n"), output,
                                      commands[i]->get_name(),
-                                     commands[i]->get_last_gpu_execution_time());
+                                     commands[i]->get_performance_metric_string());
             }
-            INFO("GPU[{:d}] Profiling: {:s}", gpu_id, output);
+            INFO("GPU[{:d}] Profiling: \n{:s}", gpu_id, output);
         }
 
         final_signals[gpu_frame_id]->reset();

--- a/lib/gpu/gpuProcess.hpp
+++ b/lib/gpu/gpuProcess.hpp
@@ -23,6 +23,14 @@ public:
                kotekan::bufferContainer& buffer_container);
     virtual ~gpuProcess();
     void main_thread() override;
+
+    /**
+     * @brief Reset server call back function for the profiling information
+     *
+     * @param conn The connection object required for the callback
+     * @todo This function will be deprecated by the KotekanTrackers stats once the
+     *       python script for monitoring GPU utilization is updated to that system.
+     */
     void profile_callback(kotekan::connectionInstance& conn);
 
     /// Returns the dot string formatted graph for the GPU pipeline
@@ -33,6 +41,7 @@ protected:
                                        const std::string& unique_name) = 0;
     virtual gpuEventContainer* create_signal() = 0;
     virtual void queue_commands(int gpu_frame_id) = 0;
+    virtual void register_host_memory(struct Buffer * host_buffer) = 0;
     void results_thread();
     void init(void);
 
@@ -50,6 +59,7 @@ protected:
     // Config variables
     uint32_t _gpu_buffer_depth;
     uint32_t gpu_id;
+    uint32_t gpu_thread_id;
 };
 
 #endif // GPU_PROCESS_H

--- a/lib/hsa/hsaCommand.cpp
+++ b/lib/hsa/hsaCommand.cpp
@@ -109,9 +109,12 @@ void hsaCommand::finalize_frame(int frame_id) {
             ((double)(kernel_time.end - kernel_time.start)) / (double)timestamp_frequency_hz;
     } else if (command_type == gpuCommandType::COPY_IN
                || command_type == gpuCommandType::COPY_OUT) {
-        hsa_status = hsa_amd_profiling_get_async_copy_time(signals[frame_id], &copy_time);
-        last_gpu_execution_time =
-            ((double)(copy_time.end - copy_time.start)) / (double)timestamp_frequency_hz;
+        if (profiling)
+            hsa_status = hsa_amd_profiling_get_async_copy_time(signals[frame_id], &copy_time);
+            double active_time =
+                ((double)(copy_time.end - copy_time.start)) / (double)timestamp_frequency_hz;
+            excute_time->add_sample(active_time);
+            utilization->add_sample(active_time/frame_arrival_period);
     } else {
         return;
     }

--- a/lib/hsa/hsaProcess.cpp
+++ b/lib/hsa/hsaProcess.cpp
@@ -51,3 +51,9 @@ void hsaProcess::queue_commands(int gpu_frame_id) {
     }
     final_signals[gpu_frame_id]->set_signal(&signal);
 }
+
+void clProcess::register_host_memory(struct Buffer *host_buffer) {
+    // Since we use hsa_host_malloc for all memory with HSA configurations
+    // we do not need to register the memory with the GPU drivers.
+    (void)host_buffer;
+}

--- a/lib/hsa/hsaProcess.hpp
+++ b/lib/hsa/hsaProcess.hpp
@@ -20,6 +20,7 @@ protected:
                                const std::string& unique_name) override;
     gpuEventContainer* create_signal() override;
     void queue_commands(int gpu_frame_id) override;
+    void register_host_memory(struct Buffer * host_buffer) override;
 };
 
 #endif // HSA_PROCESS_H

--- a/lib/opencl/clCommand.cpp
+++ b/lib/opencl/clCommand.cpp
@@ -32,7 +32,6 @@ clCommand::~clCommand() {
 }
 
 void clCommand::finalize_frame(int gpu_frame_id) {
-    bool profiling = true;
     if (post_events[gpu_frame_id] != nullptr) {
         if (profiling) {
             cl_ulong start_time, stop_time;
@@ -42,7 +41,9 @@ void clCommand::finalize_frame(int gpu_frame_id) {
             CHECK_CL_ERROR(clGetEventProfilingInfo(post_events[gpu_frame_id],
                                                    CL_PROFILING_COMMAND_END, sizeof(stop_time),
                                                    &stop_time, nullptr));
-            last_gpu_execution_time = ((double)(stop_time - start_time)) * 1e-9;
+            double active_time = (double)(stop_time - start_time) * 1e-9;
+            excute_time->add_sample(active_time);
+            utilization->add_sample(active_time/frame_arrival_period);
         }
 
         CHECK_CL_ERROR(clReleaseEvent(post_events[gpu_frame_id]));

--- a/lib/opencl/clProcess.cpp
+++ b/lib/opencl/clProcess.cpp
@@ -24,7 +24,17 @@ clProcess::clProcess(Config& config_, const std::string& unique_name,
     init();
 }
 
-clProcess::~clProcess() {}
+clProcess::~clProcess() {
+    // Unregister the host memory from the OpenCL runtime
+    for (auto &opencl_frame: opencl_host_frames) {
+        cl_event wait_event;
+        clEnqueueUnmapMemObject(device->getQueue(0),
+                                std::get<0>(opencl_frame),
+                                std::get<1>(opencl_frame), 0, nullptr, &wait_event);
+        // Block here to make sure the memory actually gets unmapped.
+        clWaitForEvents(1, &wait_event);
+    }
+}
 
 gpuEventContainer* clProcess::create_signal() {
     return new clEventContainer();
@@ -46,5 +56,36 @@ void clProcess::queue_commands(int gpu_frame_id) {
         signal = ((clCommand*)command)->execute(gpu_frame_id, signal);
     }
     final_signals[gpu_frame_id]->set_signal(signal);
-    INFO("Commands executed.");
+    DEBUG("Commands executed.");
+}
+
+void clProcess::register_host_memory(struct Buffer *host_buffer) {
+    // Register the host memory in in_buf with the OpenCL run time.
+    ERROR("Called register_host_memory !");
+    for (int i = 0; i < host_buffer->num_frames; i++) {
+        cl_int err;
+        cl_mem cl_mem_prt = clCreateBuffer(device->get_context(),
+                                           CL_MEM_READ_WRITE | CL_MEM_USE_HOST_PTR,
+                                           host_buffer->frame_size,
+                                           host_buffer->frames[i],
+                                           &err);
+        CHECK_CL_ERROR(err);
+        void* pinned_ptr = clEnqueueMapBuffer(device->getQueue(0), cl_mem_prt, CL_TRUE,
+                                              CL_MAP_READ, 0, host_buffer->frame_size, 0,
+                                              nullptr, nullptr, &err);
+        CHECK_CL_ERROR(err);
+
+        // As far as I can tell pinned_ptr should always be the same as the host pointer,
+        // if it's not this as implications for upstream processes and so the system should fail
+        // when the condition isn't meet.
+        if ((void*)host_buffer->frames[i] != pinned_ptr) {
+            ERROR("OpenCL registered pointer is different from normal host pointer: {:p}, opencl pointer: {:p}",
+                  (void*)host_buffer->frames[i],
+                  pinned_ptr);
+            throw std::runtime_error("Something wrong with the registration of host memory in OpenCL");
+        }
+
+        INFO("Registed frame: {:s}[{:d}]", host_buffer->buffer_name, i);
+        opencl_host_frames.push_back(std::make_tuple(cl_mem_prt, pinned_ptr));
+    }
 }

--- a/lib/opencl/clProcess.hpp
+++ b/lib/opencl/clProcess.hpp
@@ -15,12 +15,18 @@ public:
               kotekan::bufferContainer& buffer_container);
     virtual ~clProcess();
 
+protected:
     gpuCommand* create_command(const std::string& cmd_name,
                                const std::string& unique_name) override;
     gpuEventContainer* create_signal() override;
     void queue_commands(int gpu_frame_id) override;
+    void register_host_memory(struct Buffer * host_buffer) override;
 
     clDeviceInterface* device;
+
+    /// Keep track of the OpenCL registered host memory corresponding
+    /// to the host memory frames.
+    std::vector<std::tuple<cl_mem, void*>> opencl_host_frames;
 };
 
 #endif // CL_PROCESS_H

--- a/lib/utils/visUtil.cpp
+++ b/lib/utils/visUtil.cpp
@@ -364,6 +364,13 @@ double StatTracker::get_std_dev() {
     return std_dev;
 }
 
+double StatTracker::get_current() {
+    std::lock_guard<std::mutex> lock(tracker_lock);
+
+    size_t ind = (end + buf_size - 1) % buf_size;
+    return count ? rbuf[ind].value : NAN;
+}
+
 nlohmann::json StatTracker::get_json() {
     std::lock_guard<std::mutex> lock(tracker_lock);
 

--- a/lib/utils/visUtil.hpp
+++ b/lib/utils/visUtil.hpp
@@ -637,6 +637,13 @@ public:
     double get_std_dev();
 
     /**
+     * @brief Return the last value added, will be NAN if no samples have been added
+     *
+     * @return The last sample or NAN
+     **/
+    double get_current();
+
+    /**
      * @brief Return tracker content in json format.
      *
      * @return A json object of tracker content.


### PR DESCRIPTION
This PR is the first a few PRs designed to breakup #940 into more manageable PRs. 

* Adds a memory registration function for CUDA and OpenCL to improve host<->device async copy speeds
* Switch to using the new `KotekanTrackers` object to generate more stats from the command run times
* Add new profiling output functions for command line based kernel performance logging (useful for rapid testing)