### PR TITLE
Revert branch used for running kotekan on the HCO Outrigger

### DIFF
--- a/config/chime_gbo_gpu.j2
+++ b/config/chime_gbo_gpu.j2
@@ -101,13 +101,11 @@ lost_samples_buffers:
 {%- for id in range(16) %}
     lost_samples_buffer_{{ id }}:
         numa_node: 0
-        zeroing_thread_affinity: [8]
         kotekan_buffer: standard
 {%- endfor %}
 {%- for id in range(16,32) %}
     lost_samples_buffer_{{ id }}:
         numa_node: 1
-        zeroing_thread_affinity: [32]
         kotekan_buffer: standard
 {%- endfor %}
 

--- a/config/chime_hco_gpu.j2
+++ b/config/chime_hco_gpu.j2
@@ -101,13 +101,11 @@ lost_samples_buffers:
 {%- for id in range(16) %}
     lost_samples_buffer_{{ id }}:
         numa_node: 0
-        zeroing_thread_affinity: [8]
         kotekan_buffer: standard
 {%- endfor %}
 {%- for id in range(16,32) %}
     lost_samples_buffer_{{ id }}:
         numa_node: 1
-        zeroing_thread_affinity: [32]
         kotekan_buffer: standard
 {%- endfor %}
 

--- a/config/chime_kko_adc_dump.j2
+++ b/config/chime_kko_adc_dump.j2
@@ -97,7 +97,6 @@ lost_samples_buffers:
 {%- if id in selected_links %}
     lost_samples_buffer_{{ id }}:
         numa_node: 0
-        zeroing_thread_affinity: [8]
         kotekan_buffer: standard
 {%- endif %}
 {%- endfor %}
@@ -105,7 +104,6 @@ lost_samples_buffers:
 {%- if id in selected_links %}
     lost_samples_buffer_{{ id }}:
         numa_node: 1
-        zeroing_thread_affinity: [32]
         kotekan_buffer: standard
 {%- endif %}
 {%- endfor %}

--- a/config/chime_kko_gpu.j2
+++ b/config/chime_kko_gpu.j2
@@ -99,13 +99,11 @@ lost_samples_buffers:
 {%- for id in range(16) %}
     lost_samples_buffer_{{ id }}:
         numa_node: 0
-        zeroing_thread_affinity: [8]
         kotekan_buffer: standard
 {%- endfor %}
 {%- for id in range(16,32) %}
     lost_samples_buffer_{{ id }}:
         numa_node: 1
-        zeroing_thread_affinity: [32]
         kotekan_buffer: standard
 {%- endfor %}
 

--- a/config/chime_science_run_gpu.yaml
+++ b/config/chime_science_run_gpu.yaml
@@ -39,7 +39,6 @@ vbuffer_depth: 32
 num_links: 4
 timesamples_per_packet: 2
 cpu_affinity: [2,3,8,9]
-zeroing_thread_affinity: [5]
 block_size: 32
 num_gpus: 4
 link_map: [0,1,2,3]

--- a/config/chime_science_run_gpu_no_output.yaml
+++ b/config/chime_science_run_gpu_no_output.yaml
@@ -39,7 +39,6 @@ vbuffer_depth: 32
 num_links: 4
 timesamples_per_packet: 2
 cpu_affinity: [2,3,8,9]
-zeroing_thread_affinity: [5]
 block_size: 32
 num_gpus: 4
 link_map: [0,1,2,3]

