### PR TITLE
Add function to create a GPU ring-buffer view

### DIFF
--- a/lib/gpu/gpuDeviceInterface.cpp
+++ b/lib/gpu/gpuDeviceInterface.cpp
@@ -191,9 +191,9 @@ metadataContainer* gpuDeviceInterface::create_gpu_memory_array_metadata(const st
 }
 
 bool gpuDeviceInterface::is_view_of_same_size(const std::string& name) {
-    return gpu_memory[name].view_source.size() &&
-        (gpu_memory[gpu_memory[name].view_source].metadata_pointers.size() ==
-         gpu_memory[name].metadata_pointers.size());
+    return gpu_memory[name].view_source.size()
+           && (gpu_memory[gpu_memory[name].view_source].metadata_pointers.size()
+               == gpu_memory[name].metadata_pointers.size());
 }
 
 void gpuDeviceInterface::claim_gpu_memory_array_metadata(const std::string& name,

--- a/lib/gpu/gpuDeviceInterface.cpp
+++ b/lib/gpu/gpuDeviceInterface.cpp
@@ -143,7 +143,8 @@ void gpuDeviceInterface::create_gpu_memory_ringbuffer(const std::string& source_
     gpu_memory[dest_name].len = dest_len;
     gpu_memory[dest_name].view_source = source_name;
     for (uint32_t i = 0; i < gpu_buffer_depth; ++i) {
-        gpu_memory[dest_name].gpu_pointers.push_back((unsigned char*)source + offset + i*dest_len);
+        gpu_memory[dest_name].gpu_pointers.push_back((unsigned char*)source + offset
+                                                     + i * dest_len);
         gpu_memory[dest_name].gpu_pointers_to_free.push_back(nullptr);
         gpu_memory[dest_name].metadata_pointers.push_back(nullptr);
     }

--- a/lib/gpu/gpuDeviceInterface.hpp
+++ b/lib/gpu/gpuDeviceInterface.hpp
@@ -93,6 +93,27 @@ public:
                                  const size_t view_len);
 
     /**
+     * @brief Creates a large GPU memory chunk, and then multiple
+     * views into that memory chunk that look like a GPU memory array.
+     * This method should be called once during setup.  After this has
+     * been called, *get_gpu_memory* for the "source" name will return
+     * the full memory chunk, and *get_gpu_memory_array* for the
+     * "view" name will return a view into the full memory chunk,
+     * where adjacent array indices are contiguous.
+     *
+     * @param source_name like the "name" of get_gpu_memory, the
+     *   name of the "real" GPU memory array.
+     * @param source_len  the size in bytes of the "real" GPU memory array.
+     * @param view_name   the name of the view onto the "real" GPU memory array.
+     * @param view_offset the offset in bytes of the views.
+     * @param view_len the length in bytes of the views.  *view_offset*
+     *   + *view_len* * gpu_buffer_depth must be <= *source_len*.
+     */
+    void create_gpu_memory_ringbuffer(const std::string& source_name, const size_t source_len,
+                                      const std::string& view_name, const size_t view_offset,
+                                      const size_t view_len);
+
+    /**
      * @brief Fetches the metadata (if any) attached to the given GPU
      * memory array element.  Return NULL if no metadata.
      * @param name  the name of the GPU buffer whose metadata you want

--- a/lib/gpu/gpuDeviceInterface.hpp
+++ b/lib/gpu/gpuDeviceInterface.hpp
@@ -176,6 +176,11 @@ protected:
     virtual void* alloc_gpu_memory(size_t len) = 0;
     virtual void free_gpu_memory(void*) = 0;
 
+    // Internal function to check whether the memory array "name" is a
+    // view onto another memory array with the same number of
+    // elements; the "create_gpu_memory_ringbuffer" method creates an
+    // array of views onto a monolithic chunk of memory, and we need
+    // to treat that case differently.
     bool is_view_of_same_size(const std::string& name);
 
     // Extra data

--- a/lib/gpu/gpuDeviceInterface.hpp
+++ b/lib/gpu/gpuDeviceInterface.hpp
@@ -101,6 +101,9 @@ public:
      * "view" name will return a view into the full memory chunk,
      * where adjacent array indices are contiguous.
      *
+     * The "source" singleton and "dest" array each have their own
+     * metadata objects.
+     *
      * @param source_name like the "name" of get_gpu_memory, the
      *   name of the "real" GPU memory array.
      * @param source_len  the size in bytes of the "real" GPU memory array.
@@ -172,6 +175,8 @@ public:
 protected:
     virtual void* alloc_gpu_memory(size_t len) = 0;
     virtual void free_gpu_memory(void*) = 0;
+
+    bool is_view_of_same_size(const std::string& name);
 
     // Extra data
     kotekan::Config& config;


### PR DESCRIPTION
* add create_gpu_memory_ringbuffer(), to create a large underlying array with an array of views into it.

The motivating use-case is for the GPU upchannelizer, where the inputs are voltages (copied from CPU memory), and the upchannelizer needs to keep a bit of overlap between frames.  This could be implemented using GPU buffer views and having each upchannelizer stage manage its own overlaps, but an alternative is to implement ring-buffer-friendly wrap-around indexing in the upchannelizer kernel, and then have the upchannelizer `execute()` method pass an index into the underlying ring buffer to the kernel.
