### PR TITLE
New phase generation template

### DIFF
--- a/lib/stages/BeamformingPhaseUpdate.cpp
+++ b/lib/stages/BeamformingPhaseUpdate.cpp
@@ -1,12 +1,12 @@
 #include "BeamformingPhaseUpdate.hpp"
 
-#include "Config.hpp"          // for Config
-#include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE, StageMakerTemplate
-#include "buffer.h"            // for mark_frame_empty, register_consumer, wait_for_full_frame
-#include "configUpdater.hpp"      // for configUpdater
-#include "kotekanLogging.hpp"  // for DEBUG
-#include "util.h"              // for hex_dump
+#include "Config.hpp"       // for Config
+#include "StageFactory.hpp" // for REGISTER_KOTEKAN_STAGE, StageMakerTemplate
+#include "buffer.h"         // for mark_frame_empty, register_consumer, wait_for_full_frame
 #include "chimeMetadata.hpp"
+#include "configUpdater.hpp"  // for configUpdater
+#include "kotekanLogging.hpp" // for DEBUG
+#include "util.h"             // for hex_dump
 
 
 using kotekan::bufferContainer;
@@ -36,7 +36,8 @@ STAGE_CONSTRUCTOR(BeamformingPhaseUpdate) {
     frequencies_in_frame.resize(_num_local_freq);
 
     // Get feed locations
-    feed_locations = config.get<std::vector<std::pair<double, double>>>(unique_name, "feed_positions");
+    feed_locations =
+        config.get<std::vector<std::pair<double, double>>>(unique_name, "feed_positions");
 
     // Register function to listen for new beam, and update ra and dec
     using namespace std::placeholders;
@@ -75,8 +76,7 @@ bool BeamformingPhaseUpdate::tracking_update_callback(nlohmann::json& json, cons
             return false;
         }
         INFO("[tracking] Updated Beam={:d} RA={:.2f} Dec={:.2f} Scl={:d}", beam_id,
-             _beam_coord.ra[beam_id], _beam_coord.dec[beam_id],
-             _beam_coord.scaling[beam_id]);
+             _beam_coord.ra[beam_id], _beam_coord.dec[beam_id], _beam_coord.scaling[beam_id]);
     }
     return true;
 }
