### PR TITLE
add input 37 to excluded inputs in EigenVisIter

### DIFF
--- a/config/chime_kko_gpu.j2
+++ b/config/chime_kko_gpu.j2
@@ -381,7 +381,7 @@ eigcalc:
     subspace: 1
     # Masking config
     bands_filled: [[0, 7], [61, 67]]
-    exclude_inputs: [51, 61, 104, 110, 111, 123]
+    exclude_inputs: [37, 51, 61, 104, 110, 111, 123]
     eigcalc_0:
         kotekan_stage: EigenVisIter
         cpu_affinity: [15]


### PR DESCRIPTION
Input 37 is turned off at KKO, so we should not use in the eigendecomposition.