### PR TITLE
beamforming kernel for outriggers added

### DIFF
--- a/lib/opencl/clBeamformKernelOutrigger.cpp
+++ b/lib/opencl/clBeamformKernelOutrigger.cpp
@@ -1,0 +1,164 @@
+#include "clBeamformKernel.hpp"
+
+#include "Telescope.hpp"
+#include "chimeMetadata.hpp"
+
+#include <string>
+
+using std::string;
+
+using kotekan::bufferContainer;
+using kotekan::Config;
+
+REGISTER_CL_COMMAND(clBeamformKernel);
+
+clBeamformKernel::clBeamformKernel(Config& config, const std::string& unique_name,
+                                   bufferContainer& host_buffers, clDeviceInterface& device,
+                                   int inst) :
+    clCommand(config, unique_name, host_buffers, device, inst, no_cl_command_state,
+              "gpu_beamforming", "outrigger_beamformer.cl") {
+    _num_elements = config.get<int>(unique_name, "num_elements");
+    _num_data_sets = config.get<int>(unique_name, "num_data_sets");
+    _num_pointings = config.get<int>(unique_name, "num_pointings");
+    _num_local_freq = config.get<int>(unique_name, "num_local_freq");
+    _samples_per_data_set = config.get<int>(unique_name, "samples_per_data_set");
+    network_buf = host_buffers.get_buffer("network_buf");
+
+    // _element_mask = config.get<std::vector<int>>(unique_name, "element_mask");
+    // _product_remap = config.get<std::vector<int>>(unique_name, "product_remap");
+    // int remap_size = _product_remap.size();
+
+    // if (remap_size != _num_elements) {
+    //     ERROR("The remap array must have the same size as the number of elements. array size {:d}, "
+    //           "num_elements {:d}",
+    //           remap_size, _num_elements);
+    // }
+    // _inverse_product_remap.reserve(remap_size);
+    // // Given a channel ID, where is it in FPGA order.
+    // for (int i = 0; i < remap_size; ++i) {
+    //     _inverse_product_remap[_product_remap[i]] = i;
+    // }
+    _scale_factor = config.get<int>(unique_name, "scale_factor");
+
+    num_local_freq = Telescope::instance().num_freq_per_stream();
+}
+
+clBeamformKernel::~clBeamformKernel() {
+    //clReleaseMemObject(device_mask);
+}
+
+void clBeamformKernel::build() {
+    clCommand::build();
+
+    cl_int err;
+
+    cl_device_id dev_id = device.get_id();
+
+    std::string cl_options = "";
+    cl_options += " -D NUM_ELEMENTS=" + std::to_string(_num_elements);
+    cl_options += " -D NUM_TIMESAMPLES=" + std::to_string(_samples_per_data_set);
+    cl_options += " -D NUM_POINTINGS=" + std::to_string(_num_pointings);
+
+    CHECK_CL_ERROR(clBuildProgram(program, 1, &dev_id, cl_options.c_str(), nullptr, nullptr));
+
+    kernel = clCreateKernel(program, kernel_command.c_str(), &err);
+    CHECK_CL_ERROR(err);
+
+    // unsigned char mask[_num_elements];
+
+    // for (int i = 0; i < _num_elements; ++i) {
+    //     mask[i] = 1;
+    // }
+    // for (uint32_t i = 0; i < _element_mask.size(); ++i) {
+    //     int mask_position = _element_mask[i];
+    //     mask_position = _inverse_product_remap[mask_position];
+    //     mask[mask_position] = 0;
+    // }
+
+    // device_mask = clCreateBuffer(device.get_context(), CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
+    //                              _num_elements * sizeof(unsigned char), mask, &err);
+
+    // CHECK_CL_ERROR(clSetKernelArg(kernel, 4, sizeof(cl_mem), (void*)&device_mask));
+
+    // float scale_factor = _scale_factor;
+    // INFO("setup_clBeamformKernel_worksize, setting scale factor to {:f}", scale_factor);
+    // CHECK_CL_ERROR(clSetKernelArg(kernel, 5, sizeof(float), &scale_factor));
+
+
+    // set group size
+    int group_size = 64;
+    CHECK_CL_ERROR(clSetKernelArg(kernel, 4, sizeof(float), &_scale_factor)); //not making this pointing dependent
+    CHECK_CL_ERROR(clSetKernelArg(kernel, 5, sizeof(unsigned int), &_num_pointings));
+
+    // Beamforming kernel global and local work space sizes.
+    // HERE FIX
+    gws[0] = _num_pointings*group_size;
+    gws[1] = _num_local_freq;
+    gws[2] = _samples_per_data_set;
+
+    lws[0] = group_size;
+    lws[1] = 1;
+    lws[2] = 1;
+}
+
+cl_event clBeamformKernel::execute(cl_event pre_event) {
+    pre_execute();
+
+    // TODO Make this a config file option
+    // 390625 == 1 second.
+    const uint64_t phase_update_period = 390625;
+
+    int gpu_frame_index = gpu_frame_id % _gpu_buffer_depth;
+    int64_t current_seq = get_fpga_seq_num(network_buf, gpu_frame_index);
+    int64_t bankID = 0; //(current_seq / phase_update_period) % 2;
+
+    stream_t streamID = get_stream_id(network_buf, gpu_frame_index);
+
+    uint32_t input_frame_len = _num_elements * num_local_freq * _samples_per_data_set * _num_data_sets * sizeof(char);
+
+    cl_mem input_memory = device.get_gpu_memory_array("input", gpu_frame_id, input_frame_len);
+    cl_mem phase_memory =
+        device.get_gpu_memory_array("phases", gpu_frame_id, _num_elements * num_local_freq * _num_pointings * _num_data_sets * sizeof(cl_float2));
+    //std::cout<< "test gpu allocate buffer size" << "\n";
+    //std::cout<< sizeof(uint32_t) << "\n";
+    //std::cout<< sizeof(cl_float2) << "\n";
+
+
+    uint32_t output_len = _samples_per_data_set * _num_data_sets * num_local_freq * _num_pointings * 2  * sizeof(char);//cl_float2);
+    cl_mem output_memory_frame =
+        device.get_gpu_memory_array("output", gpu_frame_id, output_len);
+
+    // HERE FIX
+    setKernelArg(0, input_memory);
+    setKernelArg(1, phase_memory);
+    setKernelArg(2, output_memory_frame);
+
+    CHECK_CL_ERROR(clEnqueueNDRangeKernel(device.getQueue(1), kernel, 3, nullptr, gws, lws, 1,
+                                          &pre_event, &post_event));
+
+    return post_event;
+}
+
+
+cl_mem clBeamformKernel::get_freq_map(stream_t encoded_stream_id) {
+    // TODO: convert to use standard mem alloc!
+    // TODO: stream_t - uses internal structure
+    auto it = device_freq_map.find(encoded_stream_id.id);
+
+    if (it == device_freq_map.end()) {
+        // Create the freq map for the first time.
+        auto& tel = Telescope::instance();
+        cl_int err;
+        float freq[num_local_freq];
+
+        for (int j = 0; j < num_local_freq; ++j) {
+            freq[j] = tel.to_freq(encoded_stream_id, j) / 1000.0;
+        }
+
+        device_freq_map[encoded_stream_id.id] =
+            clCreateBuffer(device.get_context(), CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
+                           num_local_freq * sizeof(float), freq, &err);
+        CHECK_CL_ERROR(err);
+    }
+    return device_freq_map.at(encoded_stream_id.id);
+}

