### PR TITLE
HDF5 plugins set programatically

### DIFF
--- a/cmake/Features/FeatureIO.cmake
+++ b/cmake/Features/FeatureIO.cmake
@@ -60,7 +60,7 @@ endif()
 
 
 # HDF5 + HighFive + HDF5Plugin
-if(${USE_HDF5} STREQUAL "AUTO" OR "${USE_GDAL}" STREQUAL "ON")
+if(${USE_HDF5} STREQUAL "AUTO" OR "${USE_HDF5}" STREQUAL "ON")
     find_package(HDF5)
     find_package(HighFive)
     # Try to locate the runtime HDF5 plugin directory (e.g., libh5blosc)
@@ -81,7 +81,6 @@ if(${USE_HDF5} STREQUAL "AUTO" OR "${USE_GDAL}" STREQUAL "ON")
             CACHE INTERNAL "Detected HDF5 plugin directory for runtime use")
         kmsg_status("HDF5 plugin dir detected: ${KOTEKAN_HDF5_PLUGIN_DIR} (will set at runtime)")
     else()
-        set(USE_HDF5 OFF)
         set(_missing_hdf5 "")
         if(NOT HDF5_FOUND)
             list(APPEND _missing_hdf5 "HDF5")
@@ -95,7 +94,6 @@ if(${USE_HDF5} STREQUAL "AUTO" OR "${USE_GDAL}" STREQUAL "ON")
             kmsg_warn("HDF5 plugins not found (libh5blosc, etc.). Set HDF5_PLUGIN_PATH if needed.")
         endif()
         
-        set(USE_HDF5 "OFF")
         if(${USE_HDF5} STREQUAL "AUTO")
             set(HDF5_REASON "auto-detected")
             kmsg_warn("HDF5 not fully found (missing: ${_missing_hdf5}); HDF5 stages disabled.")
@@ -103,6 +101,9 @@ if(${USE_HDF5} STREQUAL "AUTO" OR "${USE_GDAL}" STREQUAL "ON")
             set(HDF5_REASON "enabled, not found")
             kmsg_error("HDF5 not fully found (missing: ${_missing_hdf5}) when requested! HDF5 stages disabled.")
         endif()
+        
+        # Set this at the end so the informative "AUTO" message can be sent.
+        set(USE_HDF5 "OFF")
         
     endif()
 else()

--- a/cmake/Modules/FindHDF5Plugin.cmake
+++ b/cmake/Modules/FindHDF5Plugin.cmake
@@ -1,22 +1,28 @@
 # cmake/FindHDF5Plugin.cmake
 # Try multiple strategies in order of preference
-find_path(HDF5Plugin_PLUGIN_DIR
-    NAMES libh5blosc.so libh5blosc.dylib h5blosc.dll
-    PATHS
-        # 1. Respect any existing HDF5_PLUGIN_PATH
-        $ENV{HDF5_PLUGIN_PATH}
-        # 2. System locations
-        ${HDF5_ROOT}/lib/plugin
-        /usr/lib/x86_64-linux-gnu/hdf5/plugins
-        /usr/lib/hdf5/plugins
-        /usr/local/lib/hdf5/plugins
-        # 3. Common conda/mamba locations
-        $ENV{CONDA_PREFIX}/lib/hdf5/plugins
-        $ENV{MAMBA_ROOT_PREFIX}/lib/hdf5/plugins
-    PATH_SUFFIXES plugins hdf5/plugins
-)
 
