### PR TITLE
Update dataset broker tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,12 @@ import subprocess
 import os
 import sys
 import faulthandler
+import re
+import signal
+import shutil
+import tempfile
+
+from time import sleep
 
 faulthandler.enable()
 _fh_interval = os.environ.get("FAULTHANDLER_DUMP_INTERVAL")
@@ -104,3 +110,66 @@ def cal_broker(request, old_gains, new_gains):
     yield server
 
     server.stop()
+
+
+def has_redis(host="localhost", port=6379):
+    """Check if redis is available."""
+
+    try:
+        import redis
+
+        r = redis.Redis(host, port)
+        return r.ping()
+
+    except Exception as e:
+        print(e)
+        return False
+
+
+@pytest.fixture(scope="module")
+def comet_broker_port(*broker_args):
+    """Yield the port on which the comet broker is running."""
+    broker_path = shutil.which("comet")
+    if not broker_path:
+        pytest.skip(
+            "Make sure PYTHONPATH is set to where the comet dataset broker is installed."
+        )
+
+    if not has_redis():
+        pytest.skip("Redis is not available and so comet will fail.")
+
+    if not broker_args:
+        # By default, open on a random port
+        broker_args = ["-p", "0"]
+
+    with tempfile.NamedTemporaryFile(mode="w") as f_out:
+        # Start comet
+        broker = subprocess.Popen(
+            [broker_path, "broker", *broker_args], stdout=f_out, stderr=f_out
+        )
+        sleep(3)
+
+        # Find port in the log
+        regex = re.compile("Selected random port: ([0-9]+)$")
+        log = open(f_out.name, "r").read().split("\n")
+        port = None
+        for line in log:
+            print(line)
+            match = regex.search(line)
+            if match:
+                port = match.group(1)
+                print("Test found comet port in log: %s" % port)
+                break
+        if not match:
+            print("Could not find comet port in logs.")
+            exit(1)
+
+        try:
+            yield port
+        finally:
+            pid = broker.pid
+            os.kill(pid, signal.SIGTERM)
+            broker.terminate()
+            log = open(f_out.name, "r").read().split("\n")
+            for line in log:
+                print(line)

--- a/tests/test_dataset_broker.py
+++ b/tests/test_dataset_broker.py
@@ -1,83 +1,22 @@
 import pytest
 import os.path
-import re
-import time
-import tempfile
-import shutil
-import signal
-import sys
 
-from subprocess import call, Popen
+from subprocess import call
 
 producer_path = "../build/tests/boost/dataset_broker_producer"
 producer2_path = "../build/tests/boost/dataset_broker_producer2"
 consumer_path = "../build/tests/boost/dataset_broker_consumer"
 
 
-def has_redis(host="localhost", port=6379):
-    """Check if redis is available."""
-
-    try:
-        import redis
-
-        r = redis.Redis(host, port)
-        return r.ping()
-
-    except Exception as e:
-        print(e)
-        return False
-
-
-@pytest.mark.skipif(
-    sys.version_info > (3, 7),
-    reason="Test only passes when comet works, which needs old python3.7.",
-)
 @pytest.mark.serial
-def test_produce_consume():
-    broker_path = shutil.which("comet")
+def test_produce_consume(comet_broker_port):
     if (
         not os.path.isfile(producer_path)
         or not os.path.isfile(consumer_path)
         or not os.path.isfile(producer2_path)
     ):
         pytest.skip("Build with -DBOOST_TESTS=ON to activate this test")
-    if not broker_path:
-        pytest.skip(
-            "Make sure PYTHONPATH is set to where the comet dataset broker is installed."
-        )
-    if not has_redis():
-        pytest.skip("Redis is not available and so comet will fail.")
 
-    with tempfile.NamedTemporaryFile(mode="w") as f_out:
-        # Start comet with a random port
-        broker = Popen(
-            [broker_path, "-p", "0", "--recover", "False"], stdout=f_out, stderr=f_out
-        )
-        time.sleep(3)
-
-        # Find port in the log
-        regex = re.compile("Selected random port: ([0-9]+)$")
-        log = open(f_out.name, "r").read().split("\n")
-        port = None
-        for line in log:
-            print(line)
-            match = regex.search(line)
-            if match:
-                port = match.group(1)
-                print("Test found comet port in log: %s" % port)
-                break
-        if not match:
-            print("Could not find comet port in logs.")
-            exit(1)
-
-        try:
-            assert call([producer_path, "--", port]) == 0
-            assert call([producer2_path, "--", port]) == 0
-            assert call([consumer_path, "--", port]) == 0
-        finally:
-            pid = broker.pid
-            os.kill(pid, signal.SIGTERM)
-            broker.terminate()
-            log = open(f_out.name, "r").read().split("\n")
-            for line in log:
-                print(line)
+    assert call([producer_path, "--", comet_broker_port]) == 0
+    assert call([producer2_path, "--", comet_broker_port]) == 0
+    assert call([consumer_path, "--", comet_broker_port]) == 0

