### PR TITLE
Add reset() to Telescope to clean up REST internals

### DIFF
--- a/lib/core/kotekanMode.cpp
+++ b/lib/core/kotekanMode.cpp
@@ -47,6 +47,7 @@ kotekanMode::kotekanMode(Config& config_) : config(config_) {
 kotekanMode::~kotekanMode() {
 
     configUpdater::instance().reset();
+    Telescope::instance().reset();
     restServer::instance().remove_get_callback("/config");
     restServer::instance().remove_get_callback("/buffers");
     restServer::instance().remove_get_callback("/pipeline_dot");

--- a/lib/testing/fakeGpu.hpp
+++ b/lib/testing/fakeGpu.hpp
@@ -101,6 +101,8 @@ class FakeTelescope : public Telescope {
 public:
     FakeTelescope(const kotekan::Config& config, const std::string& path);
 
+    void reset() const override {}
+
     // Dummy freq map implementations
     freq_id_t to_freq_id(stream_t stream_id, uint32_t ind) const override;
     double to_freq(freq_id_t freq_id) const override;

--- a/lib/utils/CHORDTelescope.cpp
+++ b/lib/utils/CHORDTelescope.cpp
@@ -135,10 +135,12 @@ CHORDTelescope::CHORDTelescope(const kotekan::Config& config, const std::string&
                                       std::bind(&CHORDTelescope::send_time0_ns, this, _1));
 }
 
-CHORDTelescope::~CHORDTelescope() {
-    // Must manually remove the POST callback
-    restServer& rest_server = restServer::instance();
-    rest_server.remove_json_callback(_unique_name + "/time0_ns");
+CHORDTelescope::~CHORDTelescope() {}
+    
+void CHORDTelescope::reset() const {
+    // Must manually remove the POST callback. This function must be called 
+    // before the CHORDTelescope destructor.
+    restServer::instance().remove_json_callback(_unique_name + "/time0_ns");
 }
 
 

--- a/lib/utils/CHORDTelescope.cpp
+++ b/lib/utils/CHORDTelescope.cpp
@@ -136,9 +136,9 @@ CHORDTelescope::CHORDTelescope(const kotekan::Config& config, const std::string&
 }
 
 CHORDTelescope::~CHORDTelescope() {}
-    
+
 void CHORDTelescope::reset() const {
-    // Must manually remove the POST callback. This function must be called 
+    // Must manually remove the POST callback. This function must be called
     // before the CHORDTelescope destructor.
     restServer::instance().remove_json_callback(_unique_name + "/time0_ns");
 }

--- a/lib/utils/CHORDTelescope.hpp
+++ b/lib/utils/CHORDTelescope.hpp
@@ -91,6 +91,12 @@ class CHORDTelescope : public Telescope {
 public:
     CHORDTelescope(const kotekan::Config& config, const std::string& path);
 
+    /**
+     * Reset the internal state, removing REST endpoints, making the telescope
+     * safe to have its destructor run.
+     */
+    void reset() const override;
+
     // Implementations of the required time mapping functions
     bool gps_time_enabled() const override;
     timespec to_time(uint64_t seq) const override;

--- a/lib/utils/ICETelescope.hpp
+++ b/lib/utils/ICETelescope.hpp
@@ -30,6 +30,8 @@ class ICETelescope : public Telescope {
 public:
     ICETelescope(const kotekan::Config& config, const std::string& path);
 
+    void reset() const override {}
+
     // Implementations of the required frequency mapping functions
     freq_id_t to_freq_id(stream_t stream, uint32_t ind) const override;
     double to_freq(freq_id_t freq_id) const override;

--- a/lib/utils/Telescope.hpp
+++ b/lib/utils/Telescope.hpp
@@ -93,6 +93,12 @@ public:
     }
 
     /**
+     * Reset the internal state, removing REST endpoints, making the telescope
+     * safe to have its destructor run.
+     */
+    virtual void reset() const = 0;
+
+    /**
      * Get the frequency ID from the FPGA stream ID.
      *
      * @param  stream  The generic stream ID.


### PR DESCRIPTION
Fixes a race condition on `kotekan` exit that can cause the program to hang.  The Telescope (CHORDTelescope in particular) was calling `restServer::remove_json_callback()` in its destructor, potentially after the `restServer` itself had been destructed.  This PR adds a `reset()` function to the Telescope analogous to `configUpdater::reset()` which handles the REST cleanup before the destructor is called.  `Telescope::reset()` is called in the `kotekanMode` destructor which is guaranteed to be called before the `restServer` destructor.