### PR TITLE
Disable warnings from CUDA library headers

### DIFF
--- a/lib/cuda/CMakeLists.txt
+++ b/lib/cuda/CMakeLists.txt
@@ -53,9 +53,11 @@ target_link_libraries(
     PRIVATE libexternal kotekan_libs -lstdc++
     INTERFACE ${CUDA_LIBRARIES} cuda nvrtc nvptxcompiler_static)
 
+
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --forward-unknown-to-host-compiler")
 
-target_include_directories(kotekan_cuda PUBLIC . ${CUDA_INCLUDE_DIR} ${CUDA_INCLUDE_DIRS})
+target_include_directories(kotekan_cuda SYSTEM PUBLIC ${CUDA_INCLUDE_DIR} ${CUDA_INCLUDE_DIRS})
+target_include_directories(kotekan_cuda PUBLIC .)
 
 target_compile_options(kotekan_cuda PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:-gencode
                                             arch=compute_86,code=sm_86 -lineinfo>)

--- a/lib/cuda/CMakeLists.txt
+++ b/lib/cuda/CMakeLists.txt
@@ -53,7 +53,6 @@ target_link_libraries(
     PRIVATE libexternal kotekan_libs -lstdc++
     INTERFACE ${CUDA_LIBRARIES} cuda nvrtc nvptxcompiler_static)
 
-
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --forward-unknown-to-host-compiler")
 
 target_include_directories(kotekan_cuda SYSTEM PUBLIC ${CUDA_INCLUDE_DIR} ${CUDA_INCLUDE_DIRS})

--- a/lib/cuda/cudaBasebandBeamformer.cpp
+++ b/lib/cuda/cudaBasebandBeamformer.cpp
@@ -68,6 +68,7 @@ typedef CuDeviceArray<int32_t, 1> kernel_arg;
 
 cudaEvent_t cudaBasebandBeamformer::execute(int gpu_frame_id,
                                             const std::vector<cudaEvent_t>& pre_events) {
+    (void)pre_events;
     pre_execute(gpu_frame_id);
 
     void* voltage_memory = device.get_gpu_memory_array(_gpu_mem_voltage, gpu_frame_id, voltage_len);

--- a/lib/cuda/cudaCorrelatorAstron.cpp
+++ b/lib/cuda/cudaCorrelatorAstron.cpp
@@ -51,6 +51,7 @@ cudaCorrelatorAstron::~cudaCorrelatorAstron() {}
 
 cudaEvent_t cudaCorrelatorAstron::execute(int gpu_frame_id,
                                           const std::vector<cudaEvent_t>& pre_events) {
+    (void)pre_events;
     pre_execute(gpu_frame_id);
 
     size_t input_frame_len = (size_t)_num_elements * _num_local_freq * _samples_per_data_set;

--- a/lib/cuda/cudaOutputDataZero.cpp
+++ b/lib/cuda/cudaOutputDataZero.cpp
@@ -23,6 +23,7 @@ cudaOutputDataZero::~cudaOutputDataZero() {
 
 cudaEvent_t cudaOutputDataZero::execute(int gpu_frame_id,
                                         const std::vector<cudaEvent_t>& pre_events) {
+    (void)pre_events;
     pre_execute(gpu_frame_id);
 
     void* gpu_memory_frame = device.get_gpu_memory_array("output", gpu_frame_id, output_len);


### PR DESCRIPTION
* Prevent warnings form CUDA headers from being included in cmake output. 
* Fix a few unused variable warnings. 