### PR TITLE
Docker ubuntu 18.04 build - revert ROCM container image from 3.7 to 3.0 to support CHIME code

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -576,6 +576,7 @@ jobs:
             -DNO_MEMLOCK=ON \
             -DUSE_OMP=ON \
             -DWITH_TESTS=ON \
+            -DUSA_HSA=ON \
             -DCCACHE=ON ..
         docker run "${OPTS[@]}" make -j 2
         docker run "${OPTS[@]}" rm -r lib

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -576,7 +576,6 @@ jobs:
             -DNO_MEMLOCK=ON \
             -DUSE_OMP=ON \
             -DWITH_TESTS=ON \
-            -DUSA_HSA=ON \
             -DCCACHE=ON ..
         docker run "${OPTS[@]}" make -j 2
         docker run "${OPTS[@]}" rm -r lib
@@ -637,6 +636,7 @@ jobs:
             -DARCH=haswell \
             -DNO_MEMLOCK=ON \
             -DUSE_OMP=ON \
+            -DUSA_HSA=ON \
             -DWITH_TESTS=OFF \
             -DCCACHE=ON ..
         docker run "${OPTS[@]}" make -j 2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -636,7 +636,7 @@ jobs:
             -DARCH=haswell \
             -DNO_MEMLOCK=ON \
             -DUSE_OMP=ON \
-            -DUSA_HSA=ON \
+            -DUSE_HSA=ON \
             -DWITH_TESTS=OFF \
             -DCCACHE=ON ..
         docker run "${OPTS[@]}" make -j 2

--- a/lib/core/buffer.cpp
+++ b/lib/core/buffer.cpp
@@ -981,6 +981,7 @@ uint8_t* buffer_malloc(size_t len, int numa_node, bool use_hugepages, bool mlock
 void buffer_free(uint8_t* frame_pointer, size_t size, bool use_hugepages) {
 #ifdef WITH_HSA
     (void)size;
+    (void)use_hugepages;
     hsa_host_free(frame_pointer);
 #else
     if (use_hugepages) {

--- a/lib/core/buffer.cpp
+++ b/lib/core/buffer.cpp
@@ -909,7 +909,8 @@ uint8_t* buffer_malloc(size_t len, int numa_node, bool use_hugepages, bool mlock
     uint8_t* frame = NULL;
 
 #ifdef WITH_HSA // Support for legacy HSA support used in CHIME
-    frame = hsa_host_malloc(len, numa_node);
+    (void)use_hugepages;
+    frame = (uint8_t*)hsa_host_malloc(len, numa_node);
     if (frame == NULL) {
         return NULL;
     }

--- a/lib/hsa/hsaDeviceInterface.cpp
+++ b/lib/hsa/hsaDeviceInterface.cpp
@@ -87,7 +87,7 @@ hsaDeviceInterface::~hsaDeviceInterface() {
     HSA_CHECK(hsa_status);
 }
 
-void* hsaDeviceInterface::alloc_gpu_memory(int len) {
+void* hsaDeviceInterface::alloc_gpu_memory(size_t len) {
     void* ptr;
     hsa_status_t hsa_status = hsa_amd_memory_pool_allocate(global_region, len, 0, &ptr);
     HSA_CHECK(hsa_status);

--- a/lib/hsa/hsaDeviceInterface.hpp
+++ b/lib/hsa/hsaDeviceInterface.hpp
@@ -51,7 +51,7 @@ public:
     uint32_t get_gpu_numa_node();
 
 protected:
-    void* alloc_gpu_memory(int len) override;
+    void* alloc_gpu_memory(size_t len) override;
     void free_gpu_memory(void*) override;
 
     // GPU HSA variables

--- a/tools/docker/18.04/Dockerfile
+++ b/tools/docker/18.04/Dockerfile
@@ -1,4 +1,6 @@
-FROM rocm/dev-ubuntu-18.04:3.7
+# NOTE, for HSA support, the latest version of the rocm package we can use is 3.0.  Later versions
+# have removed files required by the kotekan CHIME code.
+FROM rocm/dev-ubuntu-18.04:3.0
 
 ## The maintainer name and email 
 MAINTAINER Rick Nitsche <rick@phas.ubc.ca>
@@ -10,7 +12,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN rm /etc/apt/sources.list.d/rocm.list && \
     apt-get update && \
     apt-get install -y wget=1.19.* && \
-    echo 'deb [arch=amd64] https://repo.radeon.com/rocm/apt/debian ubuntu main' | tee /etc/apt/sources.list.d/rocm.list  && \
+    echo 'deb [arch=amd64] https://repo.radeon.com/rocm/apt/3.0 xenial main' | tee /etc/apt/sources.list.d/rocm.list  && \
     wget -q -O - https://repo.radeon.com/rocm/rocm.gpg.key | apt-key add - && \
     apt-get update
 
@@ -50,7 +52,7 @@ RUN apt-get update && \
 RUN python3.7 -m pip install --upgrade pip==20.2.2 && \
     python3.7 -m pip install --upgrade --force-reinstall setuptools==49.6.0 && \
     python3.7 -m pip install --upgrade wheel==0.35.1 && \
-    python3.7 -m pip install --no-cache-dir numpy==1.19.1 && \
+    python3.7 -m pip install --no-cache-dir numpy && \
     python3.7 -m pip install --no-cache-dir pkgconfig==1.5.1 && \
     python3.7 -m pip install --no-cache-dir --upgrade cython==0.29.21 && \
     python3.7 -m pip install --no-cache-dir black==19.10b0 &&\


### PR DESCRIPTION
This is needed for the kotekan/lib/hsa build to work.

I droped the specific version requirement on numpy, since it gets upgraded later by some other package's requirements.

There are a few fixes to the HSA code to catch up with changes we've made on devel, or because this build treats all warnings as errors!
