### PR TITLE
checked access in chordMetadata and N2 hdf5 writing

### DIFF
--- a/lib/metadata/chordMetadata.hpp
+++ b/lib/metadata/chordMetadata.hpp
@@ -175,7 +175,7 @@ public:
 
     beamCoord get_beam_coord() const {
         std::lock_guard<std::mutex> lock(this->lock);
-        return metadata[jsonMetadata::BEAM_COORD].template get<beamCoord>();
+        return metadata.at(jsonMetadata::BEAM_COORD).template get<beamCoord>();
     }
 
     // TODO: add set_beam_coord
@@ -192,7 +192,7 @@ public:
 
     int64_t get_fpga_seq_num() const {
         std::lock_guard<std::mutex> lock(this->lock);
-        return metadata[jsonMetadata::FPGA_SEQ_NUM].template get<int64_t>();
+        return metadata.at(jsonMetadata::FPGA_SEQ_NUM).template get<int64_t>();
     }
 
     void set_frame_counter(const int frame_counter) {
@@ -207,7 +207,7 @@ public:
 
     int get_frame_counter() const {
         std::lock_guard<std::mutex> lock(this->lock);
-        return metadata[jsonMetadata::FRAME_COUNTER].template get<int>();
+        return metadata.at(jsonMetadata::FRAME_COUNTER).template get<int>();
     }
 
     bool has_nfreq() const {
@@ -217,7 +217,7 @@ public:
 
     int get_nfreq() const {
         std::lock_guard<std::mutex> lock(this->lock);
-        return static_cast<int>(metadata[jsonMetadata::COARSE_FREQ].size());
+        return static_cast<int>(metadata.at(jsonMetadata::COARSE_FREQ).size());
     }
 
     // TODO: this should really be a freq_id_t array
@@ -234,7 +234,7 @@ public:
 
     std::vector<int> get_coarse_freq() const {
         std::lock_guard<std::mutex> lock(this->lock);
-        return metadata[jsonMetadata::COARSE_FREQ].template get<std::vector<int>>();
+        return metadata.at(jsonMetadata::COARSE_FREQ).template get<std::vector<int>>();
     }
 
     // TODO: remove this, it's not setting anything anymore (and assumes that
@@ -273,7 +273,7 @@ public:
 
     uint32_t get_rfi_num_bad_inputs() const {
         std::lock_guard<std::mutex> lock(this->lock);
-        return metadata[jsonMetadata::RFI_NUM_BAD_INPUTS].template get<uint32_t>();
+        return metadata.at(jsonMetadata::RFI_NUM_BAD_INPUTS).template get<uint32_t>();
     }
 
     /// The number of FPGA frames flagged as containing RFI.
@@ -293,7 +293,7 @@ public:
 
     int32_t get_rfi_flagged_samples() const {
         std::lock_guard<std::mutex> lock(this->lock);
-        return metadata[jsonMetadata::RFI_FLAGGED_SAMPLES].template get<int32_t>();
+        return metadata.at(jsonMetadata::RFI_FLAGGED_SAMPLES).template get<int32_t>();
     }
 
     void set_lost_timesamples(int32_t lost_timesamples) {
@@ -308,13 +308,13 @@ public:
 
     int32_t get_lost_timesamples() const {
         std::lock_guard<std::mutex> lock(this->lock);
-        return metadata[jsonMetadata::LOST_TIMESAMPLES].template get<int32_t>();
+        return metadata.at(jsonMetadata::LOST_TIMESAMPLES).template get<int32_t>();
     }
 
     void atomic_add_lost_timesamples(const int32_t lost_samples) {
         std::lock_guard<std::mutex> lock(this->lock);
-        metadata[jsonMetadata::LOST_TIMESAMPLES] =
-            metadata[jsonMetadata::LOST_TIMESAMPLES].template get<int32_t>() + lost_samples;
+        metadata.at(jsonMetadata::LOST_TIMESAMPLES) =
+            metadata.at(jsonMetadata::LOST_TIMESAMPLES).template get<int32_t>() + lost_samples;
     }
 
     // All time samples in this buffer (or the whole buffer, if the
@@ -339,7 +339,7 @@ public:
 
     int64_t get_sample0_offset() const {
         std::lock_guard<std::mutex> lock(this->lock);
-        return metadata[jsonMetadata::SAMPLE0_OFFSET].template get<int64_t>();
+        return metadata.at(jsonMetadata::SAMPLE0_OFFSET).template get<int64_t>();
     }
 
     void set_offset_downsampling(const int offset_downsampling) {
@@ -354,7 +354,7 @@ public:
 
     int get_offset_downsampling() const {
         std::lock_guard<std::mutex> lock(this->lock);
-        return metadata[jsonMetadata::OFFSET_DOWNSAMPLING].template get<int>();
+        return metadata.at(jsonMetadata::OFFSET_DOWNSAMPLING).template get<int>();
     }
 
     // Per-frequency arrays
@@ -374,7 +374,7 @@ public:
 
     std::vector<int> get_freq_upchan_factor() const {
         std::lock_guard<std::mutex> lock(this->lock);
-        return metadata[jsonMetadata::FREQ_UPCHAN_FACTOR].template get<std::vector<int>>();
+        return metadata.at(jsonMetadata::FREQ_UPCHAN_FACTOR).template get<std::vector<int>>();
     }
 
     // TODO: Store upchannelization index as well
@@ -397,7 +397,7 @@ public:
 
     std::vector<int64_t> get_half_fpga_sample0() const {
         std::lock_guard<std::mutex> lock(this->lock);
-        return metadata[jsonMetadata::HALF_FPGA_SAMPLE0].template get<std::vector<int64_t>>();
+        return metadata.at(jsonMetadata::HALF_FPGA_SAMPLE0).template get<std::vector<int64_t>>();
     }
 
     // Time sampling -- for each coarse frequency channel, the factor
@@ -416,7 +416,7 @@ public:
 
     std::vector<int> get_time_downsampling_fpga() const {
         std::lock_guard<std::mutex> lock(this->lock);
-        return metadata[jsonMetadata::TIME_DOWNSAMPLING_FPGA];
+        return metadata.at(jsonMetadata::TIME_DOWNSAMPLING_FPGA);
     }
 
     // non-science metadata
@@ -433,7 +433,7 @@ public:
 
     timeval get_first_packet_recv_time() const {
         std::lock_guard<std::mutex> lock(this->lock);
-        return metadata[jsonMetadata::FIRST_PACKET_RECV_TIME].template get<timeval>();
+        return metadata.at(jsonMetadata::FIRST_PACKET_RECV_TIME).template get<timeval>();
     }
 
     // links to other data
@@ -450,7 +450,7 @@ public:
 
     stream_t get_stream_id() const {
         std::lock_guard<std::mutex> lock(this->lock);
-        return stream_t{.id = metadata[jsonMetadata::STREAM_ID].template get<uint64_t>()};
+        return stream_t{.id = metadata.at(jsonMetadata::STREAM_ID).template get<uint64_t>()};
     }
 
     /// ID of the dataset
@@ -466,7 +466,7 @@ public:
 
     dset_id_t get_dataset_id() const {
         std::lock_guard<std::mutex> lock(this->lock);
-        return metadata[jsonMetadata::DATASET_ID].template get<dset_id_t>();
+        return metadata.at(jsonMetadata::DATASET_ID).template get<dset_id_t>();
     }
 
 private:
@@ -522,7 +522,7 @@ get_chord_metadata(const std::shared_ptr<const metadataObject>& mc) {
 inline std::shared_ptr<chordMetadata> get_chord_metadata(Buffer* buf, int frame_id) {
     if (!buf || frame_id < 0 || frame_id >= (int)buf->metadata.size())
         return std::shared_ptr<chordMetadata>();
-    std::shared_ptr<metadataObject> meta = buf->metadata[frame_id];
+    std::shared_ptr<metadataObject> meta = buf->metadata.at(frame_id);
     return get_chord_metadata(meta);
 }
 

--- a/lib/metadata/jsonMetadata.hpp
+++ b/lib/metadata/jsonMetadata.hpp
@@ -79,7 +79,7 @@ struct beamCoord {
 
 static inline void from_json(const nlohmann::json& j, beamCoord& c) {
     {
-        const auto& ra(j[RIGHT_ASCENSION]);
+        const auto& ra(j.at(RIGHT_ASCENSION));
         if (ra.size() > MAX_NUM_BEAMS)
             throw std::runtime_error("Number of beams request exceeds MAX_NUM_BEAMS");
         size_t i = 0;
@@ -94,7 +94,7 @@ static inline void from_json(const nlohmann::json& j, beamCoord& c) {
     }
 
     {
-        const auto& dec(j[DECLINATION]);
+        const auto& dec(j.at(DECLINATION));
         if (dec.size() > MAX_NUM_BEAMS)
             throw std::runtime_error("Number of beams request exceeds MAX_NUM_BEAMS");
         size_t i = 0;
@@ -109,7 +109,7 @@ static inline void from_json(const nlohmann::json& j, beamCoord& c) {
     }
 
     {
-        const auto& scale(j[SCALING]);
+        const auto& scale(j.at(SCALING));
         if (scale.size() > MAX_NUM_BEAMS)
             throw std::runtime_error("Number of beams request exceeds MAX_NUM_BEAMS");
         size_t i = 0;
@@ -134,8 +134,8 @@ static inline void to_json(nlohmann::json& j, const timeval& tv) {
 
 static inline void from_json(const nlohmann::json& j, timeval& tv) {
     using namespace jsonMetadata;
-    tv.tv_sec = j[TV_SEC].template get<std::int64_t>();
-    tv.tv_usec = j[TV_USEC].template get<std::int64_t>();
+    tv.tv_sec = j.at(TV_SEC).template get<std::int64_t>();
+    tv.tv_usec = j.at(TV_USEC).template get<std::int64_t>();
 }
 
 #endif

--- a/lib/stages/hdf5FileWrite.cpp
+++ b/lib/stages/hdf5FileWrite.cpp
@@ -1,5 +1,7 @@
-#include "Config.hpp"          // for Config
-#include "DataType.hpp"        // for type_to_string
+#include "Config.hpp"   // for Config
+#include "DataType.hpp" // for type_to_string
+#include "N2FrameView.hpp"
+#include "N2Metadata.hpp"
 #include "buffer.hpp"          // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
 #include "hdf5Files.hpp"       // for BITSHUFFLE_BLOCKSIZE_AUTO, BITSHUFFLE_C...
@@ -93,6 +95,260 @@ public:
 
     virtual ~hdf5FileWrite() {}
 
+    /**
+     * @brief Create and write a file for a frame with chordMetadata
+     *
+     * @param full_path The full path, including file name, for the file.
+     * @param frame uint8_t pointer to the frame data
+     * @param meta shared pointer to the chordMetadata object for this frame.
+     */
+    void write_chord(const std::string& full_path, const std::uint8_t* const frame,
+                     const std::shared_ptr<const chordMetadata> meta) {
+
+        // Create HDF5 file
+        File file(full_path, File::Truncate);
+
+        // Choose dataspace
+        const DataSpace space(meta->dim, meta->dim + meta->dims);
+        {
+            [[maybe_unused]] std::ptrdiff_t npoints = 1;
+            for (int d = meta->dims - 1; d >= 0; --d) {
+                assert(meta->stride[d] == npoints);
+                npoints *= meta->dim[d];
+            }
+            assert(std::ptrdiff_t(space.getElementCount()) == npoints);
+            assert(meta->offset == 0);
+        }
+        assert(std::ptrdiff_t(space.getNumberDimensions()) == meta->dims);
+
+        // Choose datatype
+        const DataType type = chord2hdf5(meta->type);
+
+        RawPropertyList<PropertyType::DATASET_CREATE> props;
+
+        // Enable chunking
+        std::vector<hsize_t> chunk_dims(meta->dim, meta->dim + meta->dims);
+        if (!chunk_dims.empty()) {
+            // Choose chunk size
+            std::size_t npoints_lo = 1;
+            for (std::size_t d = 1; d < chunk_dims.size(); ++d)
+                npoints_lo *= chunk_dims.at(d);
+            std::size_t npoints_hi = 10 * 1000 * 1000 / npoints_lo;
+            using std::max, std::min;
+            npoints_hi = min(std::size_t(chunk_dims.at(0)), max(std::size_t(1), npoints_hi));
+            chunk_dims.at(0) = npoints_hi;
+        }
+        (*(DataSetCreateProps*)&props).add(Chunking(chunk_dims));
+
+        // // Enable compression
+        // constexpr int blosc_compression_level = 9;
+        // const std::vector<unsigned int> blosc_flags{
+        //     blosc_compression_level,
+        //     BLOSC_SHUFFLE_BIT,
+        //     BLOSC_COMPRESS_ZSTD,
+        // };
+        // props.add(H5Pset_filter, H5Z_BLOSC, H5Z_FLAG_MANDATORY, blosc_flags.size(),
+        //           blosc_flags.data());
+        constexpr int bitshuffle_compression_level = 9;
+        const std::vector<unsigned int> bitshuffle_flags{
+            BITSHUFFLE_BLOCKSIZE_AUTO,
+            BITSHUFFLE_COMPRESS_ZSTD,
+            bitshuffle_compression_level,
+        };
+        props.add(H5Pset_filter, H5Z_BITSHUFFLE, H5Z_FLAG_MANDATORY, bitshuffle_flags.size(),
+                  bitshuffle_flags.data());
+
+        // Create dataset
+        auto dataset = file.createDataSet(file_name, space, type, props);
+
+        // Write metadata (attributes)
+
+        dataset.createAttribute("chord_metadata_version", chord_metadata_version);
+        dataset.createAttribute("name", meta->get_name());
+        dataset.createAttribute("type", type_to_string(meta->type));
+        std::vector<std::string> dim_names;
+        for (int d = 0; d < meta->dims; ++d)
+            dim_names.push_back(meta->get_dimension_name(d));
+        dataset.createAttribute("dim_names", dim_names);
+
+        if (meta->has_fpga_seq_num())
+            dataset.createAttribute("fpga_seq_num", meta->get_fpga_seq_num());
+
+        if (meta->has_sample0_offset())
+            dataset.createAttribute("sample0_offset", meta->get_sample0_offset());
+
+        if (meta->has_offset_downsampling())
+            dataset.createAttribute("offset_downsampling", meta->get_offset_downsampling());
+
+        if (meta->has_coarse_freq())
+            dataset.createAttribute("coarse_freq", meta->get_coarse_freq());
+
+        if (meta->has_freq_upchan_factor())
+            dataset.createAttribute("freq_upchan_factor", meta->get_freq_upchan_factor());
+
+        if (meta->has_half_fpga_sample0())
+            dataset.createAttribute("half_fpga_sample0", meta->get_half_fpga_sample0());
+
+        if (meta->has_time_downsampling_fpga())
+            dataset.createAttribute("time_downsampling_fpga",
+                                    meta->get_time_downsampling_fpga());
+
+        if (meta->ndishes >= 0) {
+            dataset.createAttribute("ndishes", meta->ndishes);
+            // const DataSpace space{std::size_t(meta->n_dish_locations_ns),
+            //                       std::size_t(meta->n_dish_locations_ew)};
+            // auto attr = dataset.createAttribute<int>("dish_index", space);
+            // attr.write(meta->dish_index);
+            dataset.createAttribute("n_dish_locations_ns", meta->n_dish_locations_ns);
+            dataset.createAttribute("n_dish_locations_ew", meta->n_dish_locations_ew);
+            dataset.createAttribute(
+                "dish_index",
+                std::vector<int>(meta->dish_index,
+                                 meta->dish_index
+                                     + meta->n_dish_locations_ns * meta->n_dish_locations_ew));
+        }
+
+        // Write data
+        assert(dataset.getElementCount() * dataset.getDataType().getSize() == buffer->frame_size);
+        dataset.write_raw(frame, type);
+    }
+
+    /**
+     * @brief Create and write a file for an N2FrameView
+     *
+     * @param full_path The full path, including file name, for the file.
+     * @param frame An N2FrameView object for the frame to output.
+     */
+    void write_n2(const std::string& full_path, const N2FrameView& frame) {
+        // Create HDF5 file
+        File file(full_path, File::Truncate);
+
+        DEBUG("Writing N2 frame seq: {:d} to HDF5 file {:s}", frame.fpga_start_tick, full_path);
+
+        const std::vector<size_t> vis_dims({frame.num_prod, 2});
+        const std::vector<size_t> weight_dims({frame.num_prod});
+        const std::vector<size_t> flags_dims({frame.num_elements});
+        const std::vector<size_t> eval_dims({frame.num_ev});
+        const std::vector<size_t> evec_dims({frame.num_ev, frame.num_elements, 2});
+        const std::vector<size_t> emethod_dims({1});
+        const std::vector<size_t> erms_dims({1});
+        const std::vector<size_t> gain_dims({frame.num_elements, 2});
+
+        // Create dataspaces
+        const DataSpace vis_space(vis_dims);
+        const DataSpace weight_space(weight_dims);
+        const DataSpace flags_space(flags_dims);
+        const DataSpace eval_space(eval_dims);
+        const DataSpace evec_space(evec_dims);
+        const DataSpace emethod_space(emethod_dims);
+        const DataSpace erms_space(erms_dims);
+        const DataSpace gain_space(gain_dims);
+
+        // Create datatypes
+        const DataType float_type = chord2hdf5(kotekan::float32);
+        const DataType int_type = chord2hdf5(kotekan::int32);
+
+        // Make props
+        auto vis_props = make_chunked_props(vis_dims);
+        auto weight_props = make_chunked_props(weight_dims);
+        auto flags_props = make_chunked_props(flags_dims);
+        auto eval_props = make_chunked_props(eval_dims);
+        auto evec_props = make_chunked_props(evec_dims);
+        auto emethod_props = make_chunked_props(emethod_dims);
+        auto erms_props = make_chunked_props(erms_dims);
+        auto gain_props = make_chunked_props(gain_dims);
+
+        // Create dataset
+        auto vis_dset = file.createDataSet("vis", vis_space, float_type, vis_props);
+        auto weight_dset = file.createDataSet("weight", weight_space, float_type, weight_props);
+        auto flags_dset = file.createDataSet("flags", flags_space, float_type, flags_props);
+        auto eval_dset = file.createDataSet("eval", eval_space, float_type, eval_props);
+        auto evec_dset = file.createDataSet("evec", evec_space, float_type, evec_props);
+        auto emethod_dset = file.createDataSet("emethod", emethod_space, int_type, emethod_props);
+        auto erms_dset = file.createDataSet("erms", erms_space, float_type, erms_props);
+        auto gain_dset = file.createDataSet("gain", gain_space, float_type, gain_props);
+
+        vis_dset.write_raw(frame.vis.data(), float_type);
+        weight_dset.write_raw(frame.weight.data(), float_type);
+        flags_dset.write_raw(frame.flags.data(), float_type);
+        eval_dset.write_raw(frame.eval.data(), float_type);
+        evec_dset.write_raw(frame.evec.data(), float_type);
+        emethod_dset.write_raw(&frame.emethod, int_type);
+        erms_dset.write_raw(&frame.erms, float_type);
+        gain_dset.write_raw(frame.gain.data(), float_type);
+
+        // Set metadata as file-level attributes
+        file.createAttribute("num_elements", frame.num_elements);
+        file.createAttribute("num_prod", frame.num_prod);
+        file.createAttribute("num_ev", frame.num_ev);
+        file.createAttribute("nfreq", frame.nfreq);
+        file.createAttribute("freq_id", frame.freq_id);
+        file.createAttribute("freq_Hz", frame.freq_Hz);
+        file.createAttribute("eop.t_inst", frame.eop.t_inst);
+        file.createAttribute("eop.t_ut1", frame.eop.t_ut1);
+        file.createAttribute("eop.delta_UT1_inst", frame.eop.delta_UT1_inst);
+        file.createAttribute("eop.ERA_deg", frame.eop.ERA_deg);
+        file.createAttribute("eop.xp_as", frame.eop.xp_as);
+        file.createAttribute("eop.yp_as", frame.eop.yp_as);
+        file.createAttribute("fpga_start_tick", frame.fpga_start_tick);
+        file.createAttribute("frame_start_time_ns", frame.frame_start_time_ns);
+        file.createAttribute("frame_length_fpga_ticks", frame.frame_length_fpga_ticks);
+        file.createAttribute("n_valid_fpga_ticks", frame.n_valid_fpga_ticks);
+        file.createAttribute("n_rfi_fpga_ticks", frame.n_rfi_fpga_ticks);
+    }
+
+    /**
+     * @brief Build a property list for dataset creation that enables compression
+     * and chunking.
+     *
+     * @param dims The dataset dimensions.
+     * @return RawPropertyList<PropertyType::DATASET_CREATE> The property list.
+     */
+    RawPropertyList<PropertyType::DATASET_CREATE>
+    make_chunked_props(const std::vector<size_t>& dims) {
+
+        RawPropertyList<PropertyType::DATASET_CREATE> props;
+
+        std::vector<hsize_t> chunk_dims;
+        bool dims_nonzero = true;
+        for (size_t d = 0; d < dims.size(); d++) {
+            chunk_dims.push_back((hsize_t)dims[d]);
+            if(dims[d] == 0)
+                dims_nonzero = false;
+        }
+        if(dims_nonzero) {
+
+            // Enable chunking
+            if (!chunk_dims.empty()) {
+                // Choose chunk size
+                std::size_t npoints_lo = 1;
+                for (std::size_t d = 1; d < chunk_dims.size(); ++d)
+                    npoints_lo *= chunk_dims.at(d);
+                std::size_t npoints_hi = 10 * 1000 * 1000 / npoints_lo;
+                using std::max, std::min;
+                npoints_hi = min(std::size_t(chunk_dims.at(0)), max(std::size_t(1), npoints_hi));
+                chunk_dims.at(0) = npoints_hi;
+            }
+            (*(DataSetCreateProps*)&props).add(Chunking(chunk_dims));
+
+            constexpr int bitshuffle_compression_level = 9;
+            const std::vector<unsigned int> bitshuffle_flags{
+                BITSHUFFLE_BLOCKSIZE_AUTO,
+                BITSHUFFLE_COMPRESS_ZSTD,
+                bitshuffle_compression_level,
+            };
+            props.add(H5Pset_filter, H5Z_BITSHUFFLE, H5Z_FLAG_MANDATORY, bitshuffle_flags.size(),
+                      bitshuffle_flags.data());
+        }
+
+        return props;
+    }
+
+    /**
+     * @brief The main thread function for hdf5FileWrite.
+     *
+     * This function is responsible for the main logic of the hdf5FileWrite class.
+     */
     void main_thread() override {
         auto& write_time_metric = kotekan::prometheus::Metrics::instance().add_gauge(
             "kotekan_hdf5filewrite_write_time_seconds", unique_name);
@@ -115,27 +371,12 @@ public:
             // Start timer
             const double t0 = current_time();
 
-            // Fetch metadata
-            const std::shared_ptr<const metadataObject> mc = buffer->get_metadata(frame_id);
-            if (!mc)
-                FATAL_ERROR("Buffer \"{:s}\" frame {:d} does not have metadata",
-                            buffer->buffer_name, frame_id);
-            assert(mc);
-            if (!metadata_is_chord(mc))
-                FATAL_ERROR("Metadata of buffer \"{:s}\" frame {:d} is not of type CHORD",
-                            buffer->buffer_name, frame_id);
-            assert(metadata_is_chord(mc));
-            const std::shared_ptr<const chordMetadata> meta = get_chord_metadata(mc);
 
             const double this_time = current_time();
             const double elapsed_time = this_time - start_time;
 
-            if (meta->has_sample0_offset())
-                INFO("Received buffer {} frame {} time sample {} (duration {} sec)", unique_name,
-                     frame_counter, meta->get_sample0_offset(), elapsed_time);
-            else
-                INFO("Received buffer {} frame {} (duration {} sec)", unique_name, frame_counter,
-                     elapsed_time);
+            INFO("Received buffer {} frame {} (duration {} sec)", unique_name, frame_counter,
+                 elapsed_time);
 
             if (!skip_writing) {
                 // Define file name
@@ -160,112 +401,26 @@ public:
                     }
                 }
 
-                // Create HDF5 file
-                File file(full_path, File::Truncate);
+                // Fetch metadata
+                const std::shared_ptr<const metadataObject> mc = buffer->get_metadata(frame_id);
+                if (!mc)
+                    FATAL_ERROR("Buffer \"{:s}\" frame {:d} does not have metadata",
+                                buffer->buffer_name, frame_id);
+                assert(mc);
+                if (!(metadata_is_chord(mc) || metadata_is_N2(mc)))
+                    FATAL_ERROR("Metadata of buffer \"{:s}\" frame {:d} is not of type CHORD or N2",
+                                buffer->buffer_name, frame_id);
 
-                // Choose dataspace
-                const DataSpace space(meta->dim, meta->dim + meta->dims);
-                {
-                    [[maybe_unused]] std::ptrdiff_t npoints = 1;
-                    for (int d = meta->dims - 1; d >= 0; --d) {
-                        assert(meta->stride[d] == npoints);
-                        npoints *= meta->dim[d];
-                    }
-                    assert(std::ptrdiff_t(space.getElementCount()) == npoints);
-                    assert(meta->offset == 0);
+                // Call one of the writers, depending if metadata is chord or N2
+                if (metadata_is_chord(mc)) {
+                    assert(metadata_is_chord(mc));
+                    const std::shared_ptr<const chordMetadata> meta = get_chord_metadata(mc);
+                    write_chord(full_path, frame, meta);
+                } else if (metadata_is_N2(mc)) {
+                    assert(metadata_is_N2(mc));
+                    N2FrameView frame(buffer, frame_id);
+                    write_n2(full_path, frame);
                 }
-                assert(std::ptrdiff_t(space.getNumberDimensions()) == meta->dims);
-
-                // Choose datatype
-                const DataType type = chord2hdf5(meta->type);
-
-                RawPropertyList<PropertyType::DATASET_CREATE> props;
-
-                // Enable chunking
-                std::vector<hsize_t> chunk_dims(meta->dim, meta->dim + meta->dims);
-                if (!chunk_dims.empty()) {
-                    // Choose chunk size
-                    std::size_t npoints_lo = 1;
-                    for (std::size_t d = 1; d < chunk_dims.size(); ++d)
-                        npoints_lo *= chunk_dims.at(d);
-                    std::size_t npoints_hi = 10 * 1000 * 1000 / npoints_lo;
-                    using std::max, std::min;
-                    npoints_hi =
-                        min(std::size_t(chunk_dims.at(0)), max(std::size_t(1), npoints_hi));
-                    chunk_dims.at(0) = npoints_hi;
-                }
-                (*(DataSetCreateProps*)&props).add(Chunking(chunk_dims));
-
-                // // Enable compression
-                // constexpr int blosc_compression_level = 9;
-                // const std::vector<unsigned int> blosc_flags{
-                //     blosc_compression_level,
-                //     BLOSC_SHUFFLE_BIT,
-                //     BLOSC_COMPRESS_ZSTD,
-                // };
-                // props.add(H5Pset_filter, H5Z_BLOSC, H5Z_FLAG_MANDATORY, blosc_flags.size(),
-                //           blosc_flags.data());
-                constexpr int bitshuffle_compression_level = 9;
-                const std::vector<unsigned int> bitshuffle_flags{
-                    BITSHUFFLE_BLOCKSIZE_AUTO,
-                    BITSHUFFLE_COMPRESS_ZSTD,
-                    bitshuffle_compression_level,
-                };
-                props.add(H5Pset_filter, H5Z_BITSHUFFLE, H5Z_FLAG_MANDATORY,
-                          bitshuffle_flags.size(), bitshuffle_flags.data());
-
-                // Create dataset
-                auto dataset = file.createDataSet(file_name, space, type, props);
-
-                // Write metadata (attributes)
-
-                dataset.createAttribute("chord_metadata_version", chord_metadata_version);
-                dataset.createAttribute("name", meta->get_name());
-                dataset.createAttribute("type", type_to_string(meta->type));
-                std::vector<std::string> dim_names;
-                for (int d = 0; d < meta->dims; ++d)
-                    dim_names.push_back(meta->get_dimension_name(d));
-                dataset.createAttribute("dim_names", dim_names);
-
-                if (meta->has_sample0_offset())
-                    dataset.createAttribute("sample0_offset", meta->get_sample0_offset());
-
-                if (meta->has_offset_downsampling())
-                    dataset.createAttribute("offset_downsampling", meta->get_offset_downsampling());
-
-                if (meta->has_coarse_freq())
-                    dataset.createAttribute("coarse_freq", meta->get_coarse_freq());
-
-                if (meta->has_freq_upchan_factor())
-                    dataset.createAttribute("freq_upchan_factor", meta->get_freq_upchan_factor());
-
-                if (meta->has_half_fpga_sample0())
-                    dataset.createAttribute("half_fpga_sample0", meta->get_half_fpga_sample0());
-
-                if (meta->has_time_downsampling_fpga())
-                    dataset.createAttribute("time_downsampling_fpga",
-                                            meta->get_time_downsampling_fpga());
-
-                if (meta->ndishes >= 0) {
-                    dataset.createAttribute("ndishes", meta->ndishes);
-                    // const DataSpace space{std::size_t(meta->n_dish_locations_ns),
-                    //                       std::size_t(meta->n_dish_locations_ew)};
-                    // auto attr = dataset.createAttribute<int>("dish_index", space);
-                    // attr.write(meta->dish_index);
-                    dataset.createAttribute("n_dish_locations_ns", meta->n_dish_locations_ns);
-                    dataset.createAttribute("n_dish_locations_ew", meta->n_dish_locations_ew);
-                    dataset.createAttribute(
-                        "dish_index",
-                        std::vector<int>(meta->dish_index, meta->dish_index
-                                                               + meta->n_dish_locations_ns
-                                                                     * meta->n_dish_locations_ew));
-                }
-
-                // Write data
-                assert(dataset.getElementCount() * dataset.getDataType().getSize()
-                       == buffer->frame_size);
-                dataset.write_raw(frame, type);
-
             } // if !skip_writing
 
             // Stop timer

--- a/lib/stages/hdf5FileWrite.cpp
+++ b/lib/stages/hdf5FileWrite.cpp
@@ -407,9 +407,6 @@ public:
                     FATAL_ERROR("Buffer \"{:s}\" frame {:d} does not have metadata",
                                 buffer->buffer_name, frame_id);
                 assert(mc);
-                if (!(metadata_is_chord(mc) || metadata_is_N2(mc)))
-                    FATAL_ERROR("Metadata of buffer \"{:s}\" frame {:d} is not of type CHORD or N2",
-                                buffer->buffer_name, frame_id);
 
                 // Call one of the writers, depending if metadata is chord or N2
                 if (metadata_is_chord(mc)) {
@@ -420,6 +417,9 @@ public:
                     assert(metadata_is_N2(mc));
                     N2FrameView frame(buffer, frame_id);
                     write_n2(full_path, frame);
+                } else {
+                    FATAL_ERROR("Metadata of buffer \"{:s}\" frame {:d} is not of type CHORD or N2",
+                                buffer->buffer_name, frame_id);
                 }
             } // if !skip_writing
 

--- a/lib/stages/hdf5FileWrite.cpp
+++ b/lib/stages/hdf5FileWrite.cpp
@@ -190,8 +190,7 @@ public:
             dataset.createAttribute("half_fpga_sample0", meta->get_half_fpga_sample0());
 
         if (meta->has_time_downsampling_fpga())
-            dataset.createAttribute("time_downsampling_fpga",
-                                    meta->get_time_downsampling_fpga());
+            dataset.createAttribute("time_downsampling_fpga", meta->get_time_downsampling_fpga());
 
         if (meta->ndishes >= 0) {
             dataset.createAttribute("ndishes", meta->ndishes);
@@ -313,10 +312,10 @@ public:
         bool dims_nonzero = true;
         for (size_t d = 0; d < dims.size(); d++) {
             chunk_dims.push_back((hsize_t)dims[d]);
-            if(dims[d] == 0)
+            if (dims[d] == 0)
                 dims_nonzero = false;
         }
-        if(dims_nonzero) {
+        if (dims_nonzero) {
 
             // Enable chunking
             if (!chunk_dims.empty()) {


### PR DESCRIPTION
Replaces the `chordMetadata` and `jsonMetadata` getters with `at` accesses instead of `[]`.  This will throw exceptions on invalid accesses instead of an assertion error.

Also adds capability to `hdf5FileWrite` to write buffers with `N2Metadata`.