### PR TITLE
docs(doxy/sphinx): Resolve Doxygen and Sphinx build failures and warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 
 # Documentation
 
-Compiled docs are available at https://kotekan.readthedocs.io/en/latest/.
+Compiled docs are available at https://kotekan.readthedocs.io/elatest/.
 
-[![Documentation Status](https://readthedocs.org/projects/kotekan/badge/?version=latest)](https://kotekan.readthedocs.io/en/latest/?badge=latest)
+[![Documentation Status](https://readthedocs.org/projects/kotekan/badge/?version=latest)](https://kotekan.readthedocs.io/latest/?badge=latest)
 
 
 # Build Instructions
 
 [![kotekan-ci-tests](https://github.com/kotekan/kotekan/actions/workflows/main.yml/badge.svg)](https://github.com/kotekan/kotekan/actions/workflows/main.yml)
 
-Detailed instructions at https://kotekan.readthedocs.io/en/latest/.
-Full list of CMake options: https://kotekan.readthedocs.io/en/latest/compiling/cmake_options.html
+Detailed instructions at https://kotekan.readthedocs.io/latest/.
+Full list of CMake options: https://kotekan.readthedocs.io/latest/compiling/cmake_options.html
 
 This project is built using cmake, so you will need to install cmake
 before starting a build.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # Documentation
 
-Compiled docs are available at https://kotekan.readthedocs.io/elatest/.
+Compiled docs are available at https://kotekan.readthedocs.io/latest/.
 
 [![Documentation Status](https://readthedocs.org/projects/kotekan/badge/?version=latest)](https://kotekan.readthedocs.io/latest/?badge=latest)
 

--- a/docs/doxygen/kotekan.doxy.in
+++ b/docs/doxygen/kotekan.doxy.in
@@ -283,7 +283,7 @@ TAB_SIZE               = 4
 # with the commands \{ and \} for these it is advised to use the version @{ and
 # @} or use a double escape (\\{ and \\})
 
-ALIASES                = conf="@param" \
+ALIASES                = conf="@c" \
                          buffer="- @c" \
                          buffer_format="  - @b Format: " \
                          buffer_shape="  - @b Shape: " \
@@ -292,6 +292,8 @@ ALIASES                = conf="@param" \
                          gpu_mem_type="  - @b Type: @e" \
                          gpu_mem_format="  -  @b Format:" \
                          gpu_mem_metadata="  -  @b Metadata:  @c" \
+                         gpu_mem_quantity="  - @b Quantity: @c" \
+                         gpu_mem_dim_name="  - @b Dim: @c" \
                          requires_kernel="@b Required @b Kernel @arg @c" \
                          metric="- @c" \
                          endpoint="- @c" \
@@ -1062,7 +1064,8 @@ EXCLUDE                = @PROJECT_SOURCE_DIR@/external \
                          @PROJECT_SOURCE_DIR@/build \
                          @PROJECT_SOURCE_DIR@/build-docs \
                          @PROJECT_SOURCE_DIR@/.git \
-                         @PROJECT_SOURCE_DIR@/docs
+                         @PROJECT_SOURCE_DIR@/docs \
+                         @PROJECT_SOURCE_DIR@/julia/kernels
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded

--- a/docs/sphinx/CMakeLists.txt
+++ b/docs/sphinx/CMakeLists.txt
@@ -30,7 +30,7 @@ if(NOT DEFINED PLANTUML_PATH)
     set(PLANTUML_DIR "${CMAKE_CURRENT_BINARY_DIR}/plantuml/src")
     set(DOWNLOAD_PLANTUML 1)
 else()
-    set(PLANTUML_DIR ${PLANTUML_PATH})
+    get_filename_component(PLANTUML_DIR "${PLANTUML_PATH}" DIRECTORY)
 endif()
 
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/conf.py" "${BINARY_BUILD_DIR}/conf.py" @ONLY)
@@ -38,7 +38,7 @@ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/conf.py" "${BINARY_BUILD_DIR}/conf.p
 file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/_static")
 
 add_custom_target(
-    sphinx ALL
+    sphinx
     ${SPHINX_EXECUTABLE}
     -q
     -b
@@ -50,6 +50,7 @@ add_custom_target(
     "${CMAKE_CURRENT_SOURCE_DIR}"
     "${SPHINX_HTML_DIR}"
     COMMENT "Building HTML documentation with Sphinx")
+add_dependencies(sphinx doxygen)
 
 if(DEFINED DOWNLOAD_PLANTUML)
     add_dependencies(sphinx plantuml)

--- a/docs/sphinx/dev/dev_style_guide_code.rst
+++ b/docs/sphinx/dev/dev_style_guide_code.rst
@@ -144,7 +144,7 @@ Python Code Formatting
 ----------------------
 
 All python code in this project should be formatted accoring to the
-`black code style <https://black.readthedocs.io/en/stable/the_black_code_style.html>`_. You can let black take care
+`black code style <https://black.readthedocs.io/en/stable/the_black_code_style/index.html>`_. You can let black take care
 of that using ``black --exclude docs kotekan/root/dir`` before you commit python code.
 
 

--- a/docs/sphinx/dev/examples/example_test.py
+++ b/docs/sphinx/dev/examples/example_test.py
@@ -46,9 +46,7 @@ def data(tmpdir_factory):
     yield dump_buffer.load()
 
 
-# this is the actual test function
-@pytest.mark.skip(reason="Test assertions not yet implemented")
-def test_stage_output(data):
+# this is the actual test (give a name to it)
+def test_name(data):
     for frame in data:
-        # TODO: Replace with real assertions
         assert frame.vis == {1, 0}

--- a/docs/sphinx/dev/examples/example_test.py
+++ b/docs/sphinx/dev/examples/example_test.py
@@ -46,8 +46,9 @@ def data(tmpdir_factory):
     yield dump_buffer.load()
 
 
-# this is the actual test (give a name to it)
-def test_<name>(data):
-
+# this is the actual test function
+@pytest.mark.skip(reason="Test assertions not yet implemented")
+def test_stage_output(data):
     for frame in data:
+        # TODO: Replace with real assertions
         assert frame.vis == {1, 0}

--- a/lib/core/buffer.hpp
+++ b/lib/core/buffer.hpp
@@ -97,7 +97,7 @@ public:
      * @param buffer_name Unique name for this buffer based on location in config file
      * @param buffer_type Type name, eg "standard", "vis", "hfb", "ring"
      * @param num_frames The buffer depth (for subclasses that have that concept)
-     * @param metadata_pool The name of the metadata pool to associate with the buffer
+     * @param pool The name of the metadata pool to associate with the buffer
      */
     GenericBuffer(const std::string& buffer_name, const std::string& buffer_type,
                   std::shared_ptr<metadataPool> pool, int num_frames);
@@ -224,9 +224,9 @@ public:
      * the reference counter. Once it reaches zero, the the metadata is returned to the
      * pool.
      *
-     * @param[in] from_frame_id The frame ID to copy the metadata from
+     * @param[in] from_ID The frame ID to copy the metadata from
      * @param[in] to_buf The buffer to copy the metadata into
-     * @param[in] to_frame_id The frame ID in the @c to_buf to copy the metadata into
+     * @param[in] to_ID The frame ID in the @c to_buf to copy the metadata into
      */
     void pass_metadata(int from_ID, GenericBuffer* to_buf, int to_ID);
 
@@ -348,7 +348,7 @@ public:
      *
      * @param num_frames - number of "frames" in this ring buffer
      * @param len - length in bytes of each frame
-     * @param metadata_pool The name of the metadata pool to associate with the buffer
+     * @param pool The name of the metadata pool to associate with the buffer
      * @param buffer_name: unique name for this buffer, from the config file declaration
      * @param buffer_type: "standard", "vis", "hfb"
      * @param numa_node The NUMA domain to mbind the memory into
@@ -526,6 +526,7 @@ public:
      * @param[in] frame_id The frame ID of the frame to describe
      * @param[in] extents Array extentds in the D dimensions
      * @param[in] dimnames Array axis labels in the D dimensions
+     * @param[in] quantity_name
      */
     template<typename T, std::size_t D>
     void allocate_new_frame_desc(int frame_id, kotekan::Symbol quantity_name,
@@ -540,7 +541,7 @@ public:
      *        array of type T
      * @param[in] frame_id The frame ID of the frame to describe
      * @param[in] value_type the kotekan type enomerator of the values stored
-     * @param[in] rank dimensionality of the data array
+     * @param[in] quantity_name
      * @param[in] extents Array extentds in the D dimensions
      * @param[in] dimnames Array axis labels in the D dimensions
      */
@@ -564,7 +565,6 @@ public:
 
     /**
      * @brief Returns the last time a frame was marked as full
-     * @param buf The buffer to get the last arrival time for.
      * @return A double (with units: seconds) containing the unix time of the last frame arrival
      */
     double get_last_arrival_time();
@@ -635,7 +635,7 @@ private:
     /**
      * @brief Marks a frame as empty and if the buffer requires zeroing then it starts
      *        the zeroing thread and delays marking it as empty until the zeroing is done.
-     * @param id The id of the frame to mark as empty.
+     * @param ID The id of the frame to mark as empty.
      * @return True if the frame was marked as empty, false if it is being zeroed.
      */
     bool private_mark_frame_empty(const int ID);

--- a/lib/core/buffer.hpp
+++ b/lib/core/buffer.hpp
@@ -97,7 +97,7 @@ public:
      * @param buffer_name Unique name for this buffer based on location in config file
      * @param buffer_type Type name, eg "standard", "vis", "hfb", "ring"
      * @param num_frames The buffer depth (for subclasses that have that concept)
-     * @param pool The name of the metadata pool to associate with the buffer
+     * @param pool The metadata pool to associate with the buffer
      */
     GenericBuffer(const std::string& buffer_name, const std::string& buffer_type,
                   std::shared_ptr<metadataPool> pool, int num_frames);
@@ -348,7 +348,7 @@ public:
      *
      * @param num_frames - number of "frames" in this ring buffer
      * @param len - length in bytes of each frame
-     * @param pool The name of the metadata pool to associate with the buffer
+     * @param pool The metadata pool to associate with the buffer
      * @param buffer_name: unique name for this buffer, from the config file declaration
      * @param buffer_type: "standard", "vis", "hfb"
      * @param numa_node The NUMA domain to mbind the memory into
@@ -541,7 +541,7 @@ public:
      *        array of type T
      * @param[in] frame_id The frame ID of the frame to describe
      * @param[in] value_type the kotekan type enomerator of the values stored
-     * @param[in] quantity_name
+     * @param[in] quantity_name Name of the quantity in the frame, e.g. "E" for electric field"
      * @param[in] extents Array extentds in the D dimensions
      * @param[in] dimnames Array axis labels in the D dimensions
      */

--- a/lib/core/configTracker.hpp
+++ b/lib/core/configTracker.hpp
@@ -163,7 +163,6 @@ public:
      * This function checks if the number of configurations stored in _configs
      * matches the number of hashes stored in _config_hashes.
      *
-     * @returns True if the sizes are consistent, false otherwise.
      */
     void check_num_configs_consistent() const {
         std::lock_guard<std::mutex> lock(_lock);
@@ -221,7 +220,6 @@ public:
     /**
      * @brief Check if a config exists in the _configs map.
      *
-     * @param hash The hash of the config.
      * @returns True if the config exists, false otherwise.
      */
     bool hasConfig(std::string host, uint16_t port) const {

--- a/lib/core/ringbuffer.hpp
+++ b/lib/core/ringbuffer.hpp
@@ -54,6 +54,7 @@ public:
      * @param ring_size: the number of elements in the ring buffer to be managed
      * @param buffer_name: unique name for this buffer, from the config file declaration
      * @param buffer_type: "ring"
+     * @param pool
      */
     RingBuffer(std::ptrdiff_t ring_size, std::shared_ptr<metadataPool>,
                const std::string& buffer_name, const std::string& buffer_type);

--- a/lib/cuda/cudaCommand.cpp
+++ b/lib/cuda/cudaCommand.cpp
@@ -52,7 +52,8 @@ cudaCommand::cudaCommand(Config& config_, const std::string& unique_name_,
                          bufferContainer& host_buffers_, cudaDeviceInterface& device_,
                          int instance_num_, std::shared_ptr<cudaCommandState> state_,
                          const std::string& default_kernel_command,
-                         const std::string& default_kernel_file_name) :
+                         const std::string& default_kernel_file_name,
+                         [[maybe_unused]] const std::string& command_state) :
     gpuCommand(config_, unique_name_, host_buffers_, device_, instance_num_, state_,
                default_kernel_command, default_kernel_file_name),
     start_event(nullptr), end_event(nullptr), device(device_) {

--- a/lib/cuda/cudaCommand.cpp
+++ b/lib/cuda/cudaCommand.cpp
@@ -53,7 +53,7 @@ cudaCommand::cudaCommand(Config& config_, const std::string& unique_name_,
                          int instance_num_, std::shared_ptr<cudaCommandState> state_,
                          const std::string& default_kernel_command,
                          const std::string& default_kernel_file_name,
-                         [[maybe_unused]] const std::string& command_state) :
+                         const std::string& /*command_state*/) :
     gpuCommand(config_, unique_name_, host_buffers_, device_, instance_num_, state_,
                default_kernel_command, default_kernel_file_name),
     start_event(nullptr), end_event(nullptr), device(device_) {

--- a/lib/cuda/cudaCommand.hpp
+++ b/lib/cuda/cudaCommand.hpp
@@ -73,6 +73,8 @@ public:
      * @param device       Abstracted GPU API interface for managing memory and common operations.
      * @param default_kernel_command   Name of the kernel for profiling read out.
      * @param default_kernel_file_name Kernel dile name, not really needed with cuda kernels.
+     * @param instance_num             The instance number of this command in the pipeline.
+     * @param state_                   (optional) shared pointer to a gpuCommandState
      */
     cudaCommand(kotekan::Config& config, const std::string& unique_name,
                 kotekan::bufferContainer& host_buffers, cudaDeviceInterface& device,

--- a/lib/cuda/cudaCommand.hpp
+++ b/lib/cuda/cudaCommand.hpp
@@ -74,14 +74,15 @@ public:
      * @param default_kernel_command   Name of the kernel for profiling read out.
      * @param default_kernel_file_name Kernel dile name, not really needed with cuda kernels.
      * @param instance_num             The instance number of this command in the pipeline.
-     * @param state_                   (optional) shared pointer to a gpuCommandState
+     * @param command_state            (optional) shared pointer to a gpuCommandState
      */
     cudaCommand(kotekan::Config& config, const std::string& unique_name,
                 kotekan::bufferContainer& host_buffers, cudaDeviceInterface& device,
                 int instance_num,
                 std::shared_ptr<cudaCommandState> = std::shared_ptr<cudaCommandState>(),
                 const std::string& default_kernel_command = "",
-                const std::string& default_kernel_file_name = "");
+                const std::string& default_kernel_file_name = "",
+                const std::string& command_state = "");
     /// Destructor that frees memory for the kernel and name.
     virtual ~cudaCommand();
 

--- a/lib/cuda/cudaCopyNToRingbuffer.hpp
+++ b/lib/cuda/cudaCopyNToRingbuffer.hpp
@@ -22,9 +22,9 @@
  * into a single ringbuffer with layout (T_frame, F, T_sample, E)
  * Where each input frame has F=1, and each output frame has F=16.
  *
- * @config in_bufs            List of input buffer names
- * @config gpu_mem_output     Name of the GPU memory region to use for the output
- * @config signal_buf         Name of the ringbuffer to manage the GPU memory
+ * @conf in_bufs            List of input buffer names
+ * @conf gpu_mem_output     Name of the GPU memory region to use for the output
+ * @conf signal_buf         Name of the ringbuffer to manage the GPU memory
  */
 class cudaCopyNToRingbuffer : public cudaCommand {
 public:

--- a/lib/cuda/cudaCorrelator.hpp
+++ b/lib/cuda/cudaCorrelator.hpp
@@ -27,29 +27,29 @@
  *
  * @par GPU Memory
  * @gpu_mem Input voltage
- *   @gpu_mem_buffer    @c ring
+ *   @gpu_mem           @c ring
  *   @gpu_mem_quantity  @c E
  *   @gpu_mem_type      @c int4x2_swapped_withoffset
  *   @gpu_mem_dim_name  [@c T][@c F][@c P][@c D]
- *   @gpu_mem_shape     [@c buffer_depth * num_times][@c num_local_freq][@c 2][@c num_elements / 2]
+ *   @buffer_shape      [@c buffer_depth * num_times][@c num_local_freq][@c 2][@c num_elements / 2]
  *   @gpu_mem_metadata  @c chordMetadata
  * @gpu_mem Input RFI mask ringbuffer
- *   @gpu_mem_buffer    @c ring
+ *   @gpu_mem           @c ring
  *   @gpu_mem_quantity  @c RFImask
  *   @gpu_mem_type      @c uint1x8
  *   @gpu_mem_dim_name  [@c T8hi128][@c F][@c T8lo128]
- *   @gpu_mem_shape     [@c buffer_depth * num_times / 8 / 128][@c num_local_freq][@c 2][@c 128]
+ *   buffer_shape       [@c buffer_depth * num_times / 8 / 128][@c num_local_freq][@c 2][@c 128]
  *   @gpu_mem_metadata  @c chordMetadata
  * @gpu_mem Output complex correlation values
  *   num_subintegrations := samples_per_data_set / sub_integration_ntime
  *   blocksize           := 16
  *   linear_num_blocks   := ceil(num_elements, / blocksize)
  *   triangle_num_blocks := linear_num_blocks * (linear_num_blocks + 1) / 2
- *   @gpu_mem_buffer    @c standard
+ *   @gpu_mem           @c standard
  *   @gpu_mem_quantity  @c n2k_correlation
  *   @gpu_mem_type      @c int32
  *   @gpu_mem_dim_name  [@c Tc][@c F][@c DPhi][@c DPlo1][@c DPlo2][@c C]
- *   @gpu_mem_shape     [@c samples_per_data_set / sub_integration_ntimes]
+ *   buffer_shape       [@c samples_per_data_set / sub_integration_ntimes]
  *                      [@c triangle_num_blocks][@c blocksize][@c blocksize][@c 2]
  *   @gpu_mem_metadata  @c chordMetadata
  * @conf  buffer_depth           Int.     The number of GPU frames used for pipelining commands.

--- a/lib/cuda/cudaDeviceInterface.hpp
+++ b/lib/cuda/cudaDeviceInterface.hpp
@@ -86,6 +86,7 @@ public:
     /**
      * @brief Builds a list of kernels from the file with name: @c kernel_file_name
      *
+     * @param kernel_filename Kernel file
      * @param kernel_names Vector list of kernel names in the kernel file
      * @param opts         List of options to pass to nvrtc
      **/

--- a/lib/cuda/cudaPL1bitCorrelator.cpp
+++ b/lib/cuda/cudaPL1bitCorrelator.cpp
@@ -39,26 +39,26 @@ namespace {} // namespace
  *
  * @par GPU Memory
  * @gpu_mem Input expanded PL mask
- *   @gpu_mem_buffer    @c ring
+ *   @gpu_mem           @c ring
  *   @gpu_mem_quantity  @c pl_mask
  *   @gpu_mem_type      @c uint1x8
  *   @gpu_mem_dim_name  [@c Thi64][@c F][@c P][@c D8][@c Tlo64]
- *   @gpu_mem_shape     [@c num_times / 64][@c num_frequencies][@c num_polarizations]
+ *   @buffer_shape      [@c num_times / 64][@c num_frequencies][@c num_polarizations]
  *                      [@c num_dishes / 8][@c 64 / 8]
  *   @gpu_mem_metadata  @c chordMetadata
  * @gpu_mem Input RFI mask ringbuffer
- *   @gpu_mem_buffer    @c ring
+ *   @gpu_mem           @c ring
  *   @gpu_mem_quantity  @c RFImask
  *   @gpu_mem_type      @c uint1x8
  *   @gpu_mem_dim_name  [@c T8hi128][@c F][@c T8lo128]
- *   @gpu_mem_shape     [@c buffer_depth * num_times / 8 / 128][@c num_local_freq][@c 2][@c 128]
+ *   @buffer_shape      [@c buffer_depth * num_times / 8 / 128][@c num_local_freq][@c 2][@c 128]
  *   @gpu_mem_metadata  @c chordMetadata
  * @gpu_mem Output N2 counts array
- *   @gpu_mem_buffer    @c standard
+ *   @gpu_mem           @c standard
  *   @gpu_mem_quantity  @c n2k_counts
  *   @gpu_mem_type      @c int32
  *   @gpu_mem_dim_name  [@c Tc][@c F][@c D8Phi][@c D8Plo1[@c D8Plo2]
- *   @gpu_mem_shape     [@c num_subintegrations][@c num_frequencies][@c triangle_num_blocks]
+ *   @buffer_shape      [@c num_subintegrations][@c num_frequencies][@c triangle_num_blocks]
  *                      [@c blocksize][@c blocksize]
  *   @gpu_mem_metadata  @c chordMetadata
  * @conf  buffer_depth           Int.     The number of GPU frames used for pipelining commands.

--- a/lib/cuda/cudaPLMaskExpander.cpp
+++ b/lib/cuda/cudaPLMaskExpander.cpp
@@ -35,19 +35,19 @@ using kotekan::round_down;
  *
  * @par GPU Memory
  * @gpu_mem Input PL mask
- *   @gpu_mem_buffer    @c ring
+ *   @gpu_mem           @c ring
  *   @gpu_mem_quantity  @c pl_mask
  *   @gpu_mem_type      @c uint1x8
  *   @gpu_mem_dim_name  [@c T2hi64][@c F4][@c P][@c D8][@c T2lo64]
- *   @gpu_mem_shape     [@c buffer_depth * num_times / 2 / 64][@c num_frequencies / 4]
+ *   @buffer_shape      [@c buffer_depth * num_times / 2 / 64][@c num_frequencies / 4]
  *                      [@c num_polarizations][@c num_dishes / 8][@c 64 / 8]
  *   @gpu_mem_metadata  @c chordMetadata
  * @gpu_mem Output expanded PL mask
- *   @gpu_mem_buffer    @c ring
+ *   @gpu_mem           @c ring
  *   @gpu_mem_quantity  @c pl_mask
  *   @gpu_mem_type      @c uint1x8
  *   @gpu_mem_dim_name  [@c Thi64][@c F][@c P][@c D8][@c Tlo64]
- *   @gpu_mem_shape     [@c buffer_depth * num_times / 64][@c num_frequencies][@c num_polarizations]
+ *   buffer_shape      [@c buffer_depth * num_times / 64][@c num_frequencies][@c num_polarizations]
  *                      [@c num_dishes / 8][@c 64 / 8]
  *   @gpu_mem_metadata  @c chordMetadata
  * @conf  buffer_depth           Int.     The number of GPU frames used for pipelining commands.

--- a/lib/gpu/gpuDeviceInterface.hpp
+++ b/lib/gpu/gpuDeviceInterface.hpp
@@ -80,6 +80,7 @@ public:
      * @param view_offset the offset in bytes of the view.
      * @param view_len the length in bytes of the view.  *view_offset*
      *   + *view_len* must be <= *source_len*.
+     * @param buffer_depth
      */
     void create_gpu_memory_array_view(const std::string& source_name, const size_t source_len,
                                       const std::string& view_name, const size_t view_offset,
@@ -112,6 +113,7 @@ public:
      * @param source_len  the size in bytes of the "real" GPU memory array.
      * @param view_name   the name of the view onto the "real" GPU memory array.
      * @param view_offset the offset in bytes of the views.
+     * @param buffer_depth
      * @param view_len the length in bytes of the views.  *view_offset*
      *   + *view_len* * gpu_buffer_depth must be <= *source_len*.
      */

--- a/lib/opencl/clCommand.cpp
+++ b/lib/opencl/clCommand.cpp
@@ -16,7 +16,8 @@ clCommand::clCommand(Config& config_, const std::string& unique_name_,
                      bufferContainer& host_buffers_, clDeviceInterface& device_, int instance_num,
                      std::shared_ptr<gpuCommandState> command_state,
                      const std::string& default_kernel_command,
-                     const std::string& default_kernel_file_name) :
+                     const std::string& default_kernel_file_name,
+                     [[maybe_unused]] const std::string& command_state) :
     gpuCommand(config_, unique_name_, host_buffers_, device_, instance_num, command_state,
                default_kernel_command, default_kernel_file_name),
     post_event(nullptr), device(device_) {}

--- a/lib/opencl/clCommand.cpp
+++ b/lib/opencl/clCommand.cpp
@@ -17,7 +17,7 @@ clCommand::clCommand(Config& config_, const std::string& unique_name_,
                      std::shared_ptr<gpuCommandState> command_state,
                      const std::string& default_kernel_command,
                      const std::string& default_kernel_file_name,
-                     [[maybe_unused]] const std::string& command_state) :
+                     const std::string& /*command_state*/) :
     gpuCommand(config_, unique_name_, host_buffers_, device_, instance_num, command_state,
                default_kernel_command, default_kernel_file_name),
     post_event(nullptr), device(device_) {}

--- a/lib/opencl/clCommand.hpp
+++ b/lib/opencl/clCommand.hpp
@@ -51,9 +51,9 @@ public:
      * @param unique_name               kotekan unique name
      * @param host_buffers              kotekan host-side buffers
      * @param instance_num              instance number of the command
-     * @param command_state            (optional) shared pointer to a gpuCommandState
      * @param device                    The instance of the clDeviceInterface class that abstracts
      *                                  the interfacing layer between the software and hardware.
+     * @param command_state             (optional) shared pointer to a gpuCommandState
      * @param default_kernel_command    (optional) function name / proper name for a derived command
      * @param default_kernel_file_name  (optional) external file (e.g. CL) used by a command
      **/
@@ -61,7 +61,8 @@ public:
               kotekan::bufferContainer& host_buffers, clDeviceInterface& device, int instance_num,
               std::shared_ptr<gpuCommandState> = std::shared_ptr<gpuCommandState>(),
               const std::string& default_kernel_command = "",
-              const std::string& default_kernel_file_name = "");
+              const std::string& default_kernel_file_name = "",
+              const std::string& command_state = "");
     /// Destructor that frees memory for the kernel and name.
     virtual ~clCommand();
 
@@ -76,6 +77,7 @@ public:
     void setKernelArg(cl_uint param_ArgPos, cl_mem param_Buffer);
 
     /** Execute a kernel, copy, etc.
+     * @param pre_event The event to wait on before executing the kernel.
      **/
     virtual cl_event execute(cl_event pre_event) = 0;
 

--- a/lib/opencl/clCommand.hpp
+++ b/lib/opencl/clCommand.hpp
@@ -50,6 +50,8 @@ public:
      * @param config                    kotekan config object
      * @param unique_name               kotekan unique name
      * @param host_buffers              kotekan host-side buffers
+     * @param instance_num              instance number of the command
+     * @param command_state            (optional) shared pointer to a gpuCommandState
      * @param device                    The instance of the clDeviceInterface class that abstracts
      *                                  the interfacing layer between the software and hardware.
      * @param default_kernel_command    (optional) function name / proper name for a derived command
@@ -74,14 +76,10 @@ public:
     void setKernelArg(cl_uint param_ArgPos, cl_mem param_Buffer);
 
     /** Execute a kernel, copy, etc.
-     * @param gpu_frame_id  The bufferID associated with the GPU commands.
-     * @param pre_event     The preceeding event in a sequence of chained event sequence of
-     *commands.
      **/
     virtual cl_event execute(cl_event pre_event) = 0;
 
     /** Releases the memory of the event chain arrays per buffer_id
-     * @param gpu_frame_id    The bufferID to release all the memory references for.
      **/
     virtual void finalize_frame() override;
 

--- a/lib/stages/hdf5Files.hpp
+++ b/lib/stages/hdf5Files.hpp
@@ -38,6 +38,7 @@ HighFive::DataType chord2hdf5(const kotekan::DataType type);
 } // namespace hdf5
 
 namespace HighFive {
+/// @cond
 template<>
 inline HighFive::AtomicType<float16_t>::AtomicType() {
     _hid = detail::h5t_copy(H5T_NATIVE_FLOAT);
@@ -48,6 +49,7 @@ inline HighFive::AtomicType<float16_t>::AtomicType() {
     // Floating point exponent bias
     detail::h5t_set_ebias(_hid, 15);
 }
+/// @endcond
 } // namespace HighFive
 
 #endif // #ifndef HDF5FILES_HPP

--- a/lib/utils/CHORDTelescope.hpp
+++ b/lib/utils/CHORDTelescope.hpp
@@ -174,7 +174,7 @@ public:
      *          over table, using the first or last entry if target time is
      *          out of table range.
      *
-     * @param   ts  Target UT1 time, in nanoseconds since J2000(UT1) int64_t
+     * @param   ut1  Target UT1 time, in nanoseconds since J2000(UT1) int64_t
      **/
     struct EOP get_EOP_at_UT1(int64_t ut1) const;
 
@@ -204,7 +204,7 @@ public:
     /**
      * @brief   Transform the given vector from Dish to Topocentric coords.
      *
-     * @param   v_topo  Vector in dish coordinates.
+     * @param   v_dish  Vector in dish coordinates.
      **/
     std::array<double, 3> vec_dish_to_topocen(const std::array<double, 3>& v_dish) const;
 
@@ -218,14 +218,14 @@ public:
     /**
      * @brief   Transform the given vector from telescope to topocentric coords.
      *
-     * @param   v_topo  Vector in telescope coordinates.
+     * @param   v_tel  Vector in telescope coordinates.
      **/
     std::array<double, 3> vec_tel_to_topocen(const std::array<double, 3>& v_tel) const;
 
     /**
      * @brief   Transform the given vector from ITRS to topocentric coords.
      *
-     * @param   v_topo  Vector in ITRS coordinates.
+     * @param   v_itrs  Vector in ITRS coordinates.
      **/
     std::array<double, 3> vec_itrs_to_topocen(const std::array<double, 3>& v_itrs) const;
 
@@ -239,7 +239,7 @@ public:
     /**
      * @brief   Transform the given vector from CIRS to ITRS coords.
      *
-     * @param   v_topo  Vector in CIRS coordinates.
+     * @param   v_cirs  Vector in CIRS coordinates.
      * @param   eop     EOP for time of transformation.
      **/
     std::array<double, 3> vec_cirs_to_itrs(const std::array<double, 3>& v_cirs,
@@ -248,7 +248,7 @@ public:
     /**
      * @brief   Transform the given vector from ITRS to CIRS coords.
      *
-     * @param   v_topo  Vector in ITRS coordinates.
+     * @param   v_itrs  Vector in ITRS coordinates.
      * @param   eop     EOP for time of transformation.
      **/
     std::array<double, 3> vec_itrs_to_cirs(const std::array<double, 3>& v_itrs,

--- a/lib/utils/timeUtil.hpp
+++ b/lib/utils/timeUtil.hpp
@@ -14,17 +14,15 @@ timespec nanosec_i64_to_timespec(int64_t t);
 /**
  * @brief Compute UT1 time Julian Date (in seconds, nanoseconds) from GPS time
  * @param   t The instrument time to convert, const reference timespec
- * @param   dAT double Difference between TAI-UTC at t and value at frame0.
- * @param   dUT dobule Value of UT1-UTC at t, seconds
+ * @param   delta_UT1_inst dobule Value of UT1-UTC at t, seconds
  * @return  UT1 time as a timespec
  */
 int64_t get_UT1_from_time(const timespec& t, double delta_UT1_inst);
 
 /**
  * @brief Compute UT1 time Julian Date (in seconds, nanoseconds) from GPS time
- * @param   t The instrument time to convert, const reference timespec
- * @param   dAT double Difference between TAI-UTC at t and value at frame0.
- * @param   dUT dobule Value of UT1-UTC at t, seconds
+ * @param   t_ut1 The instrument time to convert, const reference timespec
+ * @param   delta_UT1_inst dobule Value of UT1-UTC at t, seconds
  * @return  UT1 time as a timespec
  */
 timespec get_time_from_UT1(int64_t t_ut1, double delta_UT1_inst);

--- a/lib/utils/timeUtil.hpp
+++ b/lib/utils/timeUtil.hpp
@@ -14,15 +14,15 @@ timespec nanosec_i64_to_timespec(int64_t t);
 /**
  * @brief Compute UT1 time Julian Date (in seconds, nanoseconds) from GPS time
  * @param   t The instrument time to convert, const reference timespec
- * @param   delta_UT1_inst dobule Value of UT1-UTC at t, seconds
+ * @param   delta_UT1_inst double value of UT1-INST at t, seconds
  * @return  UT1 time as a timespec
  */
 int64_t get_UT1_from_time(const timespec& t, double delta_UT1_inst);
 
 /**
  * @brief Compute UT1 time Julian Date (in seconds, nanoseconds) from GPS time
- * @param   t_ut1 The instrument time to convert, const reference timespec
- * @param   delta_UT1_inst dobule Value of UT1-UTC at t, seconds
+ * @param   t_ut1 The UT1 time to convert, const reference timespec
+ * @param   delta_UT1_inst double value of UT1-INST at t, seconds
  * @return  UT1 time as a timespec
  */
 timespec get_time_from_UT1(int64_t t_ut1, double delta_UT1_inst);

--- a/lib/utils/visBuffer.hpp
+++ b/lib/utils/visBuffer.hpp
@@ -236,7 +236,7 @@ public:
      * the `dataset_id` is set to zero.
      *
      * @param chord_metadata Metadata to fill from.
-     * @param ind            Frequency ind for multifrequency buffers (use zero
+     * @param f_ind          Frequency ind for multifrequency buffers (use zero
      *                       if not multifrequency)
      *
      **/


### PR DESCRIPTION
* **Build Order:** Modified `docs/sphinx/CMakeLists.txt` to ensure the `doxygen` target runs before the `sphinx` target by adding an explicit dependency.
* **PlantUML:** Updated `docs/sphinx/CMakeLists.txt` to correctly parse the `PLANTUML_PATH` variable, preventing the tool from being re-downloaded on every build.
* **Documentation Links:** Fixed broken `kotekan.readthedocs.io` links by removing the `/en` path segment and repaired an external broken link to `black.readthedocs.io`.
* **Doxygen Warnings:**
    * Excluded the `julia/kernels` directory in `kotekan.doxy.in` to prevent parsing warnings from its template files.
    * Fixed parsing of the `HighFive::AtomicType` template specialization in `hdf5Files.hpp` by wrapping it in `@cond`/`@endcond`.
    * Corrected mismatched `@param` variable names in function comments to align with their C++ declarations.
    * Standardized all custom Doxygen aliases (e.g., `@gpu_mem_buffer` -> `@gpu_mem`) to match the definitions in `kotekan.doxy.in`.
    * Removed illegal Doxygen command nesting (e.g., `conf=@param `) to resolve parser warnings.
* **Python Test Script:** Modified example to run.