--- a/tests/test_freqslicer_broker.py
+++ b/tests/test_freqslicer_broker.py
@@ -1,14 +1,8 @@
 import pytest
-import os
-from subprocess import Popen
 import time
-import shutil
-import signal
-import sys
 
 from kotekan import runner
 
-from test_dataset_broker import has_redis
 
 params = {
     "num_elements": 5,
@@ -39,146 +33,129 @@ params_fakevis = {
 
 
 @pytest.fixture(scope="module")
-def subset_data(tmpdir_factory):
-    broker_path = shutil.which("comet")
-    if not broker_path:
-        pytest.skip(
-            "Make sure PYTHONPATH is set to where the comet dataset broker is installed."
-        )
-    if not has_redis():
-        pytest.skip("Redis is not available and so comet will fail")
+def subset_data(tmpdir_factory, comet_broker_port):
 
-    # run the dataset broker
-    broker = Popen([broker_path, "--recover", "False"])
-    time.sleep(1.5)
+    # Make sure to use the correct dataset manager port
+    params["dataset_manager"]["ds_broker_port"] = comet_broker_port
 
-    try:
-        tmpdir = tmpdir_factory.mktemp("freqsub_broker_fakevis")
+    tmpdir = tmpdir_factory.mktemp("freqsub_broker_fakevis")
 
-        dump_buffer_gen = runner.DumpVisBuffer(str(tmpdir))
+    dump_buffer_gen = runner.DumpVisBuffer(str(tmpdir))
 
-        test = runner.KotekanStageTester(
-            "FakeVis", params_fakevis, None, dump_buffer_gen, params
-        )
+    test = runner.KotekanStageTester(
+        "FakeVis", params_fakevis, None, dump_buffer_gen, params
+    )
 
-        test.run()
+    test.run()
 
-        data_gen = dump_buffer_gen.load()
+    data_gen = dump_buffer_gen.load()
 
-        ### VisFreqSubset ###
-        tmpdir = tmpdir_factory.mktemp("freqsub_broker")
+    ### VisFreqSubset ###
+    tmpdir = tmpdir_factory.mktemp("freqsub_broker")
 
-        ds_id = data_gen[0].metadata.dataset_id
-        fakevis_buffer_subset = runner.FakeVisBuffer(
-            num_frames=params["total_frames"],
-            mode=params["mode"],
-            freq_ids=params["freq_ids"],
-            use_dataset_manager=True,
-            wait=False,
-            dataset_id="{:016x}{:016x}".format(ds_id[1], ds_id[0]),
-        )
+    ds_id = data_gen[0].metadata.dataset_id
+    fakevis_buffer_subset = runner.FakeVisBuffer(
+        num_frames=params["total_frames"],
+        mode=params["mode"],
+        freq_ids=params["freq_ids"],
+        use_dataset_manager=True,
+        wait=False,
+        dataset_id="{:016x}{:016x}".format(ds_id[1], ds_id[0]),
+    )
 
-        dump_buffer_subset = runner.DumpVisBuffer(str(tmpdir))
+    dump_buffer_subset = runner.DumpVisBuffer(str(tmpdir))
 
-        test = runner.KotekanStageTester(
-            "VisFreqSubset", {}, fakevis_buffer_subset, dump_buffer_subset, params
-        )
+    test = runner.KotekanStageTester(
+        "VisFreqSubset", {}, fakevis_buffer_subset, dump_buffer_subset, params
+    )
 
-        test.run()
+    test.run()
 
-        data_subset = dump_buffer_subset.load()
+    data_subset = dump_buffer_subset.load()
 
-        ### freqSplit ###
-        time.sleep(10)
-        tmpdir = tmpdir_factory.mktemp("freqsplit_broker")
+    ### freqSplit ###
+    time.sleep(10)
+    tmpdir = tmpdir_factory.mktemp("freqsplit_broker")
 
-        ds_id = data_subset[0].metadata.dataset_id
-        fakevis_buffer_split = runner.FakeVisBuffer(
-            num_frames=params["total_frames"],
-            mode=params["mode"],
-            freq_ids=params["subset_list"],
-            use_dataset_manager=True,
-            wait=False,
-            dataset_id="{:016x}{:016x}".format(ds_id[1], ds_id[0]),
-        )
+    ds_id = data_subset[0].metadata.dataset_id
+    fakevis_buffer_split = runner.FakeVisBuffer(
+        num_frames=params["total_frames"],
+        mode=params["mode"],
+        freq_ids=params["subset_list"],
+        use_dataset_manager=True,
+        wait=False,
+        dataset_id="{:016x}{:016x}".format(ds_id[1], ds_id[0]),
+    )
 
-        dump_buffer_split_lower = runner.DumpVisBuffer(str(tmpdir))
-        dump_buffer_split_higher = runner.DumpVisBuffer(str(tmpdir))
+    dump_buffer_split_lower = runner.DumpVisBuffer(str(tmpdir))
+    dump_buffer_split_higher = runner.DumpVisBuffer(str(tmpdir))
 
-        test = runner.KotekanStageTester(
-            "freqSplit",
-            {},
-            fakevis_buffer_split,
-            (dump_buffer_split_lower, dump_buffer_split_higher),
-            params,
-        )
+    test = runner.KotekanStageTester(
+        "freqSplit",
+        {},
+        fakevis_buffer_split,
+        (dump_buffer_split_lower, dump_buffer_split_higher),
+        params,
+    )
 
-        test.run()
+    test.run()
 
-        data_split_lower = dump_buffer_split_lower.load()
-        data_split_higher = dump_buffer_split_higher.load()
+    data_split_lower = dump_buffer_split_lower.load()
+    data_split_higher = dump_buffer_split_higher.load()
 
-        ### 2 VisWriter processes ###
+    ### 2 VisWriter processes ###
 
-        tmpdir = tmpdir_factory.mktemp("freqsub_write_lower")
+    tmpdir = tmpdir_factory.mktemp("freqsub_write_lower")
 
-        params_fakevis_write_lower = params_fakevis.copy()
+    params_fakevis_write_lower = params_fakevis.copy()
 
-        ds_id = data_split_lower[0].metadata.dataset_id
+    ds_id = data_split_lower[0].metadata.dataset_id
 
-        params_fakevis_write_lower["dataset_id"] = "{:016x}{:016x}".format(
-            ds_id[1], ds_id[0]
-        )
+    params_fakevis_write_lower["dataset_id"] = "{:016x}{:016x}".format(
+        ds_id[1], ds_id[0]
+    )
 
-        # the writer is not given the subset list, it get's it through the broker
-        write_buffer_lower = runner.VisWriterBuffer(
-            str(tmpdir), "raw", None, extra_config={"use_dataset_manager": True}
-        )
+    # the writer is not given the subset list, it get's it through the broker
+    write_buffer_lower = runner.VisWriterBuffer(
+        str(tmpdir), "raw", None, extra_config={"use_dataset_manager": True}
+    )
 
-        test = runner.KotekanStageTester(
-            "FakeVis", params_fakevis_write_lower, None, write_buffer_lower, params
-        )
+    test = runner.KotekanStageTester(
+        "FakeVis", params_fakevis_write_lower, None, write_buffer_lower, params
+    )
 
-        test.run()
+    test.run()
 
-        tmpdir = tmpdir_factory.mktemp("freqsub_write_higher")
+    tmpdir = tmpdir_factory.mktemp("freqsub_write_higher")
 
-        params_fakevis_write_higher = params_fakevis.copy()
-        ds_id = data_split_higher[0].metadata.dataset_id
+    params_fakevis_write_higher = params_fakevis.copy()
+    ds_id = data_split_higher[0].metadata.dataset_id
 
-        params_fakevis_write_higher["dataset_id"] = "{:016x}{:016x}".format(
-            ds_id[1], ds_id[0]
-        )
+    params_fakevis_write_higher["dataset_id"] = "{:016x}{:016x}".format(
+        ds_id[1], ds_id[0]
+    )
 
-        # the writer is not given the subset list, it get's it through the broker
-        write_buffer_higher = runner.VisWriterBuffer(
-            str(tmpdir), "raw", None, extra_config={"use_dataset_manager": True}
-        )
+    # the writer is not given the subset list, it get's it through the broker
+    write_buffer_higher = runner.VisWriterBuffer(
+        str(tmpdir), "raw", None, extra_config={"use_dataset_manager": True}
+    )
 
-        test = runner.KotekanStageTester(
-            "FakeVis", params_fakevis_write_higher, None, write_buffer_higher, params
-        )
+    test = runner.KotekanStageTester(
+        "FakeVis", params_fakevis_write_higher, None, write_buffer_higher, params
+    )
 
-        test.run()
+    test.run()
 
-        yield [
-            data_gen,
-            data_subset,
-            data_split_lower,
-            data_split_higher,
-            write_buffer_lower.load(),
-            write_buffer_higher.load(),
-        ]
-    finally:
-        pid = broker.pid
-        os.kill(pid, signal.SIGTERM)
-        broker.terminate()
+    yield [
+        data_gen,
+        data_subset,
+        data_split_lower,
+        data_split_higher,
+        write_buffer_lower.load(),
+        write_buffer_higher.load(),
+    ]
 
 
-@pytest.mark.skipif(
-    sys.version_info > (3, 7),
-    reason="Test only passes when comet works, which needs old python3.7.",
-)
 @pytest.mark.serial
 def test_subset_broker(subset_data):
     data_gen = subset_data[0]

--- a/tests/test_vissharedmem_validation.py
+++ b/tests/test_vissharedmem_validation.py
@@ -1,16 +1,10 @@
 import copy
 import logging
-import numpy as np
 import os
 import pytest
-import re
-import signal
-from subprocess import Popen
-import shutil
 import tempfile
 import threading
 from time import sleep
-import sys
 
 from kotekan import runner, testing
 
@@ -19,47 +13,6 @@ useless_file = tempfile.NamedTemporaryFile()
 fname_buf = "calBuffer_" + os.path.split(useless_file.name)[-1]
 
 logging.basicConfig(level=logging.INFO)
-
-
-@pytest.fixture()
-def comet_broker():
-    broker_path = shutil.which("comet")
-    if not broker_path:
-        pytest.skip(
-            "Make sure PYTHONPATH is set to where the comet dataset broker is installed."
-        )
-
-    with tempfile.NamedTemporaryFile(mode="w") as f_out:
-        # Start comet with a random port
-        broker = Popen(
-            [broker_path, "-p", "0", "--recover", "False"], stdout=f_out, stderr=f_out
-        )
-        sleep(3)
-
-        # Find port in the log
-        regex = re.compile("Selected random port: ([0-9]+)$")
-        log = open(f_out.name, "r").read().split("\n")
-        port = None
-        for line in log:
-            print(line)
-            match = regex.search(line)
-            if match:
-                port = match.group(1)
-                print("Test found comet port in log: %s" % port)
-                break
-        if not match:
-            print("Could not find comet port in logs.")
-            exit(1)
-
-        try:
-            yield port
-        finally:
-            pid = broker.pid
-            os.kill(pid, signal.SIGTERM)
-            broker.terminate()
-            log = open(f_out.name, "r").read().split("\n")
-            for line in log:
-                print(line)
 
 
 # number of frames to ignore in validation
@@ -84,14 +37,14 @@ params_writer_stage = {"num_samples": 3, "name": fname_buf}
 
 
 @pytest.fixture()
-def vis_data(tmpdir_factory, comet_broker):
+def vis_data(tmpdir_factory, comet_broker_port):
 
     # keeping all the data this test produced here (probably do not need it)
     # using FakeVisBuffer to produce fake data
     fakevis_buffer = runner.FakeVisBuffer(**params_fakevis)
 
     # pass comet port to kotekan
-    params["dataset_manager"]["ds_broker_port"] = comet_broker
+    params["dataset_manager"]["ds_broker_port"] = comet_broker_port
 
     # KotekanStageTester is used to run kotekan with my config
     test = runner.KotekanStageTester(
@@ -106,12 +59,8 @@ def vis_data(tmpdir_factory, comet_broker):
 
 # This test still needs to run alone, because multiple comet instances would have conflicts
 # accessing redis.
-@pytest.mark.skipif(
-    sys.version_info > (3, 7),
-    reason="Test only passes when comet works, which needs old python3.7.",
-)
 @pytest.mark.serial
-def test_shared_mem_buffer(vis_data, comet_broker):
+def test_shared_mem_buffer(vis_data):
     # start kotekan writer in a thread, to read before it's done (it will delete the shm on exit)
     threading.Thread(target=vis_data.run).start()
     sleep(2)

--- a/tests/test_vissharedmemreaderwriter.py
+++ b/tests/test_vissharedmemreaderwriter.py
@@ -3,14 +3,9 @@ import numpy as np
 import os
 import posix_ipc
 import pytest
-import re
-import signal
-from subprocess import Popen
-import shutil
 import tempfile
 import threading
 from time import sleep
-import sys
 
 from kotekan import runner, shared_memory_buffer
 
@@ -19,47 +14,6 @@ useless_file = tempfile.NamedTemporaryFile()
 fname_buf = "calBuffer_" + os.path.split(useless_file.name)[-1]
 
 logging.basicConfig(level=logging.DEBUG)
-
-
-@pytest.fixture()
-def comet_broker():
-    broker_path = shutil.which("comet")
-    if not broker_path:
-        pytest.skip(
-            "Make sure PYTHONPATH is set to where the comet dataset broker is installed."
-        )
-
-    with tempfile.NamedTemporaryFile(mode="w") as f_out:
-        # Start comet with a random port
-        broker = Popen(
-            [broker_path, "-p", "0", "--recover", "False"], stdout=f_out, stderr=f_out
-        )
-        sleep(3)
-
-        # Find port in the log
-        regex = re.compile("Selected random port: ([0-9]+)$")
-        log = open(f_out.name, "r").read().split("\n")
-        port = None
-        for line in log:
-            print(line)
-            match = regex.search(line)
-            if match:
-                port = match.group(1)
-                print("Test found comet port in log: %s" % port)
-                break
-        if not match:
-            print("Could not find comet port in logs.")
-            exit(1)
-
-        try:
-            yield port
-        finally:
-            pid = broker.pid
-            os.kill(pid, signal.SIGTERM)
-            broker.terminate()
-            log = open(f_out.name, "r").read().split("\n")
-            for line in log:
-                print(line)
 
 
 @pytest.fixture(scope="module")
@@ -98,14 +52,14 @@ params_writer_stage = {"num_samples": 5, "name": fname_buf}
 
 
 @pytest.fixture()
-def vis_data(tmpdir_factory, comet_broker):
+def vis_data(tmpdir_factory, comet_broker_port):
 
     # keeping all the data this test produced here (probably do not need it)
     # using FakeVisBuffer to produce fake data
     fakevis_buffer = runner.FakeVisBuffer(**params_fakevis)
 
     # pass comet port to kotekan
-    params["dataset_manager"]["ds_broker_port"] = comet_broker
+    params["dataset_manager"]["ds_broker_port"] = comet_broker_port
 
     # KotekanStageTester is used to run kotekan with my config
     test = runner.KotekanStageTester(
@@ -120,17 +74,13 @@ def vis_data(tmpdir_factory, comet_broker):
 
 # This test still needs to run alone, because multiple comet instances would have conflicts
 # accessing redis.
-@pytest.mark.skipif(
-    sys.version_info > (3, 7),
-    reason="Test only passes when comet works, which needs old python3.7.",
-)
 @pytest.mark.serial
-def test_shared_mem_buffer(vis_data, comet_broker):
+def test_shared_mem_buffer(vis_data, comet_broker_port):
     # start kotekan writer in a thread, to read before it's done (it will delete the shm on exit)
     threading.Thread(target=vis_data.run).start()
     from comet import Manager
 
-    ds_manager = Manager("localhost", comet_broker)
+    ds_manager = Manager("localhost", comet_broker_port)
     sleep(2)
     reader = []
     view_size = [2, 8, 17]


### PR DESCRIPTION
chime-experiment/comet#107 modifies the command line invocation to run comet. This PR updates the relevant tests to accommodate the updated syntax.

Also, the `comet_broker` fixture was being defined in multiple places, pretty much identically. I've moved the fixture to `conftest.py` and updated the relevant tests accordingly.

The dataset broker tests are being skipped here, but I think that's expected. They should get run in the dataset broker test suite (https://github.com/chime-experiment/comet/blob/master/.github/workflows/main.yaml#L94).