### PR TITLE
clear cache memory in nDiskFileWrite

### DIFF
--- a/lib/stages/nDiskFileWrite.cpp
+++ b/lib/stages/nDiskFileWrite.cpp
@@ -211,6 +211,10 @@ void nDiskFileWrite::file_write_thread(int disk_id) {
                 // INFO("Data writen to file!");
             }
 
+            // To free the cache memory
+            syncfs(fd);
+            posix_fadvise(fd, 0, 0, POSIX_FADV_DONTNEED);
+
             if (close(fd) == -1) {
                 ERROR("Cannot close file {:s}", file_name);
             }

--- a/lib/stages/nDiskFileWrite.cpp
+++ b/lib/stages/nDiskFileWrite.cpp
@@ -211,9 +211,11 @@ void nDiskFileWrite::file_write_thread(int disk_id) {
                 // INFO("Data writen to file!");
             }
 
+#ifdef __linux__
             // To free the cache memory
             syncfs(fd);
             posix_fadvise(fd, 0, 0, POSIX_FADV_DONTNEED);
+#endif
 
             if (close(fd) == -1) {
                 ERROR("Cannot close file {:s}", file_name);


### PR DESCRIPTION
Added `syncfs` and `posix_fadvise` to clear cache memory taken by each file in `nDiskFileWrite.cpp`. It works and it solved the cache memory build-up and consequent packet loss while running kotekan with `nDiskFileWrite` stage. Could you check if this is the correct sync function?