--- a/lib/opencl/kernels/outrigger_beamformer.cl
+++ b/lib/opencl/kernels/outrigger_beamformer.cl
@@ -1,0 +1,154 @@
+#define POINTING get_group_id(0)   
+#define freq get_group_id(1)       
+#define time get_group_id(2)       
+#define local_unit get_local_id(0)  
+#define group_size get_local_size(0)
+#define NINPUT 256
+#define NFREQ 8  
+#define POLBLOCK 16 // for hco and gbo  
+#define NTIME get_global_size(2)
+#define NPOL 2
+#define ROW_SHIFT_BIT 0x100
+// imaginary data helpers
+#define RE x //x
+#define IM y //y
+// author: Shion Andrew
+
+
+
+#define DPP_SHIFT(x, ctrl) \
+    as_float(__builtin_amdgcn_mov_dpp(as_uint(x), ctrl, 0xF, 0xF, 0))
+
+// Macro for ds_bpermute with float input
+#define DS_BPERMUTE(x, offset) \
+    as_float(__builtin_amdgcn_ds_bpermute(((offset)+get_local_id(0))*4, as_uint(x)))
+
+static inline float2 truncate_uint8(float2 val)
+{
+    val.RE = (val.RE > 15) ? 15 : val.RE;
+    val.RE = (val.RE < 0) ? 0 : val.RE;
+
+    val.IM = (val.IM > 15) ? 15 : val.IM;
+    val.IM = (val.IM < 0) ? 0 : val.IM;
+
+    return val;
+}
+
+// notes: 
+// group size must be 64 - amdgpu wavefront
+// assuming phase map should contain gains and are correctly conjugated
+__kernel void gpu_beamforming(global uchar* inputData, 
+                              global float2* phaseMap,
+                              global uchar* outputData,  
+                              private float scaling,
+                              private uint NPOINTING) {
+
+    int groupData_chunk_start = time * (NFREQ * NINPUT) + freq * NINPUT; // (ntime,nfreq,ninput) -> (ntime,nfreq,npointing)
+    int groupPhase_chunk_start = POINTING * (NFREQ * NINPUT) + freq * NINPUT; // assuming (npointing,nfreq,ninput)
+    
+    float2 xpol = {0.0f, 0.0f}; 
+    float2 ypol = {0.0f, 0.0f}; 
+
+    for (int idx = local_unit; idx < NINPUT; idx = idx + group_size) {
+        uchar data_temp = inputData[groupData_chunk_start + idx];
+        float2 ph = phaseMap[groupPhase_chunk_start + idx];
+        // assuming phases are already conjugated 
+        if ((idx / POLBLOCK ) % 2 == 0) {
+            xpol.RE += ph.RE*((float)((data_temp & 0xf0)>> 4u)-8)
+                    -  ph.IM*((float)((data_temp & 0x0f)>> 0u)-8);     
+            xpol.IM += ph.IM*((float)((data_temp & 0xf0)>> 4u)-8)
+                    +  ph.RE*((float)((data_temp & 0x0f)>> 0u)-8);       
+            //double check that integer division floors here
+            // also double check float promotion in opencl
+        } else {
+            ypol.RE += ph.RE*((float)((data_temp & 0xf0)>> 4u)-8)
+                    -  ph.IM*((float)((data_temp & 0x0f)>> 0u)-8);     
+            ypol.IM += ph.IM*((float)((data_temp & 0xf0)>> 4u)-8)
+                    +  ph.RE*((float)((data_temp & 0x0f)>> 0u)-8); 
+        }
+        // clarify -8. Signed vs unsigned interpretation.
+    }
+
+    // `mov_dpp` is faster than `ds_bpermute`.
+
+    // reduce-sum using __builtin_amdgcn_mov_dpp
+    // this reads directly from other lanes using hardware paths, without going 
+    // into group memory.
+    // const uint ROW_SHIFT_BIT = 0x100;
+
+    // // x polarization RE
+    // xpol.RE += dpp_shift(xpol.RE, 0x120); // 0x120
+    // xpol.RE += dpp_shift(xpol.RE, 0x110);
+    // xpol.RE += dpp_shift(xpol.RE, 0x108);
+    // xpol.RE += dpp_shift(xpol.RE, 0x104);
+    // xpol.RE += dpp_shift(xpol.RE, 0x102); // 0x102
+
+    // DDP_SHIFT is not defined for all offsets. Need to use BPERMUTE
+    // reduce by 4x across 0-63. Now in 0-15.
+    xpol.RE += DS_BPERMUTE(xpol.RE, 16) +
+              DS_BPERMUTE(xpol.RE, 32) +
+              DS_BPERMUTE(xpol.RE, 48);
+
+    xpol.IM += DS_BPERMUTE(xpol.IM, 16) +
+              DS_BPERMUTE(xpol.IM, 32) +
+              DS_BPERMUTE(xpol.IM, 48);
+              
+    ypol.RE += DS_BPERMUTE(ypol.RE, 16) +
+              DS_BPERMUTE(ypol.RE, 32) +
+              DS_BPERMUTE(ypol.RE, 48);
+              
+    ypol.IM += DS_BPERMUTE(ypol.IM, 16) +
+              DS_BPERMUTE(ypol.IM, 32) +
+              DS_BPERMUTE(ypol.IM, 48);
+                 
+
+    // Now reducing with stride of 4. Vals in 0-3
+    xpol.RE += DPP_SHIFT(xpol.RE, ROW_SHIFT_BIT | 4)+
+               DPP_SHIFT(xpol.RE, ROW_SHIFT_BIT | 8)+
+               DPP_SHIFT(xpol.RE, ROW_SHIFT_BIT | 12);
+
+    xpol.IM += DPP_SHIFT(xpol.IM, ROW_SHIFT_BIT | 4)+
+               DPP_SHIFT(xpol.IM, ROW_SHIFT_BIT | 8)+
+               DPP_SHIFT(xpol.IM, ROW_SHIFT_BIT | 12);
+               
+    ypol.RE += DPP_SHIFT(ypol.RE, ROW_SHIFT_BIT | 4)+
+               DPP_SHIFT(ypol.RE, ROW_SHIFT_BIT | 8)+
+               DPP_SHIFT(ypol.RE, ROW_SHIFT_BIT | 12);
+
+    ypol.IM += DPP_SHIFT(ypol.IM, ROW_SHIFT_BIT | 4)+
+               DPP_SHIFT(ypol.IM, ROW_SHIFT_BIT | 8)+
+               DPP_SHIFT(ypol.IM, ROW_SHIFT_BIT | 12);
+
+    // Now adding up 0-3
+    xpol.RE += DPP_SHIFT(xpol.RE, ROW_SHIFT_BIT | 1)+
+               DPP_SHIFT(xpol.RE, ROW_SHIFT_BIT | 2)+
+               DPP_SHIFT(xpol.RE, ROW_SHIFT_BIT | 3);
+
+    xpol.IM += DPP_SHIFT(xpol.IM, ROW_SHIFT_BIT | 1)+
+               DPP_SHIFT(xpol.IM, ROW_SHIFT_BIT | 2)+
+               DPP_SHIFT(xpol.IM, ROW_SHIFT_BIT | 3);
+
+    ypol.RE += DPP_SHIFT(ypol.RE, ROW_SHIFT_BIT | 1)+
+               DPP_SHIFT(ypol.RE, ROW_SHIFT_BIT | 2)+
+               DPP_SHIFT(ypol.RE, ROW_SHIFT_BIT | 3);
+
+    ypol.IM += DPP_SHIFT(ypol.IM, ROW_SHIFT_BIT | 1)+
+               DPP_SHIFT(ypol.IM, ROW_SHIFT_BIT | 2)+
+               DPP_SHIFT(ypol.IM, ROW_SHIFT_BIT | 3);
+
+    
+    if (local_unit == 0) {
+        int out_idx = freq * (NTIME * NPOINTING*NPOL) + time * NPOINTING*NPOL + POINTING*NPOL; 
+        // note, not making scaling pointing dependent
+        //xpol = xpol / scaling[POINTING] + 8;
+        xpol = xpol / scaling + 8;
+        xpol = truncate_uint8(xpol);
+        outputData[out_idx] = (((int)xpol.RE << 4) & 0xF0) + ((int)xpol.IM & 0x0F); 
+
+        //ypol = ypol / scaling[POINTING] + 8;
+        ypol = ypol / scaling + 8;
+        ypol = truncate_uint8(ypol);
+        outputData[out_idx + 1] = (((int)ypol.RE << 4) & 0xF0) + ((int)ypol.IM & 0x0F); 
+    }
+}
+


