### PR TITLE
Fix Config.hpp build warning for boolean types

### DIFF
--- a/lib/core/Config.hpp
+++ b/lib/core/Config.hpp
@@ -86,7 +86,7 @@ public:
     }
 
     /**
-     * @brief Get a config value for a non-arithmetic type (i.e. string, vector, bool)
+     * @brief Get a config value for a non-arithmetic type (string, vector, bool, etc.)
      * @param base_path Path to the value in the config.
      * @param name      Name of the value.
      * @return  The requested value.

--- a/lib/core/Config.hpp
+++ b/lib/core/Config.hpp
@@ -53,16 +53,16 @@ public:
      * @param name      Name of the value.
      * @return  The requested value.
      */
-    template<class T, typename std::enable_if<std::is_arithmetic<T>::value, T>::type* = nullptr>
+    template<class T,
+             typename std::enable_if<std::is_arithmetic<T>::value && !std::is_same<bool, T>::value,
+                                     T>::type* = nullptr>
     T get(const std::string& base_path, const std::string& name) const {
         nlohmann::json json_value = get_value(base_path, name);
         T value;
         try {
             // If the expected type is a number and the value
             // isn't already a number then try using the configEval parser
-            if (std::is_arithmetic<T>::value && !std::is_same<bool, T>::value
-                && !json_value.is_number()) {
-
+            if (std::is_arithmetic<T>::value && !json_value.is_number()) {
                 try {
                     Config::configEval<T> eval(*this, base_path, name);
                     value = eval.compute_result();
@@ -86,12 +86,14 @@ public:
     }
 
     /**
-     * @brief Get a config value for a non-arithmetic type (i.e. string or vector)
+     * @brief Get a config value for a non-arithmetic type (i.e. string, vector, bool)
      * @param base_path Path to the value in the config.
      * @param name      Name of the value.
      * @return  The requested value.
      */
-    template<class T, typename std::enable_if<!std::is_arithmetic<T>::value, T>::type* = nullptr>
+    template<class T,
+             typename std::enable_if<!std::is_arithmetic<T>::value || std::is_same<bool, T>::value,
+                                     T>::type* = nullptr>
     T get(const std::string& base_path, const std::string& name) const {
         nlohmann::json json_value = get_value(base_path, name);
         T value;

--- a/lib/core/kotekanTrackers.cpp
+++ b/lib/core/kotekanTrackers.cpp
@@ -10,14 +10,12 @@
 #include <exception>  // for exception
 #include <fstream>    // for ofstream, ostream
 #include <functional> // for _Bind_helper<>::type, _Placeholder, bind, _1, placeholders
-#include <regex>      // for match_results<>::_Base_type
 #include <stdexcept>  // for runtime_error
 #include <stdio.h>    // for sprintf
 #include <stdlib.h>   // for exit
 #include <time.h>     // for tm, localtime, time_t
 #include <unistd.h>   // for gethostname
 #include <utility>    // for pair
-#include <vector>     // for vector
 
 namespace kotekan {
 

--- a/lib/stages/bufferCopy.cpp
+++ b/lib/stages/bufferCopy.cpp
@@ -11,7 +11,6 @@
 #include <atomic>     // for atomic_bool
 #include <exception>  // for exception
 #include <functional> // for _Bind_helper<>::type, bind, function
-#include <regex>      // for match_results<>::_Base_type
 #include <stdexcept>  // for runtime_error, invalid_argument
 #include <stdint.h>   // for uint8_t
 #include <string.h>   // for memcpy

--- a/lib/stages/chrxUplink.cpp
+++ b/lib/stages/chrxUplink.cpp
@@ -14,12 +14,10 @@
 #include <exception>    // for exception
 #include <functional>   // for _Bind_helper<>::type, bind, function
 #include <netinet/in.h> // for sockaddr_in, htons, in_addr
-#include <regex>        // for match_results<>::_Base_type
 #include <stddef.h>     // for size_t
 #include <strings.h>    // for bzero
 #include <sys/socket.h> // for send, connect, socket, AF_INET, SOCK_STREAM
 #include <unistd.h>     // for gethostname, ssize_t
-#include <vector>       // for vector
 
 
 using kotekan::bufferContainer;

--- a/lib/stages/rawFileRead.cpp
+++ b/lib/stages/rawFileRead.cpp
@@ -13,13 +13,11 @@
 #include <errno.h>    // for errno
 #include <exception>  // for exception
 #include <functional> // for _Bind_helper<>::type, bind, function
-#include <regex>      // for match_results<>::_Base_type
 #include <stdexcept>  // for runtime_error
 #include <stdint.h>   // for uint32_t, uint8_t
 #include <string.h>   // for strerror
 #include <sys/stat.h> // for stat
 #include <unistd.h>   // for sleep
-#include <vector>     // for vector
 
 
 inline bool file_exists(char* name) {


### PR DESCRIPTION
This stops the compiler from trying to compile a `configEval<bool>`, which was unsupported by the program logic already but getting compiled by the template logic and generating a warning. 