### PR TITLE
(CI) Update bitshuffle install to use pip

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -404,15 +404,8 @@ jobs:
         python3 setup.py build
 
     - name: Install bitshuffle
-      env:
-        HDF5_DIR: /usr/local/opt/hdf5@1.10/
-        LDFLAGS: -L/usr/local/opt/llvm@9/lib
-        CPPFLAGS: -I/usr/local/opt/llvm@9/include
-        CC: /usr/local/opt/llvm@9/bin/clang
       run: |
-        git clone https://github.com/kiyo-masui/bitshuffle.git bitshuffle
-        cd bitshuffle && git pull
-        python3 setup.py install --h5plugin --h5plugin-dir=/usr/local/opt/hdf5@1.10/lib/plugin
+        pip install bitshuffle
 
     - name: Clone Blaze and HighFive
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -405,7 +405,7 @@ jobs:
 
     - name: Install bitshuffle
       run: |
-        pip install bitshuffle
+        pip3 install bitshuffle
 
     - name: Clone Blaze and HighFive
       run: |

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -68,11 +68,7 @@ RUN git clone --single-branch --branch extensible-datasets https://github.com/jr
     cd HighFive && git pull && cd ..  
 
 # Install bitshuffle
-RUN git clone https://github.com/kiyo-masui/bitshuffle.git bitshuffle &&\
-    cd bitshuffle &&\
-    git pull &&\
-    python3.7 setup.py build_ext --march=haswell &&\
-    python3.7 setup.py install --h5plugin --h5plugin-dir=/usr/local/hdf5/lib/plugin
+RUN pip install bitshuffle
 
 # Install OpenBLAS and clone Blaze for the eigenvalue processes
 RUN apt-get update && \

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -68,7 +68,11 @@ RUN git clone --single-branch --branch extensible-datasets https://github.com/jr
     cd HighFive && git pull && cd ..  
 
 # Install bitshuffle
-RUN pip install bitshuffle
+RUN git clone https://github.com/kiyo-masui/bitshuffle.git bitshuffle &&\
+    cd bitshuffle &&\
+    git pull &&\
+    python3.7 setup.py build_ext --march=haswell &&\
+    python3.7 setup.py install --h5plugin --h5plugin-dir=/usr/local/hdf5/lib/plugin
 
 # Install OpenBLAS and clone Blaze for the eigenvalue processes
 RUN apt-get update && \


### PR DESCRIPTION
Was only able to update the MacOS version, because the base image for Ubuntu appears to be broken if we try to rebuild it - see: #1017