### PR TITLE
Add check to visAccumulate for number of output buffer frames

### DIFF
--- a/lib/stages/visAccumulate.cpp
+++ b/lib/stages/visAccumulate.cpp
@@ -141,6 +141,14 @@ visAccumulate::visAccumulate(Config& config, const std::string& unique_name,
     out_buf = get_buffer("out_buf");
     register_producer(out_buf, unique_name.c_str());
 
+    // Because we reserve `num_freq_in_frame` output frames for each input frame, the output
+    // buffer must have at least `num_freq_in_frame` frames allocated.
+    if ((size_t)out_buf->num_frames < num_freq_in_frame) {
+        throw std::runtime_error(fmt::format(
+            "visAccumulate: The number of frames in {:s} ({:d}) is < num_freq_in_frame ({:d})",
+            out_buf->buffer_name, out_buf->num_frames, num_freq_in_frame));
+    }
+
     // Create the state for the main visibility accumulation
     gated_datasets.emplace_back(
         out_buf, gateSpec::create("uniform", "vis", kotekan::logLevel(_member_log_level)),


### PR DESCRIPTION
This change throws a runtime error if the condition in #992 occurs.   To summarize that ticket: where the system could get into a bad state if the number of frames in the output buffer of  `visAccumulate` was less than `num_freq_in_frame` for multi-frequency configurations. 

Closes #992 