### PR TITLE
Updating GPU Simulator & testing for N2K

### DIFF
--- a/config/ci-tests/test_n2k_writeHDF5.yaml
+++ b/config/ci-tests/test_n2k_writeHDF5.yaml
@@ -1,0 +1,119 @@
+##########################################
+#
+# verify_cuda_n2k.yaml
+#
+# Config to test Kendrick's cuda N2 tensor-core kernel.
+#
+##########################################
+---
+type: config
+# Logging level can be one of:
+# OFF, ERROR, WARN, INFO, DEBUG, DEBUG2 (case insensitive)
+# Note DEBUG and DEBUG2 require a build with (-DCMAKE_BUILD_TYPE=Debug)
+log_level: DEBUG2
+#num_links: 4
+#freq_array: [4,7,10,16]
+#timesamples_per_packet: 2
+
+#num_data_sets: 1
+num_gpus: 1
+buffer_depth: 4
+num_gpu_frames: 4
+cpu_affinity: [2,3,4,5,8,9,10,11]
+sizeof_float: 4
+frame_arrival_period: 0.00000256 * samples_per_data_set
+sizeof_int: 4
+
+# For faster CHORD testing, we're using...
+sub_integration_ntime: 1024
+samples_per_data_set: 2048
+num_times: 2048  # New N2K needs this. TODO: document.
+#sub_integration_ntime: 16384
+#samples_per_data_set: 32768
+num_elements: 128
+num_local_freq: 16
+# vis matrix size
+vis_blocks_tr_root: (num_elements + 1) / 16
+num_vis_blocks: vis_blocks_tr_root * (vis_blocks_tr_root + 1) / 2
+
+# Pool
+main_pool:
+    kotekan_metadata_pool: chordMetadata
+    num_metadata_objects: 15 * buffer_depth
+
+# Buffers
+host_voltage_buffer:
+    kotekan_buffer: standard
+    num_frames: buffer_depth
+    frame_size: samples_per_data_set * num_elements * num_local_freq
+    metadata_pool: main_pool
+
+host_correlation_buffer:
+    kotekan_buffer: standard
+    num_frames: buffer_depth
+    frame_size: num_local_freq * (samples_per_data_set / sub_integration_ntime) * 16 * 16 * num_vis_blocks * 2 * sizeof_int
+    metadata_pool: main_pool
+
+# Ringbuffer signalling buffer
+host_voltage_ringbuffer:
+    kotekan_buffer: ring
+    ring_buffer_size: buffer_depth * samples_per_data_set * num_elements * num_local_freq
+    metadata_pool: main_pool
+
+gen_data:
+    # type: const
+    # value: 34 # 1i # 34 # = 2 + 2i
+    type: random_signed_offset  # const_offset
+    value: 120
+    kotekan_stage: testDataGen
+    out_buf: host_voltage_buffer
+    array_shape: [ 2048, 16, 2, 64 ]
+    dim_name: ["T", "F", "P", "D" ]
+    num_frames: buffer_depth  # Must be at least what write_n2k_correlation expects
+
+run_send_voltage:
+    gpu_0:
+        kotekan_stage: cudaProcess
+        gpu_id: 0
+        in_buffers:
+            host_voltage_buffer_in: host_voltage_buffer
+        out_buffers:
+            host_voltage_ringbuffer_out: host_voltage_ringbuffer
+        commands:
+        - name: cudaCopyToRingbuffer
+          input_size: samples_per_data_set * num_elements * num_local_freq
+          ring_buffer_size: buffer_depth * input_size
+          in_buf: host_voltage_buffer_in
+          signal_buf: host_voltage_ringbuffer_out
+          gpu_mem_output: voltage_buffer
+
+run_n2k:
+    gpu_0:
+        kotekan_stage: cudaProcess
+        gpu_id: 0
+        in_buffers:
+            host_voltage_ringbuffer: host_voltage_ringbuffer
+        out_buffers:
+            host_correlation: host_correlation_buffer
+        commands:
+        - name: cudaCorrelator
+          # in_signal: host_voltage_ringbuffer_in
+          # gpu_mem_voltage: voltage_buffer
+          # gpu_mem_correlation_triangle: correlation_matrix
+          n2k_correlation_name: correlation
+          voltage_name: voltage
+        - name: cudaSyncOutput
+        - name: cudaOutputData
+          gpu_mem: correlation_buffer
+          out_buf: host_correlation
+
+
+write_n2k_correlation:
+   kotekan_stage: hdf5FileWrite
+   base_dir: data
+   file_name: n2k_corr
+   prefix_hostname: false
+   max_frames: buffer_depth  # Will trigger exit after writing this many frames
+   skip_writing: false
+   in_buf: host_correlation_buffer
+

--- a/config/ci-tests/verify_cuda_n2k.yaml
+++ b/config/ci-tests/verify_cuda_n2k.yaml
@@ -75,7 +75,7 @@ gen_data:
     out_buf: host_voltage_buffer
     array_shape: [ 2048, 16, 2, 64 ]
     dim_name: ["T", "F", "P", "D" ]
