### PR TITLE
fixes here and there

### DIFF
--- a/lib/core/Config.hpp
+++ b/lib/core/Config.hpp
@@ -103,11 +103,9 @@ public:
                 value = checked_conversion<T>(json_value.get<LargeType<T>>());
             }
         } catch (std::exception const& ex) {
-            int status;
             throw std::runtime_error(fmt::format(
                 fmt("The value {:s} in path {:s} is not of type '{:s}' or doesn't exist: {:s}"),
-                name, base_path, abi::__cxa_demangle(typeid(T).name(), nullptr, nullptr, &status),
-                ex.what()));
+                name, base_path, demangle<T>(), ex.what()));
         }
 
         return value;
@@ -128,10 +126,9 @@ public:
         try {
             value = json_value.get<T>();
         } catch (std::exception const& ex) {
-            int status;
             throw std::runtime_error(fmt::format(
                 fmt("The value {:s} in path {:s} is not of type '{:s}' or doesn't exist"), name,
-                base_path, abi::__cxa_demangle(typeid(T).name(), nullptr, nullptr, &status)));
+                base_path, demangle<T>()));
         }
 
         return value;
@@ -265,6 +262,16 @@ private:
      **/
     void get_value_recursive(const nlohmann::json& j, const std::string& name,
                              std::vector<nlohmann::json>& results) const;
+
+    /// get demangled type name string
+    template<typename T>
+    static std::string demangle() {
+        int status;
+        char* c_typename = abi::__cxa_demangle(typeid(T).name(), nullptr, nullptr, &status);
+        std::string demangled_typename(c_typename);
+        free(c_typename);
+        return demangled_typename;
+    }
 
     /**
      * @brief Helper class, gets an arithmetic expression from the config.

--- a/lib/core/restServer.cpp
+++ b/lib/core/restServer.cpp
@@ -506,8 +506,10 @@ void restServer::http_server_thread() {
     // run event loop
     event_base_dispatch(event_base);
 
+    event_free(timer_event);
     evhttp_free(ev_server);
     event_base_free(event_base);
+    event_config_free(ev_config);
 }
 
 void restServer::set_server_affinity(Config& config) {

--- a/lib/dpdk/iceBoardShuffle.hpp
+++ b/lib/dpdk/iceBoardShuffle.hpp
@@ -474,6 +474,7 @@ inline bool iceBoardShuffle::advance_frames(uint64_t new_seq, bool first_time) {
         std::strncpy(meta->name, "E", sizeof meta->name);
         meta->dim[0] = out_bufs[i]->frame_size / sample_size;
         meta->dim[1] = sample_size;
+        meta->set_strides_simple();
         /* new style array description */
         out_bufs[i]
             ->allocate_new_frame_desc<kotekan::GetType<kotekan::int4x2_swapped_withoffset>::type,