@@ -103,8 +103,7 @@ void BeamformingPhaseUpdate::main_thread() {
         // If we have a gains buffer we check for new gains
         if (gains_buf != nullptr) {
             if (first_time) {
-                gains_frame = wait_for_full_frame(gains_buf, unique_name.c_str(),
-                                                  gains_frame_id);
+                gains_frame = wait_for_full_frame(gains_buf, unique_name.c_str(), gains_frame_id);
                 if (gains_frame == nullptr)
                     break;
                 first_time = false;
@@ -117,8 +116,8 @@ void BeamformingPhaseUpdate::main_thread() {
                 }
                 if (status == 0) {
                     mark_frame_empty(gains_buf, unique_name.c_str(), gains_frame_id++);
-                    gains_frame = wait_for_full_frame(gains_buf, unique_name.c_str(),
-                                                      gains_frame_id);
+                    gains_frame =
+                        wait_for_full_frame(gains_buf, unique_name.c_str(), gains_frame_id);
                 }
             }
         }

--- a/lib/stages/BeamformingPhaseUpdate.cpp
+++ b/lib/stages/BeamformingPhaseUpdate.cpp
@@ -1,0 +1,147 @@
+#include "BeamformingPhaseUpdate.hpp"
+
+#include "Config.hpp"          // for Config
+#include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE, StageMakerTemplate
+#include "buffer.h"            // for mark_frame_empty, register_consumer, wait_for_full_frame
+#include "configUpdater.hpp"      // for configUpdater
+#include "kotekanLogging.hpp"  // for DEBUG
+#include "util.h"              // for hex_dump
+#include "chimeMetadata.hpp"
+
+
+using kotekan::bufferContainer;
+using kotekan::Config;
+using kotekan::Stage;
+
+STAGE_CONSTRUCTOR(BeamformingPhaseUpdate) {
+
+    // Register on buffers
+    in_buf = get_buffer("in_buf");
+    register_consumer(in_buf, unique_name.c_str());
+    out_buf = get_buffer("out_buf");
+    register_producer(out_buf, unique_name.c_str());
+    if (config.exists(unique_name.c_str(), "gains_buf")) {
+        gains_buf = get_buffer("gains_buf");
+        register_consumer(gains_buf, unique_name.c_str());
+    }
+
+    _num_elements = config.get<int32_t>(unique_name, "num_elements");
+    _num_beams = config.get<int16_t>(unique_name, "num_beams");
+
+    _inst_lat = config.get<double>(unique_name, "inst_lat");
+    _inst_long = config.get<double>(unique_name, "inst_long");
+
+    _num_local_freq = config.get<double>(unique_name, "num_local_freq");
+
+    frequencies_in_frame.resize(_num_local_freq);
+
+    // Get feed locations
+    feed_locations = config.get<std::vector<std::pair<double, double>>>(unique_name, "feed_positions");
+
+    // Register function to listen for new beam, and update ra and dec
+    using namespace std::placeholders;
+    for (int beam_id = 0; beam_id < _num_beams; beam_id++) {
+        kotekan::configUpdater::instance().subscribe(
+            config.get<std::string>(unique_name, "updatable_config/tracking_pt") + "/"
+                + std::to_string(beam_id),
+            [beam_id, this](nlohmann::json& json_msg) -> bool {
+                return tracking_update_callback(json_msg, beam_id);
+            });
+    }
+}
+
+bool BeamformingPhaseUpdate::tracking_update_callback(nlohmann::json& json, const uint8_t beam_id) {
+    {
+        std::lock_guard<std::mutex> lock(beam_lock);
+        try {
+            _beam_coord.ra[beam_id] = json.at("ra").get<float>();
+        } catch (std::exception const& e) {
+            WARN("[TRACKING] Pointing update failed to read RA from beam: {:d}. {:s}", beam_id,
+                 e.what());
+            return false;
+        }
+        try {
+            _beam_coord.dec[beam_id] = json.at("dec").get<float>();
+        } catch (std::exception const& e) {
+            WARN("[TRACKING] Pointing update failed to read DEC from beam: {:d}. {:s}", beam_id,
+                 e.what());
+            return false;
+        }
+        try {
+            _beam_coord.scaling[beam_id] = json.at("scaling").get<int>();
+        } catch (std::exception const& e) {
+            WARN("[TRACKING] Pointing update failed to read scaling factor from beam: {:d}. {:s}",
+                 beam_id, e.what());
+            return false;
+        }
+        INFO("[tracking] Updated Beam={:d} RA={:.2f} Dec={:.2f} Scl={:d}", beam_id,
+             _beam_coord.ra[beam_id], _beam_coord.dec[beam_id],
+             _beam_coord.scaling[beam_id]);
+    }
+    return true;
+}
+
+BeamformingPhaseUpdate::~BeamformingPhaseUpdate() {}
+
+void BeamformingPhaseUpdate::main_thread() {
+
+    frameID in_frame_id(in_buf);
+    frameID out_frame_id(out_buf);
+    frameID gains_frame_id(gains_buf);
+    uint8_t* gains_frame = nullptr;
+    bool first_time = true;
+
+    while (!stop_thread) {
+
+        uint8_t* in_frame = wait_for_full_frame(in_buf, unique_name.c_str(), in_frame_id);
+        if (in_frame == nullptr)
+            break;
+        uint8_t* out_frame = wait_for_empty_frame(out_buf, unique_name.c_str(), out_frame_id);
+        if (out_frame == nullptr)
+            break;
+
+        // If we have a gains buffer we check for new gains
+        if (gains_buf != nullptr) {
+            if (first_time) {
+                gains_frame = wait_for_full_frame(gains_buf, unique_name.c_str(),
+                                                  gains_frame_id);
+                if (gains_frame == nullptr)
+                    break;
+                first_time = false;
+            } else {
+                auto timeout = double_to_ts(0);
+                auto status = wait_for_full_frame_timeout(gains_buf, unique_name.c_str(),
+                                                          gains_frame_id, timeout);
+                if (status == -1) {
+                    break;
+                }
+                if (status == 0) {
+                    mark_frame_empty(gains_buf, unique_name.c_str(), gains_frame_id++);
+                    gains_frame = wait_for_full_frame(gains_buf, unique_name.c_str(),
+                                                      gains_frame_id);
+                }
+            }
+        }
+
+        // Get time
+        timespec gps_time = get_gps_time(in_buf, in_frame_id);
+
+        // Get frequencies
+        for (uint32_t i = 0; i < _num_local_freq; ++i) {
+            frequencies_in_frame[i] = Telescope::instance().to_freq_id(in_buf, i);
+            // Get frequency in MHz with Telescope::instance().to_freq(frequencies_in_frame[i])
+        }
+
+        // Lock gain and metadata setting
+        {
+            std::lock_guard<std::mutex> lock(beam_lock);
+            // Set the metadata in the input frame to match what pointings we are
+            // using at the time the phases are generated
+            set_beam_coord(in_buf, in_frame_id, _beam_coord);
+            compute_phases(out_frame, gps_time, frequencies_in_frame, gains_frame);
+        }
+
+        mark_frame_full(in_buf, unique_name.c_str(), in_frame_id++);
+        mark_frame_empty(out_buf, unique_name.c_str(), out_frame_id++);
+    }
+}

--- a/lib/stages/BeamformingPhaseUpdate.hpp
+++ b/lib/stages/BeamformingPhaseUpdate.hpp
@@ -1,0 +1,113 @@
+#ifndef BEAMFORMING_PHASE_UPDATE_HPP
+#define BEAMFORMING_PHASE_UPDATE_HPP
+
+#include "Config.hpp"          // for Config
+#include "chimeMetadata.hpp"
+#include "Stage.hpp"           // for Stage
+#include "bufferContainer.hpp" // for bufferContainer
+#include "Telescope.hpp"
+
+#include <stdint.h> // for int32_t
+
+/**
+ * @brief Base class stage which generates phases for a tracking beamformer
+ *
+ * @note This stage is not used directly, but instead via one of the subclasses
+ *
+ * @par Buffers
+ * @buffer in_buf The incoming voltage data, along with metadata
+ *        @buffer_format baseband voltage data
+ *        @buffer_metadata CHIME Metadata
+ *
+ * @buffer out_buf Phase buffer sent to the GPU in the format the kernel requires
+ *        @buffer_format Format determined by subclass/kernel requirements
+ *        @buffer_metadata none
+ *
+ * @bufffer gain_buf Complex gains to multiply into the phases
+ *                   Only used for kernels which apply gains and phases in one step.
+ *        @buffer_format Format determined by subclass/kernel requirements
+ *        @buffer_metadata none
+ *
+ * @conf   num_elements             Int. Number of elements (2 * num_feeds)
+ * @conf   num_beams                Int. Number of beams
+ * @conf   inst_lat                 Double. The Instrument latitude
+ * @conf   inst_long                Double. The Instrument longitude
+ * @conf   num_local_freq           Int. Number of local frequencies
+ * @conf   beam_pointing/i/ra       Float. initial RA (in deg) to form beams on for beam_id=i
+ * @conf   beam_pointing/i/dec      Float. initial Dec (in deg) to form beams on for beam_id=i
+ * @conf   beam_pointing/i/scaling  Int. scaling for beam_id=i, not used by all subclasses
+ *
+ * @author Andre Renard
+ */
+class BeamformingPhaseUpdate : public kotekan::Stage {
+public:
+    /// Constructor
+    BeamformingPhaseUpdate(kotekan::Config& config, const std::string& unique_name,
+                           kotekan::bufferContainer& buffer_container);
+    ~BeamformingPhaseUpdate();
+
+    /// Main thread/loop
+    void main_thread() override;
+
+    /// Endpoint for providing new tracking target (RA, Dec, beam_id)
+    bool tracking_update_callback(nlohmann::json& json, const uint8_t beamID);
+
+protected:
+    /// The baseband buffer which will provide the time and frequency data
+    struct Buffer* in_buf = nullptr;
+    /// The phase buffer used by the GPU kernel to generate the beams
+    struct Buffer* out_buf = nullptr;
+    /// (Optional) Buffer with gains for the cases we combine phase + gains
+    struct Buffer* gains_buf = nullptr;
+
+    /// Number of elements
+    uint32_t _num_elements;
+    /// Number of beams
+    int16_t _num_beams;
+
+    // Coordinates of the phase center.
+    /// The instrument latitude
+    double _inst_lat;
+    /// The instrument longitude
+    double _inst_long;
+
+    /// Number of frequencies in a frame
+    uint32_t _num_local_freq;
+
+    /// List of frequencies in the current frame
+    std::vector<freq_id_t> frequencies_in_frame;
+
+    /// The feed locations [feed][x,y] in meters from phase center
+    std::vector<std::pair<double, double>> feed_locations;
+
+    /// Beam pointing coordinates
+    struct beamCoord _beam_coord;
+
+    /// mutex lock prevent beam_coord to be read while it is being updated.
+    std::mutex beam_lock;
+
+    /**
+     * @brief Pure virtual function for computing the phases of the beamformer.
+     *
+     * This fucntion implements the beamformer phase generation code.
+     * The fastest changing parameters are passed to this function, but all the
+     * static configuration values can be accessed via the protected members of
+     * the base class (e.g. feed positions)
+     *
+     * @param out_frame Location to put the gains
+     *                  (do not index past out_buf->frame_size bytes)
+     * @param gps_time The GPS timestamp of the first sample in the incoming data
+     *                  frame which will be assoicated with these gains
+     * @param frequencies_in_frame An array of all the frequency ids needed for the
+     *                             given out_frame
+     * @param gains_frame (Optional) The gains frame, used if we have combined gains
+     *                               phases.   For arrays with seperated gains/phases
+     *                               this will be set to nullptr
+     */
+    virtual void compute_phases(uint8_t * out_frame, const timespec &gps_time,
+                               const std::vector<freq_id_t> &frequencies_in_frame,
+                               uint8_t * gains_frame) = 0;
+};
+
+
+#endif // BEAMFORMING_PHASE_UPDATE_HPP

--- a/lib/stages/BeamformingPhaseUpdate.hpp
+++ b/lib/stages/BeamformingPhaseUpdate.hpp
@@ -1,11 +1,11 @@
 #ifndef BEAMFORMING_PHASE_UPDATE_HPP
 #define BEAMFORMING_PHASE_UPDATE_HPP
 
-#include "Config.hpp"          // for Config
-#include "chimeMetadata.hpp"
-#include "Stage.hpp"           // for Stage
-#include "bufferContainer.hpp" // for bufferContainer
+#include "Config.hpp" // for Config
+#include "Stage.hpp"  // for Stage
 #include "Telescope.hpp"
+#include "bufferContainer.hpp" // for bufferContainer
+#include "chimeMetadata.hpp"
 
 #include <stdint.h> // for int32_t
 
@@ -23,7 +23,7 @@
  *        @buffer_format Format determined by subclass/kernel requirements
  *        @buffer_metadata none
  *
- * @bufffer gain_buf Complex gains to multiply into the phases
+ * @buffer gain_buf Complex gains to multiply into the phases
  *                   Only used for kernels which apply gains and phases in one step.
  *        @buffer_format Format determined by subclass/kernel requirements
  *        @buffer_metadata none
@@ -104,9 +104,9 @@ protected:
      *                               phases.   For arrays with seperated gains/phases
      *                               this will be set to nullptr
      */
-    virtual void compute_phases(uint8_t * out_frame, const timespec &gps_time,
-                               const std::vector<freq_id_t> &frequencies_in_frame,
-                               uint8_t * gains_frame) = 0;
+    virtual void compute_phases(uint8_t* out_frame, const timespec& gps_time,
+                                const std::vector<freq_id_t>& frequencies_in_frame,
+                                uint8_t* gains_frame) = 0;
 };
 
 

