### PR TITLE
Allow ARO to write threads with input and frequency ranges

### DIFF
--- a/lib/dpdk/iceBoardVDIF.hpp
+++ b/lib/dpdk/iceBoardVDIF.hpp
@@ -388,6 +388,8 @@ void iceBoardVDIF::copy_packet_vdif(struct rte_mbuf* mbuf) {
 
     // Offset in output frame for first frequency of this receiver buffer thread (0-7).
     uint32_t freq_offset = tel.to_freq_id(encoded_id, 0);
+    // Sanity check: there should be an integer number of frames in the input buffer.
+    assert((mbuf_data_max - mbuf_data_ptr) % (128 * total_num_elements) == 0);
 
     // Times are in separate frames, so time stride equals the size of the VDIF framesets.
     for (uint8_t* out_t_f0 = out_t0_f0;
@@ -395,6 +397,7 @@ void iceBoardVDIF::copy_packet_vdif(struct rte_mbuf* mbuf) {
          out_t_f0 += vdif_frameset_size) {
         // Pointer to start of thread in VDIF frame (updated in loop).
         uint8_t* out_t_p = out_t_f0;
+        //
         for (uint32_t i_thread = 0; i_thread < num_threads; i_thread++) {
             // Pointer to starting input and frequency in input buffer for this thread.
             char* in = mbuf_data_ptr + buffer_offsets[i_thread];
@@ -440,6 +443,8 @@ void iceBoardVDIF::copy_packet_vdif(struct rte_mbuf* mbuf) {
             mbuf_data_base = rte_pktmbuf_mtod(mbuf, char*);
             mbuf_data_max = mbuf_data_base + mbuf->data_len;
             mbuf_data_ptr = mbuf_data_base + mbuf_offset;
+            // Sanity check: there should be an integer number of frames in the input buffer.
+            assert((mbuf_data_max - mbuf_data_ptr) % (128 * total_num_elements) == 0);
         }
     }
 }

--- a/lib/dpdk/iceBoardVDIF.hpp
+++ b/lib/dpdk/iceBoardVDIF.hpp
@@ -193,6 +193,7 @@ iceBoardVDIF::iceBoardVDIF(kotekan::Config& config, const std::string& unique_na
                                                  frequencies[i_thread]));
         }
     }
