### PR TITLE
cleanup and dataset handling for N2Accumulate to use within CHIME

### DIFF
--- a/lib/stages/N2Accumulate.cpp
+++ b/lib/stages/N2Accumulate.cpp
@@ -1,6 +1,5 @@
 #include "N2Accumulate.hpp"
 
-#include "CHORDTelescope.hpp"    // for CHORDTelescope, EOP
 #include "Config.hpp"            // for Config
 #include "N2FrameView.hpp"       // for N2FrameView
 #include "N2Metadata.hpp"        // for N2Metadata, get_N2_metadata
@@ -12,6 +11,7 @@
 #include "chordMetadata.hpp"     // for chordMetadata, get_chord_metadata
 #include "kotekanLogging.hpp"    // for FATAL_ERROR, DEBUG, INFO
 #include "prometheusMetrics.hpp" // for Metrics, Gauge
+#include "timeUtil.hpp"          // for EOP
 
 #include "fmt.hpp"      // for compile_string_to_view
 #include "gsl-lite.hpp" // for span

--- a/lib/stages/N2Accumulate.cpp
+++ b/lib/stages/N2Accumulate.cpp
@@ -512,6 +512,10 @@ bool N2Accumulate::output_and_reset(frameID& in_frame_id, frameID& out_frame_id)
 
         meta->n_rfi_fpga_ticks = _n_rfi_samples_in_vis[f];
 
+        if (chord_frame_metadata->has_dataset_id()) {
+            meta->dataset_id = chord_frame_metadata->get_dataset_id();
+        }
+
         DEBUG("Creating N2FrameView for freq f[{:d}] = {:d}", f,
               chord_frame_metadata->get_coarse_freq()[f]);
         N2FrameView out_vis(out_buf, out_frame_id);

--- a/lib/stages/N2Accumulate.hpp
+++ b/lib/stages/N2Accumulate.hpp
@@ -6,10 +6,10 @@
 #ifndef N2_ACCUMULATE_HPP
 #define N2_ACCUMULATE_HPP
 
-#include "CHORDTelescope.hpp"    // for CHORDTelescope
 #include "Config.hpp"            // for Config
 #include "N2Util.hpp"            // for frameID
 #include "Stage.hpp"             // for Stage
+#include "Telescope.hpp"         // for Telescope
 #include "buffer.hpp"            // for Buffer
 #include "bufferContainer.hpp"   // for bufferContainer
 #include "prometheusMetrics.hpp" // for Counter, MetricFamily

--- a/lib/testing/testN2kGen.cpp
+++ b/lib/testing/testN2kGen.cpp
@@ -79,6 +79,9 @@ testN2kGen::testN2kGen(Config& config, const std::string& unique_name,
     freq_ids = config.get_default<std::vector<uint32_t>>(unique_name, "freq_ids",
                                                          std::vector<uint32_t>({4096}));
     seed = config.get_default<uint32_t>(unique_name, "seed", 0);
+    if (config.exists(unique_name, "dataset_id")) {
+        dset_id = config.get<dset_id_t>(unique_name, "dataset_id");
+    }
     first_frame_index = config.get_default<int64_t>(unique_name, "first_frame_index", 0);
 
     // Check parameter compatibility
@@ -223,6 +226,10 @@ void testN2kGen::set_correlation_metadata(const std::shared_ptr<chordMetadata>& 
     meta->set_freq_upchan_factor(freq_upchan_factor);
     meta->set_freq_upchan_index(freq_upchan_index);
     assert(meta->get_nfreq() <= CHORD_META_MAX_FREQ);
+
+    if (dset_id) {
+        meta->set_dataset_id(dset_id.value());
+    }
 }
 
 void testN2kGen::set_counts_metadata(const std::shared_ptr<chordMetadata>& meta, uint64_t seq_num) {

--- a/lib/testing/testN2kGen.hpp
+++ b/lib/testing/testN2kGen.hpp
@@ -6,10 +6,12 @@
 #include "buffer.hpp"          // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
 #include "chordMetadata.hpp"   // for chordMetadata
+#include "dataset.hpp"         // for dset_id_t
 #include "visUtil.hpp"         // for frameID
 
 #include <array>    // for array
 #include <memory>   // for shared_ptr
+#include <optional> // for optional
 #include <stdint.h> // for int32_t, uint32_t, uint64_t
 #include <string>   // for string, basic_string
 #include <vector>   // for vector
@@ -40,6 +42,7 @@
  * @conf  counts_values         Vector of ints. Optional cycle for "const" count frames.
  * @conf  seed                  Int. Default 0. Seeds the deterministic RNG for "random" correlation
  *                              and counts variants.
+ * @conf  dataset_id            Hash string. Optional dataset id to set for CHIME * pipelines.
  * @conf  first_frame_index     Int. Default 0. Starting FPGA frame number, fro
  *                              frames of size samples_per_data_set.
  * @conf  samples_per_data_set  Int. How often to produce data.
@@ -79,6 +82,7 @@ private:
     int32_t num_elements;
     std::vector<uint32_t> freq_ids;
     uint32_t seed;
+    std::optional<dset_id_t> dset_id;
     int64_t first_frame_index;
 
     static constexpr int corr_blocksize = 16; // ALWAYS 16


### PR DESCRIPTION
should not affect CHORD use at all, just adds some optional configuration option and removes all CHORDTelescope files in favor of just Telescope and EOP, which is what is actually used.