### PR TITLE
Baseband Receiver Updates

### DIFF
--- a/config/chime_science_run_gpu.yaml
+++ b/config/chime_science_run_gpu.yaml
@@ -705,7 +705,7 @@ baseband_merge:
 
 # Transmit baseband data to the baseband receiver
 baseband_send:
-  server_ip: 10.6.213.19 # cfDn9
+  server_ip: 10.1.50.51 # outrigger-buffer.chime 
   reconnect_time: 60
   send_timeout: 600 # 10 minutes
   log_level: warn

--- a/config/chime_science_run_gpu_no_output.yaml
+++ b/config/chime_science_run_gpu_no_output.yaml
@@ -705,7 +705,7 @@ baseband_merge:
 
 # Transmit baseband data to the baseband receiver
 baseband_send:
-  server_ip: 10.6.213.19 # cfDn9
+  server_ip: 10.1.50.51 # outrigger-buffer.chime
   reconnect_time: 60
   send_timeout: 600 # 10 minutes
   log_level: warn


### PR DESCRIPTION
The CHIME/FRB Receiver has been moved from the cfDn9.chime node on site to outrigger-buffer.chime.