### PR TITLE
Fallback to system time if GPS time is not set

### DIFF
--- a/lib/stages/visAccumulate.cpp
+++ b/lib/stages/visAccumulate.cpp
@@ -304,6 +304,13 @@ void visAccumulate::main_thread() {
 
         // Start and end times of this frame
         timespec t_s = ((chimeMetadata*)in_buf->metadata[in_frame_id]->metadata)->gps_time;
+        // GPS time not set
+        if (t_s.tv_sec == 0) {
+            TIMEVAL_TO_TIMESPEC(
+                &((chimeMetadata*)in_buf->metadata[in_frame_id]->metadata)->first_packet_recv_time,
+                &t_s);
+            WARN("GPS time not set, using much less accurate system time instead.");
+        }
         timespec t_e = add_nsec(t_s, samples_per_data_set * tel.seq_length_nsec());
 
         // If we have wrapped around we need to write out any frames that have

--- a/lib/stages/visAccumulate.cpp
+++ b/lib/stages/visAccumulate.cpp
@@ -22,22 +22,23 @@
 #include "gsl-lite.hpp" // for span<>::iterator, span
 #include "json.hpp"     // for json, basic_json, iteration_proxy_value, basic_json<>::...
 
-#include <algorithm> // for copy, max, fill, copy_backward, equal, transform
-#include <assert.h>  // for assert
-#include <atomic>    // for atomic_bool
-#include <cmath>     // for pow
-#include <complex>   // for operator*, complex
-#include <cstring>   // for memcpy
-#include <exception> // for exception
-#include <iterator>  // for back_insert_iterator, begin, end, back_inserter
-#include <mutex>     // for lock_guard, mutex
-#include <numeric>   // for iota
-#include <optional>  // for optional
-#include <regex>     // for match_results<>::_Base_type
-#include <stdexcept> // for runtime_error, invalid_argument
-#include <time.h>    // for size_t, timespec
-#include <tuple>     // for get
-#include <vector>    // for vector, vector<>::iterator, __alloc_traits<>::value_type
+#include <algorithm>  // for copy, max, fill, copy_backward, equal, transform
+#include <assert.h>   // for assert
+#include <atomic>     // for atomic_bool
+#include <cmath>      // for pow
+#include <complex>    // for operator*, complex
+#include <cstring>    // for memcpy
+#include <exception>  // for exception
+#include <iterator>   // for back_insert_iterator, begin, end, back_inserter
+#include <mutex>      // for lock_guard, mutex
+#include <numeric>    // for iota
+#include <optional>   // for optional
+#include <regex>      // for match_results<>::_Base_type
+#include <stdexcept>  // for runtime_error, invalid_argument
+#include <sys/time.h> // for TIMEVAL_TO_TIMESPEC
+#include <time.h>     // for size_t, timespec
+#include <tuple>      // for get
+#include <vector>     // for vector, vector<>::iterator, __alloc_traits<>::value_type
 
 
 using namespace std::placeholders;

--- a/lib/stages/visAccumulate.cpp
+++ b/lib/stages/visAccumulate.cpp
@@ -276,8 +276,9 @@ void visAccumulate::main_thread() {
     // Have we initialised a frame for writing yet
     bool init = false;
 
-    bool gps_enabled = Telescope::instance().gps_time_enabled();
-    if (!gps_enabled)
+    // Check if we have gps time enabled.
+    bool gps_time_enabled = Telescope::instance().gps_time_enabled();
+    if (!gps_time_enabled)
         WARN("GPS time not set, using much less accurate system time instead.");
 
     while (!stop_thread) {
@@ -309,10 +310,10 @@ void visAccumulate::main_thread() {
 
         // Start and end times of this frame
         timespec t_s;
-        if (gps_enabled) {
+        if (gps_time_enabled) {
             t_s = ((chimeMetadata*)in_buf->metadata[in_frame_id]->metadata)->gps_time;
         } else {
-            // If GPS time is not set, fall back to the system's best guess at the time.
+            // If GPS time is not set, fall back to system time.
             TIMEVAL_TO_TIMESPEC(
                 &((chimeMetadata*)in_buf->metadata[in_frame_id]->metadata)->first_packet_recv_time,
                 &t_s);

--- a/lib/stages/visAccumulate.cpp
+++ b/lib/stages/visAccumulate.cpp
@@ -304,7 +304,7 @@ void visAccumulate::main_thread() {
 
         // Start and end times of this frame
         timespec t_s = ((chimeMetadata*)in_buf->metadata[in_frame_id]->metadata)->gps_time;
-        // GPS time not set
+        // If GPS time is not set, fall back to the system's best guess at the time.
         if (t_s.tv_sec == 0) {
             TIMEVAL_TO_TIMESPEC(
                 &((chimeMetadata*)in_buf->metadata[in_frame_id]->metadata)->first_packet_recv_time,

--- a/lib/utils/ICETelescope.cpp
+++ b/lib/utils/ICETelescope.cpp
@@ -181,7 +181,7 @@ uint64_t ICETelescope::to_seq(timespec time) const {
 
 
 bool ICETelescope::gps_time_enabled() const {
-    return true;
+    return gps_enabled;
 }
 
 uint64_t ICETelescope::seq_length_nsec() const {


### PR DESCRIPTION
Also fixes an issue where the ICETelescope object didn't correctly return the `gps_time_enabled()` value correctly.