--- a/lib/core/buffer.cpp
+++ b/lib/core/buffer.cpp
@@ -71,7 +71,7 @@ int private_mark_frame_empty(Buffer* buf, const int id);
 
 Buffer* create_buffer(int num_frames, size_t len, metadataPool* pool, const char* buffer_name,
                       const char* buffer_type, int numa_node, bool use_hugepages, bool mlock_frames,
-                      bool zero_new_frames, cpu_set_t zeroing_thread_cpuset) {
+                      bool zero_new_frames) {
 
     assert(num_frames > 0);
 
@@ -165,9 +165,6 @@ Buffer* create_buffer(int num_frames, size_t len, metadataPool* pool, const char
 
     // By default don't zero buffers at the end of their use.
     buf->zero_frames = 0;
-
-    // Set the zeroing thead CPU affinity in case we use it. 
-    buf->zeroing_thread_cpuset = zeroing_thread_cpuset;
 
     buf->last_arrival_time = 0;
 
@@ -329,9 +326,14 @@ int private_mark_frame_empty(Buffer* buf, const int id) {
         zero_args->buf = buf;
 
         cpu_set_t cpuset;
+        CPU_ZERO(&cpuset);
+        // TODO: Move this to the config file (when buffers.c updated to C++11)
+        // Review note, this needs to be fixed in _this_ PR
+        CPU_SET(8, &cpuset);
+        CPU_SET(32, &cpuset);
 
         CHECK_ERROR_F(pthread_create(&zero_t, nullptr, &private_zero_frames, (void*)zero_args));
-        CHECK_ERROR_F(pthread_setaffinity_np(zero_t, sizeof(cpu_set_t), &buf->zeroing_cpu_set));
+        CHECK_ERROR_F(pthread_setaffinity_np(zero_t, sizeof(cpu_set_t), &cpuset));
         CHECK_ERROR_F(pthread_detach(zero_t));
     } else {
         buf->is_full[id] = 0;

--- a/lib/core/buffer.hpp
+++ b/lib/core/buffer.hpp
@@ -206,9 +206,6 @@ struct Buffer {
 
     /// The NUMA node the frames are allocated in
     int numa_node;
-
-    /// Thread affinity for the zeroing threads
-    cpu_set_t zeroing_thread_cpuset;
 };
 
 /**
@@ -233,8 +230,7 @@ struct Buffer {
  */
 Buffer* create_buffer(int num_frames, size_t frame_size, metadataPool* pool,
                       const char* buffer_name, const char* buffer_type, int numa_node,
-                      bool use_huge_pages, bool mlock_frames, bool zero_new_frames, 
-                      cpu_set_t zeroing_thread_cpuset);
+                      bool use_huge_pages, bool mlock_frames, bool zero_new_frames);
 
 /**
  * @brief Deletes a buffer object and frees all frame memory

--- a/lib/core/bufferFactory.cpp
+++ b/lib/core/bufferFactory.cpp
@@ -74,8 +74,6 @@ Buffer* bufferFactory::new_buffer(const string& type_name, const string& name,
     bool use_hugepages = config.get_default<bool>(location, "use_hugepages", false);
     bool mlock_frames = config.get_default<bool>(location, "mlock_frames", true);
     bool zero_new_frames = config.get_default<bool>(location, "zero_new_frames", true);
-    std::vector<int32_t> zeroing_thread_affinity =
-        config.get_default<std::vector<int32_t>>(location, "zeroing_thread_affinity", {0});
 
     metadataPool* pool = nullptr;
     if (metadataPool_name != "none") {
@@ -99,19 +97,11 @@ Buffer* bufferFactory::new_buffer(const string& type_name, const string& name,
         throw std::runtime_error(fmt::format(fmt("No buffer type named: {:s}"), type_name));
     }
 
-    // Create the CPU affinity cpuset for the zeroing threads
-    cpu_set_t zeroing_cpuset;
-    CPU_ZERO(&zeroing_cpuset);
-    for (int32_t cpu : zeroing_thread_affinity) {
-        CPU_SET(cpu, &zeroing_cpuset);
-    }
-
     INFO_NON_OO("Creating {:s}Buffer named {:s} with {:d} frames, frame size of {:d} and "
                 "metadata pool {:s} on numa_node {:d}",
                 type_name, name, num_frames, frame_size, metadataPool_name, numa_node);
     Buffer* buf = create_buffer(num_frames, frame_size, pool, name.c_str(), type_name.c_str(),
-                                numa_node, use_hugepages, mlock_frames, zero_new_frames, 
-                                zeroing_cpuset);
+                                numa_node, use_hugepages, mlock_frames, zero_new_frames);
     if (buf == nullptr) {
         throw std::runtime_error(fmt::format(fmt("Could not create the buffer: {:s}"), name));
     }

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -1,4 +1,4 @@
 install(
-    FILES kotekan.service
+    FILES kotekan.service kotekan-kko.service
     DESTINATION /etc/systemd/system/
     PERMISSIONS OWNER_WRITE GROUP_WRITE)

--- a/scripts/kotekan-kko.service
+++ b/scripts/kotekan-kko.service
@@ -1,0 +1,12 @@
+[Service]
+Type=simple
+Restart=no
+WorkingDirectory=/var/lib/kotekan
+TimeoutStopSec=120
+KillSignal=SIGINT
+ExecStart=/usr/local/bin/kotekan -s -n -c /etc/kotekan/chime_kko_gpu.j2
+PIDFile=/var/run/kotekan.pid
+UMask=002
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
This commit rolls back 3 commits made to merge `ar/outrigger_update` into `develop`.

`develop` has diverged significantly for CHORD, so more work will be required to merge things into `develop`. These commits are no longer useful.

They are also causing some issues with compiling, so we have decided to revert back to our last stable state.