### PR TITLE
Fix GPU race condition in the updated CHORD branch GPU commandObject logic. 

### DIFF
--- a/lib/gpu/gpuProcess.cpp
+++ b/lib/gpu/gpuProcess.cpp
@@ -156,9 +156,18 @@ void gpuProcess::main_thread() {
     bool first_run = true;
 
     while (!stop_thread) {
+        int ic = gpu_frame_counter % commands.size();
+        assert(commands.size() == final_signals.size());
 
+        DEBUG2("Waiting for free slot for GPU[{:d}][{:d}] {:s}", gpu_id, gpu_frame_counter,
+              unique_name);
+
+        // We make sure we aren't using a gpu frame that's currently in-flight.
+        final_signals[ic]->wait_for_free_slot();
+
+        // Update the gpu_frame_counter and perform any reset actions on the command object
+        // for this frame.
         for (auto& command : commands) {
-            int ic = gpu_frame_counter % command.size();
             command[ic]->start_frame(gpu_frame_counter);
         }
 
@@ -168,7 +177,6 @@ void gpuProcess::main_thread() {
         DEBUG2("Waiting on preconditions for GPU[{:d}][{:d}] {:s}", gpu_id, gpu_frame_counter,
                unique_name);
         for (auto& command : commands) {
-            int ic = gpu_frame_counter % command.size();
             if (command[ic]->wait_on_precondition() != 0) {
                 INFO("Received exit signal from GPU command precondition (Command '{:s}')",
                      command[ic]->get_name());
@@ -176,19 +184,17 @@ void gpuProcess::main_thread() {
             }
         }
 
-        DEBUG("Waiting for free slot for GPU[{:d}][{:d}] {:s}", gpu_id, gpu_frame_counter,
-              unique_name);
-        // We make sure we aren't using a gpu frame that's currently in-flight.
-        int ic = gpu_frame_counter % final_signals.size();
-        final_signals[ic]->wait_for_free_slot();
-        DEBUG("Waited for free slot for GPU[{:d}][{:d}] {:s}, queuing commands", gpu_id,
-              gpu_frame_counter, unique_name);
+        DEBUG2("Preconditions met for GPU[{:d}][{:d}] {:s}, queuing commands", gpu_id, gpu_frame_counter,
+               unique_name);
+        // Queue the commands for this frame.  This calls execute on each commandObject.
         queue_commands(gpu_frame_counter);
+
+        // Launch the results thread if it hasn't been launched yet.
         if (first_run) {
             results_thread_handle = std::thread(&gpuProcess::results_thread, std::ref(*this));
 
-            // Requires Linux, this could possibly be made more general someday.
-            // TODO Move to config
+            // Set the CPU affinity for the results thread, uses the "cpu_affinity" from the
+            // gpuProcess config.
             cpu_set_t cpuset;
             CPU_ZERO(&cpuset);
             for (auto& i : config.get<std::vector<int>>(unique_name, "cpu_affinity"))

--- a/lib/gpu/gpuProcess.cpp
+++ b/lib/gpu/gpuProcess.cpp
@@ -156,8 +156,7 @@ void gpuProcess::main_thread() {
     bool first_run = true;
 
     while (!stop_thread) {
-        int ic = gpu_frame_counter % commands.size();
-        assert(commands.size() == final_signals.size());
+        int ic = gpu_frame_counter % final_signals.size();
 
         DEBUG2("Waiting for free slot for GPU[{:d}][{:d}] {:s}", gpu_id, gpu_frame_counter,
               unique_name);
@@ -168,6 +167,7 @@ void gpuProcess::main_thread() {
         // Update the gpu_frame_counter and perform any reset actions on the command object
         // for this frame.
         for (auto& command : commands) {
+            assert(command.size() == final_signals.size());
             command[ic]->start_frame(gpu_frame_counter);
         }
 

--- a/lib/gpu/gpuProcess.cpp
+++ b/lib/gpu/gpuProcess.cpp
@@ -159,7 +159,7 @@ void gpuProcess::main_thread() {
         int ic = gpu_frame_counter % final_signals.size();
 
         DEBUG2("Waiting for free slot for GPU[{:d}][{:d}] {:s}", gpu_id, gpu_frame_counter,
-              unique_name);
+               unique_name);
 
         // We make sure we aren't using a gpu frame that's currently in-flight.
         final_signals[ic]->wait_for_free_slot();
@@ -184,8 +184,8 @@ void gpuProcess::main_thread() {
             }
         }
 
-        DEBUG2("Preconditions met for GPU[{:d}][{:d}] {:s}, queuing commands", gpu_id, gpu_frame_counter,
-               unique_name);
+        DEBUG2("Preconditions met for GPU[{:d}][{:d}] {:s}, queuing commands", gpu_id,
+               gpu_frame_counter, unique_name);
         // Queue the commands for this frame.  This calls execute on each commandObject.
         queue_commands(gpu_frame_counter);
 


### PR DESCRIPTION
This PR fixes a race condition in the GPU logic reported by @eschnett 

The call to `wait_on_precondition()` happens before the call to `final_signals[ic]->wait_for_free_slot()`.  The `final_signals` logic was designed to prevent queuing into a "GPU frame" which hasn't finished yet.

In the old model where the same command object was used for every "GPU frame" this was perfectly fine, since each function had to keep its own local variables, so we only needed to guard at the GPU memory level.   However in the new model where we have a `commandObject` for each "GPU frame", this means that the  `wait_on_precondition()` for a given "GPU Frame" can actually happen before `finalize_frame()` gets called in the `gpuProcess::results_thread()`. 

This change reorders the calls in `gpuProcess::main_thread()` and should resolve the race condition. 