--- a/lib/stages/CMakeLists.txt
+++ b/lib/stages/CMakeLists.txt
@@ -50,6 +50,9 @@ add_library(
     bufferDelay.cpp
     BufferSplit.cpp
     InputSubset.cpp
+    BeamformingPhaseUpdate.cpp
+    FloatPhaseUpdate.cpp
+    TCPhaseUpdate.cpp
     # RFI Pipeline Processes
     rfiVDIF.cpp
     rfiAVXVDIF.cpp

--- a/lib/stages/FloatPhaseUpdate.cpp
+++ b/lib/stages/FloatPhaseUpdate.cpp
@@ -1,0 +1,24 @@
+#include "FloatPhaseUpdate.hpp"
+
+#include "StageFactory.hpp"
+
+REGISTER_KOTEKAN_STAGE(FloatPhaseUpdate);
+
+FloatPhaseUpdate::FloatPhaseUpdate(kotekan::Config& config, const std::string& unique_name,
+                                   kotekan::bufferContainer& buffer_container) :
+    BeamformingPhaseUpdate(config, unique_name, buffer_container) {}
+
+void FloatPhaseUpdate::compute_phases(uint8_t* out_frame, const timespec& gps_time,
+                                     const std::vector<freq_id_t>& frequencies_in_frame,
+                                     uint8_t* gains_frame) {
+    // These lines are just to suppress warnings, remove once function uses them
+    (void)out_frame;
+    (void)gps_time;
+    (void)frequencies_in_frame;
+    (void)gains_frame;
+
+    // Code to generate phases goes here.
+    // Can access configuration parameters from BeamformingPhaseUpdate
+    // e.g. _inst_lat and _inst_long, _beam_coord, _num_beams, etc.
+}
+

--- a/lib/stages/FloatPhaseUpdate.cpp
+++ b/lib/stages/FloatPhaseUpdate.cpp
@@ -9,8 +9,8 @@ FloatPhaseUpdate::FloatPhaseUpdate(kotekan::Config& config, const std::string& u
     BeamformingPhaseUpdate(config, unique_name, buffer_container) {}
 
 void FloatPhaseUpdate::compute_phases(uint8_t* out_frame, const timespec& gps_time,
-                                     const std::vector<freq_id_t>& frequencies_in_frame,
-                                     uint8_t* gains_frame) {
+                                      const std::vector<freq_id_t>& frequencies_in_frame,
+                                      uint8_t* gains_frame) {
     // These lines are just to suppress warnings, remove once function uses them
     (void)out_frame;
     (void)gps_time;
@@ -21,4 +21,3 @@ void FloatPhaseUpdate::compute_phases(uint8_t* out_frame, const timespec& gps_ti
     // Can access configuration parameters from BeamformingPhaseUpdate
     // e.g. _inst_lat and _inst_long, _beam_coord, _num_beams, etc.
 }
-

--- a/lib/stages/FloatPhaseUpdate.hpp
+++ b/lib/stages/FloatPhaseUpdate.hpp
@@ -6,12 +6,13 @@
 class FloatPhaseUpdate : public BeamformingPhaseUpdate {
 public:
     FloatPhaseUpdate(kotekan::Config& config, const std::string& unique_name,
-                           kotekan::bufferContainer& buffer_container);
+                     kotekan::bufferContainer& buffer_container);
     ~FloatPhaseUpdate() = default;
+
 protected:
-    virtual void compute_phases(uint8_t * out_frame, const timespec &gps_time,
-                               const std::vector<freq_id_t> &frequencies_in_frame,
-                               uint8_t * gains_frame) override;
+    virtual void compute_phases(uint8_t* out_frame, const timespec& gps_time,
+                                const std::vector<freq_id_t>& frequencies_in_frame,
+                                uint8_t* gains_frame) override;
 };
 
 

--- a/lib/stages/FloatPhaseUpdate.hpp
+++ b/lib/stages/FloatPhaseUpdate.hpp
@@ -1,0 +1,18 @@
+#ifndef FLOAT_PHASE_UPDATE_HPP
+#define FLOAT_PHASE_UPDATE_HPP
+
+#include "BeamformingPhaseUpdate.hpp"
+
+class FloatPhaseUpdate : public BeamformingPhaseUpdate {
+public:
+    FloatPhaseUpdate(kotekan::Config& config, const std::string& unique_name,
+                           kotekan::bufferContainer& buffer_container);
+    ~FloatPhaseUpdate() = default;
+protected:
+    virtual void compute_phases(uint8_t * out_frame, const timespec &gps_time,
+                               const std::vector<freq_id_t> &frequencies_in_frame,
+                               uint8_t * gains_frame) override;
+};
+
+
+#endif // FLOAT_PHASE_UPDATE_HPP

--- a/lib/stages/TCPhaseUpdate.cpp
+++ b/lib/stages/TCPhaseUpdate.cpp
@@ -1,0 +1,28 @@
+#include "TCPhaseUpdate.hpp"
+
+#include "StageFactory.hpp"
+
+REGISTER_KOTEKAN_STAGE(TCPhaseUpdate);
+
+TCPhaseUpdate::TCPhaseUpdate(kotekan::Config& config, const std::string& unique_name,
+                             kotekan::bufferContainer& buffer_container) :
+    BeamformingPhaseUpdate(config, unique_name, buffer_container) {}
+
+void TCPhaseUpdate::compute_phases(uint8_t* out_frame, const timespec& gps_time,
+                                  const std::vector<freq_id_t>& frequencies_in_frame,
+                                  uint8_t* gains_frame) {
+    // These lines are just to suppress warnings, remove once function uses them
+    (void)out_frame;
+    (void)gps_time;
+    (void)frequencies_in_frame;
+    // Keep this one, since it isn't used for the TC version
+    (void)gains_frame;
+
+    // Code to generate phases goes here.
+    // Can access configuration parameters from BeamformingPhaseUpdate
+    // e.g. _inst_lat and _inst_long, _beam_coord, _num_beams, etc.
+    // Note for this version the `gains_frame` will be set to nullptr
+    // and isn't used, since gains are loaded into the GPU separately.
+
+}
+

--- a/lib/stages/TCPhaseUpdate.cpp
+++ b/lib/stages/TCPhaseUpdate.cpp
@@ -9,8 +9,8 @@ TCPhaseUpdate::TCPhaseUpdate(kotekan::Config& config, const std::string& unique_
     BeamformingPhaseUpdate(config, unique_name, buffer_container) {}
 
 void TCPhaseUpdate::compute_phases(uint8_t* out_frame, const timespec& gps_time,
-                                  const std::vector<freq_id_t>& frequencies_in_frame,
-                                  uint8_t* gains_frame) {
+                                   const std::vector<freq_id_t>& frequencies_in_frame,
+                                   uint8_t* gains_frame) {
     // These lines are just to suppress warnings, remove once function uses them
     (void)out_frame;
     (void)gps_time;
@@ -23,6 +23,4 @@ void TCPhaseUpdate::compute_phases(uint8_t* out_frame, const timespec& gps_time,
     // e.g. _inst_lat and _inst_long, _beam_coord, _num_beams, etc.
     // Note for this version the `gains_frame` will be set to nullptr
     // and isn't used, since gains are loaded into the GPU separately.
-
 }
-

--- a/lib/stages/TCPhaseUpdate.hpp
+++ b/lib/stages/TCPhaseUpdate.hpp
@@ -1,0 +1,19 @@
+#ifndef TC_PHASE_UPDATE_HPP
+#define TC_PHASE_UPDATE_HPP
+
+#include "BeamformingPhaseUpdate.hpp"
+
+class TCPhaseUpdate : public BeamformingPhaseUpdate {
+public:
+    TCPhaseUpdate(kotekan::Config& config, const std::string& unique_name,
+                     kotekan::bufferContainer& buffer_container);
+    ~TCPhaseUpdate() = default;
+protected:
+    virtual void compute_phases(uint8_t * out_frame, const timespec &gps_time,
+                               const std::vector<freq_id_t> &frequencies_in_frame,
+                               uint8_t * gains_frame) override;
+};
+
+
+
+#endif // TC_PHASE_UPDATE_HPP

--- a/lib/stages/TCPhaseUpdate.hpp
+++ b/lib/stages/TCPhaseUpdate.hpp
@@ -6,14 +6,14 @@
 class TCPhaseUpdate : public BeamformingPhaseUpdate {
 public:
     TCPhaseUpdate(kotekan::Config& config, const std::string& unique_name,
-                     kotekan::bufferContainer& buffer_container);
+                  kotekan::bufferContainer& buffer_container);
     ~TCPhaseUpdate() = default;
-protected:
-    virtual void compute_phases(uint8_t * out_frame, const timespec &gps_time,
-                               const std::vector<freq_id_t> &frequencies_in_frame,
-                               uint8_t * gains_frame) override;
-};
 
+protected:
+    virtual void compute_phases(uint8_t* out_frame, const timespec& gps_time,
+                                const std::vector<freq_id_t>& frequencies_in_frame,
+                                uint8_t* gains_frame) override;
+};
 
 
 #endif // TC_PHASE_UPDATE_HPP


### PR DESCRIPTION
Base code for the new beamforming phase generation. 

TODO:

- [X] Add new UTC to UT1 endpoint - Moved to #1031
- [X] Confirm element/frequency array indices
- [ ] Phase copy functions for HSA/OpenCL
- [X] Add array element positions file for CHIME - Move to #1031
- [X] Refactor `beam_coord` struct? -> Decided against this change