-# 4. Try Python hdf5plugin as fallback
+# 1. Use the HDF5_PLUGIN_DIR CLI argument without question
+if(HDF5_PLUGIN_DIR)
+    set(HDF5Plugin_PLUGIN_DIR "${HDF5_PLUGIN_DIR}")
+endif()
+
+# 2. Respect any existing environment HDF5_PLUGIN_PATH
+if(NOT HDF5Plugin_PLUGIN_DIR)
+    if($ENV{HDF5_PLUGIN_PATH})
+        # First parse the env var in case it contains multiple paths
+        cmake_path(CONVERT $ENV{HDF5_PLUGIN_PATH} TO_CMAKE_PATH_LIST ENV_HDF5_PLUGIN_PATH NORMALIZE)
+
+        # Now search in those paths
+        find_path(HDF5Plugin_PLUGIN_DIR
+            NAMES libh5blosc.so libh5blosc.dylib h5blosc.dll
+            PATHS
+                ${ENV_HDF5_PLUGIN_PATH}
+            PATH_SUFFIXES plugins hdf5/plugins
+        )
+    endif()
+endif()
+
+# 3. Try Python hdf5plugin, this is where the deployment plugins are.
 if(NOT HDF5Plugin_PLUGIN_DIR)
     find_package(Python3 QUIET COMPONENTS Interpreter)
     if(Python3_FOUND)
@@ -41,4 +47,19 @@ except: pass"
             set(HDF5Plugin_PLUGIN_DIR "${_hdf5plugin_path}")
         endif()
     endif()
+endif()
+
+# 4. Look in likely system/conda/etc locations.
+if(NOT HDF5Plugin_PLUGIN_DIR)
+    find_path(HDF5Plugin_PLUGIN_DIR
+        NAMES libh5blosc.so libh5blosc.dylib h5blosc.dll
+        PATHS
+            ${HDF5_ROOT}/lib/plugin
+            /usr/lib/x86_64-linux-gnu/hdf5/plugins
+            /usr/lib/hdf5/plugins
+            /usr/local/lib/hdf5/plugins
+            $ENV{CONDA_PREFIX}/lib/hdf5/plugins
+            $ENV{MAMBA_ROOT_PREFIX}/lib/hdf5/plugins
+        PATH_SUFFIXES plugins hdf5/plugins
+    )
 endif()

--- a/cmake/Modules/FindHDF5Plugin.cmake
+++ b/cmake/Modules/FindHDF5Plugin.cmake
@@ -8,7 +8,7 @@ endif()
 
 # 2. Respect any existing environment HDF5_PLUGIN_PATH
 if(NOT HDF5Plugin_PLUGIN_DIR)
-    if($ENV{HDF5_PLUGIN_PATH})
+    if(DEFINED ENV{HDF5_PLUGIN_PATH})
         # First parse the env var in case it contains multiple paths
         cmake_path(CONVERT $ENV{HDF5_PLUGIN_PATH} TO_CMAKE_PATH_LIST ENV_HDF5_PLUGIN_PATH NORMALIZE)
 

--- a/cmake/Summary.cmake
+++ b/cmake/Summary.cmake
@@ -277,7 +277,8 @@ else()
 endif()
 
 set(_ktk_flag_summary
-    "${_ktk_flag_openssl} ${_ktk_flag_blaze} ${_ktk_flag_hdf5_plugin} ${_ktk_flag_cl} ${_ktk_flag_prefix} ${_ktk_flag_cuda}")
+    "${_ktk_flag_openssl} ${_ktk_flag_blaze} ${_ktk_flag_hdf5_plugin} ${_ktk_flag_cl} ${_ktk_flag_prefix} ${_ktk_flag_cuda}"
+)
 kmsg_status("Flag Overrides: ${_ktk_flag_summary}")
 kmsg_status("Cache Hint: run 'cmake -U<VAR> .' or remove CMakeCache.txt to reset")
 

--- a/cmake/Summary.cmake
+++ b/cmake/Summary.cmake
@@ -251,6 +251,12 @@ else()
     set(_ktk_flag_blaze "BLAZE_PATH=")
 endif()
 
