### PR TITLE
changes to ringbuffer and cuda RFI code to attach to dpdk

### DIFF
--- a/config/chime_upgrade_network.j2
+++ b/config/chime_upgrade_network.j2
@@ -174,7 +174,7 @@ dpdk:
 zero_samples:
   duplicate_ls_buffer: False
 {%- for id in range(16) %}
-  zero_{{ id }}}:
+  zero_{{ id }}:
     kotekan_stage: zeroSamples
     lost_samples_buf: lost_samples_buffer_{{ id // 4 }}
     out_buf: host_voltage_buffer_{{ id }}

--- a/lib/cuda/cudaCopyFromRingbuffer.cpp
+++ b/lib/cuda/cudaCopyFromRingbuffer.cpp
@@ -30,7 +30,7 @@ cudaCopyFromRingbuffer::cudaCopyFromRingbuffer(Config& config, const std::string
                                                cudaDeviceInterface& device, int instance_num) :
     cudaCommand(config, unique_name, host_buffers, device, instance_num, no_cuda_command_state,
                 "cudaCopyFromRingbuffer", ""),
-    input_cursor(0) {
+    input_cursor(0), initial_sample0_offset(-1) {
     _output_size = config.get<size_t>(unique_name, "output_size");
     _ring_buffer_size = config.get<size_t>(unique_name, "ring_buffer_size");
     _gpu_mem_input = config.get<std::string>(unique_name, "gpu_mem_input");
@@ -126,7 +126,10 @@ cudaEvent_t cudaCopyFromRingbuffer::execute(cudaPipelineState& pipestate,
     auto tmp = std::make_shared<chordMetadata>();
     tmp->deepCopy(meta);
     meta = tmp;
-    assert(meta->get_sample0_offset() == 0);
+    if (initial_sample0_offset == -1)
+        initial_sample0_offset = meta->get_sample0_offset();
+    else
+        assert(meta->get_sample0_offset() == initial_sample0_offset);
     assert(input_cursor % meta->sample_bytes() == 0);
     meta->set_sample0_offset(meta->get_sample0_offset() + input_cursor / meta->sample_bytes());
     assert(meta->dims > 0);

--- a/lib/cuda/cudaCopyFromRingbuffer.hpp
+++ b/lib/cuda/cudaCopyFromRingbuffer.hpp
@@ -52,6 +52,7 @@ private:
     size_t _ring_buffer_size;
 
     size_t input_cursor;
+    int64_t initial_sample0_offset; // sample0_offset of first frame, used for consitency checking
 
     /// GPU side memory name for the time-stream input
     std::string _gpu_mem_input;

--- a/lib/cuda/cudaCopyToRingbuffer.cpp
+++ b/lib/cuda/cudaCopyToRingbuffer.cpp
@@ -28,7 +28,7 @@ cudaCopyToRingbuffer::cudaCopyToRingbuffer(Config& config, const std::string& un
                                            cudaDeviceInterface& device, int instance_num) :
     cudaCommand(config, unique_name, host_buffers, device, instance_num, no_cuda_command_state,
                 "cudaCopyToRingbuffer", ""),
-    output_cursor(0) {
+    output_cursor(0), initial_sample0_offset(-1) {
     _input_size = config.get<size_t>(unique_name, "input_size");
     _ring_buffer_size = config.get<size_t>(unique_name, "ring_buffer_size");
     _gpu_mem_output = config.get<std::string>(unique_name, "gpu_mem_output");
@@ -156,7 +156,10 @@ cudaEvent_t cudaCopyToRingbuffer::execute(cudaPipelineState& pipestate,
         meta->set_sample0_offset(meta->get_sample0_offset()
                                  - output_cursor * meta->get_offset_downsampling()
                                        / meta->sample_bytes());
-        assert(meta->get_sample0_offset() == 0);
+        if (initial_sample0_offset == -1)
+            initial_sample0_offset = meta->get_sample0_offset();
+        else
+            assert(meta->get_sample0_offset() == initial_sample0_offset);
         assert(meta->dims > 0);
         assert(in_buffer->frame_size % meta->sample_bytes() == 0);
         assert(meta->dim[0] == std::ptrdiff_t(in_buffer->frame_size / meta->sample_bytes()));

--- a/lib/cuda/cudaCopyToRingbuffer.hpp
+++ b/lib/cuda/cudaCopyToRingbuffer.hpp
@@ -53,6 +53,7 @@ private:
     size_t _ring_buffer_size;
 
     size_t output_cursor;
+    int64_t initial_sample0_offset; // sample0_offset of first frame, used for consitency checking
 
     // One of these will be set:
     /// GPU side memory name for the frame-based input

--- a/lib/cuda/cudaRFIS012.cpp
+++ b/lib/cuda/cudaRFIS012.cpp
@@ -191,8 +191,16 @@ cudaEvent_t cudaRFIS012::execute(cudaPipelineState& /*pipestate*/,
 
     rfi_S012.set_metadata(voltage.get_metadata());
     const auto& rfi_S012_meta = rfi_S012.get_metadata();
-    auto freq_upchan_factor = rfi_S012_meta->get_freq_upchan_factor();
-    auto time_downsampling_fpga = rfi_S012_meta->get_time_downsampling_fpga();
+    std::vector<int> freq_upchan_factor;
+    if (rfi_S012_meta->has_freq_upchan_factor())
+        freq_upchan_factor = rfi_S012_meta->get_freq_upchan_factor();
+    else
+        freq_upchan_factor.assign(rfi_S012_meta->get_nfreq(), 1);
+    std::vector<int> time_downsampling_fpga;
+    if (rfi_S012_meta->has_time_downsampling_fpga())
+        time_downsampling_fpga = rfi_S012_meta->get_time_downsampling_fpga();
+    else
+        time_downsampling_fpga.assign(rfi_S012_meta->get_nfreq(), 1);
     assert(freq_upchan_factor.size() == static_cast<size_t>(rfi_S012_meta->get_nfreq()));
     assert(time_downsampling_fpga.size() == static_cast<size_t>(rfi_S012_meta->get_nfreq()));
     assert(rfi_S012_meta->get_nfreq() >= 0);

--- a/lib/stages/lostSamplesToPLMask.cpp
+++ b/lib/stages/lostSamplesToPLMask.cpp
@@ -78,7 +78,7 @@ void lostSamplesToPLMask::main_thread() {
         uint8_t* pl_mask_frame =
             pl_mask_buf->wait_for_empty_frame(unique_name, pl_mask_buf_frame_id);
         if (pl_mask_frame == nullptr)
-            break;
+            return;
         pl_mask_buf->allocate_new_metadata_object(pl_mask_buf_frame_id);
         auto pl_mask_meta = get_chord_metadata(pl_mask_buf, pl_mask_buf_frame_id);
 
@@ -87,7 +87,7 @@ void lostSamplesToPLMask::main_thread() {
             uint8_t* flag_frame =
                 lost_samples_buf->wait_for_full_frame(unique_name, lost_samples_buf_frame_id);
             if (flag_frame == nullptr)
-                break;
+                return;
 
             // constant for all iterations but only set by the producer before
             // it marks the frame as full, so cannot be checked before the first


### PR DESCRIPTION
DPDK does not always start its sequences with 0 since it may have dropped network packets trying to synchronize threads, so `sample0_offset` may not start out as `0`. Similarly dpdk currently does not set any upsampling factors for the raw input data, which trips up the first kurtosis kernel.

The changes to the RingBuffer code should be fine (and match what `cudaCopyNToRingBuffer` does), the change to `cudaRFIS012` is a bit more questionable, since it somehow just kicks the can down the road and if one ever had a situation where another cuda kernel that expects upsampling factors present is called first after dpdk then it would also fail.

A "cleaner" solution may be to have dpdk set the upsampling factors to 1 itself, even though this makes it set "unused" metadata (there's no upsampling yet at that point in the pipeline).