### PR TITLE
Change cosmology integration time

### DIFF
--- a/config/chime_keep_gpu_warm.yaml
+++ b/config/chime_keep_gpu_warm.yaml
@@ -1539,9 +1539,8 @@ rfi_stage2:
     out_buf: rfi_vis_buffer_3
 
 vis_accumulate:
-  integration_time: 5.0  # Integrate to roughly 5s cadence
-  # This (12288) is for num_sub_frames = 4, there is currently a config bug that
-  # prevents referencing the higher level samples_per_data_set and dividing it
+  # This sets a ~5s cadence which should exactly sync up with what the absorber acquisition is doing
+  num_gpu_frames: 160
   samples_per_data_set: 12288
   updatable_config:
     psr0: "/updatable_config/gating/psr0_config"

--- a/config/chime_science_run_gpu.yaml
+++ b/config/chime_science_run_gpu.yaml
@@ -1607,9 +1607,8 @@ rfi_stage2:
     out_buf: rfi_vis_buffer_3
 
 vis_accumulate:
-  integration_time: 5.0  # Integrate to roughly 5s cadence
-  # This (12288) is for num_sub_frames = 4, there is currently a config bug that
-  # prevents referencing the higher level samples_per_data_set and dividing it
+  # This sets a ~5s cadence which should exactly sync up with what the absorber acquisition is doing
+  num_gpu_frames: 160
   samples_per_data_set: 12288
   low_sample_fraction: 0.1
   updatable_config:

--- a/config/chime_science_run_gpu_no_output.yaml
+++ b/config/chime_science_run_gpu_no_output.yaml
@@ -1607,9 +1607,8 @@ rfi_stage2:
     out_buf: rfi_vis_buffer_3
 
 vis_accumulate:
-  integration_time: 5.0  # Integrate to roughly 5s cadence
-  # This (12288) is for num_sub_frames = 4, there is currently a config bug that
-  # prevents referencing the higher level samples_per_data_set and dividing it
+  # This sets a ~5s cadence which should exactly sync up with what the absorber acquisition is doing
+  num_gpu_frames: 160
   samples_per_data_set: 12288
   low_sample_fraction: 0.1
   updatable_config:


### PR DESCRIPTION
- Update kotekan config to enable outrigger-gating as receiver node for beam 10 (#1072)
- changed max dump samples
- undo reverted changes
- undid previous 2 commits by me
- changed max_dump_samples (#1091)
- config: update cosmology integration time to sync with absorber