+    buffer_offsets.resize(num_threads);
     for (uint32_t i_thread = 0; i_thread < num_threads; i_thread++) {
         // Calculate true offset in input buffer. This has every eighth frequency,
         // so for buffer 0, 16 elements for freq 0, then 16 for freq 8, etc.

--- a/lib/dpdk/iceBoardVDIF.hpp
+++ b/lib/dpdk/iceBoardVDIF.hpp
@@ -291,17 +291,17 @@ void iceBoardVDIF::copy_packet_vdif(struct rte_mbuf* mbuf) {
     char* mbuf_data_base = rte_pktmbuf_mtod(mbuf, char*);
     char* mbuf_data_max = mbuf_data_base + mbuf->data_len;
     char* mbuf_data_ptr = mbuf_data_base + header_offset + offset;
-    char* out_t0_f0 = (out_buf_frame        // Start of output buffer.
+    uint8_t* out_t0_f0 = (out_buf_frame        // Start of output buffer.
          + vdif_frame_location * frame_size // Frame location in output buffer.
          + vdif_header_len                  // Offset for the vdif header.
          + tel.to_freq_id(encoded_id, 0));  // Offset for ARO for first frequency.
     // Times are in separate frames, so time stride equals frame_size.
-    for (char* out_t_f0 = out_t0_f0;
+    for (uint8_t* out_t_f0 = out_t0_f0;
          out_t_f0 < out_t0_f0 + frame_size * samples_per_packet;
          out_t_f0 += frame_size) {
         // Location in the VDIF packet is just frequency,
         // but our buffer has every 8th frequency.
-        for (char* out_t_f = out_t_f0; out_t_f < out_t_f0+1024; out_ptr += 8) {
+        for (uint8_t* out_t_f = out_t_f0; out_t_f < out_t_f0+1024; out_t_f += 8) {
             // Store first channel.
             *out_t_f = *mbuf_data_ptr;
             // Store subsequent one in next thread.

--- a/lib/dpdk/iceBoardVDIF.hpp
+++ b/lib/dpdk/iceBoardVDIF.hpp
@@ -393,7 +393,7 @@ void iceBoardVDIF::copy_packet_vdif(struct rte_mbuf* mbuf) {
 
     // Buffer and offset to first sample in the input.
     auto mbuf0 = mbuf;
-    uint32_t mbuf_start_offset = 0;  // excludes header_offset.
+    uint32_t mbuf_start_offset = 0; // excludes header_offset.
 
     // Times are in separate frames, so time stride equals the size of the VDIF framesets.
     for (uint8_t* out_t_f0 = out_t0_f0;
@@ -409,8 +409,7 @@ void iceBoardVDIF::copy_packet_vdif(struct rte_mbuf* mbuf) {
             in += header_offset + mbuf_start_offset + buffer_offsets[i_thread];
             // Output start location.
             uint8_t* out_t_fi = out_t_f0 + i_thread * vdif_frame_size;
-            for (uint8_t* out = out_t_fi;
-                 out < out_t_fi + num_freq * num_elements;
+            for (uint8_t* out = out_t_fi; out < out_t_fi + num_freq * num_elements;
                  out += 8 * num_elements) {
                 while (unlikely(in > mbuf_last_sample)) {
                     // Input is beyond start of last sample.

--- a/lib/dpdk/iceBoardVDIF.hpp
+++ b/lib/dpdk/iceBoardVDIF.hpp
@@ -291,11 +291,14 @@ void iceBoardVDIF::copy_packet_vdif(struct rte_mbuf* mbuf) {
     int from_idx = header_offset + offset;
     int mbuf_len = mbuf->data_len;
     char* mbuf_data_ptr = rte_pktmbuf_mtod(mbuf, char*);
+    int output_idx_base_base =
+      (vdif_frame_location * frame_size +           // Frame location in output buffer.
+       vdif_header_len +        // Offset for the vdif header.
+       tel.to_freq_id(encoded_id, 0)); // Offset for ARO as in tel.to_freq_id for _num_freq_per_stream = 128
+    int time_step_offset = vdif_packet_len * num_elements;
     for (uint32_t time_step = 0; time_step < samples_per_packet; ++time_step) {
-        int output_idx_base = (vdif_frame_location * frame_size +           // Frame location in output buffer.
-			       vdif_header_len +        // Offset for the vdif header.
-			       tel.to_freq_id(encoded_id, 0) + // Offset for ARO as in tel.to_freq_id for _num_freq_per_stream = 128
-			       vdif_packet_len * num_elements * time_step); // Time step in output frame.
+        int output_idx_base = (output_idx_base_base +
+			       time_step_offset * time_step); // Time step in output frame.
         for (int freq = 0; freq < 1024; freq += 8) {
 	    int output_idx = (output_idx_base +
 			      freq); // Location in the VDIF packet is just frequency.

--- a/lib/dpdk/iceBoardVDIF.hpp
+++ b/lib/dpdk/iceBoardVDIF.hpp
@@ -290,6 +290,7 @@ void iceBoardVDIF::copy_packet_vdif(struct rte_mbuf* mbuf) {
     // Create the parts of the VDIF frame that are in this packet.
     int from_idx = header_offset + offset;
     int mbuf_len = mbuf->data_len;
+    char* mbuf_data_ptr = rte_pktmbuf_mtod(mbuf, char*);
     for (uint32_t time_step = 0; time_step < samples_per_packet; ++time_step) {
         int output_idx_base = (vdif_frame_location * frame_size +           // Frame location in output buffer.
 			       vdif_header_len +        // Offset for the vdif header.
@@ -306,9 +307,10 @@ void iceBoardVDIF::copy_packet_vdif(struct rte_mbuf* mbuf) {
                     assert(mbuf);
                     from_idx -= mbuf_len; // Subtract the last mbuf_len from the current idx.
                     mbuf_len = mbuf->data_len;
+                    mbuf_data_ptr = rte_pktmbuf_mtod(mbuf, char*);
                 }
                 // After all that indexing copy one byte :)
-                out_buf_frame[output_idx] = *(rte_pktmbuf_mtod(mbuf, char*) + from_idx);
+                out_buf_frame[output_idx] = *(mbuf_data_ptr + from_idx);
 
                 from_idx += 1;
 		output_idx += vdif_packet_len; // VDIF packet for the next element (ThreadID).

--- a/lib/dpdk/iceBoardVDIF.hpp
+++ b/lib/dpdk/iceBoardVDIF.hpp
@@ -296,9 +296,9 @@ void iceBoardVDIF::copy_packet_vdif(struct rte_mbuf* mbuf) {
 			       vdif_header_len +        // Offset for the vdif header.
 			       tel.to_freq_id(encoded_id, 0) + // Offset for ARO as in tel.to_freq_id for _num_freq_per_stream = 128
 			       vdif_packet_len * num_elements * time_step); // Time step in output frame.
-        for (int freq = 0; freq < 128; ++freq) {
+        for (int freq = 0; freq < 1024; freq += 8) {
 	    int output_idx = (output_idx_base +
-			      freq * 8); // Location in the VDIF packet is just frequency.
+			      freq); // Location in the VDIF packet is just frequency.
             for (int elem = 0; elem < num_elements; ++elem) {
 
                 // Advance to the next mbuf in the chain.

--- a/lib/dpdk/invalidateVDIFframes.cpp
+++ b/lib/dpdk/invalidateVDIFframes.cpp
@@ -8,8 +8,13 @@
 
 #include <assert.h>   // for assert
 #include <atomic>     // for atomic_bool
+#include <exception>  // for exception
 #include <functional> // for _Bind_helper<>::type, bind, function
+#include <regex>      // for match_results<>::_Base_type
 #include <stddef.h>   // for size_t
+#include <stdexcept>  // for runtime_error
+#include <vector>     // for vector
+
 
 using kotekan::bufferContainer;
 using kotekan::Config;

--- a/lib/dpdk/invalidateVDIFframes.hpp
+++ b/lib/dpdk/invalidateVDIFframes.hpp
@@ -75,7 +75,6 @@ private:
     /// The size of each VDIF frame and frame set
     uint32_t vdif_frame_size;
     uint32_t vdif_frameset_size;
-
 };
 
 #endif /* ZERO_SAMPLES_HPP */

--- a/lib/dpdk/invalidateVDIFframes.hpp
+++ b/lib/dpdk/invalidateVDIFframes.hpp
@@ -63,12 +63,19 @@ private:
     /// Current
     int32_t lost_samples_buf_frame_id = 0;
 
-    /// The number of VDIF frames expected
-    /// It might be possible to make this dynamic
-    const uint32_t num_elements = 2;
+    /// The total number of frequency channels.
+    const uint32_t total_num_freq = 1024;
 
-    /// The size of each VDIF frame
-    const uint32_t vdif_frame_size = 1056; // 32 header + 1024 data
+    /// The number of VDIF threads expected in each frameset.
+    uint32_t num_threads;
+
+    /// The standard VDIF header lenght
+    const uint32_t vdif_header_len = 32;
+
+    /// The size of each VDIF frame and frame set
+    uint32_t vdif_frame_size;
+    uint32_t vdif_frameset_size;
+
 };
 
 #endif /* ZERO_SAMPLES_HPP */


### PR DESCRIPTION
@andrerenard - this is an edit of your old `iceBoardVDIF.hpp` to allow more control over what is recorded at ARO (mostly in preparation for getting a CHORD feed there, which will need more data to be written). cc @ninaneiman 

Note that I rebased on `develop` but am not sure that is what I should do -- a quick try at compiling this on cloyd got me something without `dpdkCore`, so I'm probably doing something wrong (maybe just omitting the `CMake`?)

But I thought I would make the PR anyway as the code seems in good enough shape to ask for comments (and it does work properly on top of the branch we were using at ARO). I'll happily squash commits if needed.

The last commit is the main one. It contains also the main idea:
```
What to save is controlled by the config file, as follows:
Writing is done in num_thread chunks of num_elements * num_freq samples,
picking some of the 16 elements and some of the 1024 frequencies,
as given by offsets and frequencies.

Examples: reproduce old-style of all frequencies of 2 inputs in 2 separate threads:

num_threads: 2
num_elements: 1
num_freq: 1024
offsets: [8, 9]
frequencies: [0, 0]

CHORD-like 300-800, supposing 6&7 contain 0-400, and 8&9 400-800.

num_threads: 5
num_elements: 2
num_freq: 256
offsets: [6, 8, 8, 8, 8]
frequencies: [0, 0, 256, 512, 768]

CHORD-like 800-1500, supposing 10&11 contain 800-1200, and 8&9 1200-1500.

num_threads: 7
num_elements: 2
num_freq: 256
offsets: [10, 10, 10, 10, 8, 8, 8]
frequencies: [0, 256, 512, 768, 256, 512, 768]

Save all frequencies of four consecutive inputs

num_threads: 1
num_elements: 4
num_freq: 1024
offsets: [8]
frequencies: [0]

Save half the frequencies of eight consecutive inputs
num_threads: 1
num_elements: 8
num_freq: 512
offsets: [8]
frequencies: [0]
```