-    num_frames: -1
+    num_frames: buffer_depth  # Must be at least what check_data expects
 
 run_send_voltage:
     gpu_0:

--- a/config/ci-tests/verify_cuda_n2k.yaml
+++ b/config/ci-tests/verify_cuda_n2k.yaml
@@ -124,21 +124,3 @@ check_data:
     first_buf: host_correlation_buffer
     second_buf: simulated_correlation_buffer
     num_frames_to_test: buffer_depth
-
-write_n2k_correlation:
-   kotekan_stage: hdf5FileWrite
-   base_dir: data
-   file_name: n2k_corr
-   prefix_hostname: false
-   max_frames: -1
-   skip_writing: false
-   in_buf: host_correlation_buffer
-
-write_simulated_correlation:
-    kotekan_stage: hdf5FileWrite
-    base_dir: data
-    file_name: sim_corr
-    prefix_hostname: false
-    max_frames: -1
-    skip_writing: false
-    in_buf: simulated_correlation_buffer

--- a/config/ci-tests/verify_cuda_n2k.yaml
+++ b/config/ci-tests/verify_cuda_n2k.yaml
@@ -69,7 +69,7 @@ host_voltage_ringbuffer:
 gen_data:
     # type: const
     # value: 34 # 1i # 34 # = 2 + 2i
-    type: random_signed
+    type: random_signed_offset  # const_offset
     value: 120
     kotekan_stage: testDataGen
     out_buf: host_voltage_buffer

--- a/config/ci-tests/verify_cuda_n2k.yaml
+++ b/config/ci-tests/verify_cuda_n2k.yaml
@@ -27,9 +27,10 @@ sizeof_int: 4
 # For faster CHORD testing, we're using...
 sub_integration_ntime: 1024
 samples_per_data_set: 2048
+num_times: 2048  # New N2K needs this. TODO: document.
 #sub_integration_ntime: 16384
 #samples_per_data_set: 32768
-num_elements: 1024
+num_elements: 128
 num_local_freq: 16
 # vis matrix size
 vis_blocks_tr_root: (num_elements + 1) / 16
@@ -69,11 +70,12 @@ gen_data:
     # type: const
     # value: 34 # 1i # 34 # = 2 + 2i
     type: random_signed
-    value: 1532
+    value: 120
     kotekan_stage: testDataGen
     out_buf: host_voltage_buffer
-    array_shape: [ 2048, 16, 2, 512 ]
+    array_shape: [ 2048, 16, 2, 64 ]
     dim_name: ["T", "F", "P", "D" ]
+    num_frames: -1
 
 run_send_voltage:
     gpu_0:
@@ -96,17 +98,19 @@ run_n2k:
         kotekan_stage: cudaProcess
         gpu_id: 0
         in_buffers:
-            host_voltage_ringbuffer_in: host_voltage_ringbuffer
+            host_voltage_ringbuffer: host_voltage_ringbuffer
         out_buffers:
             host_correlation: host_correlation_buffer
         commands:
         - name: cudaCorrelator
-          in_signal: host_voltage_ringbuffer_in
-          gpu_mem_voltage: voltage_buffer
-          gpu_mem_correlation_triangle: correlation_matrix
+          # in_signal: host_voltage_ringbuffer_in
+          # gpu_mem_voltage: voltage_buffer
+          # gpu_mem_correlation_triangle: correlation_matrix
+          n2k_correlation_name: correlation
+          voltage_name: voltage
         - name: cudaSyncOutput
         - name: cudaOutputData
-          gpu_mem: correlation_matrix
+          gpu_mem: correlation_buffer
           out_buf: host_correlation
 
 cpu:
@@ -120,3 +124,21 @@ check_data:
     first_buf: host_correlation_buffer
     second_buf: simulated_correlation_buffer
     num_frames_to_test: buffer_depth
+
+write_n2k_correlation:
+   kotekan_stage: hdf5FileWrite
+   base_dir: data
+   file_name: n2k_corr
+   prefix_hostname: false
+   max_frames: -1
+   skip_writing: false
+   in_buf: host_correlation_buffer
+
+write_simulated_correlation:
+    kotekan_stage: hdf5FileWrite
+    base_dir: data
+    file_name: sim_corr
+    prefix_hostname: false
+    max_frames: -1
+    skip_writing: false
+    in_buf: simulated_correlation_buffer

--- a/config/ci-tests/verify_cuda_n2k.yaml
+++ b/config/ci-tests/verify_cuda_n2k.yaml
@@ -10,7 +10,7 @@ type: config
 # Logging level can be one of:
 # OFF, ERROR, WARN, INFO, DEBUG, DEBUG2 (case insensitive)
 # Note DEBUG and DEBUG2 require a build with (-DCMAKE_BUILD_TYPE=Debug)
-log_level: debug
+log_level: DEBUG2
 #num_links: 4
 #freq_array: [4,7,10,16]
 #timesamples_per_packet: 2

--- a/kotekan/kotekan.cpp
+++ b/kotekan/kotekan.cpp
@@ -677,7 +677,9 @@ int main(int argc, char** argv) {
         }
     }
 
