### PR TITLE
Correct CHIME transpose kernel example

### DIFF
--- a/config/fengine/include/input_init_chime.j2
+++ b/config/fengine/include/input_init_chime.j2
@@ -26,6 +26,7 @@ read_data:
         file_name: voltage
         out_buf: host_voltage_buffer
     read_scatter_indices:
+        do_once: true
         kotekan_stage: hdf5FileRead
         file_name: scatter_indices
         out_buf: host_scatter_indices_buffer


### PR DESCRIPTION
Transfer the transpose description only once to the GPU.