### PR DESCRIPTION
(copied from issue https://github.com/kotekan/kotekan/issues/1286):

please see outrigger_beamformer.cl and clBeamformKernel.cpp on branch outrigger_beamformer_kernel (linked to this issue), as well as testing detailed here: https://bao.chimenet.ca/doc/documents/2369.
Some notes:

(1) I overwrote clBeamformKernel.cpp to avoid having to make changes to the cmake lists, but if instead you want this to be a completely new stage you will need to let me know.

(2) It is not clear to me what the expected output axis ordering (i.e. what is fastest vs slowest varying out of the axes time, frequency, polarization, pointing, and real/imaginary components of the data) is for the write out stage. I took a guess based on the existing BeamExtract.cpp, but since it does not account for frequency (presumably because this has only been written for CHIME where num_local_freq=1) I just made the assumption that placing frequency as the slowest varying index would be the most convenient downstream. Again, if this needs to change, you will need to let me know so I can change the kernel accordingly.

(3) Likewise for the input axis ordering, I made guesses based on BasebandReadout.cpp and the kotekan config file that is used on outrigger devops (https://github.com/CHIMEFRB/outrigger-devops/blob/main/docker/stacks/hco/configs/kotekan/input_reorder.j2).

(4) Some basic testing with e.g. testDataGen is described here https://bao.chimenet.ca/doc/documents/2369, but this doesn’t really test (3). In principle (3) could be tested by dumping baseband data, converting with the nominal converter, and beamforming with the same phases, but the nominal baseband triggering system requires ctime metadata that doesn’t get generated in testDataGen. If the f-engine at HCO is working, it might be easier to just trigger a real baseband dump (maybe around solar transit).

(5) Note that I am not testing the phase generation code (i.e. compared to the offline beamformer which gets used for the FRB), that will need to be done in a separate issue

I can’t really think of any other additional tests beyond the integration test in (4), which requires infrastructure that goes beyond this issue.

