### PR TITLE
cudaOutputData: only copy metadata if we actually generated an output frame

### DIFF
--- a/lib/cuda/cudaOutputData.cpp
+++ b/lib/cuda/cudaOutputData.cpp
@@ -120,12 +120,6 @@ void cudaOutputData::finalize_frame(int frame_id) {
     cudaCommand::finalize_frame(frame_id);
 
     if (in_buffer) {
-        DEBUG("Passing metadata from input (host) buffer {:s}[{:d}] to {:s}[{:d}]",
-              in_buffer->buffer_name, in_buffer_id, output_buffer->buffer_name, output_buffer_id);
-        pass_metadata(in_buffer, in_buffer_id, output_buffer, output_buffer_id);
-    }
-
-    if (in_buffer) {
         mark_frame_empty(in_buffer, unique_name.c_str(), in_buffer_id);
         in_buffer_id = (in_buffer_id + 1) % in_buffer->num_frames;
     }
@@ -134,8 +128,15 @@ void cudaOutputData::finalize_frame(int frame_id) {
         DEBUG("Did not generate output for input GPU frame {:d}", frame_id);
         return;
     }
-    DEBUG("Generating output {:s}[{:d}] for input GPU frame {:d}", output_buffer->buffer_name,
+
+    DEBUG("Generated CPU output {:s}[{:d}] for input GPU frame {:d}", output_buffer->buffer_name,
           output_buffer_id, frame_id);
+
+    if (in_buffer) {
+        DEBUG("Passing metadata from input (host) buffer {:s}[{:d}] to {:s}[{:d}]",
+              in_buffer->buffer_name, in_buffer_id, output_buffer->buffer_name, output_buffer_id);
+        pass_metadata(in_buffer, in_buffer_id, output_buffer, output_buffer_id);
+    }
 
     mark_frame_full(output_buffer, unique_name.c_str(), output_buffer_id);
     output_buffer_id = (output_buffer_id + 1) % output_buffer->num_frames;

--- a/lib/cuda/cudaOutputData.cpp
+++ b/lib/cuda/cudaOutputData.cpp
@@ -122,7 +122,8 @@ void cudaOutputData::finalize_frame(int frame_id) {
     if (in_buffer) {
         if (did_generate_output[frame_id]) {
             DEBUG("Passing metadata from input (host) buffer {:s}[{:d}] to {:s}[{:d}]",
-                  in_buffer->buffer_name, in_buffer_id, output_buffer->buffer_name, output_buffer_id);
+                  in_buffer->buffer_name, in_buffer_id, output_buffer->buffer_name,
+                  output_buffer_id);
             pass_metadata(in_buffer, in_buffer_id, output_buffer, output_buffer_id);
         }
         mark_frame_empty(in_buffer, unique_name.c_str(), in_buffer_id);

--- a/lib/cuda/cudaOutputData.cpp
+++ b/lib/cuda/cudaOutputData.cpp
@@ -120,6 +120,11 @@ void cudaOutputData::finalize_frame(int frame_id) {
     cudaCommand::finalize_frame(frame_id);
 
     if (in_buffer) {
+        if (did_generate_output[frame_id]) {
+            DEBUG("Passing metadata from input (host) buffer {:s}[{:d}] to {:s}[{:d}]",
+                  in_buffer->buffer_name, in_buffer_id, output_buffer->buffer_name, output_buffer_id);
+            pass_metadata(in_buffer, in_buffer_id, output_buffer, output_buffer_id);
+        }
         mark_frame_empty(in_buffer, unique_name.c_str(), in_buffer_id);
         in_buffer_id = (in_buffer_id + 1) % in_buffer->num_frames;
     }
@@ -131,12 +136,6 @@ void cudaOutputData::finalize_frame(int frame_id) {
 
     DEBUG("Generated CPU output {:s}[{:d}] for input GPU frame {:d}", output_buffer->buffer_name,
           output_buffer_id, frame_id);
-
-    if (in_buffer) {
-        DEBUG("Passing metadata from input (host) buffer {:s}[{:d}] to {:s}[{:d}]",
-              in_buffer->buffer_name, in_buffer_id, output_buffer->buffer_name, output_buffer_id);
-        pass_metadata(in_buffer, in_buffer_id, output_buffer, output_buffer_id);
-    }
 
     mark_frame_full(output_buffer, unique_name.c_str(), output_buffer_id);
     output_buffer_id = (output_buffer_id + 1) % output_buffer->num_frames;

--- a/lib/dpdk/dpdkCore.cpp
+++ b/lib/dpdk/dpdkCore.cpp
@@ -88,11 +88,8 @@ dpdkCore::dpdkCore(Config& config, const string& unique_name, bufferContainer& b
     port_conf.rxmode.max_lro_pkt_size = max_rx_pkt_len;
     port_conf.rxmode.mtu = max_rx_pkt_len;
     port_conf.rxmode.offloads =
-        RTE_ETH_RX_OFFLOAD_KEEP_CRC | RTE_ETH_RX_OFFLOAD_IPV4_CKSUM | RTE_ETH_RX_OFFLOAD_UDP_CKSUM;
-    // port_conf.rxmode.split_hdr_size = 0;
-    port_conf.link_speeds = RTE_ETH_LINK_SPEED_100G | RTE_ETH_LINK_SPEED_FIXED;
-    //DEV_RX_OFFLOAD_KEEP_CRC | DEV_RX_OFFLOAD_IPV4_CKSUM | DEV_RX_OFFLOAD_UDP_CKSUM;
-    //port_conf.rxmode.split_hdr_size = 0;
+        DEV_RX_OFFLOAD_KEEP_CRC | DEV_RX_OFFLOAD_IPV4_CKSUM | DEV_RX_OFFLOAD_UDP_CKSUM;
+    port_conf.rxmode.split_hdr_size = 0;
 #else
     port_conf.rxmode.max_rx_pkt_len = max_rx_pkt_len;
     port_conf.rxmode.jumbo_frame =

--- a/lib/dpdk/dpdkCore.cpp
+++ b/lib/dpdk/dpdkCore.cpp
@@ -88,8 +88,11 @@ dpdkCore::dpdkCore(Config& config, const string& unique_name, bufferContainer& b
     port_conf.rxmode.max_lro_pkt_size = max_rx_pkt_len;
     port_conf.rxmode.mtu = max_rx_pkt_len;
     port_conf.rxmode.offloads =
-        DEV_RX_OFFLOAD_KEEP_CRC | DEV_RX_OFFLOAD_IPV4_CKSUM | DEV_RX_OFFLOAD_UDP_CKSUM;
-    port_conf.rxmode.split_hdr_size = 0;
+        RTE_ETH_RX_OFFLOAD_KEEP_CRC | RTE_ETH_RX_OFFLOAD_IPV4_CKSUM | RTE_ETH_RX_OFFLOAD_UDP_CKSUM;
+    // port_conf.rxmode.split_hdr_size = 0;
+    port_conf.link_speeds = RTE_ETH_LINK_SPEED_100G | RTE_ETH_LINK_SPEED_FIXED;
+    //DEV_RX_OFFLOAD_KEEP_CRC | DEV_RX_OFFLOAD_IPV4_CKSUM | DEV_RX_OFFLOAD_UDP_CKSUM;
+    //port_conf.rxmode.split_hdr_size = 0;
 #else
     port_conf.rxmode.max_rx_pkt_len = max_rx_pkt_len;
     port_conf.rxmode.jumbo_frame =


### PR DESCRIPTION
This was a residual error from the big #1111 PR.
