### PR TITLE
changed max_dump_samples, baseband_buffer_depth, and baseband_output_…

### DIFF
--- a/config/chime_gbo_gpu.j2
+++ b/config/chime_gbo_gpu.j2
@@ -19,7 +19,7 @@ log_level: info
 
 buffer_depth: 12
 # Set to something small like 30 to make startup faster
-baseband_buffer_depth: 228 # ~33 seconds after accounting for margin.
+baseband_buffer_depth: 222 # ~33 seconds after accounting for margin.
 samples_per_data_set: 32768 * 2
 num_local_freq: 8
 num_freq_in_frame: num_local_freq
@@ -110,7 +110,7 @@ lost_samples_buffers:
 
 ### Baseband dump output buffers (staging for send to baseband recv)
 baseband_output_buffers:
-    num_frames: 100 * num_local_freq
+    num_frames: 165 * num_local_freq
     frame_size: 4096 * num_elements
     metadata_pool: baseband_pool
 {%- for id in range(16) %}
@@ -227,7 +227,7 @@ zero_samples:
 
 ### Start Baseband Section ###
 baseband:
-    max_dump_samples: 1024000 # 1024ms
+    max_dump_samples: 548864 # 1.4 seconds. 
     num_frames_buffer: baseband_buffer_depth - 15
 {%- for id in range(16) %}
     baseband_{{ id }}:
@@ -382,8 +382,8 @@ eigcalc:
     krylov: 2
     subspace: 1
     # Masking config
-    bands_filled: [[0, 7], [61, 67]]
-    exclude_inputs: [37, 51, 61, 104, 110, 111, 123]
+    bands_filled: [[0, 7]] #, [125, 131]] # [[0, 7], [61, 67]]
+    exclude_inputs: [10, 13, 15, 26, 38, 56, 63, 67, 74, 78, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 104, 108, 111, 118, 120, 123, 127, 130, 138, 147, 154, 155, 156, 158, 165, 168, 171, 175, 180, 186, 199, 201, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 232, 243, 245, 248, 249, 252]
     eigcalc_0:
         kotekan_stage: EigenVisIter
         cpu_affinity: [15]


### PR DESCRIPTION
Changed the gbo gpu.j2.yaml configuration to:
baseband_buffer_depth: 222
baseband_output_buffers:
    num_frames: 165 * num_local_freq
max_dump_samples: 548864
to enable 1.4s long baseband dumps (also see https://github.com/kotekan/kotekan/pull/1093 and https://github.com/CHIMEFRB/kko_infrastructure/issues/291).
[2:13](https://chime-experiment.slack.com/archives/D03U9S37EE5/p1697912033287159)
