### PR TITLE
minor fixes

### DIFF
--- a/lib/core/buffer.hpp
+++ b/lib/core/buffer.hpp
@@ -633,9 +633,9 @@ public:
     void set_frame_desc(std::shared_ptr<kotekan::FrameDesc> new_desc) {
         buffer_lock lock(mutex);
 
-        if (new_desc->get_byte_size() != aligned_frame_size) {
+        if (new_desc->get_byte_size() != frame_size) {
             FATAL_ERROR("Frame description size ({:d}) is unexpected, buffer provides ({:d})",
-                        new_desc->get_byte_size(), aligned_frame_size);
+                        new_desc->get_byte_size(), frame_size);
         }
 
         if (!frames_desc) {

--- a/lib/utils/datasetManager.cpp
+++ b/lib/utils/datasetManager.cpp
@@ -34,10 +34,10 @@ datasetManager& datasetManager::instance() {
     datasetManager& dm = private_instance();
 
     if (!dm._config_applied) {
-        ERROR_NON_OO("A part of kotekan that is configured to load uses the datasetManager, but "
-                     "no block named '{:s}' was found in the config.\nExiting...",
-                     DS_UNIQUE_NAME);
-        exit(-1);
+        FATAL_ERROR_NON_OO(
+            "A part of kotekan that is configured to load uses the datasetManager, but "
+            "no block named '{:s}' was found in the config.\nExiting...",
+            DS_UNIQUE_NAME);
     }
 
     return dm;


### PR DESCRIPTION
* 219fa623 - DatasetManager: use FATAL_ERROR to report a failure rather than exit(-1)
* 8b1ef6c3 - buffer: compare to exact frame size when checking frame_desc