### PR TITLE
Better error message when metadata pool is too small

### DIFF
--- a/lib/core/buffer.c
+++ b/lib/core/buffer.c
@@ -788,8 +788,8 @@ void allocate_new_metadata_object(struct Buffer* buf, int ID) {
         buf->metadata[ID] = request_metadata_object(buf->metadata_pool);
     }
 
-    // We assume for now that we always have enough info objects in the pool.
-    assert(buf->metadata[ID] != NULL);
+    // Make sure we got a metadata object.
+    CHECK_MEM_F(buf->metadata[ID]);
 
     CHECK_ERROR_F(pthread_mutex_unlock(&buf->lock));
 }

--- a/lib/core/metadata.h
+++ b/lib/core/metadata.h
@@ -171,6 +171,7 @@ struct metadataPool {
  * @brief Creates a new metadata pool with a fixed number of metadata containers.
  * @param[in] num_metadata_objects The number of containers to store in the pool.
  * @param[in] object_size The size of the actual metadata contained in each container.
+ * @param[in] unique_name The name of the pool generated from the config path.
  * @return A metadata pool which can then be associated to one or more buffers.
  */
 struct metadataPool* create_metadata_pool(int num_metadata_objects, size_t object_size,

--- a/lib/core/metadata.h
+++ b/lib/core/metadata.h
@@ -162,6 +162,9 @@ struct metadataPool {
 
     /// Locks requests for metadata to avoid race conditions.
     pthread_mutex_t pool_lock;
+
+    /// Name of the metadata pool
+    char* unique_name;
 };
 
 /**
@@ -170,7 +173,8 @@ struct metadataPool {
  * @param[in] object_size The size of the actual metadata contained in each container.
  * @return A metadata pool which can then be associated to one or more buffers.
  */
-struct metadataPool* create_metadata_pool(int num_metadata_objects, size_t object_size);
+struct metadataPool* create_metadata_pool(int num_metadata_objects, size_t object_size,
+                                          const char* unique_name);
 
 /**
  * @brief Deletes a memdata pool and frees all memory associated with its containers.

--- a/lib/core/metadataFactory.cpp
+++ b/lib/core/metadataFactory.cpp
@@ -74,23 +74,28 @@ struct metadataPool* metadataFactory::new_pool(const std::string& pool_type,
     uint32_t num_metadata_objects = config.get<uint32_t>(location, "num_metadata_objects");
 
     if (pool_type == "chimeMetadata") {
-        return create_metadata_pool(num_metadata_objects, sizeof(struct chimeMetadata));
+        return create_metadata_pool(num_metadata_objects, sizeof(struct chimeMetadata),
+                                    location.c_str());
     }
 
     if (pool_type == "VisMetadata") {
-        return create_metadata_pool(num_metadata_objects, sizeof(struct VisMetadata));
+        return create_metadata_pool(num_metadata_objects, sizeof(struct VisMetadata),
+                                    location.c_str());
     }
 
     if (pool_type == "HFBMetadata") {
-        return create_metadata_pool(num_metadata_objects, sizeof(struct HFBMetadata));
+        return create_metadata_pool(num_metadata_objects, sizeof(struct HFBMetadata),
+                                    location.c_str());
     }
 
     if (pool_type == "BeamMetadata") {
-        return create_metadata_pool(num_metadata_objects, sizeof(struct BeamMetadata));
+        return create_metadata_pool(num_metadata_objects, sizeof(struct BeamMetadata),
+                                    location.c_str());
     }
 
     if (pool_type == "BasebandMetadata") {
-        return create_metadata_pool(num_metadata_objects, sizeof(struct BasebandMetadata));
+        return create_metadata_pool(num_metadata_objects, sizeof(struct BasebandMetadata),
+                                    location.c_str());
     }
     // No metadata found
     throw std::runtime_error(fmt::format(fmt("No metadata object named: {:s}"), pool_type));


### PR DESCRIPTION
Changes the error message from the confusing:
```
kotekan: /code/build/kotekan/lib/core/metadata.c:131: request_metadata_object: Assertion `container != NULL' failed.
```
To the more helpful:
```
The metadata pool `/main_pool` is out of metadata objects, try increasing `num_metadata_objects:` in the config.
```