### PR TITLE
Rhaas/n2 accumulate threads

### DIFF
--- a/lib/stages/N2Accumulate.cpp
+++ b/lib/stages/N2Accumulate.cpp
@@ -152,8 +152,6 @@ N2Accumulate::N2Accumulate(Config& config, const std::string& unique_name,
     // _num_freq_per_n2k_frame (accumulate the full, blocked matrix x frequencies from the GPU)
     _vis = std::vector<int32_t>(2 * _num_freq_per_n2k_frame * _n2k_correlation_num_products,
                                 0); // vis with complex as 2 ints
-    _vis_even = std::vector<int32_t>(2 * _num_freq_per_n2k_frame * _n2k_correlation_num_products,
-                                     0); // store even vis matrix for weights calculation
     _weights = std::vector<float>(_num_freq_per_n2k_frame * _n2k_correlation_num_products,
                                   0.0f); // real-valued weights
 
@@ -164,7 +162,7 @@ N2Accumulate::N2Accumulate(Config& config, const std::string& unique_name,
     _n_rfi_samples_in_vis = std::vector<int32_t>(_num_freq_per_n2k_frame, 0);
 
     _vis_samples_in_out_frame = 0;
-    _accum_fpga_start_tick = 0;
+    _accum_fpga_start_tick = -1;
 
     // Ensure incoming buffer frame sizes are correct
     size_t in_corr_frame_size = 2 * sizeof(int32_t) * _n2k_correlation_num_products
@@ -229,6 +227,7 @@ void N2Accumulate::main_thread() {
         Metrics::instance().add_gauge("kotekan_samples_in_accumulated_out_frame", unique_name);
 
     frameID in_frame_id(in_buf);
+    int previous_in_frame_id = -1;
     frameID in_counts_frame_id(in_counts_buf);
     frameID in_rfimask_frame_id(in_rfimask_buf);
     frameID out_frame_id(out_buf);
@@ -243,6 +242,10 @@ void N2Accumulate::main_thread() {
     uint64_t rfi_stride_f = 128; // = rfimask_fast_time_len / bits_per_entry = 1024 / 8;
     uint64_t rfi_stride_thi = rfi_stride_f * _num_freq_per_n2k_frame;
 
+    // vis_even may be an odd frame if the first frame eencountered is odd,
+    // since fpga_seq_num does not have to start from 0, in which case we skip
+    // it.
+    int32_t const* vis_even = nullptr;
 
     while (!stop_thread) {
 
@@ -303,6 +306,26 @@ void N2Accumulate::main_thread() {
             // "absolute" vis sample number
             int64_t vis_sample_num_abs = in_frame_num * _n_integrations_per_n2k_frame + vis_samp_n;
 
+            if (vis_even == nullptr) { // first time
+                // this will skip all of the vis_samp_n loop, but is easier to
+                // do here than outside due to the frame advance at the end of
+                // the outer loop
+                // if starting n2k frame fragment is not even numbered, skip whole frame
+                // if starting n2k fragment is not a multiple of the number of
+                // n2k samples to accumulate, skip whole frame
+                if (vis_sample_num_abs % 2 != 0
+                    || vis_sample_num_abs % _num_n2k_samples_to_accumulate != 0) {
+                    // NOTE: since we enforce that
+                    // _n_fpga_samples_per_n2k_frame % _n_fpga_samples_per_n2k_correlation == 0
+                    // holds we can ony get here if
+                    // _n_fpga_samples_per_n2k_frame == _n_fpga_samples_per_n2k_correlation
+                    // and the initial fpga_seq_num corresponds to an odd frame
+                    break;
+                }
+                assert(_accum_fpga_start_tick == -1);
+                _accum_fpga_start_tick = frame_metadata->get_fpga_seq_num();
+            }
+
             DEBUG("Accumulating new visibility sample ({:d} of {:d} in frame).", vis_samp_n,
                   _n_integrations_per_n2k_frame);
             // DEBUG("   Times are [start, end, out, num] = [{:d}, {:d}, {:d}, {:d}]",
@@ -330,7 +353,6 @@ void N2Accumulate::main_thread() {
 
             // Double checking the accumulation arrays are the right shape
             assert(_vis.size() == corr_stride_t);
-            assert(_vis_even.size() == corr_stride_t);
             assert(_weights.size() == corr_stride_t / 2);
 
             // The actual accumulation of visibility.
@@ -340,16 +362,13 @@ void N2Accumulate::main_thread() {
 
             // If we're working on an even sample, store it for differencing
             // with an odd sample. If odd, add to the _weights matrix.
-            // Potential optimization: copying vis_even is only really
-            // necessary if we've started accumulating a new frame
             if (vis_sample_num_abs % 2 == 0) {
-                std::copy(corr + corr_offset_t, corr + corr_offset_t + corr_stride_t,
-                          _vis_even.begin());
+                vis_even = corr + corr_offset_t;
             } else {
                 for (uint64_t d = 0;
                      d < (uint64_t)(_n2k_correlation_num_products * _num_freq_per_n2k_frame); ++d) {
-                    float dr = corr[corr_offset_t + 2 * d + 0] - _vis_even[2 * d + 0];
-                    float di = corr[corr_offset_t + 2 * d + 1] - _vis_even[2 * d + 1];
+                    float dr = corr[corr_offset_t + 2 * d + 0] - vis_even[2 * d + 0];
+                    float di = corr[corr_offset_t + 2 * d + 1] - vis_even[2 * d + 1];
                     _weights[d] += dr * dr + di * di;
                 } // d
             } // if even/odd
@@ -426,7 +445,9 @@ void N2Accumulate::main_thread() {
         } // t (vis samples in frame)
 
         // Advance to the next frame
-        in_buf->mark_frame_empty(unique_name, in_frame_id++);
+        if (previous_in_frame_id != -1)
+            in_buf->mark_frame_empty(unique_name, previous_in_frame_id);
+        previous_in_frame_id = in_frame_id++;
         in_counts_buf->mark_frame_empty(unique_name, in_counts_frame_id++);
         in_rfimask_buf->mark_frame_empty(unique_name, in_rfimask_frame_id++);
     }
@@ -453,6 +474,8 @@ bool N2Accumulate::output_and_reset(frameID& in_frame_id, frameID& out_frame_id)
         DEBUG("Allocating metadata.");
         out_buf->allocate_new_metadata_object(out_frame_id);
         std::shared_ptr<N2Metadata> meta = get_N2_metadata(out_buf, out_frame_id);
+
+        assert(_accum_fpga_start_tick >= 0);
 
         meta->fpga_start_tick = _accum_fpga_start_tick;
         meta->frame_length_fpga_ticks =

--- a/lib/stages/N2Accumulate.cpp
+++ b/lib/stages/N2Accumulate.cpp
@@ -125,6 +125,9 @@ N2Accumulate::N2Accumulate(Config& config, const std::string& unique_name,
         // number of "integrations" (coarse time samples) per n2k (gpu) frame
         _n_integrations_per_n2k_frame =
             _n_fpga_samples_per_n2k_frame / _n_fpga_samples_per_n2k_correlation;
+        assert(_n_fpga_samples_per_n2k_frame % _n_fpga_samples_per_n2k_correlation == 0
+               && "_n_fpga_samples_per_n2k_frame must be a multiple of "
+                  "_n_fpga_samples_per_n2k_correlation");
 
         // sizes for blocked input correlation matrix
         _n2k_correlation_lin_blocks = _num_elements / _n2k_correlation_blocksize;

--- a/lib/stages/N2Accumulate.cpp
+++ b/lib/stages/N2Accumulate.cpp
@@ -339,7 +339,7 @@ void N2Accumulate::main_thread() {
             // Finalize accumulation if the visibility elements are past the output time...
             //  end on an odd frame too so we accumulate weights.
             // if (t_vis_s > t_output && vis_sample_num_abs % 2 == 1) { }
-            if (_vis_samples_in_out_frame >= _num_n2k_samples_to_accumulate) {
+            if (_vis_samples_in_out_frame == _num_n2k_samples_to_accumulate) {
 
                 INFO("Finishing N2Accumulate output frame. Accumulated {:d} visibility samples.",
                      _vis_samples_in_out_frame);
@@ -482,13 +482,18 @@ bool N2Accumulate::output_and_reset(frameID& in_frame_id, frameID& out_frame_id)
         std::shared_ptr<N2Metadata> meta = get_N2_metadata(out_buf, out_frame_id);
 
         assert(_accum_fpga_start_tick >= 0);
+        assert(_vis_samples_in_out_frame == _num_n2k_samples_to_accumulate);
 
         meta->fpga_start_tick = _accum_fpga_start_tick;
         meta->frame_length_fpga_ticks =
             _vis_samples_in_out_frame * _n_fpga_samples_per_n2k_correlation;
 
-        meta->abs_time_idx = _accum_fpga_start_tick
-                             / (_vis_samples_in_out_frame * _n_fpga_samples_per_n2k_correlation);
+        meta->abs_time_idx =
+            _accum_fpga_start_tick
+            / (_num_n2k_samples_to_accumulate * _n_fpga_samples_per_n2k_correlation);
+        assert(_accum_fpga_start_tick
+                   % (_num_n2k_samples_to_accumulate * _n_fpga_samples_per_n2k_correlation)
+               == 0);
         meta->freq_id = chord_frame_metadata->get_coarse_freq()[f];
         meta->n_valid_fpga_ticks = _n_valid_fpga_samples_in_vis[f];
 

--- a/lib/stages/N2Accumulate.cpp
+++ b/lib/stages/N2Accumulate.cpp
@@ -338,7 +338,7 @@ void N2Accumulate::main_thread() {
 
             // Finalize accumulation if the visibility elements are past the output time...
             //  end on an odd frame too so we accumulate weights.
-            // if (t_vis_s > t_output && vis_sample_num_abs % 2 == 1) {
+            // if (t_vis_s > t_output && vis_sample_num_abs % 2 == 1) { }
             if (_vis_samples_in_out_frame >= _num_n2k_samples_to_accumulate) {
 
                 INFO("Finishing N2Accumulate output frame. Accumulated {:d} visibility samples.",

--- a/lib/stages/N2Accumulate.cpp
+++ b/lib/stages/N2Accumulate.cpp
@@ -47,7 +47,8 @@ N2Accumulate::N2Accumulate(Config& config, const std::string& unique_name,
     _n_fpga_samples_per_n2k_frame(config.get<int64_t>(unique_name, "samples_per_data_set")),
     _n_fpga_samples_per_n2k_correlation(config.get<int64_t>(unique_name, "sub_integration_ntime")),
     _rfi_downsampling_factor(config.get<int64_t>(unique_name, "rfi_downsampling_factor")),
-    _num_elements(config.get<int64_t>(unique_name, "num_elements")), _abs_frame_count(0),
+    _num_elements(config.get<int64_t>(unique_name, "num_elements")),
+    _num_workers(config.get_default<int>(unique_name, "num_workers", 1)), _abs_frame_count(0),
     _tel(Telescope::instance().cast<CHORDTelescope>()),
     skipped_frame_counter(Metrics::instance().add_counter(
         "kotekan_N2accumulate_skipped_frame_total", unique_name, {"freq_id", "reason"})) {
@@ -356,6 +357,7 @@ void N2Accumulate::main_thread() {
             assert(_weights.size() == corr_stride_t / 2);
 
             // The actual accumulation of visibility.
+#pragma omp parallel for simd num_threads(_num_workers)
             for (uint64_t d = 0; d < corr_stride_t; ++d) {
                 _vis[d] += corr[d + corr_offset_t];
             } // d
@@ -365,6 +367,7 @@ void N2Accumulate::main_thread() {
             if (vis_sample_num_abs % 2 == 0) {
                 vis_even = corr + corr_offset_t;
             } else {
+#pragma omp parallel for simd num_threads(_num_workers)
                 for (uint64_t d = 0;
                      d < (uint64_t)(_n2k_correlation_num_products * _num_freq_per_n2k_frame); ++d) {
                     float dr = corr[corr_offset_t + 2 * d + 0] - vis_even[2 * d + 0];

--- a/lib/stages/N2Accumulate.hpp
+++ b/lib/stages/N2Accumulate.hpp
@@ -81,6 +81,8 @@ private:
 
     int64_t _num_elements; ///< Total number of telescope elements (~2 * num dishes)
 
+    const int _num_workers; ///< number of OpenMP threads to use to process data
+
     // Absolute frame counter (TODO: determine this another way)
     uint64_t _abs_frame_count;
 

--- a/lib/stages/N2Accumulate.hpp
+++ b/lib/stages/N2Accumulate.hpp
@@ -105,7 +105,6 @@ private:
     // The below vectors are initialized in the constructor after _num_vis_products
     // and _num_freq_in_frame are known.
     std::vector<int32_t> _vis;
-    std::vector<int32_t> _vis_even;
     std::vector<float> _weights;
     // number of fpga samples, per frequency, in frame
     std::vector<int32_t> _n_valid_fpga_samples_in_vis;

--- a/lib/testing/testN2kGen.cpp
+++ b/lib/testing/testN2kGen.cpp
@@ -79,6 +79,7 @@ testN2kGen::testN2kGen(Config& config, const std::string& unique_name,
     freq_ids = config.get_default<std::vector<uint32_t>>(unique_name, "freq_ids",
                                                          std::vector<uint32_t>({4096}));
     seed = config.get_default<uint32_t>(unique_name, "seed", 0);
+    first_frame_index = config.get_default<int64_t>(unique_name, "first_frame_index", 0);
 
     // Check parameter compatibility
     if (num_elements <= 0) {
@@ -290,7 +291,7 @@ void testN2kGen::main_thread() {
     frameID count_frame_id(count_buf);
     frameID rfi_frame_id(rfi_buf);
     int num_frames_generated = 0;
-    uint64_t seq_num = 0;
+    uint64_t seq_num = first_frame_index * samples_per_data_set;
 
     std::mt19937 rng(seed);
     std::uniform_int_distribution<int32_t> count_dist(count_min, count_max);

--- a/lib/testing/testN2kGen.hpp
+++ b/lib/testing/testN2kGen.hpp
@@ -40,6 +40,8 @@
  * @conf  counts_values         Vector of ints. Optional cycle for "const" count frames.
  * @conf  seed                  Int. Default 0. Seeds the deterministic RNG for "random" correlation
  *                              and counts variants.
+ * @conf  first_frame_index     Int. Default 0. Starting FPGA frame number, fro
+ *                              frames of size samples_per_data_set.
  * @conf  samples_per_data_set  Int. How often to produce data.
  * @conf  num_frames            Int. How many frames to produce. Default inf.
  * @conf  num_freq_in_frame     Int. Number of frequencies in each GPU frame.
@@ -77,6 +79,7 @@ private:
     int32_t num_elements;
     std::vector<uint32_t> freq_ids;
     uint32_t seed;
+    int64_t first_frame_index;
 
     static constexpr int corr_blocksize = 16; // ALWAYS 16
     static constexpr int count_blocksize = 8; // ALWAYS 8


### PR DESCRIPTION
adds some speed optimization and multi-threading to N2Accumulate. Required for CHIME where 3 cores are needed to keep CPU load to 66% for each of them and not fall behind.