+if(DEFINED HDF5Plugin_PLUGIN_DIR AND NOT "${HDF5Plugin_PLUGIN_DIR}" STREQUAL "")
+    set(_ktk_flag_hdf5_plugin "HDF5_PLUGIN_DIR='${HDF5Plugin_PLUGIN_DIR}'")
+else()
+    set(_ktk_flag_hdf5_plugin "HDF5_PLUGIN_DIR=")
+endif()
+
 if(DEFINED KOTEKAN_CL_TARGET_OPENCL_VERSION AND NOT "${KOTEKAN_CL_TARGET_OPENCL_VERSION}" STREQUAL
                                                 "")
     set(_ktk_flag_cl "CL_TARGET_OPENCL_VERSION=${KOTEKAN_CL_TARGET_OPENCL_VERSION}")
@@ -271,7 +277,7 @@ else()
 endif()
 
 set(_ktk_flag_summary
-    "${_ktk_flag_openssl} ${_ktk_flag_blaze} ${_ktk_flag_cl} ${_ktk_flag_prefix} ${_ktk_flag_cuda}")
+    "${_ktk_flag_openssl} ${_ktk_flag_blaze} ${_ktk_flag_hdf5_plugin} ${_ktk_flag_cl} ${_ktk_flag_prefix} ${_ktk_flag_cuda}")
 kmsg_status("Flag Overrides: ${_ktk_flag_summary}")
 kmsg_status("Cache Hint: run 'cmake -U<VAR> .' or remove CMakeCache.txt to reset")
 

--- a/docs/sphinx/compiling/cmake_options.rst
+++ b/docs/sphinx/compiling/cmake_options.rst
@@ -97,6 +97,9 @@ Common Paths and Overrides
   libraries.
 - ``BLAZE_PATH``: Provide a custom include path for Blaze headers.
 - ``CUDAToolkit_ROOT``: Override the search path for the CUDA toolkit when required.
+- ``HDF5_PLUGIN_DIR``: Set the first path to look for HDF5 plugins (libh5blosc.so, etc). If not set will
+  check the ``HDF5_PLUGIN_PATH`` environment variable, then the active python package, then other common
+  locations.
 
 
 Notes

--- a/kotekan/CMakeLists.txt
+++ b/kotekan/CMakeLists.txt
@@ -8,7 +8,8 @@ endif()
 
 target_compile_definitions(kotekan PRIVATE mssse3 __STDC_LIMIT_MACROS)
 
-# If HDF5 is enabled and we detected a plugin directory, pass it to the binary so it can set the path programatically at runtime.
+# If HDF5 is enabled and we detected a plugin directory, pass it to the binary so it can set the
+# path programatically at runtime.
 if(HDF5_FOUND
    AND HighFive_FOUND
    AND KOTEKAN_HDF5_PLUGIN_DIR)

--- a/kotekan/CMakeLists.txt
+++ b/kotekan/CMakeLists.txt
@@ -8,11 +8,11 @@ endif()
 
 target_compile_definitions(kotekan PRIVATE mssse3 __STDC_LIMIT_MACROS)
 
-# If HDF5 is enabled and we detected a plugin directory, pass it to the binary so it can set
-# HDF5_PLUGIN_PATH at runtime when unset.
+# If HDF5 is enabled and we detected a plugin directory, pass it to the binary so it can set the path programatically at runtime.
 if(HDF5_FOUND
    AND HighFive_FOUND
    AND KOTEKAN_HDF5_PLUGIN_DIR)
+    target_include_directories(kotekan SYSTEM PRIVATE ${HDF5_INCLUDE_DIRS})
     # Escape any quotes or spaces as a C string literal
     string(REPLACE "\"" "\\\"" _HDF5_PLUGIN_DIR_ESC "${KOTEKAN_HDF5_PLUGIN_DIR}")
     target_compile_definitions(kotekan PRIVATE DEFAULT_HDF5_PLUGIN_PATH="${_HDF5_PLUGIN_DIR_ESC}")

--- a/kotekan/kotekan.cpp
+++ b/kotekan/kotekan.cpp
@@ -38,6 +38,9 @@
 #include <unistd.h>    // for close, optarg, dup2, execvp, fork, pipe, sleep, STDOUT...
 #include <utility>     // for pair
 #include <vector>      // for vector
