### PR TITLE
Telescope Reorganization

### DIFF
--- a/config/ci-tests/cpu_batch/run_n2accum.yaml
+++ b/config/ci-tests/cpu_batch/run_n2accum.yaml
@@ -52,7 +52,7 @@ telescope:
   dish_elev_axis: [1.0, 0.0, 0.0]
   dish_vert_axis: [0.0, 0.0, 1.0]
   require_gps: False
-  updatable_config: /earth_rotation_data
+  eop_updatable_config: /earth_rotation_data
   num_dishes_x: 22
   num_dishes_y: 24
   dish_inputs: []

--- a/config/ci-tests/cpu_batch/test_send_recv.yaml
+++ b/config/ci-tests/cpu_batch/test_send_recv.yaml
@@ -20,7 +20,7 @@ telescope:
     dish_elev_axis: [1.0, 0.0, 0.0]
     dish_vert_axis: [0.0, 0.0, 1.0]
     require_gps: False
-    updatable_config: /earth_rotation_data
+    eop_updatable_config: /earth_rotation_data
     num_dishes_x: 22
     num_dishes_y: 24
     num_dishes: 64

--- a/config/ci-tests/standalone/test_pipeline.j2
+++ b/config/ci-tests/standalone/test_pipeline.j2
@@ -115,7 +115,7 @@ telescope:
   num_dishes_x: 10
   num_dishes_y: 10
   require_gps: False
-  updatable_config: /earth_rotation_data
+  eop_updatable_config: /earth_rotation_data
 
 gps_time:
   frame0_nano: start_time_s * GIGA

--- a/config/fengine/include/fengine_chime.j2
+++ b/config/fengine/include/fengine_chime.j2
@@ -31,7 +31,7 @@ telescope:
     dish_vert_axis: [0.0, 0.0, 1.0]
     dish_coelev_deg: 0.0
 
-    updatable_config: "/earth_rotation_data"
+    eop_updatable_config: "/earth_rotation_data"
 
     dish_separation_x_m: 20.0
     dish_separation_y_m: 0.390625

--- a/config/fengine/include/fengine_chord.j2
+++ b/config/fengine/include/fengine_chord.j2
@@ -31,7 +31,7 @@ telescope:
     dish_vert_axis: [0.0, 0.0, 1.0]
     dish_coelev_deg: 0.0
 
-    updatable_config: "/earth_rotation_data"
+    eop_updatable_config: "/earth_rotation_data"
 
     dish_separation_x_m: 6.3
     dish_separation_y_m: 8.5

--- a/config/fengine/include/fengine_hirax.j2
+++ b/config/fengine/include/fengine_hirax.j2
@@ -31,7 +31,7 @@ telescope:
     dish_vert_axis: [0.0, 0.0, 1.0]
     dish_coelev_deg: 0.0
 
-    updatable_config: "/earth_rotation_data"
+    eop_updatable_config: "/earth_rotation_data"
 
     dish_separation_x_m: 6.3    # TODO: check
     dish_separation_y_m: 8.5    # TODO: check

--- a/config/fengine/include/fengine_pathfinder.j2
+++ b/config/fengine/include/fengine_pathfinder.j2
@@ -31,7 +31,7 @@ telescope:
     dish_vert_axis: [0.0, 0.0, 1.0]
     dish_coelev_deg: 0.0
 
-    updatable_config: "/earth_rotation_data"
+    eop_updatable_config: "/earth_rotation_data"
 
     dish_separation_x_m: 6.3
     dish_separation_y_m: 8.5

--- a/config/fengine/include/fengine_smallfinder.j2
+++ b/config/fengine/include/fengine_smallfinder.j2
@@ -31,7 +31,7 @@ telescope:
     dish_vert_axis: [0.0, 0.0, 1.0]
     dish_coelev_deg: 0.0
 
-    updatable_config: "/earth_rotation_data"
+    eop_updatable_config: "/earth_rotation_data"
 
     dish_separation_x_m: 6.3
     dish_separation_y_m: 8.5

--- a/config/tests/fringestop.yaml
+++ b/config/tests/fringestop.yaml
@@ -194,7 +194,7 @@ telescope:
   dish_vert_axis: [0.0, 0.0, 1.0]
   dish_coelev_deg: 0.0
   require_gps: false
-  updatable_config: /earth_rotation_data
+  eop_updatable_config: /earth_rotation_data
 
   dish_separation_x_m: 6.3
   dish_separation_y_m: 8.5

--- a/config/tests/point_source.yaml
+++ b/config/tests/point_source.yaml
@@ -34,7 +34,7 @@ telescope:
   dish_vert_axis: [0.0, 0.0, 1.0]
   dish_coelev_deg: 0.0
   require_gps: false
-  updatable_config: /earth_rotation_data
+  eop_updatable_config: /earth_rotation_data
   num_dishes_x: 8
   num_dishes_y: 12
 

--- a/config/tests/testCHORDTelescope.yaml
+++ b/config/tests/testCHORDTelescope.yaml
@@ -71,6 +71,8 @@ gps_time:
   frame0_nano: 50 * nsec_in_jyear
 
 num_dishes: 32
+num_dishes_x: 16
+num_dishes_y: 16
 
 # Add a consumer stage that prints the output buffer to screen
 screen_dump:

--- a/config/tests/testCHORDTelescope.yaml
+++ b/config/tests/testCHORDTelescope.yaml
@@ -49,7 +49,7 @@ telescope:
   dish_vert_axis: [0.0, 0.0, 1.0]
   dish_coelev_deg: 0.0
 
-  updatable_config: "/earth_rotation_data"
+  eop_updatable_config: "/earth_rotation_data"
 
   dish_separation_x_m: 6.3
   dish_separation_y_m: 8.5

