### PR TITLE
Update kotekan config to enable outrigger-gating as receiver node for beam 10

### DIFF
--- a/config/chime_science_run_gpu.yaml
+++ b/config/chime_science_run_gpu.yaml
@@ -1503,7 +1503,7 @@ extra_tracking_beams:
       kotekan_stage: bufferSend
       buf: beam_buffer_10_merged
       # outrigger-gating
-      server_ip: 10.1.50.12
+      server_ip: 10.1.50.52
       server_port: 11030
       log_level: error
       reconnect_time: 20

--- a/config/chime_science_run_gpu.yaml
+++ b/config/chime_science_run_gpu.yaml
@@ -1537,9 +1537,9 @@ extra_tracking_beams:
     beam_send_11:
       kotekan_stage: bufferSend
       buf: beam_buffer_11_merged
-      # Moose
-      server_ip: 10.1.50.10
-      server_port: 11030
+      # outrigger-gating
+      server_ip: 10.1.50.12
+      server_port: 68
       log_level: error
       reconnect_time: 20
 

--- a/config/chime_science_run_gpu.yaml
+++ b/config/chime_science_run_gpu.yaml
@@ -1502,8 +1502,8 @@ extra_tracking_beams:
     beam_send_10:
       kotekan_stage: bufferSend
       buf: beam_buffer_10_merged
-      # Bongo
-      server_ip: 10.1.50.13
+      # outrigger-gating
+      server_ip: 10.1.50.12
       server_port: 11030
       log_level: error
       reconnect_time: 20
@@ -1537,9 +1537,9 @@ extra_tracking_beams:
     beam_send_11:
       kotekan_stage: bufferSend
       buf: beam_buffer_11_merged
-      # outrigger-gating
-      server_ip: 10.1.50.12
-      server_port: 68
+      # bass
+      server_ip: 10.1.50.10
+      server_port: 11030
       log_level: error
       reconnect_time: 20
 

--- a/config/chime_science_run_gpu_no_output.yaml
+++ b/config/chime_science_run_gpu_no_output.yaml
@@ -1537,9 +1537,9 @@ extra_tracking_beams:
     beam_send_11:
       #kotekan_stage: bufferSend
       buf: beam_buffer_11_merged
-      # Moose
-      server_ip: 10.1.50.10
-      server_port: 11030
+      # outrigger-gating
+      server_ip: 10.1.50.12
+      server_port: 68
       log_level: error
       reconnect_time: 20
 

--- a/config/chime_science_run_gpu_no_output.yaml
+++ b/config/chime_science_run_gpu_no_output.yaml
@@ -1502,8 +1502,8 @@ extra_tracking_beams:
     beam_send_10:
       #kotekan_stage: bufferSend
       buf: beam_buffer_10_merged
-      # Bongo
-      server_ip: 10.1.50.13
+      # outrigger-gating
+      server_ip: 10.1.50.12
       server_port: 11030
       log_level: error
       reconnect_time: 20
@@ -1538,8 +1538,8 @@ extra_tracking_beams:
       #kotekan_stage: bufferSend
       buf: beam_buffer_11_merged
       # outrigger-gating
-      server_ip: 10.1.50.12
-      server_port: 68
+      server_ip: 10.1.50.10
+      server_port: 11030
       log_level: error
       reconnect_time: 20
 

--- a/config/chime_science_run_gpu_no_output.yaml
+++ b/config/chime_science_run_gpu_no_output.yaml
@@ -1503,7 +1503,7 @@ extra_tracking_beams:
       #kotekan_stage: bufferSend
       buf: beam_buffer_10_merged
       # outrigger-gating
-      server_ip: 10.1.50.12
+      server_ip: 10.1.50.52
       server_port: 11030
       log_level: error
       reconnect_time: 20


### PR DESCRIPTION
I updated both `chime_science_run_gpu.yaml` and `chime_science_run_gpu_no_output.yaml` with the 40 gig link IP on the `outrigger-gating` node.

@andrerenard - Could you please check the following:

1.  I set `server_port: 68`, based on the following on `outrigger-gating`:

```
pearlman@outrigger-gating:~$ sudo lsof -i -P -n
COMMAND     PID            USER   FD   TYPE DEVICE SIZE/OFF NODE NAME
systemd-n  1093 systemd-network   15u  IPv4 185728      0t0  UDP 10.1.50.52:68
systemd-n  1093 systemd-network   25u  IPv4  99117      0t0  UDP 10.5.2.52:68
systemd-r  1095 systemd-resolve   12u  IPv4  34044      0t0  UDP 127.0.0.53:53
systemd-r  1095 systemd-resolve   13u  IPv4  34045      0t0  TCP 127.0.0.53:53 (LISTEN)
sshd       1207            root    3u  IPv4  49228      0t0  TCP *:22 (LISTEN)
sshd       1207            root    4u  IPv6  49230      0t0  TCP *:22 (LISTEN)
nslcd      1281           nslcd    4u  IPv4  29008      0t0  TCP 10.5.2.52:54090->192.168.72.76:389 (ESTABLISHED)
nslcd      1281           nslcd    7u  IPv4  32104      0t0  TCP 10.5.2.52:59244->192.168.72.76:389 (ESTABLISHED)
nslcd      1281           nslcd    8u  IPv4    732      0t0  TCP 10.5.2.52:54072->192.168.72.76:389 (ESTABLISHED)
nslcd      1281           nslcd    9u  IPv4  56447      0t0  TCP 10.5.2.52:60706->192.168.72.76:389 (ESTABLISHED)
nslcd      1281           nslcd   11u  IPv4  36423      0t0  TCP 10.1.50.52:54962->192.168.72.76:389 (ESTABLISHED)
sshd      17875            root    4u  IPv4 193859      0t0  TCP 10.5.2.52:22->10.5.2.40:54238 (ESTABLISHED)
sshd      17957        pearlman    4u  IPv4 193859      0t0  TCP 10.5.2.52:22->10.5.2.40:54238 (ESTABLISHED)
sshd      18018            root    4u  IPv4 201776      0t0  TCP 10.5.2.52:22->10.5.2.40:54828 (ESTABLISHED)
sshd      18101        pearlman    4u  IPv4 201776      0t0  TCP 10.5.2.52:22->10.5.2.40:54828 (ESTABLISHED)
```

Can you confirm that the `server_port` looks correct?

2. While carefully going through the configs in `chime_science_run_gpu.yaml` and `chime_science_run_gpu_no_output.yaml`, I noticed that both already have the following (e.g., see https://github.com/kotekan/kotekan/blob/abp/beam11_outrigger_config/config/chime_science_run_gpu.yaml#L1745):

```
# Transmit all the data to the receiver node
buffer_send:
  server_ip: 10.1.50.12
  reconnect_time: 20
  log_level: warn
  n2:
    #kotekan_stage: bufferSend
    buf: visbuf_eig_10s_merge
    server_port: 11024
  26m:
    #kotekan_stage: bufferSend
    buf: visbuf_5s_26m
    server_port: 11025
  26m_psr0:
    #kotekan_stage: bufferSend
    buf: visbuf_psr0_5s_26m
    server_port: 11026
```

This is our 40 gig link IP for `outrigger-gating` right now. So, I wanted to confirm that our 40 gig link IP is not already in use somewhere else. Will these existing settings create any problems for us, or other experiments currently running?

3. Are there any other updates to these configuration files that I missed?