+#ifdef WITH_HDF5
+    #include "hdf5.h"
+#endif
 
 
 using std::string;
@@ -46,15 +49,18 @@ using namespace kotekan;
 
 // Ensure HDF5 plugin path is available at runtime if we know a default.
 #if defined(WITH_HDF5) && defined(DEFAULT_HDF5_PLUGIN_PATH)
-static inline void ensure_hdf5_plugin_env() {
-    const char* cur = getenv("HDF5_PLUGIN_PATH");
-    if ((cur == nullptr || cur[0] == '\0') && (sizeof(DEFAULT_HDF5_PLUGIN_PATH) > 1)) {
-        // Do not overwrite if user already sets it
-        setenv("HDF5_PLUGIN_PATH", DEFAULT_HDF5_PLUGIN_PATH, /*overwrite=*/0);
+static inline int ensure_hdf5_plugin() {
+    if(sizeof(DEFAULT_HDF5_PLUGIN_PATH) > 1) {
+        herr_t err = H5PLappend(DEFAULT_HDF5_PLUGIN_PATH);
+        if(err < 0)
+            return -1;
     }
+    return 0;
 }
 #else
-static inline void ensure_hdf5_plugin_env() {}
+static inline int ensure_hdf5_plugin() {
+    return 0;
+}
 #endif
 
 // Embedded script for converting the YAML config to json
@@ -421,8 +427,11 @@ int main(int argc, char** argv) {
     std::signal(SIGINT, signal_handler);
     std::signal(SIGTERM, signal_handler);
 
-    // Set HDF5_PLUGIN_PATH if unset and a default was detected at configure time.
-    ensure_hdf5_plugin_env();
+    // Set HDF5_PLUGIN_PATH if a default was detected at configure time.
+    if(ensure_hdf5_plugin()) {
+        std::cerr << "ERROR: Could not set HDF5 plugin path." << std::endl;
+        return FATAL_ERROR;
+    }
 
     try {
         std::locale::global(std::locale::classic());

--- a/kotekan/kotekan.cpp
+++ b/kotekan/kotekan.cpp
@@ -51,7 +51,7 @@ using namespace kotekan;
 #if defined(WITH_HDF5) && defined(DEFAULT_HDF5_PLUGIN_PATH)
 static inline int ensure_hdf5_plugin() {
     if(sizeof(DEFAULT_HDF5_PLUGIN_PATH) > 1) {
-        herr_t err = H5PLappend(DEFAULT_HDF5_PLUGIN_PATH);
+        herr_t err = H5PLprepend(DEFAULT_HDF5_PLUGIN_PATH);
         if(err < 0)
             return -1;
     }

--- a/kotekan/kotekan.cpp
+++ b/kotekan/kotekan.cpp
@@ -39,7 +39,7 @@
 #include <utility>     // for pair
 #include <vector>      // for vector
 #ifdef WITH_HDF5
-    #include "hdf5.h"
+#include "hdf5.h"
 #endif
 
 
@@ -50,9 +50,9 @@ using namespace kotekan;
 // Ensure HDF5 plugin path is available at runtime if we know a default.
 #if defined(WITH_HDF5) && defined(DEFAULT_HDF5_PLUGIN_PATH)
 static inline int ensure_hdf5_plugin() {
-    if(sizeof(DEFAULT_HDF5_PLUGIN_PATH) > 1) {
+    if (sizeof(DEFAULT_HDF5_PLUGIN_PATH) > 1) {
         herr_t err = H5PLprepend(DEFAULT_HDF5_PLUGIN_PATH);
-        if(err < 0)
+        if (err < 0)
             return -1;
     }
     return 0;
@@ -428,7 +428,7 @@ int main(int argc, char** argv) {
     std::signal(SIGTERM, signal_handler);
 
     // Set HDF5_PLUGIN_PATH if a default was detected at configure time.
-    if(ensure_hdf5_plugin()) {
+    if (ensure_hdf5_plugin()) {
         std::cerr << "ERROR: Could not set HDF5 plugin path." << std::endl;
         return FATAL_ERROR;
     }

--- a/lib/stages/hdf5FileWrite.cpp
+++ b/lib/stages/hdf5FileWrite.cpp
@@ -39,6 +39,7 @@
 #include <vector>                                // for vector
 #include <visUtil.hpp>                           // for current_time
 #include <waitingForMaxFrames.hpp>               // for waiting_for_max_frames
+#include "hdf5.h"
 
 using namespace hdf5;
 using namespace HighFive;
@@ -132,6 +133,25 @@ public:
 
             INFO("Received buffer {} frame {} time sample {} (duration {} sec)", unique_name,
                  frame_counter, meta->sample0_offset, elapsed_time);
+            unsigned int n_plugin_paths = 0;
+            herr_t err_h5 = H5PLsize(&n_plugin_paths);
+            if(err_h5 < 0)
+                INFO("BAD Could not get H5PL path list length");
+            else {
+                for(unsigned int plg_idx=0; plg_idx < n_plugin_paths; plg_idx++) {
+                    char plg_path[1024];
+                    err_h5 = H5PLget(plg_idx, plg_path, 1024);
+                    plg_path[1023] = '\0';
+                    if(err_h5 < 0)
+                        INFO("BAD Could not get H5PL path {:d}", plg_idx);
+                    else
+                        INFO("HDF5 Plugin path {:d}: {:s}", plg_idx, plg_path);
+                }
+            }
+            unsigned int h5_plg_ld_state = 0;
+            err_h5 = H5PLget_loading_state(&h5_plg_ld_state);
+            INFO("HDF5 Plugin load state: {:d}", h5_plg_ld_state);
+
 
             if (!skip_writing) {
 

--- a/lib/stages/hdf5FileWrite.cpp
+++ b/lib/stages/hdf5FileWrite.cpp
@@ -39,7 +39,6 @@
 #include <vector>                                // for vector
 #include <visUtil.hpp>                           // for current_time
 #include <waitingForMaxFrames.hpp>               // for waiting_for_max_frames
-#include "hdf5.h"
 
 using namespace hdf5;
 using namespace HighFive;
@@ -133,25 +132,6 @@ public:
 
             INFO("Received buffer {} frame {} time sample {} (duration {} sec)", unique_name,
                  frame_counter, meta->sample0_offset, elapsed_time);
-            unsigned int n_plugin_paths = 0;
-            herr_t err_h5 = H5PLsize(&n_plugin_paths);
-            if(err_h5 < 0)
-                INFO("BAD Could not get H5PL path list length");
-            else {
-                for(unsigned int plg_idx=0; plg_idx < n_plugin_paths; plg_idx++) {
-                    char plg_path[1024];
-                    err_h5 = H5PLget(plg_idx, plg_path, 1024);
-                    plg_path[1023] = '\0';
-                    if(err_h5 < 0)
-                        INFO("BAD Could not get H5PL path {:d}", plg_idx);
-                    else
-                        INFO("HDF5 Plugin path {:d}: {:s}", plg_idx, plg_path);
-                }
-            }
-            unsigned int h5_plg_ld_state = 0;
-            err_h5 = H5PLget_loading_state(&h5_plg_ld_state);
-            INFO("HDF5 Plugin load state: {:d}", h5_plg_ld_state);
-
 
             if (!skip_writing) {
 


### PR DESCRIPTION
This fixes bugs in the HDF5 cmake logic and sets the directory where plugins are searched programmatically instead of by environment variables.

On configure, the directory is set by the following in order of precedence:

1. the `HDF5_PLUGIN_DIR` cmake variable
2. the `HDF5_PLUGIN_PATH` environment variable (at time of configure)
3. the`hdf5plugin` plugin package in the active python environment
4. common system locations

This path is passed to`kotekan` on compilation, and then is passed to hdf5 at runtime via `H5PLprepend()`.  This allows kotekan to run without the `HDF5_PLUGIN_PATH` environment variable set.