### PR TITLE
Fix a memory lock issue with restricted docker instances.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -319,8 +319,10 @@ if(${COMPILE_DOCS})
     add_subdirectory(docs EXCLUDE_FROM_ALL)
 endif()
 
-# Turn off memlocking of buffers. This is useful when running in restricted environments e.g. Docker
-# containers
+# Prevent memory locking and setting any memory policies
+# This is useful when running in restricted environments e.g. Docker containers
+# Note this can also be done with the configuration file for systems which do
+# support memory locking, but were some memory shouldn't be memory locked.
 if(${NO_MEMLOCK})
     message("Do not lock buffer memory.")
     add_definitions(-DWITH_NO_MEMLOCK)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -319,10 +319,9 @@ if(${COMPILE_DOCS})
     add_subdirectory(docs EXCLUDE_FROM_ALL)
 endif()
 
-# Prevent memory locking and setting any memory policies
-# This is useful when running in restricted environments e.g. Docker containers
-# Note this can also be done with the configuration file for systems which do
-# support memory locking, but were some memory shouldn't be memory locked.
+# Prevent memory locking and setting any memory policies. This is useful when running in restricted
+# environments e.g. Docker containers Note this can also be done with the configuration file for
+# systems which do support memory locking, but were some memory shouldn't be memory locked.
 if(${NO_MEMLOCK})
     message("Do not lock buffer memory.")
     add_definitions(-DWITH_NO_MEMLOCK)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -320,8 +320,8 @@ if(${COMPILE_DOCS})
 endif()
 
 # Prevent memory locking and setting any memory policies. This is useful when running in restricted
-# environments e.g. Docker containers Note this can also be done with the configuration file for
-# systems which do support memory locking, but were some memory shouldn't be memory locked.
+# environments, e.g. Docker containers.  Note this can also be done with the configuration file for
+# systems which do support memory locking, but where some memory shouldn't be memory locked.
 if(${NO_MEMLOCK})
     message("Do not lock buffer memory.")
     add_definitions(-DWITH_NO_MEMLOCK)

