### PR TITLE
Fixed time downsampling factors in cuda 1 bit PL

### DIFF
--- a/lib/cuda/cudaPL1bitCorrelator.cpp
+++ b/lib/cuda/cudaPL1bitCorrelator.cpp
@@ -201,6 +201,13 @@ cudaEvent_t cudaPL1bitCorrelator::execute(cudaPipelineState& /*pipestate*/,
     // TODO: do this automatically in `NDArrayRingBuffer`
     out_meta->sample0_offset = rfi_RFImask.get_read_valid().begin();
 
+    // The PL mask time_downsampling_factor includes a factor of 64 from
+    // the fast time axis which is eaten up by the correlator.
+    for (int f = 0; f < out_meta->nfreq; f++) {
+        out_meta->time_downsampling_fpga[f] = n2k_sub_integration_ntime
+            * div_noremainder(pl_meta->time_downsampling_fpga[f], 64);
+    }
+
     n2k_counts.set_to_poison(0xff);
 
     // The ringbuffering here is fishy. We should fix the kernel instead.

--- a/lib/cuda/cudaPL1bitCorrelator.cpp
+++ b/lib/cuda/cudaPL1bitCorrelator.cpp
@@ -204,8 +204,8 @@ cudaEvent_t cudaPL1bitCorrelator::execute(cudaPipelineState& /*pipestate*/,
     // The PL mask time_downsampling_factor includes a factor of 64 from
     // the fast time axis which is eaten up by the correlator.
     for (int f = 0; f < out_meta->nfreq; f++) {
-        out_meta->time_downsampling_fpga[f] = n2k_sub_integration_ntime
-            * div_noremainder(pl_meta->time_downsampling_fpga[f], 64);
+        out_meta->time_downsampling_fpga[f] =
+            n2k_sub_integration_ntime * div_noremainder(pl_meta->time_downsampling_fpga[f], 64);
     }
 
     n2k_counts.set_to_poison(0xff);


### PR DESCRIPTION
Quick fix to `cudaPL1bitCorrelator` to compute correct `time_downsampling_fpga` values.