-    INFO_NON_OO("kotekan shutdown with status: {:s}", get_exit_code_string(get_exit_code()));
+    enum ReturnCode exit_code = get_exit_code();
+
+    INFO_NON_OO("kotekan shutdown with status: {:s}", get_exit_code_string(exit_code));
 
     // Print error message if there is one.
     if (string(get_error_message()) != "not set") {
@@ -686,5 +688,10 @@ int main(int argc, char** argv) {
 
     closelog();
 
-    return get_exit_code();
+    // If a test was run and passed, we have already printed the status message,
+    // exit with a CLEAN_EXIT signal.
+    if(exit_code == TEST_PASSED)
+        exit_code = CLEAN_EXIT;
+
+    return exit_code;
 }

--- a/lib/cuda/cudaCorrelator.hpp
+++ b/lib/cuda/cudaCorrelator.hpp
@@ -42,6 +42,11 @@
  * Note: While the output is only supposed to fill the upper triangle
  * of the correlation matrices, this implementation fills a few of the
  * below-the-diagonal elements with non-zero values.
+ *
+ * TODO: -Update docs to note new parameter names,
+ *       -buffer name requirements (for NDArray conventions)
+ *       -input data name in metadata must be "E"
+ *       -input data type must be int4x2_swapped_withoffset_t
  */
 class cudaCorrelator : public cudaCommand {
 public:

--- a/lib/cuda/cudaCorrelator.hpp
+++ b/lib/cuda/cudaCorrelator.hpp
@@ -83,14 +83,14 @@ private:
     /// Name for the correlation output
     const std::string _n2k_correlation_name;
 
-    // Signalling ring buffer for the input (voltage) data.
+    /// Signaling ring buffer for the input (voltage) data.
     NDArrayRingBuffer<kotekan::int4x2_swapped_withoffset_t, 4> voltage;
     NDArrayBuffer<std::int32_t, 6> n2k_correlation;
 
-    // Cuda kernel wrapper object
+    /// Cuda kernel wrapper object
     n2k::Correlator n2correlator;
 
-    // Placeholder rfi mask
+    /// Placeholder rfi mask
     std::uint32_t* rfimask;
 };
 

--- a/lib/cuda/cudaDeviceInterface.cpp
+++ b/lib/cuda/cudaDeviceInterface.cpp
@@ -4,18 +4,32 @@
 
 #include <cuda.h>
 #include <errno.h>
+#include <mutex>
 #include <nvPTXCompiler.h>
 #include <nvrtc.h>
 
 using kotekan::Config;
 
-std::map<int, std::shared_ptr<cudaDeviceInterface>> cudaDeviceInterface::inst_map;
+std::map<int32_t, std::weak_ptr<cudaDeviceInterface>> cudaDeviceInterface::inst_map;
+
+// Protects access to inst_map
+static std::mutex cuda_inst_map_mutex;
 
 std::shared_ptr<cudaDeviceInterface>
 cudaDeviceInterface::get(int32_t gpu_id, const std::string& name, Config& config) {
-    if (inst_map.count(gpu_id) == 0)
-        inst_map[gpu_id] = std::make_shared<cudaDeviceInterface>(config, name, gpu_id);
-    return inst_map[gpu_id];
+    std::lock_guard<std::mutex> lock(cuda_inst_map_mutex);
+    auto it = inst_map.find(gpu_id);
+    if (it != inst_map.end()) {
+        if (auto existing = it->second.lock())
+            // it->second is a std::weak_ptr. lock() attempts to create a new
+            // shared_ptr that shares ownership with any existing shared owners.
+            // If the weak_ptr has not expired, 'existing' becomes a valid shared_ptr.
+            return existing;
+    }
+    auto dev = std::make_shared<cudaDeviceInterface>(config, name,
+                                                     gpu_id); // creates an owning std::shared_ptr
+    inst_map[gpu_id] = dev; // store weak reference (implicit conversion)
+    return dev;
 }
 
 cudaDeviceInterface::cudaDeviceInterface(Config& config, const std::string& unique_name,
@@ -71,6 +85,7 @@ void cudaDeviceInterface::prepareStreams(uint32_t num_streams) {
         streams.push_back(stream);
     }
 }
+
 void cudaDeviceInterface::async_copy_host_to_gpu(void* dst, void* src, size_t len,
                                                  uint32_t cuda_stream_id, cudaEvent_t pre_event,
                                                  cudaEvent_t* copy_start_event,
@@ -89,6 +104,7 @@ void cudaDeviceInterface::async_copy_host_to_gpu(void* dst, void* src, size_t le
         CHECK_CUDA_ERROR(cudaEventRecord(*copy_end_event, getStream(cuda_stream_id)));
     }
 }
+
 void cudaDeviceInterface::async_copy_gpu_to_host(void* dst, void* src, size_t len,
                                                  uint32_t cuda_stream_id, cudaEvent_t pre_event,
                                                  cudaEvent_t* copy_start_event,

--- a/lib/cuda/cudaDeviceInterface.hpp
+++ b/lib/cuda/cudaDeviceInterface.hpp
@@ -104,8 +104,8 @@ protected:
     // Cuda Streams
     std::vector<cudaStream_t> streams;
 
-    // Singleton dictionary
-    static std::map<int, std::shared_ptr<cudaDeviceInterface>> inst_map;
+    // Cache of device instances (weak to avoid lifetime extension)
+    static std::map<int32_t, std::weak_ptr<cudaDeviceInterface>> inst_map;
 };
 
 #endif // CUDA_DEVICE_INTERFACE_H

--- a/lib/cuda/cudaProcess.cpp
+++ b/lib/cuda/cudaProcess.cpp
@@ -35,7 +35,11 @@ cudaProcess::cudaProcess(Config& config_, const std::string& unique_name,
 }
 
 cudaProcess::~cudaProcess() {
+    // Ensure this thread is set to the correct device before final CUDA cleanup.
+    if (device)
+        device->set_thread_device();
     CHECK_CUDA_ERROR(cudaProfilerStop());
+    // With weak_ptr cache, simply letting the last shared_ptr go triggers cleanup.
 }
 
 gpuEventContainer* cudaProcess::create_signal() {

--- a/lib/metadata/DataType.hpp
+++ b/lib/metadata/DataType.hpp
@@ -142,8 +142,8 @@ struct int4x2_swapped_withoffset_t {
 #if KOTEKAN_FLOAT16
 // In C++17, std::memcpy is not constexpr, so these can't be constexpr.
 // In C++20+, prefer std::bit_cast to keep them constexpr-capable.
-#  if (__cplusplus >= 202002L) || defined(__cpp_lib_bit_cast)
-#    include <bit>
+#if (__cplusplus >= 202002L) || defined(__cpp_lib_bit_cast)
+#include <bit>
 constexpr inline bool isfinite(const float16_t x) {
     const std::uint16_t bits = std::bit_cast<std::uint16_t>(x);
     return (bits & 0b0111110000000000) != 0b0111110000000000;
@@ -162,7 +162,7 @@ constexpr inline bool signbit(const float16_t x) {
     const std::uint16_t bits = std::bit_cast<std::uint16_t>(x);
     return bits >> 15;
 }
-#  else
+#else
 inline bool isfinite(const float16_t x) {
     std::uint16_t bits = 0;
     std::memcpy(&bits, &x, sizeof bits);
@@ -184,7 +184,7 @@ inline bool signbit(const float16_t x) {
     std::memcpy(&bits, &x, sizeof bits);
     return bits >> 15;
 }
-#  endif
+#endif
 
 inline std::ostream& operator<<(std::ostream& os, const float16_t x) {
     return os << float(x);

--- a/lib/metadata/chordMetadata.hpp
+++ b/lib/metadata/chordMetadata.hpp
@@ -189,10 +189,10 @@ public:
         // Compute the strides from the set dims assuming simple contiguous
         // access.
         assert(this->dims > 0);
-        this->stride[this->dims-1] = 1;
-        for(int d = this->dims-2; d >= 0; d--) {
-            assert(this->dim[d+1] > 0);
-            this->stride[d] = this->dim[d+1]*stride[d+1];
+        this->stride[this->dims - 1] = 1;
+        for (int d = this->dims - 2; d >= 0; d--) {
+            assert(this->dim[d + 1] > 0);
+            this->stride[d] = this->dim[d + 1] * stride[d + 1];
         }
     }
 

--- a/lib/metadata/chordMetadata.hpp
+++ b/lib/metadata/chordMetadata.hpp
@@ -185,6 +185,17 @@ public:
 #pragma GCC diagnostic pop
     }
 
+    void set_strides_simple() {
+        // Compute the strides from the set dims assuming simple contiguous
+        // access.
+        assert(this->dims > 0);
+        this->stride[this->dims-1] = 1;
+        for(int d = this->dims-2; d >= 0; d--) {
+            assert(this->dim[d+1] > 0);
+            this->stride[d] = this->dim[d+1]*stride[d+1];
+        }
+    }
+
     void set_name(const std::string& name) {
         // GCC helpfully tries to warn us that the destination string may end up not
         // NUL-terminated, which we know.

--- a/lib/stages/testDataGen.cpp
+++ b/lib/stages/testDataGen.cpp
@@ -200,9 +200,11 @@ void testDataGen::main_thread() {
         std::shared_ptr<chordMetadata> chordmeta;
         if (metadata_is_chord(buf, frame_id)) {
             chordmeta = get_chord_metadata(buf, frame_id);
+            chordmeta->set_name("E");
             chordmeta->dims = (int)_array_shape.size();
             for (int d = 0; d < chordmeta->dims; ++d)
                 chordmeta->set_array_dimension(d, _array_shape[d], _dim_name[d]);
+            chordmeta->set_strides_simple();
         }
 
         unsigned char temp_output;
@@ -218,7 +220,7 @@ void testDataGen::main_thread() {
             n_to_set /= sizeof(int8_t);
             frame8 = (int8_t*)frame;
             if (chordmeta)
-                chordmeta->type = kotekan::int4x2;
+                chordmeta->type = kotekan::int4x2_swapped_withoffset;
         } else if (type == "const8") {
             n_to_set /= sizeof(int8_t);
             frame8 = (int8_t*)frame;
@@ -243,7 +245,7 @@ void testDataGen::main_thread() {
 #endif
         } else if (type == "random_signed") {
             if (chordmeta)
-                chordmeta->type = kotekan::int4x2;
+                chordmeta->type = kotekan::int4x2_swapped_withoffset;
         }
         if (type == "onehot") {
             int val = value;
@@ -375,7 +377,8 @@ void testDataGen::main_thread() {
                 r >>= 4;
                 new_imaginary = (r % 15) + 1; // Limit to [-7, 7]
                 temp_output = ((new_real << 4) & 0xF0) + (new_imaginary & 0x0F);
-                frame[j] = temp_output ^ 0x88;
+                //frame[j] = temp_output ^ 0x88;  //TODO: verify this is ok
+                frame[j] = temp_output;
             } else if (type == "tpluse") {
                 int time_idx = j / num_elements;
                 int elem_idx = j % num_elements;

--- a/lib/stages/testDataGen.cpp
+++ b/lib/stages/testDataGen.cpp
@@ -218,6 +218,7 @@ void testDataGen::main_thread() {
         uint n_to_set = buf->frame_size / sizeof(uint8_t);
 
         if (chordmeta) {
+            chordmeta->fpga_seq_num = seq_num;
             chordmeta->sample0_offset = frame_id_abs * samples_per_data_set;
             chordmeta->offset_downsampling = 1;
         }

--- a/lib/stages/testDataGen.cpp
+++ b/lib/stages/testDataGen.cpp
@@ -48,13 +48,19 @@ testDataGen::testDataGen(Config& config, const std::string& unique_name,
     buf = get_buffer("out_buf");
     buf->register_producer(unique_name);
     type = config.get<std::string>(unique_name, "type");
-    assert(type == "const" || type == "const8" || type == "const16" || type == "const32"
-           || type == "constf16" || type == "random" || type == "random_signed" || type == "ramp"
-           || type == "tpluse" || type == "tpluseplusf" || type == "tpluseplusfprime"
-           || type == "square" || type == "onehot");
+    assert(type == "const" || type == "const_offset" || type == "const8"
+            || type == "const16" || type == "const32"
+            || type == "constf16" || type == "random"
+            || type == "random_signed" || type == "random_signed_offset"
+            || type == "ramp"
+            || type == "tpluse" || type == "tpluseplusf"
+            || type == "tpluseplusfprime"
+            || type == "square" || type == "onehot");
     assert(!((type == "constf16") && (KOTEKAN_FLOAT16 == 0)));
     int type_size = 1; // default
     if (type == "const")
+        type_size = 1;
+    if (type == "const_offset")
         type_size = 1;
     if (type == "const8")
         type_size = 1;
@@ -64,8 +70,8 @@ testDataGen::testDataGen(Config& config, const std::string& unique_name,
         type_size = 4;
     if (type == "constf16")
         type_size = 2;
-    if (type == "const" || type == "const8" || type == "const16" || type == "const32"
-        || type == "random" || type == "random_signed" || type == "ramp" || type == "onehot") {
+    if (type == "const" || type == "const_offset" || type == "const8" || type == "const16" || type == "const32"
+        || type == "random" || type == "random_signed" || type == "random_signed_offset" || type == "ramp" || type == "onehot") {
         value = config.get_default<int>(unique_name, "value", -1999);
         _value_array =
             config.get_default<std::vector<int>>(unique_name, "values", std::vector<int>());
@@ -175,7 +181,7 @@ void testDataGen::main_thread() {
     double frame_length =
         samples_per_data_set * ts_to_double(Telescope::instance().seq_length()) / num_links;
 
-    if (((type == "random") || (type == "random_signed") || (type == "onehot")) && _seed)
+    if (((type == "random") || (type == "random_signed") || (type == "random_signed_offset") || (type == "onehot")) && _seed)
         srand(_seed);
 
     while (!stop_thread) {
@@ -220,6 +226,11 @@ void testDataGen::main_thread() {
             n_to_set /= sizeof(int8_t);
             frame8 = (int8_t*)frame;
             if (chordmeta)
+                chordmeta->type = kotekan::int4x2;
+        } else if (type == "const_offset") {
+            n_to_set /= sizeof(int8_t);
+            frame8 = (int8_t*)frame;
+            if (chordmeta)
                 chordmeta->type = kotekan::int4x2_swapped_withoffset;
         } else if (type == "const8") {
             n_to_set /= sizeof(int8_t);
@@ -245,8 +256,12 @@ void testDataGen::main_thread() {
 #endif
         } else if (type == "random_signed") {
             if (chordmeta)
+                chordmeta->type = kotekan::int4x2;
+        } else if (type == "random_signed_offset") {
+            if (chordmeta)
                 chordmeta->type = kotekan::int4x2_swapped_withoffset;
         }
+
         if (type == "onehot") {
             int val = value;
             if (_value_array.size())
@@ -327,13 +342,18 @@ void testDataGen::main_thread() {
             }
             n_to_set = 0;
         }
+
         if (_value_array.size()
-            && ((type == "const") || (type == "const8") || (type == "const16")
+            && ((type == "const") || (type == "const_offset") || (type == "const8") || (type == "const16")
                 || (type == "const32")))
             // Cycle through "values" array, if given
             value = _value_array[frame_id_abs % _value_array.size()];
         for (uint j = 0; j < n_to_set; ++j) {
             if (type == "const") {
+                if (finished_seeding_constant)
+                    break;
+                frame[j] = value;
+            } else if (type == "const_offset") {
                 if (finished_seeding_constant)
                     break;
                 frame[j] = value;
@@ -377,8 +397,17 @@ void testDataGen::main_thread() {
                 r >>= 4;
                 new_imaginary = (r % 15) + 1; // Limit to [-7, 7]
                 temp_output = ((new_real << 4) & 0xF0) + (new_imaginary & 0x0F);
-                //frame[j] = temp_output ^ 0x88;  //TODO: verify this is ok
-                frame[j] = temp_output;
+                frame[j] = temp_output ^ 0x88;
+            } else if (type == "random_signed_offset") {
+                char new_real;
+                char new_imaginary;
+                if (_reuse_random && finished_seeding_constant)
+                    break;
+                int r = rand();
+                new_real = (r % 15) + 1; // Limit to [-7, 7]
+                r >>= 4;
+                new_imaginary = (r % 15) + 1; // Limit to [-7, 7]
+                frame[j] = ((new_real << 4) & 0xF0) + (new_imaginary & 0x0F);
             } else if (type == "tpluse") {
                 int time_idx = j / num_elements;
                 int elem_idx = j % num_elements;

--- a/lib/stages/testDataGen.cpp
+++ b/lib/stages/testDataGen.cpp
@@ -48,14 +48,11 @@ testDataGen::testDataGen(Config& config, const std::string& unique_name,
     buf = get_buffer("out_buf");
     buf->register_producer(unique_name);
     type = config.get<std::string>(unique_name, "type");
-    assert(type == "const" || type == "const_offset" || type == "const8"
-            || type == "const16" || type == "const32"
-            || type == "constf16" || type == "random"
-            || type == "random_signed" || type == "random_signed_offset"
-            || type == "ramp"
-            || type == "tpluse" || type == "tpluseplusf"
-            || type == "tpluseplusfprime"
-            || type == "square" || type == "onehot");
+    assert(type == "const" || type == "const_offset" || type == "const8" || type == "const16"
+           || type == "const32" || type == "constf16" || type == "random" || type == "random_signed"
+           || type == "random_signed_offset" || type == "ramp" || type == "tpluse"
+           || type == "tpluseplusf" || type == "tpluseplusfprime" || type == "square"
+           || type == "onehot");
     assert(!((type == "constf16") && (KOTEKAN_FLOAT16 == 0)));
     int type_size = 1; // default
     if (type == "const")
@@ -70,8 +67,9 @@ testDataGen::testDataGen(Config& config, const std::string& unique_name,
         type_size = 4;
     if (type == "constf16")
         type_size = 2;
-    if (type == "const" || type == "const_offset" || type == "const8" || type == "const16" || type == "const32"
-        || type == "random" || type == "random_signed" || type == "random_signed_offset" || type == "ramp" || type == "onehot") {
+    if (type == "const" || type == "const_offset" || type == "const8" || type == "const16"
+        || type == "const32" || type == "random" || type == "random_signed"
+        || type == "random_signed_offset" || type == "ramp" || type == "onehot") {
         value = config.get_default<int>(unique_name, "value", -1999);
         _value_array =
             config.get_default<std::vector<int>>(unique_name, "values", std::vector<int>());
@@ -181,7 +179,9 @@ void testDataGen::main_thread() {
     double frame_length =
         samples_per_data_set * ts_to_double(Telescope::instance().seq_length()) / num_links;
 
-    if (((type == "random") || (type == "random_signed") || (type == "random_signed_offset") || (type == "onehot")) && _seed)
+    if (((type == "random") || (type == "random_signed") || (type == "random_signed_offset")
+         || (type == "onehot"))
+        && _seed)
         srand(_seed);
 
     while (!stop_thread) {
@@ -344,8 +344,8 @@ void testDataGen::main_thread() {
         }
 
         if (_value_array.size()
-            && ((type == "const") || (type == "const_offset") || (type == "const8") || (type == "const16")
-                || (type == "const32")))
+            && ((type == "const") || (type == "const_offset") || (type == "const8")
+                || (type == "const16") || (type == "const32")))
             // Cycle through "values" array, if given
             value = _value_array[frame_id_abs % _value_array.size()];
         for (uint j = 0; j < n_to_set; ++j) {

--- a/lib/testing/gpuSimulateN2k.cpp
+++ b/lib/testing/gpuSimulateN2k.cpp
@@ -82,10 +82,16 @@ void gpuSimulateN2k::main_thread() {
                                     int iy = (t * _num_local_freq + f) * _num_elements
                                              + (16 * jhi + jlo);
 
+                                    /*
                                     int xi = ((input[ix] + 8) & 0xf) - 8;
                                     int xr = (((input[ix] >> 4) + 8) & 0xf) - 8;
                                     int yi = ((input[iy] + 8) & 0xf) - 8;
                                     int yr = (((input[iy] >> 4) + 8) & 0xf) - 8;
+                                    */
+                                    int xi =  (input[ix] & 0x0f)       - 8;
+                                    int xr = ((input[ix] & 0xf0) >> 4) - 8;
+                                    int yi =  (input[iy] & 0x0f)       - 8;
+                                    int yr = ((input[iy] & 0xf0) >> 4) - 8;
                                     real += xr * yr + xi * yi;
                                     imag += xi * yr - yi * xr;
                                 }
@@ -112,7 +118,38 @@ void gpuSimulateN2k::main_thread() {
                 break;
         } // tout
 
-        input_buf->pass_metadata(input_frame_id, output_buf, output_frame_id);
+        //input_buf->pass_metadata(input_frame_id, output_buf, output_frame_id);
+        output_buf->allocate_new_metadata_object(output_frame_id);    
+        const std::shared_ptr<metadataObject> mc = output_buf->get_metadata(output_frame_id);
+        if(!mc) {
+            FATAL_ERROR("Buffer {:s} frame {:d} cannot allocate metadata",
+                        output_buf->buffer_name, output_frame_id);
+        }
+        assert(mc);
+        if(!metadata_is_chord(mc)) {
+            FATAL_ERROR("Buffer {:s} frame {:d} does not have CHORD metadata",
+                        output_buf->buffer_name, output_frame_id);
+        }
+        assert(metadata_is_chord(mc));
+        const std::shared_ptr<chordMetadata> meta_out = get_chord_metadata(mc);
+        assert(meta_out);
+
+        meta_out->set_name("cpusim_correlation");
+        meta_out->type = kotekan::int32;
+        meta_out->dims = 6;
+        assert(meta_out->dims <= CHORD_META_MAX_DIM);
+        meta_out->set_array_dimension(0, nt_outer, "Tc");
+        meta_out->set_array_dimension(1, _num_local_freq, "F");
+        meta_out->set_array_dimension(2, (_num_elements/16) * (_num_elements/16 + 1)/2, "DPhi");
+        meta_out->set_array_dimension(3, 16, "DPlo1");
+        meta_out->set_array_dimension(4, 16, "DPlo2");
+        meta_out->set_array_dimension(5, 2, "C");
+        meta_out->set_strides_simple();
+        meta_out->nfreq = _num_local_freq;
+        assert(meta_out->nfreq <= CHORD_META_MAX_FREQ);
+        meta_out->sample0_offset = 0;
+        meta_out->offset_downsampling = 1;
+
         input_buf->mark_frame_empty(unique_name, input_frame_id);
 
         // Pretend some samples were lost

--- a/lib/testing/gpuSimulateN2k.cpp
+++ b/lib/testing/gpuSimulateN2k.cpp
@@ -82,12 +82,9 @@ void gpuSimulateN2k::main_thread() {
                                     int iy = (t * _num_local_freq + f) * _num_elements
                                              + (16 * jhi + jlo);
 
-                                    /*
-                                    int xi = ((input[ix] + 8) & 0xf) - 8;
-                                    int xr = (((input[ix] >> 4) + 8) & 0xf) - 8;
-                                    int yi = ((input[iy] + 8) & 0xf) - 8;
-                                    int yr = (((input[iy] >> 4) + 8) & 0xf) - 8;
-                                    */
+                                    // Decode input with the CHIME convention:
+                                    // offset encoded by 8, imaginary part in
+                                    // lo 4 bits, real part in high 4 bits.
                                     int xi = (input[ix] & 0x0f) - 8;
                                     int xr = ((input[ix] & 0xf0) >> 4) - 8;
                                     int yi = (input[iy] & 0x0f) - 8;
@@ -118,6 +115,11 @@ void gpuSimulateN2k::main_thread() {
                 break;
         } // tout
 
+        // Fetch input metadata
+        const std::shared_ptr<const metadataObject> mc_in = input_buf->get_metadata(input_frame_id);
+        const std::shared_ptr<const chordMetadata> meta_in = (mc_in && metadata_is_chord(mc_in)) ? get_chord_metadata(mc_in) : nullptr;
+
+        // Create output metadata
         output_buf->allocate_new_metadata_object(output_frame_id);
         const std::shared_ptr<metadataObject> mc = output_buf->get_metadata(output_frame_id);
         if (!mc) {
@@ -147,8 +149,16 @@ void gpuSimulateN2k::main_thread() {
         meta_out->set_strides_simple();
         meta_out->nfreq = _num_local_freq;
         assert(meta_out->nfreq <= CHORD_META_MAX_FREQ);
-        meta_out->sample0_offset = 0;
-        meta_out->offset_downsampling = 1;
+        
+        if(meta_in) {
+            meta_out->fpga_seq_num = meta_in->fpga_seq_num;
+            meta_out->sample0_offset = meta_in->sample0_offset;
+            meta_out->offset_downsampling = meta_in->offset_downsampling;
+        } else {
+            meta_out->fpga_seq_num = 0;
+            meta_out->sample0_offset = 0;
+            meta_out->offset_downsampling = 1;
+        }
 
         input_buf->mark_frame_empty(unique_name, input_frame_id);
 

--- a/lib/testing/gpuSimulateN2k.cpp
+++ b/lib/testing/gpuSimulateN2k.cpp
@@ -88,9 +88,9 @@ void gpuSimulateN2k::main_thread() {
                                     int yi = ((input[iy] + 8) & 0xf) - 8;
                                     int yr = (((input[iy] >> 4) + 8) & 0xf) - 8;
                                     */
-                                    int xi =  (input[ix] & 0x0f)       - 8;
+                                    int xi = (input[ix] & 0x0f) - 8;
                                     int xr = ((input[ix] & 0xf0) >> 4) - 8;
-                                    int yi =  (input[iy] & 0x0f)       - 8;
+                                    int yi = (input[iy] & 0x0f) - 8;
                                     int yr = ((input[iy] & 0xf0) >> 4) - 8;
                                     real += xr * yr + xi * yi;
                                     imag += xi * yr - yi * xr;
@@ -118,15 +118,14 @@ void gpuSimulateN2k::main_thread() {
                 break;
         } // tout
 
-        //input_buf->pass_metadata(input_frame_id, output_buf, output_frame_id);
-        output_buf->allocate_new_metadata_object(output_frame_id);    
+        output_buf->allocate_new_metadata_object(output_frame_id);
         const std::shared_ptr<metadataObject> mc = output_buf->get_metadata(output_frame_id);
-        if(!mc) {
-            FATAL_ERROR("Buffer {:s} frame {:d} cannot allocate metadata",
-                        output_buf->buffer_name, output_frame_id);
+        if (!mc) {
+            FATAL_ERROR("Buffer {:s} frame {:d} cannot allocate metadata", output_buf->buffer_name,
+                        output_frame_id);
         }
         assert(mc);
-        if(!metadata_is_chord(mc)) {
+        if (!metadata_is_chord(mc)) {
             FATAL_ERROR("Buffer {:s} frame {:d} does not have CHORD metadata",
                         output_buf->buffer_name, output_frame_id);
         }
@@ -140,7 +139,8 @@ void gpuSimulateN2k::main_thread() {
         assert(meta_out->dims <= CHORD_META_MAX_DIM);
         meta_out->set_array_dimension(0, nt_outer, "Tc");
         meta_out->set_array_dimension(1, _num_local_freq, "F");
-        meta_out->set_array_dimension(2, (_num_elements/16) * (_num_elements/16 + 1)/2, "DPhi");
+        meta_out->set_array_dimension(2, (_num_elements / 16) * (_num_elements / 16 + 1) / 2,
+                                      "DPhi");
         meta_out->set_array_dimension(3, 16, "DPlo1");
         meta_out->set_array_dimension(4, 16, "DPlo2");
         meta_out->set_array_dimension(5, 2, "C");

--- a/lib/testing/testDataCheck.hpp
+++ b/lib/testing/testDataCheck.hpp
@@ -141,7 +141,8 @@ void testDataCheck<A_Type>::main_thread() {
             }
         }
 
-        if (num_errors > 0) {
+        //if (num_errors > 0) {
+        if (num_errors == 0) {
             INFO("The buffers {:s}[{:d}] and {:s}[{:d}] contained values that were equal.",
                  first_buf->buffer_name, first_buf_id, second_buf->buffer_name, second_buf_id);
             if (use_almost_equal) {

--- a/lib/testing/testDataCheck.hpp
+++ b/lib/testing/testDataCheck.hpp
@@ -141,7 +141,6 @@ void testDataCheck<A_Type>::main_thread() {
             }
         }
 
-        //if (num_errors > 0) {
         if (num_errors == 0) {
             INFO("The buffers {:s}[{:d}] and {:s}[{:d}] contained values that were equal.",
                  first_buf->buffer_name, first_buf_id, second_buf->buffer_name, second_buf_id);

--- a/tests/boost/CMakeLists.txt
+++ b/tests/boost/CMakeLists.txt
@@ -131,3 +131,6 @@ add_custom_target(
     test_timeUtil_script ALL
     DEPENDS ${PROJECT_BINARY_DIR}/timeUtil.py
     COMMENT "Generating timeUtil.py script")
+
+# add_executable(test_CHORDTelescope test_CHORDTelescope.cpp)
+# target_link_libraries(test_CHORDTelescope PRIVATE kotekan_utils)

--- a/tests/boost/CMakeLists.txt
+++ b/tests/boost/CMakeLists.txt
@@ -131,6 +131,3 @@ add_custom_target(
     test_timeUtil_script ALL
     DEPENDS ${PROJECT_BINARY_DIR}/timeUtil.py
     COMMENT "Generating timeUtil.py script")
-
-# add_executable(test_CHORDTelescope test_CHORDTelescope.cpp)
-# target_link_libraries(test_CHORDTelescope PRIVATE kotekan_utils)


### PR DESCRIPTION
Updates the `testDataGen` and `gpuSimulateN2k` stages to work with updated `chordMetadata`. Updates `verify_cuda_n2k` config setup to work with updated n2k framework.  This test now passes and is moved to `ci-tests`