--- a/lib/core/buffer.c
+++ b/lib/core/buffer.c
@@ -948,7 +948,8 @@ uint8_t* buffer_malloc(size_t len, int numa_node, bool use_hugepages, bool mlock
 #else
         (void)numa_node;
         // Create a page aligned block of memory for the buffer
-        if (posix_memalign((void**)&(frame), PAGESIZE_MEM, len) != 0) {
+        int err = posix_memalign((void**)&(frame), PAGESIZE_MEM, len)
+        if (err != 0) {
             ERROR_F("Error creating aligned memory: %d", err);
             return NULL;
         }

--- a/lib/core/buffer.c
+++ b/lib/core/buffer.c
@@ -948,7 +948,7 @@ uint8_t* buffer_malloc(size_t len, int numa_node, bool use_hugepages, bool mlock
 #else
         (void)numa_node;
         // Create a page aligned block of memory for the buffer
-        int err = posix_memalign((void**)&(frame), PAGESIZE_MEM, len)
+        int err = posix_memalign((void**)&(frame), PAGESIZE_MEM, len);
         if (err != 0) {
             ERROR_F("Error creating aligned memory: %d", err);
             return NULL;

--- a/lib/core/buffer.c
+++ b/lib/core/buffer.c
@@ -970,6 +970,8 @@ uint8_t* buffer_malloc(size_t len, int numa_node, bool use_hugepages, bool mlock
             return NULL;
         }
     }
+#else
+    (void)mlock_frames;
 #endif
     // Zero the new frame
     if (zero_new_frames)

--- a/lib/core/buffer.c
+++ b/lib/core/buffer.c
@@ -71,11 +71,11 @@ int private_mark_frame_empty(struct Buffer* buf, const int id);
 
 struct Buffer* create_buffer(int num_frames, size_t len, struct metadataPool* pool,
                              const char* buffer_name, const char* buffer_type, int numa_node,
-                             bool use_hugepages, bool mlock_frames) {
+                             bool use_hugepages, bool mlock_frames, bool zero_new_frames) {
 
     assert(num_frames > 0);
 
-#ifdef WITH_NUMA
+#if defined(WITH_NUMA) && !defined(WITH_NO_MEMLOCK)
     // Allocate all memory for a buffer on the NUMA domain it's frames are located.
     struct bitmask* node_mask = numa_allocate_nodemask();
     numa_bitmask_setbit(node_mask, numa_node);
@@ -170,13 +170,13 @@ struct Buffer* create_buffer(int num_frames, size_t len, struct metadataPool* po
 
     // Create the frames.
     for (int i = 0; i < num_frames; ++i) {
-        buf->frames[i] =
-            buffer_malloc(buf->aligned_frame_size, numa_node, use_hugepages, mlock_frames);
+        buf->frames[i] = buffer_malloc(buf->aligned_frame_size, numa_node, use_hugepages,
+                                       mlock_frames, zero_new_frames);
         if (buf->frames[i] == NULL)
             return NULL;
     }
 
-#ifdef WITH_NUMA
+#if defined(WITH_NUMA) && !defined(WITH_NO_MEMLOCK)
     // Reset the memory policy so that we don't impact other parts of the
     if (set_mempolicy(MPOL_DEFAULT, NULL, 0) < 0) {
         ERROR_F("Failed to reset the memory policy to default: %s (%d)", strerror(errno), errno);
@@ -903,10 +903,10 @@ void safe_swap_frame(struct Buffer* src_buf, int src_frame_id, struct Buffer* de
     }
 }
 
-uint8_t* buffer_malloc(size_t len, int numa_node, bool use_hugepages, bool mlock_frames) {
+uint8_t* buffer_malloc(size_t len, int numa_node, bool use_hugepages, bool mlock_frames,
+                       bool zero_new_frames) {
 
     uint8_t* frame = NULL;
-    int err;
 
 #ifdef WITH_HSA // Support for legacy HSA support used in CHIME
     (void)err;
@@ -959,9 +959,10 @@ uint8_t* buffer_malloc(size_t len, int numa_node, bool use_hugepages, bool mlock
     }
 #endif
 
+#ifndef WITH_NO_MEMLOCK
     if (mlock_frames) {
         // Ask that all pages be kept in memory
-        err = mlock((void*)frame, len);
+        int err = mlock((void*)frame, len);
 
         if (err == -1) {
             ERROR_F("Error locking memory: %d - check ulimit -a to check memlock limits", errno);
@@ -969,8 +970,10 @@ uint8_t* buffer_malloc(size_t len, int numa_node, bool use_hugepages, bool mlock
             return NULL;
         }
     }
+#endif
     // Zero the new frame
-    memset(frame, 0x0, len);
+    if (zero_new_frames)
+        memset(frame, 0x0, len);
 
     return frame;
 }

--- a/lib/core/buffer.h
+++ b/lib/core/buffer.h
@@ -229,11 +229,14 @@ struct Buffer {
  * @param[in] numa_node The CPU NUMA memory region to allocate memory in.+
  * @param[in] use_huge_pages Map huge pages with mmap
  * @param[in] mlock_frames If set, mlock the pages of the frame memory
+ * @param[in] zero_new_frames In theory some memory allocators don't zero new allocations
+ *                            so by default we zero new frames on startup, but this is expensive
+ *                            and can be disabled by setting this to false.
  * @returns A buffer object.
  */
 struct Buffer* create_buffer(int num_frames, size_t frame_size, struct metadataPool* pool,
                              const char* buffer_name, const char* buffer_type, int numa_node,
-                             bool use_huge_pages, bool mlock_frames);
+                             bool use_huge_pages, bool mlock_frames, bool zero_new_frames);
 
 /**
  * @brief Deletes a buffer object and frees all frame memory
@@ -478,9 +481,11 @@ void swap_frames(struct Buffer* from_buf, int from_frame_id, struct Buffer* to_b
  * @param numa_node The CPU NUMA region to allocate the memory in.
  * @param use_huge_pages Use mmap to allocate huge pages for frames
  * @param memlock_frames Use mlock to lock frame pages
+ * @param zero_new_frames If true, new frames are zeroed with memset
  * @return A pointer to the new memory, or @c NULL if allocation failed.
  */
-uint8_t* buffer_malloc(size_t len, int numa_node, bool use_huge_pages, bool memlock_frames);
+uint8_t* buffer_malloc(size_t len, int numa_node, bool use_huge_pages, bool memlock_frames,
+                       bool zero_new_frames);
 
 /**
  * @brief Deallocate a frame of memory with the required free method.

--- a/lib/core/bufferFactory.cpp
+++ b/lib/core/bufferFactory.cpp
@@ -73,6 +73,7 @@ struct Buffer* bufferFactory::new_buffer(const string& type_name, const string& 
     int32_t numa_node = config.get_default<int32_t>(location, "numa_node", 0);
     bool use_hugepages = config.get_default<bool>(location, "use_hugepages", false);
     bool mlock_frames = config.get_default<bool>(location, "mlock_frames", true);
+    bool zero_new_frames = config.get_default<bool>(location, "zero_new_frames", true);
 
     struct metadataPool* pool = nullptr;
     if (metadataPool_name != "none") {
@@ -99,8 +100,9 @@ struct Buffer* bufferFactory::new_buffer(const string& type_name, const string& 
     INFO_NON_OO("Creating {:s}Buffer named {:s} with {:d} frames, frame size of {:d} and "
                 "metadata pool {:s} on numa_node {:d}",
                 type_name, name, num_frames, frame_size, metadataPool_name, numa_node);
-    struct Buffer* buf = create_buffer(num_frames, frame_size, pool, name.c_str(),
-                                       type_name.c_str(), numa_node, use_hugepages, mlock_frames);
+    struct Buffer* buf =
+        create_buffer(num_frames, frame_size, pool, name.c_str(), type_name.c_str(), numa_node,
+                      use_hugepages, mlock_frames, zero_new_frames);
     if (buf == nullptr) {
         throw std::runtime_error(fmt::format(fmt("Could not create the buffer: {:s}"), name));
     }

--- a/lib/stages/bufferRecv.cpp
+++ b/lib/stages/bufferRecv.cpp
@@ -335,7 +335,7 @@ connInstance::connInstance(const std::string& producer_name, Buffer* buf, buffer
     read_timeout(read_timeout) {
 
     frame_space = buffer_malloc(buf->aligned_frame_size, buf->numa_node, buf->use_hugepages,
-                                buf->mlock_frames);
+                                buf->mlock_frames, false);
     CHECK_MEM(frame_space);
 
     metadata_space = (uint8_t*)malloc(buf->metadata_pool->metadata_object_size);


### PR DESCRIPTION
In #1074 we introduced an issue for restricted docker containers which don't allow memory locking or adjusting the memory policy.  This was preventing some github CI tests from running.   To fix this we add back the `NO_MEMLOCK` compiler option which removes the binary's ability to make memory policy changes.

This change also introduces a "zero_new_frames" config option to override the default behavior of zeroing new frames.   This is useful in situations where a stage doesn't assume anything about the frame contents (true for almost all stages), and so can reduce the startup time by just not zeroing the memory.   The option is `true` by default to preserve backwards compatibility with any configs that assume it's true. 