### PR TITLE
Include buffer json data with tracker dump file

### DIFF
--- a/kotekan/kotekan.cpp
+++ b/kotekan/kotekan.cpp
@@ -484,6 +484,9 @@ int main(int argc, char** argv) {
                 INFO_NON_OO("Attempting to stop and join kotekan_stages...");
                 kotekan_mode->stop_stages();
                 kotekan_mode->join();
+                if (string(get_error_message()) != "not set") {
+                    KotekanTrackers::instance().dump_trackers();
+                }
                 delete kotekan_mode;
             }
             break;
@@ -495,9 +498,6 @@ int main(int argc, char** argv) {
     // Print error message if there is one.
     if (string(get_error_message()) != "not set") {
         INFO_NON_OO("Fatal error message was: {:s}", get_error_message());
-
-        // Dump all trackers before cleanup.
-        KotekanTrackers::instance().dump_trackers();
     }
 
     closelog();

--- a/lib/core/kotekanMode.hpp
+++ b/lib/core/kotekanMode.hpp
@@ -10,6 +10,8 @@
 #include "cpuMonitor.hpp"
 #endif
 
+#include "json.hpp" // for json
+
 #include <map>    // for map
 #include <string> // for string
 

--- a/lib/core/kotekanMode.hpp
+++ b/lib/core/kotekanMode.hpp
@@ -42,6 +42,16 @@ public:
     // HTTP callback that dumps the current buffer state in JSON.
     void buffer_data_callback(connectionInstance& conn);
 
+    /**
+     * @brief Generate a json structure with active buffer data
+     *
+     * This json also contains all the consumer and producer data needed to generate
+     * a pipeline graph.
+     *
+     * @return Returns JSON formatted data with all the current buffer information
+     */
+    nlohmann::json get_buffer_json();
+
     // HTTP callback that dumps the current pipeline graph in `dot` format.
     void pipeline_dot_graph_callback(connectionInstance& conn);
 

--- a/lib/core/kotekanTrackers.hpp
+++ b/lib/core/kotekanTrackers.hpp
@@ -6,8 +6,6 @@
 #include "restServer.hpp"  // for connectionInstance, restServer
 #include "visUtil.hpp"     // for StatTracker
 
-#include "json.hpp" // for json
-
 #include <map>      // for map, map<>::value_compare
 #include <memory>   // for shared_ptr
 #include <mutex>    // for mutex

--- a/lib/core/kotekanTrackers.hpp
+++ b/lib/core/kotekanTrackers.hpp
@@ -6,6 +6,8 @@
 #include "restServer.hpp"  // for connectionInstance, restServer
 #include "visUtil.hpp"     // for StatTracker
 
+#include "json.hpp" // for json
+
 #include <map>      // for map, map<>::value_compare
 #include <memory>   // for shared_ptr
 #include <mutex>    // for mutex
@@ -67,7 +69,7 @@ public:
      *        we need to have a call back to the current kotekan mode.  This function should
      *        only be used by the active kotekanMode object, and be set to nullptr
      *        when the kotekan mode is deleted.
-     * @param kotekan_mode_ptr Pointer to the kotekan mode object or nullptr
+     * @param _kotekan_mode_ptr Pointer to the kotekan mode object or nullptr
      */
     void set_kotekan_mode_ptr(kotekan::kotekanMode* _kotekan_mode_ptr);
 

--- a/lib/core/kotekanTrackers.hpp
+++ b/lib/core/kotekanTrackers.hpp
@@ -1,9 +1,10 @@
 #ifndef KOTEKAN_TRACKERS_HPP
 #define KOTEKAN_TRACKERS_HPP
 
-#include "Config.hpp"     // for Config
-#include "restServer.hpp" // for connectionInstance, restServer
-#include "visUtil.hpp"    // for StatTracker
+#include "Config.hpp"      // for Config
+#include "kotekanMode.hpp" // for kotekanMode
+#include "restServer.hpp"  // for connectionInstance, restServer
+#include "visUtil.hpp"     // for StatTracker
 
 #include <map>      // for map, map<>::value_compare
 #include <memory>   // for shared_ptr
@@ -60,6 +61,15 @@ public:
      * @param rest_server The server to register with.
      */
     void register_with_server(restServer* rest_server);
+
+    /**
+     * @brief To get the buffer information needed in the trackers dump file,
+     *        we need to have a call back to the current kotekan mode.  This function should
+     *        only be used by the active kotekanMode object, and be set to nullptr
+     *        when the kotekan mode is deleted.
+     * @param kotekan_mode_ptr Pointer to the kotekan mode object or nullptr
+     */
+    void set_kotekan_mode_ptr(kotekan::kotekanMode* _kotekan_mode_ptr);
 
     /**
      * @brief The call back function for the REST server to use.
@@ -130,6 +140,9 @@ private:
     std::string dump_path;
 
     std::mutex trackers_lock;
+
+    /// Reference back to the active kotekan_mode object
+    kotekan::kotekanMode* kotekan_mode_ptr = nullptr;
 };
 
 } // namespace kotekan

--- a/lib/stages/testDataGen.cpp
+++ b/lib/stages/testDataGen.cpp
@@ -209,5 +209,4 @@ void testDataGen::main_thread() {
                 usleep((int)(1e6 * (frame_end_time - time)));
         }
     }
-    INFO("Calling dump_trackers");
 }

--- a/lib/stages/testDataGen.cpp
+++ b/lib/stages/testDataGen.cpp
@@ -209,4 +209,5 @@ void testDataGen::main_thread() {
                 usleep((int)(1e6 * (frame_end_time - time)));
         }
     }
+    INFO("Calling dump_trackers");
 }


### PR DESCRIPTION
The dump file from `KotekanTrackers` needs the data about the buffers in order to generate the pipeline graph.   This PR adds this feature.  The dump file now contains two JSON objects in the root JSON object called `buffers` and `trackers`.

For example this is a simple JSON dump file with this change:
```
{
   "buffers":{
      "example_buffer":{
         "consumers":{
            "/screen_dump":{
               "last_frame_acquired":1,
               "last_frame_released":1,
               "marked_frame_empty":[
                  0,
                  0,
                  0,
                  0,
                  0,
                  0,
                  0,
                  0,
                  0,
                  0
               ]
            }
         },
         "frame_size":128,
         "frames":[
            0,
            0,
            0,
            0,
            0,
            0,
            0,
            0,
            0,
            0
         ],
         "last_frame_arrival_time":1629399352.481672,
         "num_frames":10,
         "num_full_frame":0,
         "producers":{
            "/data_gen":{
               "last_frame_acquired":1,
               "last_frame_released":1,
               "marked_frame_empty":[
                  0,
                  0,
                  0,
                  0,
                  0,
                  0,
                  0,
                  0,
                  0,
                  0
               ]
            }
         },
         "type":"standard"
      }
   },
   "trackers":{
      "/data_gen":{
         "frame_fill_time":{
            "samples":[
               {
                  "timestamp":1629399349879,
                  "value":2.5510787963867188e-05
               },
               {
                  "timestamp":1629399349963,
                  "value":2.7894973754882813e-05
               },
               {
                  "timestamp":1629399350047,
                  "value":2.2411346435546875e-05
               },
               {
                  "timestamp":1629399350131,
                  "value":1.7642974853515625e-05
               },
               {
                  "timestamp":1629399350215,
                  "value":2.2172927856445313e-05
               },
               {
                  "timestamp":1629399350299,
                  "value":1.9788742065429688e-05
               },
               {
                  "timestamp":1629399350382,
                  "value":1.6927719116210938e-05
               },
               {
                  "timestamp":1629399350466,
                  "value":2.6941299438476563e-05
               },
               {
                  "timestamp":1629399350550,
                  "value":1.7881393432617188e-05
               },
               {
                  "timestamp":1629399350634,
                  "value":2.2649765014648438e-05
               },
               {
                  "timestamp":1629399350718,
                  "value":1.6927719116210938e-05
               },
               {
                  "timestamp":1629399350802,
                  "value":1.811981201171875e-05
               },
               {
                  "timestamp":1629399350886,
                  "value":1.5497207641601563e-05
               },
               {
                  "timestamp":1629399350970,
                  "value":1.71661376953125e-05
               },
               {
                  "timestamp":1629399351054,
                  "value":1.7404556274414063e-05
               },
               {
                  "timestamp":1629399351138,
                  "value":1.5735626220703125e-05
               },
               {
                  "timestamp":1629399351222,
                  "value":1.7404556274414063e-05
               },
               {
                  "timestamp":1629399351306,
                  "value":2.8848648071289063e-05
               },
               {
                  "timestamp":1629399351390,
                  "value":2.0742416381835938e-05
               },
               {
                  "timestamp":1629399351474,
                  "value":2.4318695068359375e-05
               },
               {
                  "timestamp":1629399351558,
                  "value":2.193450927734375e-05
               },
               {
                  "timestamp":1629399351642,
                  "value":2.2411346435546875e-05
               },
               {
                  "timestamp":1629399351726,
                  "value":2.0742416381835938e-05
               },
               {
                  "timestamp":1629399351810,
                  "value":1.7642974853515625e-05
               },
               {
                  "timestamp":1629399351894,
                  "value":2.4557113647460938e-05
               },
               {
                  "timestamp":1629399351978,
                  "value":2.384185791015625e-05
               },
               {
                  "timestamp":1629399352061,
                  "value":1.9788742065429688e-05
               },
               {
                  "timestamp":1629399352145,
                  "value":1.811981201171875e-05
               },
               {
                  "timestamp":1629399352229,
                  "value":1.6450881958007813e-05
               },
               {
                  "timestamp":1629399352313,
                  "value":1.7642974853515625e-05
               },
               {
                  "timestamp":1629399352397,
                  "value":2.0503997802734375e-05
               },
               {
                  "timestamp":1629399352481,
                  "value":1.9311904907226563e-05
               }
            ],
            "unit":"sec"
         }
      }
   }
}
```