### PR TITLE
n2k: Correct ring buffer checks

### DIFF
--- a/external/n2k/src_lib/SkKernel.cu
+++ b/external/n2k/src_lib/SkKernel.cu
@@ -100,10 +100,10 @@ __global__ void sk_kernel(
     int rfimask_T1024min,                // First (coarse) time sample in rfimask array
     int rfimask_T1024size)               // Number of (coarse) time samples in rfimask array
 {
-    assert(S012_Tsize & (S012_Tsize - 1) == 0 && "S012_Tsize must be a power of two");
-    assert(sk_feed_averaged_Tsize & (sk_feed_averaged_Tsize - 1) == 0 && "sk_feed_averaged_Tsize must be a power of two");
-    assert(sk_single_feed_Tsize & (sk_single_feed_Tsize - 1) == 0 && "sk_single_feed_Tsize must be a power of two");
-    assert(rfimask_T1024size & (rfimask_T1024size - 1) == 0 && "rfimask_T1024size must be a power of two");
+    assert((S012_Tsize & (S012_Tsize - 1)) == 0 && "S012_Tsize must be a power of two");
+    assert((sk_feed_averaged_Tsize & (sk_feed_averaged_Tsize - 1)) == 0 && "sk_feed_averaged_Tsize must be a power of two");
+    assert((sk_single_feed_Tsize & (sk_single_feed_Tsize - 1)) == 0 && "sk_single_feed_Tsize must be a power of two");
+    assert((rfimask_T1024size & (rfimask_T1024size - 1)) == 0 && "rfimask_T1024size must be a power of two");
 
 #ifdef DEBUGGING
     const int64_t S012_size = S012_Tsize * F * 3 * S;

--- a/external/n2k/src_lib/s012_station_downsample.cu
+++ b/external/n2k/src_lib/s012_station_downsample.cu
@@ -83,7 +83,7 @@ struct template_magic<1,1>
     // Base case: L == N == 1.
     static __device__ ulong load_and_sum(const ulong *Sin, uint bf, int m0, int T, int Tmin, int Tsize, int F, int S)
     {
-        assert(Tsize & (Tsize - 1) == 0 && "Tsize must be a power of 2");
+        assert((Tsize & (Tsize - 1)) == 0 && "Tsize must be a power of 2");
 
         const int M = T * F * 3;
 	m0 = (m0 < M) ? m0 : (M-1);

--- a/external/n2k/src_lib/s012_time_downsample.cu
+++ b/external/n2k/src_lib/s012_time_downsample.cu
@@ -37,8 +37,8 @@ namespace n2k {
 __global__ void s012_time_downsample_kernel(ulong *Sout, const ulong *Sin, int Tds, int M, int Nds,
                                             int Trfi_min, int Trfi_size, int Trfibar_min, int Trfibar_size)
 {
-    assert(Trfi_size & (Trfi_size - 1) == 0 && "Trfi_size must be a power of 2");
-    assert(Trfibar_size & (Trfibar_size - 1) == 0 && "Trfibar_size must be a power of 2");
+    assert((Trfi_size & (Trfi_size - 1)) == 0 && "Trfi_size must be a power of 2");
+    assert((Trfibar_size & (Trfibar_size - 1)) == 0 && "Trfibar_size must be a power of 2");
 
     // Per-thread (downsampled time, spectator index)
     uint m = (blockIdx.x * blockDim.x) + threadIdx.x;
@@ -97,9 +97,9 @@ void launch_s012_time_downsample_kernel(ulong *Sout, const ulong *Sin, long T, l
 	throw runtime_error("launch_s012_time_downsample_kernel(): expected M to be a multiple of 32");
     if (Nds <= 0)
 	throw runtime_error("launch_s012_time_downsample_kernel(): expected Nds > 0");
-    if (Trfi_size & (Trfi_size - 1) != 0)
+    if ((Trfi_size & (Trfi_size - 1)) != 0)
         throw runtime_error("launch_s012_time_downsample_kernel(): Trfi_size must be a power of 2");
-    if (Trfibar_size & (Trfibar_size - 1) != 0)
+    if ((Trfibar_size & (Trfibar_size - 1)) != 0)
         throw runtime_error("launch_s012_time_downsample_kernel(): Trfibar_size must be a power of 2");
     if ((T >= INT_MAX) || (M >= INT_MAX) || (Nds >= INT_MAX) || (Trfi_min >= INT_MAX)
         || (Trfi_size >= INT_MAX) || (Trfibar_min >= INT_MAX) || (Trfibar_size >= INT_MAX))

--- a/external/n2k/src_lib/s0_kernel.cu
+++ b/external/n2k/src_lib/s0_kernel.cu
@@ -112,7 +112,7 @@ __global__ void s0_kernel(ulong4_16a *s0, const uint *pl, int T, int Tmin, int T
 {
     static constexpr uint ALL_LANES = 0xffffffffU;
 
-    assert((Tsize >> 7) & ((Tsize >> 7) - 1) == 0 && "Tsize / 128 must be a power of 2");
+    assert(((Tsize >> 7) & ((Tsize >> 7) - 1)) == 0 && "Tsize / 128 must be a power of 2");
     
     // Warp location within larger kerenl
     int tds = (blockIdx.z * blockDim.z + threadIdx.z);              // output time

--- a/external/n2k/src_lib/s12_kernel.cu
+++ b/external/n2k/src_lib/s12_kernel.cu
@@ -67,7 +67,7 @@ s12_kernel(ulong *S12, const uint *E, int Tds, int Tmin, int Tsize, int F, int S
 {
     const uint to_offset_encoded = offset_encoded ? 0 : 0x88888888U;
 
-    assert(Tsize & (Tsize - 1) == 0 && "Tsize must be a power of 2");
+    assert((Tsize & (Tsize - 1)) == 0 && "Tsize must be a power of 2");
     
     ulong s1_0, s1_1, s1_2, s1_3, s2_0, s2_1, s2_2, s2_3;
     s1_0 = s1_1 = s1_2 = s1_3 = s2_0 = s2_1 = s2_2 = s2_3 = 0;
@@ -140,7 +140,7 @@ void launch_s12_kernel(ulong* S12, const uint8_t* E, long T, long Tmin, long Tsi
 	throw runtime_error("launch_s12_kernel: first sample Tmin must be >= 0");
     if (Tsize <= 0)
 	throw runtime_error("launch_s12_kernel: ringbuffer size Tsize be > 0");
-    if (Tsize & (Tsize - 1) != 0)
+    if ((Tsize & (Tsize - 1)) != 0)
         throw runtime_error("launch_s12_kernel: Tsize must be a power of 2");
     if (F <= 0)
 	throw runtime_error("launch_s12_kernel: number of frequency samples F must be > 0");


### PR DESCRIPTION
C++ operator precedence. Enough said.