--- a/lib/metadata/Symbol.cpp
+++ b/lib/metadata/Symbol.cpp
@@ -4,7 +4,7 @@
 namespace kotekan {
 
 std::mutex Symbol::mutex;
-std::unordered_set<std::string_view> Symbol::known_symbols;
+owning_unordered_set<std::string_view> Symbol::known_symbols;
 
 // Look up a string in the known symbols. If it is not known, insert
 // it.

--- a/lib/metadata/Symbol.hpp
+++ b/lib/metadata/Symbol.hpp
@@ -8,11 +8,21 @@
 #include <iostream>      // for ostream
 #include <mutex>         // for mutex
 #include <string>        // for string, basic_string
-#include <string_view>   // for string_view, hash
 #include <unordered_set> // for unordered_set
 
 
 namespace kotekan {
+
+template<typename T>
+struct owning_unordered_set;
+template<>
+struct owning_unordered_set<std::string_view> : public std::unordered_set<std::string_view> {
+    ~owning_unordered_set() {
+        for (auto s : *this) {
+            delete[] s.data();
+        }
+    }
+};
 
 // A symbol is similar to a string: A symbol can be created from a
 // string (this is expensive). As pay-off, comparing symbols to each
@@ -22,7 +32,7 @@ class Symbol {
     // We keep a set of all symbols that have been created
     // (`known_symbols). It is protected by a mutex.
     static std::mutex mutex;
-    static std::unordered_set<std::string_view> known_symbols;
+    static owning_unordered_set<std::string_view> known_symbols;
 
     // A symbol's value is a pointer to a C string.
     const char* value;

--- a/lib/stages/testDataGen.cpp
+++ b/lib/stages/testDataGen.cpp
@@ -81,9 +81,9 @@ testDataGen::testDataGen(Config& config, const std::string& unique_name,
     _seed = config.get_default<int>(unique_name, "seed", 0);
     _pathfinder_test_mode = config.get_default<bool>(unique_name, "pathfinder_test_mode", false);
     _name = config.get_default<std::string>(unique_name, "name", "E");
-    _array_shape =
-        config.get_default<std::vector<int>>(unique_name, "array_shape", std::vector<int>());
-    if (_array_shape.size()) {
+    _array_shape = config.get_default<std::vector<int>>(
+        unique_name, "array_shape", std::vector<int>({int(buf->frame_size) / type_size}));
+    {
         size_t sz = type_size;
         for (int s : _array_shape)
             sz *= s;
@@ -93,14 +93,10 @@ testDataGen::testDataGen(Config& config, const std::string& unique_name,
         // clang-format on
     }
     _dim_name = config.get_default<std::vector<std::string>>(unique_name, "dim_name",
-                                                             std::vector<std::string>());
-    if (_dim_name.size()) {
-        if (_array_shape.size()) {
-            if (_array_shape.size() != _dim_name.size()) {
-                throw std::invalid_argument("testDataGen: 'array_shape' and 'dim_name' config "
-                                            "settings must be the same length!");
-            }
-        }
+                                                             std::vector<std::string>({"D"}));
+    if (_array_shape.size() != _dim_name.size()) {
+        throw std::invalid_argument("testDataGen: 'array_shape' and 'dim_name' config "
+                                    "settings must be the same length!");
     }
 
     samples_per_data_set = config.get_default<int>(unique_name, "samples_per_data_set", 32768);
@@ -308,8 +304,9 @@ void testDataGen::main_thread() {
 
         // this needs the decoded type
         /* new style array description */
-        std::vector<ptrdiff_t> extents(_array_shape.begin(), _array_shape.end());
-        std::vector<kotekan::Symbol> dimnames(_dim_name.begin(), _dim_name.end());
+        const std::vector<ptrdiff_t> extents(_array_shape.begin(), _array_shape.end());
+        const std::vector<kotekan::Symbol> dimnames(_dim_name.begin(), _dim_name.end());
+
         buf->allocate_new_frame_desc(frame_id, chordmeta->type, _name, extents, dimnames);
         /* test that things are consistent */
         chordmeta->check_frame_desc(buf->get_frame_desc(frame_id));
@@ -319,38 +316,30 @@ void testDataGen::main_thread() {
             if (_value_array.size())
                 val = _value_array[frame_id_abs % _value_array.size()];
             bzero(frame, n_to_set);
-            if (_array_shape.size()) {
-                std::string istring = "";
-                size_t j = 0;
-                std::vector<int> indices;
-                for (size_t i = 0; i < _array_shape.size(); i++) {
-                    int n = _array_shape[i];
-                    int k = rng() % n;
-                    j = j * n + k;
-                    if (i)
-                        istring += ", ";
-                    istring += std::to_string(k);
-                    indices.push_back(k);
-                }
-                frame[j] = val;
-                INFO("Set {:s}[{:d}] index [{:s}] (flat: {:d} = 0x{:x}) to 0x{:x} ({:d})",
-                     buf->buffer_name, frame_id, istring, j, j, val, val);
-                if (metadata_is_onehot(buf, frame_id)) {
-                    DEBUG("One-hot metadata; setting indices");
-                    set_onehot_indices(buf, frame_id, indices);
-                    set_onehot_frame_counter(buf, frame_id, frame_id_abs);
-                    INFO("Set {:s}[{:d}] frame counter {:d}", buf->buffer_name, frame_id,
-                         frame_id_abs);
-                } else {
-                    ERROR("Metadata type is not one-hot, not recording one-hot indices anywhere!");
-                }
-                DEBUG("PY onehot[{:d}] = (({:s}), 0x{:x})", frame_id_abs, istring, val);
-            } else {
-                int j = rng() % n_to_set;
-                INFO("Set {:s}[{:d}] flat index {:d} = 0x{:x} to 0x{:x} ({:d})", buf->buffer_name,
-                     frame_id, j, j, val, val);
-                frame[j] = val;
+            std::string istring = "";
+            size_t j = 0;
+            std::vector<int> indices;
+            for (size_t i = 0; i < _array_shape.size(); i++) {
+                int n = _array_shape[i];
+                int k = rng() % n;
+                j = j * n + k;
+                if (i)
+                    istring += ", ";
+                istring += std::to_string(k);
+                indices.push_back(k);
             }
+            frame[j] = val;
+            INFO("Set {:s}[{:d}] index [{:s}] (flat: {:d} = 0x{:x}) to 0x{:x} ({:d})",
+                 buf->buffer_name, frame_id, istring, j, j, val, val);
+            if (metadata_is_onehot(buf, frame_id)) {
+                DEBUG("One-hot metadata; setting indices");
+                set_onehot_indices(buf, frame_id, indices);
+                set_onehot_frame_counter(buf, frame_id, frame_id_abs);
+                INFO("Set {:s}[{:d}] frame counter {:d}", buf->buffer_name, frame_id, frame_id_abs);
+            } else {
+                ERROR("Metadata type is not one-hot, not recording one-hot indices anywhere!");
+            }
+            DEBUG("PY onehot[{:d}] = (({:s}), 0x{:x})", frame_id_abs, istring, val);
             n_to_set = 0;
         }
 

--- a/lib/stages/testDataGen.cpp
+++ b/lib/stages/testDataGen.cpp
@@ -289,6 +289,21 @@ void testDataGen::main_thread() {
         } else if (type == "random1x8") {
             if (chordmeta)
                 chordmeta->type = kotekan::uint1x8;
+        } else if (type == "tpluse") {
+            if (chordmeta)
+                chordmeta->type = kotekan::uint1x8;
+        } else if (type == "tpluseplusf") {
+            if (chordmeta)
+                chordmeta->type = kotekan::uint1x8;
+        } else if (type == "tpluseplusfprime") {
+            if (chordmeta)
+                chordmeta->type = kotekan::uint1x8;
+        } else if (type == "square") {
+            if (chordmeta)
+                chordmeta->type = kotekan::int4x2;
+        } else {
+            ERROR("unexpected type: {s}", type);
+            throw std::runtime_error("unexpected type: " + type);
         }
 
         // this needs the decoded type
@@ -443,6 +458,9 @@ void testDataGen::main_thread() {
                 }
                 temp_output = ((new_real << 4) & 0xF0) + (new_imaginary & 0x0F);
                 frame[j] = temp_output;
+            } else {
+                ERROR("unexpected type: {s}", type);
+                throw std::runtime_error("unexpected type: " + type);
             }
         }
         DEBUG("Generated a {:s} test data set in {:s}[{:d}] at seq {:d}", type, buf->buffer_name,

--- a/lib/utils/Telescope.cpp
+++ b/lib/utils/Telescope.cpp
@@ -11,11 +11,11 @@ Telescope::Telescope(const std::string& log_level) {
 }
 
 const Telescope& Telescope::instance() {
-    if (tel_instance == nullptr) {
+    if (!tel_instance()) {
         FATAL_ERROR_NON_OO("Telescope singleton must be configured before use.");
     }
 
-    return *tel_instance;
+    return *tel_instance();
 }
 
 const Telescope& Telescope::instance(const kotekan::Config& config) {
@@ -25,11 +25,18 @@ const Telescope& Telescope::instance(const kotekan::Config& config) {
         FATAL_ERROR_NON_OO("Requested telescope type {} is not registered", telescope_name);
     }
 
-    tel_instance = FACTORY(Telescope)::create_unique(telescope_name, config, "/telescope");
+    tel_instance() = FACTORY(Telescope)::create_unique(telescope_name, config, "/telescope");
 
-    return *tel_instance;
+    return *tel_instance();
 }
 
+std::unique_ptr<Telescope>& Telescope::tel_instance() {
+    // this must be declare in a function to ensure correct order of
+    // desctructors when unwinding the ctor stack
+    static std::unique_ptr<Telescope> the_tel_instance;
+
+    return the_tel_instance;
+}
 
 freq_id_t Telescope::to_freq_id(stream_t stream) const {
     if (num_freq_per_stream() != 1) {

--- a/lib/utils/Telescope.hpp
+++ b/lib/utils/Telescope.hpp
@@ -218,7 +218,7 @@ public:
     virtual uint64_t seq_length_nsec() const = 0;
 
 private:
-    static inline std::unique_ptr<Telescope> tel_instance = nullptr;
+    static std::unique_ptr<Telescope>& tel_instance();
 
 protected:
     /**

--- a/python/kotekan/runner.py
+++ b/python/kotekan/runner.py
@@ -145,7 +145,7 @@ class KotekanRunner(object):
                 print(cmd)
                 p = subprocess.run(cmd, stdout=f_out, stderr=f_out, shell=True)
             else:
-                print("Config file %s", fh.name, file=sys.stderr)
+                print("Config file %s" % fh.name, file=sys.stderr)
                 cmd = "%s -b %s -c %s" % (self.kotekan_binary(), rest_addr, fh.name)
                 print(cmd)
                 p = subprocess.Popen(cmd.split(), stdout=f_out, stderr=f_out)


### PR DESCRIPTION
Mostly harmless, except the change to `testDataGen` that will make up an `array_shape` given the frame size and type size if no `array_shape` is given. This removes one code path in the `onehot` test data. 

If that needs to be retained then one needs extra options.