### PR TITLE
more int overflows

### DIFF
--- a/external/n2k/src_lib/SkKernel.cu
+++ b/external/n2k/src_lib/SkKernel.cu
@@ -238,13 +238,13 @@ __global__ void sk_kernel(
 	ulong S1i = in_S012[s+S];
 	ulong S2i = in_S012[s+2*S];
 #ifdef DEBUGGING
-        assert(&in_S012[s] == &ringbuffer_S012(dbg_in_S012[s]));
-        assert(&in_S012[s+S] == &ringbuffer_S012(dbg_in_S012[s+S]));
-        assert(&in_S012[s+2*S] == &ringbuffer_S012(dbg_in_S012[s+2*S]));
-
         assert((&in_S012[s] - incoming_in_S012) >= 0 && (&in_S012[s] - incoming_in_S012) < S012_size);
         assert((&in_S012[s+S] - incoming_in_S012) >= 0 && (&in_S012[s+S] - incoming_in_S012) < S012_size);
         assert((&in_S012[s+2*S] - incoming_in_S012) >= 0 && (&in_S012[s+2*S] - incoming_in_S012) < S012_size);
+
+        assert(&in_S012[s] == &ringbuffer_S012(dbg_in_S012[s]));
+        assert(&in_S012[s+S] == &ringbuffer_S012(dbg_in_S012[s+S]));
+        assert(&in_S012[s+2*S] == &ringbuffer_S012(dbg_in_S012[s+2*S]));
 #endif
 
 	float S0f = float(S0i);

--- a/external/n2k/src_lib/SkKernel.cu
+++ b/external/n2k/src_lib/SkKernel.cu
@@ -639,12 +639,20 @@ void SkKernel::launch(
     // Check assumptions made for efficient wrapping of the ringbuffer data
     if ((S012_Tsize & (S012_Tsize-1)) != 0)
         throw runtime_error("SkKernel::launch: expected S012_Tsize to be a power of 2, but got " + std::to_string(S012_Tsize) + ".");
+    if (S012_Tsize > 0 && S012_Tmin >= S012_Tsize)
+        throw runtime_error("SkKernel::launch: expected S012_Tmin to be smaller than S012_Tsize, but got " + std::to_string(S012_Tmin) + ".");
     if ((sk_feed_averaged_Tsize & (sk_feed_averaged_Tsize-1)) != 0)
         throw runtime_error("SkKernel::launch: expected sk_feed_averaged_Tsize to be a power of 2, but got " + std::to_string(sk_feed_averaged_Tsize) + ".");
+    if (sk_feed_averaged_Tsize > 0 && sk_feed_averaged_Tmin >= sk_feed_averaged_Tsize)
+        throw runtime_error("SkKernel::launch: expected sk_feed_averaged_Tmin to be smaller than sk_feed_averaged_Tsize, but got " + std::to_string(sk_feed_averaged_Tmin) + ".");
     if ((sk_single_feed_Tsize & (sk_single_feed_Tsize-1)) != 0)
         throw runtime_error("SkKernel::launch: expected sk_single_feed_Tsize to be a power of 2, but got " + std::to_string(sk_single_feed_Tsize) + ".");
+    if (sk_single_feed_Tsize > 0 && sk_single_feed_Tmin >= sk_single_feed_Tsize)
+        throw runtime_error("SkKernel::launch: expected sk_single_feed_Tmin to be smaller than sk_single_feed_Tsize, but got " + std::to_string(sk_single_feed_Tmin) + ".");
     if ((rfimask_T1024size & (rfimask_T1024size-1)) != 0)
         throw runtime_error("SkKernel::launch: expected rfimask_T1024size to be a power of 2, but got " + std::to_string(rfimask_T1024size) + ".");
+    if (rfimask_T1024size > 0 && rfimask_T1024min >= rfimask_T1024size)
+        throw runtime_error("SkKernel::launch: expected rfimask_T1024min to be smaller than rfimask_T1024size, but got " + std::to_string(rfimask_T1024min) + ".");
 
     // If an RFI bitmask is being computed, check 'sk_rfimask_sigmas' argument.
     

--- a/external/n2k/src_lib/s012_station_downsample.cu
+++ b/external/n2k/src_lib/s012_station_downsample.cu
@@ -175,6 +175,8 @@ void launch_s012_station_downsample_kernel(ulong* Sout, const ulong* Sin, const 
 	throw runtime_error("launch_s012_station_downsample_kernel(): expected S to be a multple of 128");
     if (S > rfi_max_stations)
 	throw runtime_error("launch_s012_station_downsample_kernel(): expected S to be <= max_rfi_stations");
+    if (Tsize > 0 && Tmin >= Tsize)
+        throw runtime_error("launch_s012_station_downsample_kernel(): expected Tmin to be smaller than Tsize, but got " + std::to_string(Tmin) + ".");
     if ((T >= INT_MAX) || (Tmin >= INT_MAX) || (Tsize >= INT_MAX) || (F >= INT_MAX)
         || (S >= INT_MAX) || (M*S) > INT_MAX)
 	throw runtime_error("launch_s012_station_downsample_kernel(): 32-bit overflow");

--- a/external/n2k/src_lib/s012_time_downsample.cu
+++ b/external/n2k/src_lib/s012_time_downsample.cu
@@ -101,6 +101,8 @@ void launch_s012_time_downsample_kernel(ulong *Sout, const ulong *Sin, long T, l
         throw runtime_error("launch_s012_time_downsample_kernel(): Trfi_size must be a power of 2");
     if ((Trfibar_size & (Trfibar_size - 1)) != 0)
         throw runtime_error("launch_s012_time_downsample_kernel(): Trfibar_size must be a power of 2");
+    if (Trfi_size > 0 && Trfi_min >= Trfi_size)
+        throw runtime_error("launch_s012_time_downsample_kernel(): expected Trfi_min to be smaller than Trfi_size, but got " + std::to_string(Trfi_min) + ".");
     if ((T >= INT_MAX) || (M >= INT_MAX) || (Nds >= INT_MAX) || (Trfi_min >= INT_MAX)
         || (Trfi_size >= INT_MAX) || (Trfibar_min >= INT_MAX) || (Trfibar_size >= INT_MAX))
 	throw runtime_error("launch_s012_time_downsample_kernel(): 32-bit overflow");

--- a/external/n2k/src_lib/s0_kernel.cu
+++ b/external/n2k/src_lib/s0_kernel.cu
@@ -245,6 +245,8 @@ void launch_s0_kernel(ulong* s0, const ulong* pl_mask, long T, long Tmin, long T
 	throw runtime_error("launch_s0_kernel(): out_fstride must be >= S");	
     if (out_fstride & 3)
 	throw runtime_error("launch_s0_kernel(): out_fstride must be a multiple of 4");
+    if (Tsize > 0 && Tmin >= Tsize)
+        throw runtime_error("launch_s0_kernel(): expected Tmin to be smaller than Tsize, but got " + std::to_string(Tmin) + ".");
     if ((T >= INT_MAX) || (Tmin >= INT_MAX) || (Tsize >= INT_MAX) || (F >= INT_MAX)
         || (S >= INT_MAX) || (Nds >= INT_MAX) || (out_fstride >= INT_MAX))
         throw runtime_error("launch_s0_kernel(): 32-bit overflow");

--- a/external/n2k/src_lib/s12_kernel.cu
+++ b/external/n2k/src_lib/s12_kernel.cu
@@ -154,6 +154,8 @@ void launch_s12_kernel(ulong* S12, const uint8_t* E, long T, long Tmin, long Tsi
 	throw runtime_error("launch_s12_kernel: out_fstride must be >= 2*S");	
     if (out_fstride & 3)
 	throw runtime_error("launch_s12_kernel: out_fstride must be a multiple of 4");
+    if (Tsize > 0 && Tmin >= Tsize)
+        throw runtime_error("launch_s12_kernel: expected Tmin to be smaller than Tsize, but got " + std::to_string(Tmin) + ".");
     if ((T >= INT_MAX) || (Tmin >= INT_MAX) || (Tsize >= INT_MAX) || (F >= INT_MAX)
         || (S >= INT_MAX) || (Nds >= INT_MAX) || (out_fstride >= INT_MAX))
         throw runtime_error("launch_s12_kernel: 32-bit overflow");

--- a/lib/cuda/cudaPLMaskExpander.cpp
+++ b/lib/cuda/cudaPLMaskExpander.cpp
@@ -182,10 +182,12 @@ cudaEvent_t cudaPLMaskExpander::execute(cudaPipelineState& /*pipestate*/,
     kotekan::uint1x8_t* const pl_mask_memory = pl_mask.get_ndarray().data();
     const kotekan::uint1x8_t* const pl_expanded_mask_memory = pl_expanded_mask.get_ndarray().data();
 
+    // Tmin_in wraps around into actual array index to avoid overflows
     const std::ptrdiff_t Tsize_in = pl_mask.get_ndarray().extent(0);
-    const std::ptrdiff_t Tmin_in = pl_mask.get_read_valid().begin();
+    const std::ptrdiff_t Tmin_in = pl_mask.get_read_valid().begin() % Tsize_in;
+    // Tmin_out wraps around into actual array index to avoid overflows
     const std::ptrdiff_t Tsize_out = pl_expanded_mask.get_ndarray().extent(0);
-    const std::ptrdiff_t Tmin_out = pl_expanded_mask.get_write_valid().begin();
+    const std::ptrdiff_t Tmin_out = pl_expanded_mask.get_write_valid().begin() % Tsize_out;
     const std::ptrdiff_t Tout = pl_expanded_mask.get_write_valid().size() * 64;
 
     n2k::launch_pl_mask_expander((ulong*)pl_expanded_mask_memory, (const ulong*)pl_mask_memory,

--- a/lib/cuda/cudaRFISKbar.cpp
+++ b/lib/cuda/cudaRFISKbar.cpp
@@ -210,12 +210,16 @@ cudaEvent_t cudaRFISKbar::execute(cudaPipelineState& /*pipestate*/,
     const long F = rfi_S012bar.get_ndarray().get_extent(1);
     const long S = rfi_S012bar.get_ndarray().get_extent(3)
                    * rfi_S012bar.get_ndarray().get_extent(4); // Number of stations (= 2 * dishes)
-    const long S012_Tmin = rfi_S012bar.get_read_valid().begin();
+    // S012_Tmin wraps around into actual array index to avoid overflows
     const long S012_Tsize = rfi_S012bar.get_ndarray().get_extent(0);
-    const long sk_feed_averaged_Tmin = rfi_SKbartilde.get_write_valid().begin();
+    const long S012_Tmin = rfi_S012bar.get_read_valid().begin() % S012_Tsize;
+    // sk_feed_averaged_Tmin wraps around into actual array index to avoid overflows
     const long sk_feed_averaged_Tsize = rfi_SKbartilde.get_ndarray().get_extent(0);
-    const long sk_single_feed_Tmin = rfi_SKbar.get_write_valid().begin();
+    const long sk_feed_averaged_Tmin =
+        rfi_SKbartilde.get_write_valid().begin() % sk_feed_averaged_Tsize;
+    // sk_single_feed_Tmin wraps around into actual array index to avoid overflows
     const long sk_single_feed_Tsize = rfi_SKbar.get_ndarray().get_extent(0);
+    const long sk_single_feed_Tmin = rfi_SKbar.get_write_valid().begin() % sk_single_feed_Tsize;
     const long rfimask_T1024min = 0;
     const long rfimask_T1024size = 0;
     const cudaStream_t stream = device.getStream(cuda_stream_id);

--- a/lib/cuda/cudaRFISKtilde.cpp
+++ b/lib/cuda/cudaRFISKtilde.cpp
@@ -220,8 +220,10 @@ cudaEvent_t cudaRFISKtilde::execute(cudaPipelineState& /*pipestate*/,
     const long S012_Tsize = rfi_S012.get_ndarray().get_extent(0);
     // S012_Tmin wraps around into actual array index to avoid overflows
     const long S012_Tmin = rfi_S012.get_read_valid().begin() % S012_Tsize;
-    const long sk_feed_averaged_Tmin = rfi_SKtilde.get_write_valid().begin();
+    // sk_feed_averaged_Tmin wraps around into actual array index to avoid overflows
     const long sk_feed_averaged_Tsize = rfi_SKtilde.get_ndarray().get_extent(0);
+    const long sk_feed_averaged_Tmin =
+        rfi_SKtilde.get_write_valid().begin() % sk_feed_averaged_Tsize;
     const long sk_single_feed_Tmin = 0;
     const long sk_single_feed_Tsize = 0;
     // rfimask_T512min wraps around into actual array index to avoid overflows

--- a/lib/cuda/cudaRFISKtilde.cpp
+++ b/lib/cuda/cudaRFISKtilde.cpp
@@ -217,14 +217,16 @@ cudaEvent_t cudaRFISKtilde::execute(cudaPipelineState& /*pipestate*/,
     const long F = rfi_S012.get_ndarray().get_extent(1);
     const long S = rfi_S012.get_ndarray().get_extent(3)
                    * rfi_S012.get_ndarray().get_extent(4); // Number of stations (= 2 * dishes)
-    const long S012_Tmin = rfi_S012.get_read_valid().begin();
     const long S012_Tsize = rfi_S012.get_ndarray().get_extent(0);
+    // S012_Tmin wraps around into actual array index to avoid overflows
+    const long S012_Tmin = rfi_S012.get_read_valid().begin() % S012_Tsize;
     const long sk_feed_averaged_Tmin = rfi_SKtilde.get_write_valid().begin();
     const long sk_feed_averaged_Tsize = rfi_SKtilde.get_ndarray().get_extent(0);
     const long sk_single_feed_Tmin = 0;
     const long sk_single_feed_Tsize = 0;
-    const long rfimask_T512min = rfi_RFImask.get_write_valid().begin();
+    // rfimask_T512min wraps around into actual array index to avoid overflows
     const long rfimask_T512size = rfi_RFImask.get_ndarray().get_extent(0);
+    const long rfimask_T512min = rfi_RFImask.get_write_valid().begin() % rfimask_T512size;
     const cudaStream_t stream = device.getStream(cuda_stream_id);
     skKernel.launch(out_sk_feed_averaged, out_sk_single_feed, out_rfimask, in_S012, in_bf_mask, T,
                     F, S, S012_Tmin, S012_Tsize, sk_feed_averaged_Tmin, sk_feed_averaged_Tsize,


### PR DESCRIPTION
In https://github.com/kotekan/kotekan/pull/1397 I did not apparently catch all int32 overflow issues in the sk-related kernels, which triggered some asserts in the rfi kernels recently.

This pull requests adds the missing `Tmin % Tsize` code in the C++ wrappers where I forgot it before and also adds the same sort of check that `Tmin < Tsize` to the CUDA source files' kernel launch wrappers.