--- a/lib/stages/N2Accumulate.cpp
+++ b/lib/stages/N2Accumulate.cpp
@@ -49,7 +49,7 @@ N2Accumulate::N2Accumulate(Config& config, const std::string& unique_name,
     _rfi_downsampling_factor(config.get<int64_t>(unique_name, "rfi_downsampling_factor")),
     _num_elements(config.get<int64_t>(unique_name, "num_elements")),
     _num_workers(config.get_default<int>(unique_name, "num_workers", 1)), _abs_frame_count(0),
-    _tel(Telescope::instance().cast<CHORDTelescope>()),
+    _tel(Telescope::instance()),
     skipped_frame_counter(Metrics::instance().add_counter(
         "kotekan_N2accumulate_skipped_frame_total", unique_name, {"freq_id", "reason"})) {
 

--- a/lib/stages/N2Accumulate.hpp
+++ b/lib/stages/N2Accumulate.hpp
@@ -117,7 +117,7 @@ private:
     int64_t _accum_fpga_start_tick;
 
     // The telescope
-    const CHORDTelescope& _tel;
+    const Telescope& _tel;
 
     // Reference to the prometheus metric that we will use for counting skipped
     // frames

--- a/lib/stages/hdf5N2Write.cpp
+++ b/lib/stages/hdf5N2Write.cpp
@@ -329,7 +329,7 @@ std::unique_ptr<HighFive::File> N2FileData::_open_or_create_file(const std::stri
                 std::vector<double> eop_yp_as(eop_len);
 
                 for (int i = 0; i < eop_len; i++) {
-                    EOP eop = telescope.get_EOP_at_idx(i);
+                    EOP eop = telescope.get_EOP_at_table_idx(i);
                     eop_t_inst[i] = eop.t_inst;
                     eop_t_ut1[i] = eop.t_ut1;
                     eop_delta_UT1_inst[i] = eop.delta_UT1_inst;

--- a/lib/stages/hdf5N2Write.cpp
+++ b/lib/stages/hdf5N2Write.cpp
@@ -312,14 +312,14 @@ std::unique_ptr<HighFive::File> N2FileData::_open_or_create_file(const std::stri
         _check_create_attribute(*file, "origin_itrs_lat_deg", telescope.get_origin_itrs_lat_deg());
         _check_create_attribute(*file, "dish_coelev_deg", telescope.get_dish_coelev_deg());
         _check_create_attribute(*file, "num_dishes", telescope.get_num_dishes());
-        _check_create_attribute(*file, "EOP_table_len", telescope.get_EOP_table_len());
         _check_create_attribute(*file, "num_file_f",
                                 telescope.num_science_freqs()); // "science-case" frequencies only
         _check_create_attribute(*file, "num_telescope_f", telescope.num_freq());
 
-        // Store EOP table ERA_deg and t_ut1 only
+        // Store EOP table.
         {
-            const int eop_len = telescope.get_EOP_table_len();
+            std::vector<EOP> eop_table = telescope.get_current_EOP_table();
+            const int eop_len = eop_table.size();
             if (eop_len > 0) {
                 std::vector<int64_t> eop_t_inst(eop_len);
                 std::vector<int64_t> eop_t_ut1(eop_len);
@@ -329,7 +329,7 @@ std::unique_ptr<HighFive::File> N2FileData::_open_or_create_file(const std::stri
                 std::vector<double> eop_yp_as(eop_len);
 
                 for (int i = 0; i < eop_len; i++) {
-                    EOP eop = telescope.get_EOP_at_table_idx(i);
+                    EOP eop = eop_table[i];
                     eop_t_inst[i] = eop.t_inst;
                     eop_t_ut1[i] = eop.t_ut1;
                     eop_delta_UT1_inst[i] = eop.delta_UT1_inst;

--- a/lib/testing/fakeGpu.cpp
+++ b/lib/testing/fakeGpu.cpp
@@ -176,8 +176,7 @@ void FakeGpu::main_thread() {
 
 
 FakeTelescope::FakeTelescope(const kotekan::Config& config, const std::string& path) :
-    Telescope(path,
-              config.get<std::string>(path, "log_level"),
+    Telescope(path, config.get<std::string>(path, "log_level"),
               config.get_default<std::string>(path, "updatable_config", "")) {
     _num_local_freq = config.get_default<size_t>(path, "num_local_freq", 1);
 }

--- a/lib/testing/fakeGpu.cpp
+++ b/lib/testing/fakeGpu.cpp
@@ -177,7 +177,7 @@ void FakeGpu::main_thread() {
 
 FakeTelescope::FakeTelescope(const kotekan::Config& config, const std::string& path) :
     Telescope(path, config.get<std::string>(path, "log_level"),
-              config.get_default<std::string>(path, "updatable_config", "")) {
+              config.get_default<std::string>(path, "eop_updatable_config", "")) {
     _num_local_freq = config.get_default<size_t>(path, "num_local_freq", 1);
 }
 

--- a/lib/testing/fakeGpu.cpp
+++ b/lib/testing/fakeGpu.cpp
@@ -176,7 +176,9 @@ void FakeGpu::main_thread() {
 
 
 FakeTelescope::FakeTelescope(const kotekan::Config& config, const std::string& path) :
-    Telescope(config.get<std::string>(path, "log_level")) {
+    Telescope(path,
+              config.get<std::string>(path, "log_level"),
+              config.get_default<std::string>(path, "updatable_config", "")) {
     _num_local_freq = config.get_default<size_t>(path, "num_local_freq", 1);
 }
 
@@ -209,6 +211,11 @@ nyquist_zone_t FakeTelescope::nyquist_zone() const {
 timespec FakeTelescope::to_time(uint64_t seq) const {
     uint64_t ns = seq_length_nsec() * seq;
     return {time_t(ns / 1000000000ULL), time_t(ns % 1000000000ULL)};
+}
+
+int64_t FakeTelescope::to_time_ns(uint64_t seq) const {
+    uint64_t ns = seq_length_nsec() * seq;
+    return int64_t(ns);
 }
 
 uint64_t FakeTelescope::to_seq(timespec time) const {

--- a/lib/testing/fakeGpu.hpp
+++ b/lib/testing/fakeGpu.hpp
@@ -111,6 +111,7 @@ public:
 
     // Dummy time map implementations
     timespec to_time(uint64_t seq) const override;
+    int64_t to_time_ns(uint64_t seq) const override;
     uint64_t to_seq(timespec time) const override;
     uint64_t seq_length_nsec() const override;
     bool gps_time_enabled() const override;

--- a/lib/testing/testCHORDTelescope.cpp
+++ b/lib/testing/testCHORDTelescope.cpp
@@ -90,7 +90,7 @@ void TestCHORDTelescope::main_thread() {
         int i;
         INFO("            EOP entries: {:d}", n_eop);
         for (i = 0; i < n_eop; i++) {
-            struct EOP eop = tel.get_EOP_at_idx(i);
+            struct EOP eop = tel.get_EOP_at_table_idx(i);
             eop_times.push_back(eop.t_inst);
             INFO("            {0: 2d} - t_inst: {1:d} s + {2:d} ns", i, eop.t_inst / GIGA,
                  eop.t_inst % GIGA);

--- a/lib/testing/testCHORDTelescope.cpp
+++ b/lib/testing/testCHORDTelescope.cpp
@@ -83,14 +83,15 @@ void TestCHORDTelescope::main_thread() {
         INFO("                              {0:.6f} {1:.6f} {2:.6f}",
              tel.get_dish_orientation_el(2, 0), tel.get_dish_orientation_el(2, 1),
              tel.get_dish_orientation_el(2, 2));
-        int n_eop = tel.get_EOP_table_len();
+
+        std::vector<EOP> eop_tab = tel.get_current_EOP_table();
 
         std::vector<int64_t> eop_times;
 
-        int i;
-        INFO("            EOP entries: {:d}", n_eop);
-        for (i = 0; i < n_eop; i++) {
-            struct EOP eop = tel.get_EOP_at_table_idx(i);
+        size_t i;
+        INFO("            EOP entries: {:d}", eop_tab.size());
+        for (i = 0; i < eop_tab.size(); i++) {
+            struct EOP eop = eop_tab[i];
             eop_times.push_back(eop.t_inst);
             INFO("            {0: 2d} - t_inst: {1:d} s + {2:d} ns", i, eop.t_inst / GIGA,
                  eop.t_inst % GIGA);
@@ -101,7 +102,7 @@ void TestCHORDTelescope::main_thread() {
             INFO("               - yp:     {:f} arcsec", eop.yp_as);
         }
 
-        int nt = eop_times.size();
+        size_t nt = eop_times.size();
 
         INFO("            EOP Probes:");
 
@@ -161,7 +162,7 @@ void TestCHORDTelescope::main_thread() {
             }
         }
 
-        int n_dish = tel.get_num_dishes();
+        size_t n_dish = tel.get_num_dishes();
         INFO("            Num Dishes:  {:d}", n_dish);
         for (i = 0; i < n_dish; i++) {
             std::array<double, 3> pos = tel.get_dish_position_in_grid_coords(i);

--- a/lib/utils/CHIMETelescope.cpp
+++ b/lib/utils/CHIMETelescope.cpp
@@ -17,8 +17,7 @@
 REGISTER_TELESCOPE(CHIMETelescope, "CHIMETelescope");
 
 CHIMETelescope::CHIMETelescope(const kotekan::Config& config, const std::string& path) :
-    ICETelescope(path,
-                 config.get<std::string>(path, "log_level"),
+    ICETelescope(path, config.get<std::string>(path, "log_level"),
                  config.get_default<std::string>(path, "updatable_config", "")) {
     INFO("Building CHIMETelescope");
 

--- a/lib/utils/CHIMETelescope.cpp
+++ b/lib/utils/CHIMETelescope.cpp
@@ -18,7 +18,7 @@ REGISTER_TELESCOPE(CHIMETelescope, "CHIMETelescope");
 
 CHIMETelescope::CHIMETelescope(const kotekan::Config& config, const std::string& path) :
     ICETelescope(path, config.get<std::string>(path, "log_level"),
-                 config.get_default<std::string>(path, "updatable_config", "")) {
+                 config.get_default<std::string>(path, "eop_updatable_config", "")) {
     INFO("Building CHIMETelescope");
 
     // This is always 1 for CHIME

--- a/lib/utils/CHIMETelescope.cpp
+++ b/lib/utils/CHIMETelescope.cpp
@@ -17,7 +17,10 @@
 REGISTER_TELESCOPE(CHIMETelescope, "CHIMETelescope");
 
 CHIMETelescope::CHIMETelescope(const kotekan::Config& config, const std::string& path) :
-    ICETelescope(config.get<std::string>(path, "log_level")) {
+    ICETelescope(path,
+                 config.get<std::string>(path, "log_level"),
+                 config.get_default<std::string>(path, "updatable_config", "")) {
+    INFO("Building CHIMETelescope");
 
     // This is always 1 for CHIME
     _num_freq_per_stream = 1;

--- a/lib/utils/CHORDTelescope.cpp
+++ b/lib/utils/CHORDTelescope.cpp
@@ -378,7 +378,7 @@ void GPSTimeParams::set_gps_time_params_from_remote(GPSTimeParams& gps, const st
 
 CHORDTelescope::CHORDTelescope(const kotekan::Config& config, const std::string& path) :
     Telescope(path, config.get<std::string>(path, "log_level"),
-              config.get_default<std::string>(path, "updatable_config", "")),
+              config.get_default<std::string>(path, "eop_updatable_config", "")),
     // Frequency sampling parameters
     _freq_params(FreqParams::from_config(config, path)),
     // GPS time configuration parameters

--- a/lib/utils/CHORDTelescope.cpp
+++ b/lib/utils/CHORDTelescope.cpp
@@ -1056,14 +1056,6 @@ EOP CHORDTelescope::build_EOP_from_update(int64_t time_ns, double delta_ut1_inst
     return eop;
 }
 
-bool EOP_comp_time(const EOP& eop1, const EOP& eop2) {
-    return eop1.t_inst < eop2.t_inst;
-}
-
-bool EOP_comp_ut1(const EOP& eop1, const EOP& eop2) {
-    return eop1.t_ut1 < eop2.t_ut1;
-}
-
 void to_json(nlohmann::json& j, const EOP& m) {
     assert(j.empty());
 

--- a/lib/utils/CHORDTelescope.cpp
+++ b/lib/utils/CHORDTelescope.cpp
@@ -389,7 +389,9 @@ CHORDTelescope::CHORDTelescope(const kotekan::Config& config, const std::string&
     INFO("Building CHORDTelescope");
 }
 
-CHORDTelescope::~CHORDTelescope() {}
+CHORDTelescope::~CHORDTelescope() {
+    INFO("Removing CHORDTelescope");
+}
 
 timespec CHORDTelescope::to_time(uint64_t seq) const {
     return nanosec_i64_to_timespec(to_time_ns(seq));
@@ -733,175 +735,6 @@ double CHORDTelescope::get_dish_separation_x_m() const {
 double CHORDTelescope::get_dish_separation_y_m() const {
     return _geographic_params.dish_separation_y_m;
 }
-
-size_t CHORDTelescope::get_EOP_table_len() const {
-    std::shared_lock lock(_eop_lock);
-    return _eop_table.size();
-}
-
-EOP CHORDTelescope::get_EOP_at_idx(uint64_t i) const {
-    std::shared_lock lock(_eop_lock);
-
-    if (i < _eop_table.size()) {
-        EOP eop = _eop_table[i];
-        return eop;
-    }
-
-    return eop_null;
-}
-
-EOP CHORDTelescope::get_EOP_at_time(const timespec& ts_target) const {
-    // Interpolate on the EOP table to find EOP for the given instrument time.
-
-    EOP eop;
-
-    int64_t t_target = timespec_to_nanosec_i64(ts_target);
-    eop.t_inst = t_target;
-
-    {
-        std::shared_lock lock(_eop_lock);
-
-        if (_eop_table.empty()) {
-            WARN("EOP table is empty, cannot interpolate EOP at UT1 time {:d} s + {:d} ns.",
-                 t_target / GIGA, t_target % GIGA);
-            return eop_null;
-        }
-
-        // _eop_table is always sorted by instrument time. Do a quick search
-        // for the first table entry with larger time than the target.
-        auto eop_b = std::lower_bound(_eop_table.begin(), _eop_table.end(), eop, EOP_comp_time);
-
-        // DUT1, xp_as, and yp_as evolve slowly, on secular time scales, so we
-        // interpolate these, and calculate ERA after.
-
-        if (eop_b == _eop_table.begin()) {
-            // Time is earlier than covered by the table, use the first value.
-            eop.delta_UT1_inst = eop_b->delta_UT1_inst;
-            eop.xp_as = eop_b->xp_as;
-            eop.yp_as = eop_b->yp_as;
-            WARN(
-                "Requesting EOP earlier than in table. Requested time = {:d} s + {:d} ns. Earliest "
-                "time = {:d} s + {:d} ns.",
-                t_target / GIGA, t_target % GIGA, eop_b->t_inst / GIGA, eop_b->t_inst % GIGA);
-        } else if (eop_b == _eop_table.end()) {
-            // Time is later than covered by the table, use the last value.
-            auto eop_last = eop_b - 1;
-            eop.delta_UT1_inst = eop_last->delta_UT1_inst;
-            eop.xp_as = eop_last->xp_as;
-            eop.yp_as = eop_last->yp_as;
-            WARN("Requesting EOP later than in table. Requested time = {:d} s + {:d} ns. Latest "
-                 "UT1 = "
-                 "{:d} s + {:d} ns.",
-                 t_target / GIGA, t_target % GIGA, eop_last->t_inst / GIGA,
-                 eop_last->t_inst % GIGA);
-        } else {
-            // Interpolate!
-            auto eop_a = eop_b - 1;
-            // t - ta in ns. Should be > 0
-            int64_t diff_ns_a = t_target - eop_a->t_inst;
-            // t - tb in ns. Should be < 0
-            int64_t diff_ns_b = t_target - eop_b->t_inst;
-            // tb - ta in ns.
-            int64_t diff_ns = diff_ns_a - diff_ns_b;
-
-            // weights for points a and b.
-            double wb = diff_ns_a / ((double)diff_ns);
-            double wa = 1.0 - wb;
-
-            // interpolate
-            eop.delta_UT1_inst = wa * eop_a->delta_UT1_inst + wb * eop_b->delta_UT1_inst;
-            eop.xp_as = wa * eop_a->xp_as + wb * eop_b->xp_as;
-            eop.yp_as = wa * eop_a->yp_as + wb * eop_b->yp_as;
-        }
-    }
-
-    // now that we have a delta_UT1, can compute UT1 and ERA
-    int64_t ut1 = get_UT1_from_time(ts_target, eop.delta_UT1_inst);
-    double era = get_ERA_from_UT1(ut1, nullptr);
-
-    eop.t_ut1 = ut1;
-    eop.ERA_deg = era;
-
-    return eop;
-}
-
-EOP CHORDTelescope::get_EOP_at_UT1(int64_t t_ut1) const {
-    // Interpolate on the EOP table to find EOP for the given UT1 time.
-
-    EOP eop;
-    eop.t_ut1 = t_ut1;
-
-    {
-        std::shared_lock lock(_eop_lock);
-
-        if (_eop_table.empty()) {
-            WARN("EOP table is empty, cannot interpolate EOP at UT1 time {:d} s + {:d} ns.",
-                 t_ut1 / GIGA, t_ut1 % GIGA);
-            return eop_null;
-        }
-
-        // _eop_table is always sorted by instrument time. UT1 is monotonic
-        // with instrument time, unless the Earth has been met with catastrophe.
-        // Do a quick search for the first table entry with larger UT1 time than
-        // the target.
-        auto eop_b = std::lower_bound(_eop_table.begin(), _eop_table.end(), eop, EOP_comp_ut1);
-
-        // DUT1, xp_as, and yp_as evolve slowly, on secular time scales, so we
-        // interpolate these, and calculate ERA after.
-
-        if (eop_b == _eop_table.begin()) {
-            // Time is earlier than covered by the table, use the first value.
-            eop.delta_UT1_inst = eop_b->delta_UT1_inst;
-            eop.xp_as = eop_b->xp_as;
-            eop.yp_as = eop_b->yp_as;
-            WARN("Requesting EOP earlier than in table. Requested UT1 = {:d} s + {:d} ns. Earliest "
-                 "UT1 "
-                 "= {:d} s + {:d} ns.",
-                 t_ut1 / GIGA, t_ut1 % GIGA, eop_b->t_ut1 / GIGA, eop_b->t_ut1 % GIGA);
-        } else if (eop_b == _eop_table.end()) {
-            // Time is later than covered by the table, use the last value.
-            auto eop_last = eop_b - 1;
-            eop.delta_UT1_inst = eop_last->delta_UT1_inst;
-            eop.xp_as = eop_last->xp_as;
-            eop.yp_as = eop_last->yp_as;
-            WARN("Requesting EOP later than in table. Requested UT1 = {:d} s + {:d} ns. Latest UT1 "
-                 "= "
-                 "{:d} s + {:d} ns.",
-                 t_ut1 / GIGA, t_ut1 % GIGA, eop_last->t_ut1 / GIGA, eop_last->t_ut1 % GIGA);
-        } else {
-            // Interpolate! Target time = t, in table interval [ta, tb]
-            auto eop_a = eop_b - 1;
-
-            // t - ta in ns. Should be > 0
-            int64_t diff_ns_a = t_ut1 - eop_a->t_ut1;
-            // t - tb in ns. Should be < 0
-            int64_t diff_ns_b = t_ut1 - eop_b->t_ut1;
-
-            // tb - ta in ns.
-            int64_t diff_ns = diff_ns_a - diff_ns_b;
-
-            // weight for b point
-            double wb = diff_ns_a / ((double)diff_ns);
-            // weight for a point.
-            double wa = 1.0 - wb;
-
-            // interpolate.
-            eop.delta_UT1_inst = wa * eop_a->delta_UT1_inst + wb * eop_b->delta_UT1_inst;
-            eop.xp_as = wa * eop_a->xp_as + wb * eop_b->xp_as;
-            eop.yp_as = wa * eop_a->yp_as + wb * eop_b->yp_as;
-        }
-    }
-
-    // Now that we have a delta_UT1, can get t_inst and the ERA
-    timespec ts_inst = get_time_from_UT1(t_ut1, eop.delta_UT1_inst);
-    double era = get_ERA_from_UT1(t_ut1, nullptr);
-
-    eop.t_inst = timespec_to_nanosec_i64(ts_inst);
-    eop.ERA_deg = era;
-
-    return eop;
-}
-
 const dishInfo& CHORDTelescope::get_dish_at_idx(dish_index_t idx) const {
     return _geographic_params.dish_info_table.at(idx);
 }
@@ -962,26 +795,6 @@ freq_id_t CHORDTelescope::to_freq_id(stream_t, uint32_t) const {
 size_t CHORDTelescope::num_freq_per_stream() const {
     FATAL_ERROR("CHORDTelesope does not support num_freq_per_stream()");
     return 0;
-}
-
-void to_json(nlohmann::json& j, const EOP& m) {
-    assert(j.empty());
-
-    j.emplace("t_inst", m.t_inst);                 // Instrument time, nanoseconds, UNIX epoch.
-    j.emplace("t_ut1", m.t_ut1);                   // UT1 time, nanoseconds, J2000(UT1) epoch.
-    j.emplace("delta_UT1_inst", m.delta_UT1_inst); // Diff between UT1 and Instrument time, seconds
-    j.emplace("ERA_deg", m.ERA_deg);               // Earth Rotation Angle, degrees
-    j.emplace("xp_as", m.xp_as);                   // Polar Motion x', in arcseconds.
-    j.emplace("yp_as", m.yp_as);                   // Polar Motion y', in arcseconds.
-}
-
-void from_json(const nlohmann::json& j, EOP& m) {
-    m.t_inst = j.at("t_inst");                 // Instrument time, nanoseconds, UNIX epoch.
-    m.t_ut1 = j.at("t_ut1");                   // UT1 time, nanoseconds, J2000(UT1) epoch.
-    m.delta_UT1_inst = j.at("delta_UT1_inst"); // Diff between UT1 and Instrument time, seconds
-    m.ERA_deg = j.at("ERA_deg");               // Earth Rotation Angle, degrees
-    m.xp_as = j.at("xp_as");                   // Polar Motion x', in arcseconds.
-    m.yp_as = j.at("yp_as");                   // Polar Motion y', in arcseconds.
 }
 
 void to_json(nlohmann::json& j, const dishInfo& d) {

--- a/lib/utils/CHORDTelescope.cpp
+++ b/lib/utils/CHORDTelescope.cpp
@@ -1,10 +1,8 @@
 #include "CHORDTelescope.hpp"
 
 #include "Telescope.hpp"      // for Telescope, freq_id_t, REGISTER_TELESCOPE, _factory_aliasTe...
-#include "configUpdater.hpp"  // for configUpdater
 #include "kotekanLogging.hpp" // for WARN, INFO, DEBUG
 #include "restClient.hpp"     // for restClient
-#include "restServer.hpp"     // for restServer, connectionInstance
 #include "timeUtil.hpp" // for EOP, get_ERA_from_UT1, get_UT1_from_time, nanosec_i64_to_timespec
 
 #include "fmt.hpp"  // for compile_string_to_view
@@ -26,9 +24,6 @@ REGISTER_TELESCOPE(CHORDTelescope, "CHORDTelescope");
 static constexpr double C = 2.99792458e8;
 static constexpr double deg2rad = M_PI / 180.0;
 static constexpr double arcsec2rad = M_PI / (180.0 * 3600);
-
-using kotekan::connectionInstance;
-using kotekan::restServer;
 
 
 // Dish parameters calculation/initialization
@@ -382,89 +377,20 @@ void GPSTimeParams::set_gps_time_params_from_remote(GPSTimeParams& gps, const st
 // CHORD telescope
 
 CHORDTelescope::CHORDTelescope(const kotekan::Config& config, const std::string& path) :
-    Telescope(config.get<std::string>(path, "log_level")), _unique_name(path),
+    Telescope(path,
+              config.get<std::string>(path, "log_level"),
+              config.get_default<std::string>(path, "updatable_config", "")),
     // Frequency sampling parameters
     _freq_params(FreqParams::from_config(config, path)),
     // GPS time configuration parameters
     _gps_time_params(GPSTimeParams::from_config(config, path)),
     // Instrument geographic coordinates
     _geographic_params(GeographicParams::from_config(config, path)) {
-
-    // Set up callbacks for updating EOP and sending time0_ns
-    using namespace std::placeholders;
-
-    kotekan::configUpdater::instance().subscribe(
-        config.get<std::string>(path, "updatable_config"),
-        std::bind(&CHORDTelescope::receive_eop_updates, this, _1));
-
-    restServer& rest_server = restServer::instance();
-
-    rest_server.register_get_callback(path + "/time0_ns",
-                                      std::bind(&CHORDTelescope::send_time0_ns, this, _1));
-    rest_server.register_get_callback(path + "/eop_table",
-                                      std::bind(&CHORDTelescope::send_eop_table, this, _1));
+    
+    INFO("Building CHORDTelescope");
 }
 
-CHORDTelescope::~CHORDTelescope() {
-    // Must manually remove the GET callbacks
-    restServer& rest_server = restServer::instance();
-    rest_server.remove_get_callback(_unique_name + "/time0_ns");
-    rest_server.remove_get_callback(_unique_name + "/eop_table");
-}
-
-bool CHORDTelescope::receive_eop_updates(nlohmann::json& json) {
-    try {
-        // Fill a temporary table with the updated values.
-        std::vector<EOP> tmp_eop_table;
-        for (const auto& elem : json.at("earth_orientation_parameter_table")) {
-            INFO("CHORDTelescope EOP update: {:s}", elem.dump());
-            int64_t t_ns = elem.at("time_inst_ns").get<int64_t>();
-            double dut1 = elem.at("delta_UT1_inst").get<double>();
-            double x_pm = elem.at("x_pm").get<double>();
-            double y_pm = elem.at("y_pm").get<double>();
-            tmp_eop_table.push_back(build_EOP_from_update(t_ns, dut1, x_pm, y_pm));
-        }
-
-        if (tmp_eop_table.empty()) {
-            ERROR(
-                "CHORDTelescope {}: earth_orientation_parameter_table update contained no entries.",
-                _unique_name);
-            return false;
-        }
-
-        // Sort chronologically
-        std::sort(tmp_eop_table.begin(), tmp_eop_table.end(), EOP_comp_time);
-
-        // Replace old table with new.
-        {
-            // Make sure no one is using the EOP table while we're updating it.
-            std::unique_lock lock(_eop_lock);
-            _eop_table = tmp_eop_table;
-            INFO("Updated EOP Table with {:d} entries", _eop_table.size());
-        }
-
-    } catch (std::exception& e) {
-        WARN("CHORDTelescope failed to read EOP update: {:s}", e.what());
-        return false;
-    }
-
-    return true;
-}
-
-void CHORDTelescope::send_eop_table(connectionInstance& conn) {
-    nlohmann::json reply;
-    {
-        std::shared_lock lock(_eop_lock);
-        reply["eop_table"] = _eop_table;
-    }
-    conn.send_json_reply(reply);
-}
-
-void CHORDTelescope::send_time0_ns(connectionInstance& conn) {
-    nlohmann::json reply;
-    reply["time0_ns"] = _gps_time_params.time0_ns;
-    conn.send_json_reply(reply);
-}
+CHORDTelescope::~CHORDTelescope() {}
 
 timespec CHORDTelescope::to_time(uint64_t seq) const {
     return nanosec_i64_to_timespec(to_time_ns(seq));
@@ -1037,23 +963,6 @@ freq_id_t CHORDTelescope::to_freq_id(stream_t, uint32_t) const {
 size_t CHORDTelescope::num_freq_per_stream() const {
     FATAL_ERROR("CHORDTelesope does not support num_freq_per_stream()");
     return 0;
-}
-
-EOP CHORDTelescope::build_EOP_from_update(int64_t time_ns, double delta_ut1_inst, double xp_as,
-                                          double yp_as) const {
-
-    struct timespec ts_inst = nanosec_i64_to_timespec(time_ns);
-    int64_t ut1 = get_UT1_from_time(ts_inst, delta_ut1_inst);
-    double era = get_ERA_from_UT1(ut1, nullptr);
-
-    EOP eop{.t_inst = time_ns,
-            .t_ut1 = ut1,
-            .delta_UT1_inst = delta_ut1_inst,
-            .ERA_deg = era,
-            .xp_as = xp_as,
-            .yp_as = yp_as};
-
-    return eop;
 }
 
 void to_json(nlohmann::json& j, const EOP& m) {

--- a/lib/utils/CHORDTelescope.cpp
+++ b/lib/utils/CHORDTelescope.cpp
@@ -377,8 +377,7 @@ void GPSTimeParams::set_gps_time_params_from_remote(GPSTimeParams& gps, const st
 // CHORD telescope
 
 CHORDTelescope::CHORDTelescope(const kotekan::Config& config, const std::string& path) :
-    Telescope(path,
-              config.get<std::string>(path, "log_level"),
+    Telescope(path, config.get<std::string>(path, "log_level"),
               config.get_default<std::string>(path, "updatable_config", "")),
     // Frequency sampling parameters
     _freq_params(FreqParams::from_config(config, path)),
@@ -386,7 +385,7 @@ CHORDTelescope::CHORDTelescope(const kotekan::Config& config, const std::string&
     _gps_time_params(GPSTimeParams::from_config(config, path)),
     // Instrument geographic coordinates
     _geographic_params(GeographicParams::from_config(config, path)) {
-    
+
     INFO("Building CHORDTelescope");
 }
 

--- a/lib/utils/CHORDTelescope.cpp
+++ b/lib/utils/CHORDTelescope.cpp
@@ -385,12 +385,11 @@ CHORDTelescope::CHORDTelescope(const kotekan::Config& config, const std::string&
     _gps_time_params(GPSTimeParams::from_config(config, path)),
     // Instrument geographic coordinates
     _geographic_params(GeographicParams::from_config(config, path)) {
-
-    INFO("Building CHORDTelescope");
+    DEBUG("Building CHORDTelescope");
 }
 
 CHORDTelescope::~CHORDTelescope() {
-    INFO("Removing CHORDTelescope");
+    DEBUG("Removing CHORDTelescope");
 }
 
 timespec CHORDTelescope::to_time(uint64_t seq) const {

--- a/lib/utils/CHORDTelescope.hpp
+++ b/lib/utils/CHORDTelescope.hpp
@@ -416,7 +416,8 @@ private:
  * @see FreqParams::from_config (frequency sampling)
  * @see GeographicParams::from_config (dish and array geometry)
  *
- * @conf    updatable_config    string. ConfigUpdater path for dynamic EOP updates.
+ * @conf    eop_updatable_config    string. ConfigUpdater path for dynamic EOP updates. For more
+ *information see Telescope.hpp
  * @conf    log_level           string. Optional log level for this telescope instance.
  *
  * @author Geoffrey Ryan
@@ -429,6 +430,7 @@ private:
  *              introduced with per-dish grid placement, positioning, pointing, and labels. GR
  * 2025/12/04: Factor telescope members into logical groups: frequency parameters,
  *              gps time parameters, geographic/dish parameters. JM (PR #1373)
+ * 2026/01/28:  Remove EOP functionality and move to Telescope.
  */
 
 class CHORDTelescope : public Telescope {

--- a/lib/utils/CHORDTelescope.hpp
+++ b/lib/utils/CHORDTelescope.hpp
@@ -11,7 +11,6 @@
 #include <array>        // for array
 #include <complex>      // for complex
 #include <mutex>        // for mutex
-#include <shared_mutex> // for shared_mutex
 #include <stdint.h>     // for uint64_t, uint32_t, int64_t, uint8_t
 #include <string>       // for string, basic_string
 #include <time.h>       // for timespec
@@ -479,7 +478,7 @@ public:
      * @brief   Return the time corresponding to the given fpga sequence number as an int64_t.
      *          Uses the epoch of time0_ns.
      */
-    int64_t to_time_ns(uint64_t seq) const;
+    int64_t to_time_ns(uint64_t seq) const override;
 
     /**
      * @brief   Return the longitude of the instrument.
@@ -774,41 +773,6 @@ public:
     ~CHORDTelescope();
 
 protected:
-    /**
-     * @brief Callback to update EOP data
-     *
-     * @param json JSON reference of the config
-     */
-    bool receive_eop_updates(nlohmann::json& json);
-
-    /**
-     * @brief   Callback to send current EOP table
-     *
-     * @param   conn    Kotekan connection.
-     */
-    void send_eop_table(kotekan::connectionInstance& conn);
-
-    /**
-     * @brief   Callback to send time0_ns value
-     *
-     * @param   conn    Kotekan connection.
-     */
-    void send_time0_ns(kotekan::connectionInstance& conn);
-
-    /**
-     * @brief   Build a single EOP struct from config values
-     *
-     * @param   t_ns    Instrument time in nanoseconds.
-     * @param   delta_ut1_inst  Diff between UT1 and Instrument time in seconds
-     * @param   xp_as   Polar Motion x' coordinate in arcseconds
-     * @param   yp_as   Polar Motion y' coordinate in arcseconds
-     **/
-    EOP build_EOP_from_update(int64_t t_ns, double delta_ut1_inst, double xp_as,
-                              double yp_as) const;
-
-    // The telescope's name in the config
-    const std::string _unique_name;
-
     // Frequency parameters
     const FreqParams _freq_params;
 
@@ -817,10 +781,6 @@ protected:
 
     /// Dish / array geometry and coordinate transforms.
     const GeographicParams _geographic_params;
-
-    /// Earth Orientation Parameters
-    mutable std::shared_mutex _eop_lock;
-    std::vector<EOP> _eop_table;
 };
 
 #endif // CHORD_TELESCOPE_HPP

--- a/lib/utils/CHORDTelescope.hpp
+++ b/lib/utils/CHORDTelescope.hpp
@@ -823,23 +823,4 @@ protected:
     std::vector<EOP> _eop_table;
 };
 
-/**
- * @brief   Comparison function for searching/sorting the EOP table. Compares
- *          EOP based on t_inst, orders chronologically.
- *
- * @params  eop1    First EOP to compare.
- * @params  eop2    Second EOP to compare.
- **/
-bool EOP_comp_time(const EOP& eop1, const EOP& eop2);
-
-/**
- * @brief   Comparison function for searching/sorting the EOP table. Compares
- *          EOP based on t_ut1, orders by increasing rotation. Will produce the
- *          same order as t_inst, unless something is apocalyptically wrong.
- *
- * @params  eop1    First EOP to compare.
- * @params  eop2    Second EOP to compare.
- **/
-bool EOP_comp_ut1(const EOP& eop1, const EOP& eop2);
-
 #endif // CHORD_TELESCOPE_HPP

--- a/lib/utils/CHORDTelescope.hpp
+++ b/lib/utils/CHORDTelescope.hpp
@@ -8,14 +8,14 @@
 
 #include "json.hpp" // for json
 
-#include <array>        // for array
-#include <complex>      // for complex
-#include <mutex>        // for mutex
-#include <stdint.h>     // for uint64_t, uint32_t, int64_t, uint8_t
-#include <string>       // for string, basic_string
-#include <time.h>       // for timespec
-#include <utility>      // for forward
-#include <vector>       // for vector
+#include <array>    // for array
+#include <complex>  // for complex
+#include <mutex>    // for mutex
+#include <stdint.h> // for uint64_t, uint32_t, int64_t, uint8_t
+#include <string>   // for string, basic_string
+#include <time.h>   // for timespec
+#include <utility>  // for forward
+#include <vector>   // for vector
 
 // Types for frequency and dish indexing
 // (Not necessarily logical IDs)

--- a/lib/utils/CHORDTelescope.hpp
+++ b/lib/utils/CHORDTelescope.hpp
@@ -531,35 +531,6 @@ public:
     double get_dish_separation_x_m() const;
     double get_dish_separation_y_m() const;
 
-    /**
-     * @brief   Return the number of entries in the EOP table.
-     **/
-    size_t get_EOP_table_len() const;
-
-    /**
-     * @brief   Return the EOP table entry at an index.
-     *
-     * @param   i   Index of desired EOP entry, 0 <= i < EOP_table_len
-     **/
-    EOP get_EOP_at_idx(uint64_t i) const;
-
-    /**
-     * @brief   Return the EOP at the desired instrument time. Will interpolate
-     *          over table, use first or last entry if target time is out of
-     *          table range.
-     *
-     * @param   ts  Target instrument time, as a timespec.
-     **/
-    EOP get_EOP_at_time(const timespec& ts) const;
-
-    /**
-     * @brief   Return the EOP at the desired UT1 time. Will interpolate
-     *          over table, using the first or last entry if target time is
-     *          out of table range.
-     *
-     * @param   ts  Target UT1 time, in nanoseconds since J2000(UT1) int64_t
-     **/
-    EOP get_EOP_at_UT1(int64_t ut1) const;
 
     /**
      * @brief get information about a specific dish.

--- a/lib/utils/ICETelescope.cpp
+++ b/lib/utils/ICETelescope.cpp
@@ -16,8 +16,7 @@ REGISTER_TELESCOPE(ICETelescope, "ICETelescope");
 #define GIGA 1000000000
 
 ICETelescope::ICETelescope(const kotekan::Config& config, const std::string& path) :
-    Telescope(path,
-              config.get<std::string>(path, "log_level"),
+    Telescope(path, config.get<std::string>(path, "log_level"),
               config.get_default<std::string>(path, "updatable_config", "")) {
     INFO("Building ICETelescope");
 

--- a/lib/utils/ICETelescope.cpp
+++ b/lib/utils/ICETelescope.cpp
@@ -16,7 +16,10 @@ REGISTER_TELESCOPE(ICETelescope, "ICETelescope");
 #define GIGA 1000000000
 
 ICETelescope::ICETelescope(const kotekan::Config& config, const std::string& path) :
-    Telescope(config.get<std::string>(path, "log_level")) {
+    Telescope(path,
+              config.get<std::string>(path, "log_level"),
+              config.get_default<std::string>(path, "updatable_config", "")) {
+    INFO("Building ICETelescope");
 
     // TODO: rename this parameter to `num_freq_per_stream` in the config
     _num_freq_per_stream = config.get_default<uint32_t>(path, "num_local_freq", 128);
@@ -168,6 +171,11 @@ double ICETelescope::freq_width_MHz(freq_id_t freq_id) const {
 timespec ICETelescope::to_time(uint64_t seq) const {
     auto time_ns = time0_ns + seq * dt_ns;
     return {(time_t)(time_ns / GIGA), (long)(time_ns % GIGA)};
+}
+
+int64_t ICETelescope::to_time_ns(uint64_t seq) const {
+    int64_t time_ns = time0_ns + seq * dt_ns;
+    return time_ns;
 }
 
 uint64_t ICETelescope::to_seq(timespec time) const {

--- a/lib/utils/ICETelescope.cpp
+++ b/lib/utils/ICETelescope.cpp
@@ -17,7 +17,7 @@ REGISTER_TELESCOPE(ICETelescope, "ICETelescope");
 
 ICETelescope::ICETelescope(const kotekan::Config& config, const std::string& path) :
     Telescope(path, config.get<std::string>(path, "log_level"),
-              config.get_default<std::string>(path, "updatable_config", "")) {
+              config.get_default<std::string>(path, "eop_updatable_config", "")) {
     INFO("Building ICETelescope");
 
     // TODO: rename this parameter to `num_freq_per_stream` in the config

--- a/lib/utils/ICETelescope.hpp
+++ b/lib/utils/ICETelescope.hpp
@@ -40,6 +40,7 @@ public:
     // Implementations of the required time mapping functions
     bool gps_time_enabled() const override;
     timespec to_time(uint64_t seq) const override;
+    int64_t to_time_ns(uint64_t seq) const override;
     uint64_t to_seq(timespec time) const override;
     uint64_t seq_length_nsec() const override;
 

--- a/lib/utils/Telescope.cpp
+++ b/lib/utils/Telescope.cpp
@@ -13,6 +13,8 @@
 using kotekan::connectionInstance;
 using kotekan::restServer;
 
+#define GIGA 1'000'000'000L
+
 Telescope::Telescope(const std::string& tel_path, const std::string& log_level,
                      const std::string& updatable_config_path) : _unique_name(tel_path) {
     set_log_level(log_level);
@@ -163,3 +165,172 @@ EOP Telescope::build_EOP_from_update(int64_t time_ns, double delta_ut1_inst, dou
 
     return eop;
 }
+
+size_t Telescope::get_EOP_table_len() const {
+    std::shared_lock lock(_eop_lock);
+    return _eop_table.size();
+}
+
+EOP Telescope::get_EOP_at_table_idx(uint64_t i) const {
+    std::shared_lock lock(_eop_lock);
+
+    if (i < _eop_table.size()) {
+        EOP eop = _eop_table[i];
+        return eop;
+    }
+
+    return eop_null;
+}
+
+EOP Telescope::get_EOP_at_time(const timespec& ts_target) const {
+    // Interpolate on the EOP table to find EOP for the given instrument time.
+
+    EOP eop;
+
+    int64_t t_target = timespec_to_nanosec_i64(ts_target);
+    eop.t_inst = t_target;
+
+    {
+        std::shared_lock lock(_eop_lock);
+
+        if (_eop_table.empty()) {
+            WARN("EOP table is empty, cannot interpolate EOP at UT1 time {:d} s + {:d} ns.",
+                 t_target / GIGA, t_target % GIGA);
+            return eop_null;
+        }
+
+        // _eop_table is always sorted by instrument time. Do a quick search
+        // for the first table entry with larger time than the target.
+        auto eop_b = std::lower_bound(_eop_table.begin(), _eop_table.end(), eop, EOP_comp_time);
+
+        // DUT1, xp_as, and yp_as evolve slowly, on secular time scales, so we
+        // interpolate these, and calculate ERA after.
+
+        if (eop_b == _eop_table.begin()) {
+            // Time is earlier than covered by the table, use the first value.
+            eop.delta_UT1_inst = eop_b->delta_UT1_inst;
+            eop.xp_as = eop_b->xp_as;
+            eop.yp_as = eop_b->yp_as;
+            WARN(
+                "Requesting EOP earlier than in table. Requested time = {:d} s + {:d} ns. Earliest "
+                "time = {:d} s + {:d} ns.",
+                t_target / GIGA, t_target % GIGA, eop_b->t_inst / GIGA, eop_b->t_inst % GIGA);
+        } else if (eop_b == _eop_table.end()) {
+            // Time is later than covered by the table, use the last value.
+            auto eop_last = eop_b - 1;
+            eop.delta_UT1_inst = eop_last->delta_UT1_inst;
+            eop.xp_as = eop_last->xp_as;
+            eop.yp_as = eop_last->yp_as;
+            WARN("Requesting EOP later than in table. Requested time = {:d} s + {:d} ns. Latest "
+                 "UT1 = "
+                 "{:d} s + {:d} ns.",
+                 t_target / GIGA, t_target % GIGA, eop_last->t_inst / GIGA,
+                 eop_last->t_inst % GIGA);
+        } else {
+            // Interpolate!
+            auto eop_a = eop_b - 1;
+            // t - ta in ns. Should be > 0
+            int64_t diff_ns_a = t_target - eop_a->t_inst;
+            // t - tb in ns. Should be < 0
+            int64_t diff_ns_b = t_target - eop_b->t_inst;
+            // tb - ta in ns.
+            int64_t diff_ns = diff_ns_a - diff_ns_b;
+
+            // weights for points a and b.
+            double wb = diff_ns_a / ((double)diff_ns);
+            double wa = 1.0 - wb;
+
+            // interpolate
+            eop.delta_UT1_inst = wa * eop_a->delta_UT1_inst + wb * eop_b->delta_UT1_inst;
+            eop.xp_as = wa * eop_a->xp_as + wb * eop_b->xp_as;
+            eop.yp_as = wa * eop_a->yp_as + wb * eop_b->yp_as;
+        }
+    }
+
+    // now that we have a delta_UT1, can compute UT1 and ERA
+    int64_t ut1 = get_UT1_from_time(ts_target, eop.delta_UT1_inst);
+    double era = get_ERA_from_UT1(ut1, nullptr);
+
+    eop.t_ut1 = ut1;
+    eop.ERA_deg = era;
+
+    return eop;
+}
+
+EOP Telescope::get_EOP_at_UT1(int64_t t_ut1) const {
+    // Interpolate on the EOP table to find EOP for the given UT1 time.
+
+    EOP eop;
+    eop.t_ut1 = t_ut1;
+
+    {
+        std::shared_lock lock(_eop_lock);
+
+        if (_eop_table.empty()) {
+            WARN("EOP table is empty, cannot interpolate EOP at UT1 time {:d} s + {:d} ns.",
+                 t_ut1 / GIGA, t_ut1 % GIGA);
+            return eop_null;
+        }
+
+        // _eop_table is always sorted by instrument time. UT1 is monotonic
+        // with instrument time, unless the Earth has been met with catastrophe.
+        // Do a quick search for the first table entry with larger UT1 time than
+        // the target.
+        auto eop_b = std::lower_bound(_eop_table.begin(), _eop_table.end(), eop, EOP_comp_ut1);
+
+        // DUT1, xp_as, and yp_as evolve slowly, on secular time scales, so we
+        // interpolate these, and calculate ERA after.
+
+        if (eop_b == _eop_table.begin()) {
+            // Time is earlier than covered by the table, use the first value.
+            eop.delta_UT1_inst = eop_b->delta_UT1_inst;
+            eop.xp_as = eop_b->xp_as;
+            eop.yp_as = eop_b->yp_as;
+            WARN("Requesting EOP earlier than in table. Requested UT1 = {:d} s + {:d} ns. Earliest "
+                 "UT1 "
+                 "= {:d} s + {:d} ns.",
+                 t_ut1 / GIGA, t_ut1 % GIGA, eop_b->t_ut1 / GIGA, eop_b->t_ut1 % GIGA);
+        } else if (eop_b == _eop_table.end()) {
+            // Time is later than covered by the table, use the last value.
+            auto eop_last = eop_b - 1;
+            eop.delta_UT1_inst = eop_last->delta_UT1_inst;
+            eop.xp_as = eop_last->xp_as;
+            eop.yp_as = eop_last->yp_as;
+            WARN("Requesting EOP later than in table. Requested UT1 = {:d} s + {:d} ns. Latest UT1 "
+                 "= "
+                 "{:d} s + {:d} ns.",
+                 t_ut1 / GIGA, t_ut1 % GIGA, eop_last->t_ut1 / GIGA, eop_last->t_ut1 % GIGA);
+        } else {
+            // Interpolate! Target time = t, in table interval [ta, tb]
+            auto eop_a = eop_b - 1;
+
+            // t - ta in ns. Should be > 0
+            int64_t diff_ns_a = t_ut1 - eop_a->t_ut1;
+            // t - tb in ns. Should be < 0
+            int64_t diff_ns_b = t_ut1 - eop_b->t_ut1;
+
+            // tb - ta in ns.
+            int64_t diff_ns = diff_ns_a - diff_ns_b;
+
+            // weight for b point
+            double wb = diff_ns_a / ((double)diff_ns);
+            // weight for a point.
+            double wa = 1.0 - wb;
+
+            // interpolate.
+            eop.delta_UT1_inst = wa * eop_a->delta_UT1_inst + wb * eop_b->delta_UT1_inst;
+            eop.xp_as = wa * eop_a->xp_as + wb * eop_b->xp_as;
+            eop.yp_as = wa * eop_a->yp_as + wb * eop_b->yp_as;
+        }
+    }
+
+    // Now that we have a delta_UT1, can get t_inst and the ERA
+    timespec ts_inst = get_time_from_UT1(t_ut1, eop.delta_UT1_inst);
+    double era = get_ERA_from_UT1(t_ut1, nullptr);
+
+    eop.t_inst = timespec_to_nanosec_i64(ts_inst);
+    eop.ERA_deg = era;
+
+    return eop;
+}
+

--- a/lib/utils/Telescope.cpp
+++ b/lib/utils/Telescope.cpp
@@ -16,20 +16,20 @@ using kotekan::restServer;
 #define GIGA 1'000'000'000L
 
 Telescope::Telescope(const std::string& tel_path, const std::string& log_level,
-                     const std::string& updatable_config_path) : _unique_name(tel_path) {
+                     const std::string& eop_updatable_config_path) : _unique_name(tel_path) {
     set_log_level(log_level);
     set_log_prefix("/telescope");
 
-    INFO("Building Telescope");
+    DEBUG("Building Telescope");
 
     // Set up callbacks for updating EOP and sending time0_ns
     using namespace std::placeholders;
 
     // Subscribe to config updates if updatable_config is set.
-    if (updatable_config_path.length() > 0) {
-        INFO("Subscribing {:s} to updatable config.", updatable_config_path);
+    if (eop_updatable_config_path.length() > 0) {
+        INFO("Subscribing {:s} to updatable config.", eop_updatable_config_path);
         kotekan::configUpdater::instance().subscribe(
-            updatable_config_path, std::bind(&Telescope::receive_eop_updates, this, _1));
+            eop_updatable_config_path, std::bind(&Telescope::receive_eop_updates, this, _1));
     }
 
     INFO("Adding telescope REST GET endpoints");
@@ -46,7 +46,7 @@ Telescope::~Telescope() {
     restServer& rest_server = restServer::instance();
     rest_server.remove_get_callback(_unique_name + "/time0_ns");
     rest_server.remove_get_callback(_unique_name + "/eop_table");
-    INFO_NON_OO("/telescope: Removed REST GET endpoints");
+    INFO("Removed REST GET endpoints");
 }
 
 const Telescope& Telescope::instance() {
@@ -166,20 +166,14 @@ EOP Telescope::build_EOP_from_update(int64_t time_ns, double delta_ut1_inst, dou
     return eop;
 }
 
-size_t Telescope::get_EOP_table_len() const {
-    std::shared_lock lock(_eop_lock);
-    return _eop_table.size();
-}
+std::vector<EOP> Telescope::get_current_EOP_table() const {
 
-EOP Telescope::get_EOP_at_table_idx(uint64_t i) const {
-    std::shared_lock lock(_eop_lock);
-
-    if (i < _eop_table.size()) {
-        EOP eop = _eop_table[i];
-        return eop;
+    std::vector<EOP> tab_copy;
+    {
+        std::shared_lock lock(_eop_lock);
+        tab_copy = _eop_table;
     }
-
-    return eop_null;
+    return tab_copy;
 }
 
 EOP Telescope::get_EOP_at_time(const timespec& ts_target) const {

--- a/lib/utils/Telescope.cpp
+++ b/lib/utils/Telescope.cpp
@@ -25,6 +25,7 @@ Telescope::Telescope(const std::string& tel_path, const std::string& log_level,
 
     // Subscribe to config updates if updatable_config is set.
     if (updatable_config_path.length() > 0) {
+        INFO("Subscribing {:s} to updatable config.", updatable_config_path);
         kotekan::configUpdater::instance().subscribe(
             updatable_config_path, std::bind(&Telescope::receive_eop_updates, this, _1));
     }

--- a/lib/utils/Telescope.cpp
+++ b/lib/utils/Telescope.cpp
@@ -1,13 +1,49 @@
 #include "Telescope.hpp"
 
+#include "configUpdater.hpp"  // for configUpdater
 #include "fmt.hpp" // for compile_string_to_view
+#include "restServer.hpp"   // for restServer, connectionInstance
+#include "timeUtil.hpp"
 
+#include <mutex>
+#include <shared_mutex>
 #include <stdexcept> // for invalid_argument
 
+using kotekan::connectionInstance;
+using kotekan::restServer;
 
-Telescope::Telescope(const std::string& log_level) {
+Telescope::Telescope(const std::string& tel_path, const std::string& log_level, const std::string& updatable_config_path) :
+    _unique_name(tel_path) {
     set_log_level(log_level);
     set_log_prefix("/telescope");
+    
+    INFO("Building Telescope");
+
+    // Set up callbacks for updating EOP and sending time0_ns
+    using namespace std::placeholders;
+
+    // Subscribe to config updates if updatable_config is set.
+    if (updatable_config_path.length() > 0) {
+        kotekan::configUpdater::instance().subscribe(
+            updatable_config_path,
+            std::bind(&Telescope::receive_eop_updates, this, _1));
+    }
+
+    INFO("Adding telescope REST GET endpoints");
+    restServer& rest_server = restServer::instance();
+
+    rest_server.register_get_callback(tel_path + "/time0_ns",
+                                      std::bind(&Telescope::send_time0_ns, this, _1));
+    rest_server.register_get_callback(tel_path + "/eop_table",
+                                      std::bind(&Telescope::send_eop_table, this, _1));
+}
+
+Telescope::~Telescope() {
+    // Must manually remove the GET callbacks
+    restServer& rest_server = restServer::instance();
+    rest_server.remove_get_callback(_unique_name + "/time0_ns");
+    rest_server.remove_get_callback(_unique_name + "/eop_table");
+    INFO_NON_OO("/telescope: removed REST GET endpoints");
 }
 
 const Telescope& Telescope::instance() {
@@ -20,6 +56,8 @@ const Telescope& Telescope::instance() {
 
 const Telescope& Telescope::instance(const kotekan::Config& config) {
 
+    // This defaults to ICETelescope because the "Telescope" is virtual
+    // and is not registered with the Factory.
     auto telescope_name = config.get_default<std::string>("/telescope", "name", "ICETelescope");
 #if !defined(WITH_TESTS)
     if (telescope_name == "fake")
@@ -53,4 +91,75 @@ freq_id_t Telescope::to_freq_id(stream_t stream) const {
 timespec Telescope::seq_length() const {
     auto dt_ns = seq_length_nsec();
     return {(time_t)(dt_ns / 1000000000), (long)(dt_ns % 1000000000)};
+}
+
+bool Telescope::receive_eop_updates(nlohmann::json& json) {
+    try {
+        // Fill a temporary table with the updated values.
+        std::vector<EOP> tmp_eop_table;
+        for (const auto& elem : json.at("earth_orientation_parameter_table")) {
+            INFO("Telescope EOP update: {:s}", elem.dump());
+            int64_t t_ns = elem.at("time_inst_ns").get<int64_t>();
+            double dut1 = elem.at("delta_UT1_inst").get<double>();
+            double x_pm = elem.at("x_pm").get<double>();
+            double y_pm = elem.at("y_pm").get<double>();
+            tmp_eop_table.push_back(build_EOP_from_update(t_ns, dut1, x_pm, y_pm));
+        }
+
+        if (tmp_eop_table.empty()) {
+            ERROR(
+                "Telescope {}: earth_orientation_parameter_table update contained no entries.",
+                _unique_name);
+            return false;
+        }
+
+        // Sort chronologically
+        std::sort(tmp_eop_table.begin(), tmp_eop_table.end(), EOP_comp_time);
+
+        // Replace old table with new.
+        {
+            // Make sure no one is using the EOP table while we're updating it.
+            std::unique_lock lock(_eop_lock);
+            _eop_table = tmp_eop_table;
+            INFO("Updated EOP Table with {:d} entries", _eop_table.size());
+        }
+
+    } catch (std::exception& e) {
+        WARN("Telescope failed to read EOP update: {:s}", e.what());
+        return false;
+    }
+
+    return true;
+}
+
+void Telescope::send_eop_table(connectionInstance& conn) {
+    nlohmann::json reply;
+    {
+        std::shared_lock lock(_eop_lock);
+        reply["eop_table"] = _eop_table;
+    }
+    conn.send_json_reply(reply);
+}
+
+void Telescope::send_time0_ns(connectionInstance& conn) {
+    nlohmann::json reply;
+    reply["time0_ns"] = to_time_ns(0);
+    conn.send_json_reply(reply);
+}
+
+EOP Telescope::build_EOP_from_update(int64_t time_ns, double delta_ut1_inst,
+                                     double xp_as, double yp_as) const {
+
+    struct timespec ts_inst = nanosec_i64_to_timespec(time_ns);
+    int64_t ut1 = get_UT1_from_time(ts_inst, delta_ut1_inst);
+    double era = get_ERA_from_UT1(ut1, nullptr);
+
+    EOP eop{.t_inst = time_ns,
+            .t_ut1 = ut1,
+            .delta_UT1_inst = delta_ut1_inst,
+            .ERA_deg = era,
+            .xp_as = xp_as,
+            .yp_as = yp_as};
+
+    return eop;
 }

--- a/lib/utils/Telescope.cpp
+++ b/lib/utils/Telescope.cpp
@@ -1,9 +1,10 @@
 #include "Telescope.hpp"
 
-#include "configUpdater.hpp"  // for configUpdater
-#include "fmt.hpp" // for compile_string_to_view
-#include "restServer.hpp"   // for restServer, connectionInstance
+#include "configUpdater.hpp" // for configUpdater
+#include "restServer.hpp"    // for restServer, connectionInstance
 #include "timeUtil.hpp"
+
+#include "fmt.hpp" // for compile_string_to_view
 
 #include <mutex>
 #include <shared_mutex>
@@ -12,11 +13,11 @@
 using kotekan::connectionInstance;
 using kotekan::restServer;
 
-Telescope::Telescope(const std::string& tel_path, const std::string& log_level, const std::string& updatable_config_path) :
-    _unique_name(tel_path) {
+Telescope::Telescope(const std::string& tel_path, const std::string& log_level,
+                     const std::string& updatable_config_path) : _unique_name(tel_path) {
     set_log_level(log_level);
     set_log_prefix("/telescope");
-    
+
     INFO("Building Telescope");
 
     // Set up callbacks for updating EOP and sending time0_ns
@@ -25,8 +26,7 @@ Telescope::Telescope(const std::string& tel_path, const std::string& log_level, 
     // Subscribe to config updates if updatable_config is set.
     if (updatable_config_path.length() > 0) {
         kotekan::configUpdater::instance().subscribe(
-            updatable_config_path,
-            std::bind(&Telescope::receive_eop_updates, this, _1));
+            updatable_config_path, std::bind(&Telescope::receive_eop_updates, this, _1));
     }
 
     INFO("Adding telescope REST GET endpoints");
@@ -107,9 +107,8 @@ bool Telescope::receive_eop_updates(nlohmann::json& json) {
         }
 
         if (tmp_eop_table.empty()) {
-            ERROR(
-                "Telescope {}: earth_orientation_parameter_table update contained no entries.",
-                _unique_name);
+            ERROR("Telescope {}: earth_orientation_parameter_table update contained no entries.",
+                  _unique_name);
             return false;
         }
 
@@ -147,8 +146,8 @@ void Telescope::send_time0_ns(connectionInstance& conn) {
     conn.send_json_reply(reply);
 }
 
-EOP Telescope::build_EOP_from_update(int64_t time_ns, double delta_ut1_inst,
-                                     double xp_as, double yp_as) const {
+EOP Telescope::build_EOP_from_update(int64_t time_ns, double delta_ut1_inst, double xp_as,
+                                     double yp_as) const {
 
     struct timespec ts_inst = nanosec_i64_to_timespec(time_ns);
     int64_t ut1 = get_UT1_from_time(ts_inst, delta_ut1_inst);

--- a/lib/utils/Telescope.cpp
+++ b/lib/utils/Telescope.cpp
@@ -46,7 +46,7 @@ Telescope::~Telescope() {
     restServer& rest_server = restServer::instance();
     rest_server.remove_get_callback(_unique_name + "/time0_ns");
     rest_server.remove_get_callback(_unique_name + "/eop_table");
-    INFO("Removed REST GET endpoints");
+    DEBUG("Removed REST GET endpoints");
 }
 
 const Telescope& Telescope::instance() {

--- a/lib/utils/Telescope.cpp
+++ b/lib/utils/Telescope.cpp
@@ -46,7 +46,7 @@ Telescope::~Telescope() {
     restServer& rest_server = restServer::instance();
     rest_server.remove_get_callback(_unique_name + "/time0_ns");
     rest_server.remove_get_callback(_unique_name + "/eop_table");
-    INFO_NON_OO("/telescope: removed REST GET endpoints");
+    INFO_NON_OO("/telescope: Removed REST GET endpoints");
 }
 
 const Telescope& Telescope::instance() {
@@ -194,7 +194,7 @@ EOP Telescope::get_EOP_at_time(const timespec& ts_target) const {
         std::shared_lock lock(_eop_lock);
 
         if (_eop_table.empty()) {
-            WARN("EOP table is empty, cannot interpolate EOP at UT1 time {:d} s + {:d} ns.",
+            WARN("EOP table is empty, cannot interpolate EOP at instrument time {:d} s + {:d} ns.",
                  t_target / GIGA, t_target % GIGA);
             return eop_null;
         }
@@ -333,4 +333,3 @@ EOP Telescope::get_EOP_at_UT1(int64_t t_ut1) const {
 
     return eop;
 }
-

--- a/lib/utils/Telescope.hpp
+++ b/lib/utils/Telescope.hpp
@@ -4,17 +4,17 @@
 #include "Config.hpp"         // for Config
 #include "factory.hpp"        // for FACTORY, CREATE_FACTORY, REGISTER_NAMED_TYPE_WITH_FACTORY
 #include "kotekanLogging.hpp" // for ERROR, kotekanLogging
-#include "restServer.hpp" // for connectionInstance
-#include "timeUtil.hpp"   // for EOP
+#include "restServer.hpp"     // for connectionInstance
+#include "timeUtil.hpp"       // for EOP
 
 #include "fmt.hpp" // for compile_string_to_view
 
-#include <exception> // for exception
-#include <memory>    // for unique_ptr
+#include <exception>    // for exception
+#include <memory>       // for unique_ptr
 #include <shared_mutex> // for shared_mutex
-#include <stdint.h>  // for uint32_t, uint64_t, UINT32_MAX, uint8_t
-#include <string>    // for string, basic_string
-#include <time.h>    // for timespec
+#include <stdint.h>     // for uint32_t, uint64_t, UINT32_MAX, uint8_t
+#include <string>       // for string, basic_string
+#include <time.h>       // for timespec
 
 // Create the abstract factory for generating patterns
 class Telescope;
@@ -182,7 +182,7 @@ public:
      * @return  The corresponding UNIX time.
      **/
     virtual timespec to_time(uint64_t seq) const = 0;
-    
+
     /**
      * @brief   Return the time corresponding to the given fpga sequence number as an int64_t.
      *          Uses the epoch of time0_ns.
@@ -236,7 +236,8 @@ protected:
      *
      * TODO: UPDATE THIS
      **/
-    Telescope(const std::string& tel_path, const std::string& log_level, const std::string& updatable_config_path);
+    Telescope(const std::string& tel_path, const std::string& log_level,
+              const std::string& updatable_config_path);
 
     /**
      * @brief Callback to update EOP data
@@ -280,7 +281,7 @@ protected:
      * UT1 time and Earth Rotation Angle.
      */
     std::vector<EOP> _eop_table;
-    
+
     /**
      * This mutex locks access to the _eop_table which can be updated via REST
      * calls.

--- a/lib/utils/Telescope.hpp
+++ b/lib/utils/Telescope.hpp
@@ -224,6 +224,36 @@ public:
      * @return  Length of an FPGA sequence number tick.
      **/
     virtual uint64_t seq_length_nsec() const = 0;
+    
+    /**
+     * @brief   Return the number of entries in the EOP table.
+     **/
+    size_t get_EOP_table_len() const;
+
+    /**
+     * @brief   Return the EOP table entry at an index.
+     *
+     * @param   i   Index of desired EOP entry, 0 <= i < EOP_table_len
+     **/
+    EOP get_EOP_at_table_idx(uint64_t i) const;
+
+    /**
+     * @brief   Return the EOP at the desired instrument time. Will interpolate
+     *          over table, use first or last entry if target time is out of
+     *          table range.
+     *
+     * @param   ts  Target instrument time, as a timespec.
+     **/
+    EOP get_EOP_at_time(const timespec& ts) const;
+
+    /**
+     * @brief   Return the EOP at the desired UT1 time. Will interpolate
+     *          over table, using the first or last entry if target time is
+     *          out of table range.
+     *
+     * @param   ts  Target UT1 time, in nanoseconds since J2000(UT1) int64_t
+     **/
+    EOP get_EOP_at_UT1(int64_t ut1) const;
 
 private:
     static std::unique_ptr<Telescope>& tel_instance();

--- a/lib/utils/Telescope.hpp
+++ b/lib/utils/Telescope.hpp
@@ -64,7 +64,7 @@ public:
     static const Telescope& instance();
 
 
-    ~Telescope();
+    virtual ~Telescope();
 
     /**
      * @brief   Get the type name of this telescope object.

--- a/lib/utils/Telescope.hpp
+++ b/lib/utils/Telescope.hpp
@@ -231,7 +231,7 @@ public:
     virtual nyquist_zone_t nyquist_zone() const = 0;
 
     /**
-     * Convert a sequence number into a UNIX epoch time.
+     * Convert a sequence number into an Instrument (~UNIX epoch) time.
      *
      * @param  seq  The sequence number.
      *
@@ -240,19 +240,20 @@ public:
     virtual timespec to_time(uint64_t seq) const = 0;
 
     /**
-     * @brief   Return the time corresponding to the given fpga sequence number as an int64_t.
-     *          Uses the epoch of time0_ns.
+     * @brief   Return the Instrument time in ns corresponding to the given fpga sequence number as
+     * an int64_t.
      */
     virtual int64_t to_time_ns(uint64_t seq) const = 0;
 
     /**
-     * @brief Convert a UNIX epoch time into the nearest sequence number.
+     * @brief Convert an Instrument (~UNIX epoch) time into the nearest sequence number.
      *
      * @note When there is not an exact correspondence between the given time
      *       and FPGA sequence numbers, this routine will return the latest valid
      *       FPGA sequence number before the given timestamp.
      *
-     * @param  time  The UNIX time.
+     * @param  time  The Instrument time (a UNIX time unless a leap second has occured since
+     *instrument startup, or one will occur in the next 24 hours).
      *
      * @return  The corresponding sequence number.
      **/
@@ -282,16 +283,9 @@ public:
     virtual uint64_t seq_length_nsec() const = 0;
 
     /**
-     * @brief   Return the number of entries in the EOP table.
+     * @brief   Return a copy of the current EOP table.
      **/
-    size_t get_EOP_table_len() const;
-
-    /**
-     * @brief   Return the EOP table entry at an index.
-     *
-     * @param   i   Index of desired EOP entry, 0 <= i < EOP_table_len
-     **/
-    EOP get_EOP_at_table_idx(uint64_t i) const;
+    std::vector<EOP> get_current_EOP_table() const;
 
     /**
      * @brief   Return the EOP at the desired instrument time. Will interpolate
@@ -326,12 +320,12 @@ protected:
      *
      * @param   tel_path    Path to the telescope in the Config (e.g. /telescope)
      * @param   log_level   The level to set logging at.
-     * @param   updatable_config_path   The value of "eop_updatable_config" in
+     * @param   eop_updatable_config_path   The value of "eop_updatable_config" in
      *          the telescope Config, pointing to the updatable field which
      *          contains "earth_orientation_parameter_table"
      **/
     Telescope(const std::string& tel_path, const std::string& log_level,
-              const std::string& updatable_config_path);
+              const std::string& eop_updatable_config_path);
 
     /**
      * @brief Callback to update EOP data

--- a/lib/utils/Telescope.hpp
+++ b/lib/utils/Telescope.hpp
@@ -42,7 +42,13 @@ struct stream_t {
 /**
  * @brief A class to hold telescope specific functionality.
  *
- *
+ * This serves as a generic Telescope base class. It cannot be instantiated,
+ * only derived classes can.  It provides virtual hooks for routines to map
+ * between sequence number and instrument time, and for returning sampling
+ * parameters (raw sample rate, frequency spacing, map from freq_id to physical
+ * frequency, etc).  It also contains the Earth Orientation Parameter (EOP) table,
+ * which holds data to compute UT1 time and CIRS coordinate transformations from
+ * instrument time.
  **/
 class Telescope : public kotekan::kotekanLogging {
 
@@ -260,11 +266,19 @@ private:
 
 protected:
     /**
-     * This constructor sets up the logging. Implement a specific constructor
-     * in a derived class to parse the config, and call this one to make sure
-     * the logging is done correctly.
+     * @brief   The primary constructor which should be called by derived classes
+     *          upon instantiation.
      *
-     * TODO: UPDATE THIS
+     * This constructor sets up the logging and REST endpoints for Earth
+     * Orientation Parameters (EOP) and time0. Implement a specific constructor
+     * in a derived class to parse the config, and call this one to make sure
+     * the logging is done correctly and endpoints are active.
+     *
+     * @param   tel_path    Path to the telescope in the Config (e.g. /telescope)
+     * @param   log_level   The level to set logging at.
+     * @param   updatable_config_path   The value of "eop_updatable_config" in
+     *          the telescope Config, pointing to the updatable field which
+     *          contains "earth_orientation_parameter_table"
      **/
     Telescope(const std::string& tel_path, const std::string& log_level,
               const std::string& updatable_config_path);

--- a/lib/utils/Telescope.hpp
+++ b/lib/utils/Telescope.hpp
@@ -4,11 +4,14 @@
 #include "Config.hpp"         // for Config
 #include "factory.hpp"        // for FACTORY, CREATE_FACTORY, REGISTER_NAMED_TYPE_WITH_FACTORY
 #include "kotekanLogging.hpp" // for ERROR, kotekanLogging
+#include "restServer.hpp" // for connectionInstance
+#include "timeUtil.hpp"   // for EOP
 
 #include "fmt.hpp" // for compile_string_to_view
 
 #include <exception> // for exception
 #include <memory>    // for unique_ptr
+#include <shared_mutex> // for shared_mutex
 #include <stdint.h>  // for uint32_t, uint64_t, UINT32_MAX, uint8_t
 #include <string>    // for string, basic_string
 #include <time.h>    // for timespec
@@ -61,7 +64,7 @@ public:
     static const Telescope& instance();
 
 
-    virtual ~Telescope() = default;
+    ~Telescope();
 
     /**
      * @brief   Get the type name of this telescope object.
@@ -179,7 +182,12 @@ public:
      * @return  The corresponding UNIX time.
      **/
     virtual timespec to_time(uint64_t seq) const = 0;
-
+    
+    /**
+     * @brief   Return the time corresponding to the given fpga sequence number as an int64_t.
+     *          Uses the epoch of time0_ns.
+     */
+    virtual int64_t to_time_ns(uint64_t seq) const = 0;
 
     /**
      * @brief Convert a UNIX epoch time into the nearest sequence number.
@@ -225,8 +233,59 @@ protected:
      * This constructor sets up the logging. Implement a specific constructor
      * in a derived class to parse the config, and call this one to make sure
      * the logging is done correctly.
+     *
+     * TODO: UPDATE THIS
      **/
-    Telescope(const std::string& log_level);
+    Telescope(const std::string& tel_path, const std::string& log_level, const std::string& updatable_config_path);
+
+    /**
+     * @brief Callback to update EOP data
+     *
+     * @param json JSON reference of the config
+     */
+    bool receive_eop_updates(nlohmann::json& json);
+
+    /**
+     * @brief   Callback to send current EOP table
+     *
+     * @param   conn    Kotekan connection.
+     */
+    void send_eop_table(kotekan::connectionInstance& conn);
+
+    /**
+     * @brief   Callback to send time0_ns value
+     *
+     * @param   conn    Kotekan connection.
+     */
+    void send_time0_ns(kotekan::connectionInstance& conn);
+
+    /**
+     * @brief   Build a single EOP struct from config values
+     *
+     * @param   t_ns    Instrument time in nanoseconds.
+     * @param   delta_ut1_inst  Diff between UT1 and Instrument time in seconds
+     * @param   xp_as   Polar Motion x' coordinate in arcseconds
+     * @param   yp_as   Polar Motion y' coordinate in arcseconds
+     **/
+    EOP build_EOP_from_update(int64_t t_ns, double delta_ut1_inst, double xp_as,
+                              double yp_as) const;
+
+    /**
+     * The telescope's name in the config
+     */
+    const std::string _unique_name;
+
+    /**
+     * This is the Earth Orientation Parameter (EOP) table used to determine
+     * UT1 time and Earth Rotation Angle.
+     */
+    std::vector<EOP> _eop_table;
+    
+    /**
+     * This mutex locks access to the _eop_table which can be updated via REST
+     * calls.
+     */
+    mutable std::shared_mutex _eop_lock;
 };
 
 #endif // TELESCOPE_HPP

--- a/lib/utils/Telescope.hpp
+++ b/lib/utils/Telescope.hpp
@@ -224,7 +224,7 @@ public:
      * @return  Length of an FPGA sequence number tick.
      **/
     virtual uint64_t seq_length_nsec() const = 0;
-    
+
     /**
      * @brief   Return the number of entries in the EOP table.
      **/

--- a/lib/utils/Telescope.hpp
+++ b/lib/utils/Telescope.hpp
@@ -49,6 +49,56 @@ struct stream_t {
  * frequency, etc).  It also contains the Earth Orientation Parameter (EOP) table,
  * which holds data to compute UT1 time and CIRS coordinate transformations from
  * instrument time.
+ *
+ * REST Endpoints
+ *
+ * @endpoint    /time0_ns   GET     Returns a JSON object with a single field
+ *                                  "time0_ns" which contains the instrument time
+ *                                  in nanoseconds at fpga_seq_num = 0. Instrument
+ *                                  time at seq = 0 is represented as a UNIX time
+ *                                  with nanosecond resolution.
+ * @endpoint    /eop_table  GET     Returns a JSON object with a single field "eop_table" which
+ *                                  contains a list of EOP objects. Each EOP object contains 6
+ *                                  fields:
+ *                                  - t_inst            int64   Instrument time in nanoseconds.
+ *                                  - t_ut1             int64   UT1 time in nanoseconds since
+ *                                                              2451545.0 JD(UT1).
+ *                                  - delta_UT1_inst    double  Difference in seconds between
+ *                                                              UT1 and Instrument time.
+ *                                  - ERA_deg           double  Earth Rotation Angle in degrees.
+ *                                  - xp_as             double  Polar Motion x', arcseconds.
+ *                                  - yp_as             double  Polar Motion y', arcseconds.
+ *
+ * Updatable Config
+ *
+ * @conf    eop_updatable_config    Optional. If not present, EOP table will be empty and only
+ *                                  null values (all 0s) will be returned by get_EOP functions.
+ *                                  If present, the config path to an updatable config field
+ *                                  containing the field "earth_orientation_parameter_table",
+ *                                  which is a list of EOP Update objects. Each contains 4
+ *                                  fields:
+ *                                  - time_inst_ns      int     Instrument time in nanoseconds.
+ *                                  - delta_UT1_inst    double  As in EOP.
+ *                                  - x_pm              double  As in EOP.
+ *                                  - y_pm              double  As in EOP.
+ *                                  Upon receiving an update, the entire EOP table is replaced
+ *                                  with the new table. UT1 and ERA values are calculated from
+ *                                  the given time_inst_ns and delta_UT1_inst.
+ *
+ * To maintain continuity, tools updating the EOP table should first GET the current table, and
+ * only update or add values at least two entries in the future.  The table is linearly
+ * interpolated between the most recent past & future entries, so changing the closest future
+ * entry will immediately change values currently being used in Kotekan.
+ *
+ * For example, given a current table:
+ * [Jan 1 UTC 00:00:00,
+ *  Jan 2 UTC 00:00:00,
+ *  Jan 3 UTC 00:00:00,
+ *  Jan 4 UTC 00:00:00]
+ *
+ *  An update on Jan 2 UTC 12:00:00 should keep the exact Jan 2 and Jan 3 entries as they are
+ *  currently being used for interpolation.  Jan 4 may be modified, Jan 5 (or later) could be
+ *  added, and Jan 1 can be removed.
  **/
 class Telescope : public kotekan::kotekanLogging {
 

--- a/lib/utils/timeUtil.cpp
+++ b/lib/utils/timeUtil.cpp
@@ -196,3 +196,23 @@ double get_ERA_from_time(const timespec& time, double dUT) {
     int64_t ut1 = get_UT1_from_time(time, dUT);
     return get_ERA_from_UT1(ut1, nullptr);
 }
+
+void to_json(nlohmann::json& j, const EOP& m) {
+    assert(j.empty());
+
+    j.emplace("t_inst", m.t_inst);                 // Instrument time, nanoseconds, UNIX epoch.
+    j.emplace("t_ut1", m.t_ut1);                   // UT1 time, nanoseconds, J2000(UT1) epoch.
+    j.emplace("delta_UT1_inst", m.delta_UT1_inst); // Diff between UT1 and Instrument time, seconds
+    j.emplace("ERA_deg", m.ERA_deg);               // Earth Rotation Angle, degrees
+    j.emplace("xp_as", m.xp_as);                   // Polar Motion x', in arcseconds.
+    j.emplace("yp_as", m.yp_as);                   // Polar Motion y', in arcseconds.
+}
+
+void from_json(const nlohmann::json& j, EOP& m) {
+    m.t_inst = j.at("t_inst");                 // Instrument time, nanoseconds, UNIX epoch.
+    m.t_ut1 = j.at("t_ut1");                   // UT1 time, nanoseconds, J2000(UT1) epoch.
+    m.delta_UT1_inst = j.at("delta_UT1_inst"); // Diff between UT1 and Instrument time, seconds
+    m.ERA_deg = j.at("ERA_deg");               // Earth Rotation Angle, degrees
+    m.xp_as = j.at("xp_as");                   // Polar Motion x', in arcseconds.
+    m.yp_as = j.at("yp_as");                   // Polar Motion y', in arcseconds.
+}

--- a/lib/utils/timeUtil.hpp
+++ b/lib/utils/timeUtil.hpp
@@ -63,6 +63,29 @@ void to_json(nlohmann::json& j, const EOP& m);
 void from_json(const nlohmann::json& j, EOP& m);
 
 /**
+ * @brief   Comparison function for searching/sorting the EOP table. Compares
+ *          EOP based on t_inst, orders chronologically.
+ *
+ * @params  eop1    First EOP to compare.
+ * @params  eop2    Second EOP to compare.
+ **/
+inline bool EOP_comp_time(const EOP& eop1, const EOP& eop2) {
+    return eop1.t_inst < eop2.t_inst;
+}
+
+/**
+ * @brief   Comparison function for searching/sorting the EOP table. Compares
+ *          EOP based on t_ut1, orders by increasing rotation. Will produce the
+ *          same order as t_inst, unless something is apocalyptically wrong.
+ *
+ * @params  eop1    First EOP to compare.
+ * @params  eop2    Second EOP to compare.
+ **/
+inline bool EOP_comp_ut1(const EOP& eop1, const EOP& eop2) {
+    return eop1.t_ut1 < eop2.t_ut1;
+}
+
+/**
  * @brief   Directly convert timespec fields into a count of nanoseconds in an int64_t. Overflows
  *          if the timespec represents a time more than 2^63-1 nanoseconds (~292 years) past the
  * epoch.

--- a/tests/boost/test_CHORDTelescope.cpp
+++ b/tests/boost/test_CHORDTelescope.cpp
@@ -39,7 +39,7 @@ const std::string default_config_str = R"config_str({
     "dish_elev_axis": [1.0, 0.0, 0.0],
     "dish_vert_axis":    [0.0, 0.0, 1.0],
     "require_gps":        false,
-    "updatable_config":   "/earth_rotation_data"
+    "eop_updatable_config":   "/earth_rotation_data"
     },
     "num_dishes_x" : 22,
     "num_dishes_y" : 24,

--- a/tests/boost/test_utils.hpp
+++ b/tests/boost/test_utils.hpp
@@ -232,7 +232,7 @@ struct CompareCTypes {
                                                        {"coelev_disp_deg", 0.0},
                                                        {"type", "ArrayDish"},
                                                        {"label", "D01"}}});
-    telescope["updatable_config"] = "/earth_rotation_data";
+    telescope["eop_updatable_config"] = "/earth_rotation_data";
     telescope["grid_x_axis"] = {1.0, 0.0, 0.0};
     telescope["grid_y_axis"] = {0.0, 1.0, 0.0};
     telescope["dish_elev_axis"] = {1.0, 0.0, 0.0};

--- a/tests/notest_fringestop.py
+++ b/tests/notest_fringestop.py
@@ -77,7 +77,7 @@ global_params = {
         "dish_coelev_deg": 0.0,
         "num_dishes_x": 22,
         "num_dishes_y": 24,
-        "updatable_config": "/earth_rotation_data",
+        "eop_updatable_config": "/earth_rotation_data",
     },
     "dish_inputs": [
         {

--- a/tests/test_countcheck.py
+++ b/tests/test_countcheck.py
@@ -32,7 +32,7 @@ def make_chord_telescope_config(num_dishes=8):
         "dish_vert_axis": [0.0, 0.0, 1.0],
         "dish_coelev_deg": 90.0,
         "require_gps": False,
-        "updatable_config": "/earth_rotation_data",
+        "eop_updatable_config": "/earth_rotation_data",
         "num_dishes": num_dishes,
         "num_dishes_x": 4,
         "num_dishes_y": 4,

--- a/tests/test_n2_accumulate.py
+++ b/tests/test_n2_accumulate.py
@@ -41,7 +41,7 @@ global_params = {
         "dish_vert_axis": [0.0, 0.0, 1.0],
         "dish_coelev_deg": 90.0,
         "require_gps": False,
-        "updatable_config": "/earth_rotation_data",
+        "eop_updatable_config": "/earth_rotation_data",
         "num_dishes_x": 22,
         "num_dishes_y": 24,
         "dish_separation_x_m": 6.3,

--- a/tests/test_n2_time_downsample.py
+++ b/tests/test_n2_time_downsample.py
@@ -84,7 +84,7 @@ global_params = {
         "dish_coelev_deg": 0.0,
         "num_dishes_x": 22,
         "num_dishes_y": 24,
-        "updatable_config": "/earth_rotation_data",
+        "eop_updatable_config": "/earth_rotation_data",
         "dish_inputs": [],
     },
     "gps_time": {"frame0_nano": t_start_inst_ns},


### PR DESCRIPTION
Reorganizes the *Telescope objects.
- Moves EOP and related functionality (REST endpoints) into the generic Telescope
- Moves `time0_ns` GET endpoint to generic Telescope
- Adds `to_time_ns` virtual function to generic Telescope