### PR TITLE
chime n2 input file and converter stages

### DIFF
--- a/config/chime_upgrade_n2.j2
+++ b/config/chime_upgrade_n2.j2
@@ -1,0 +1,2897 @@
+##########################################
+#
+# chime_upgrade_n2
+#
+# Pipeline for running the n2k correlator, accumulate onto a visibility matrix
+# and compute eigen-decomposition.
+#
+# Currently only uses one NUMA domain, but it shouldn't be hard to extend to
+# the second NUMA domain.
+#
+# Author: Andre Renard, Roland Haas, Erik Schnetter
+#
+##########################################
+---
+########################
+#### Global options ####
+########################
+type: config
+# Logging level can be one of:
+# OFF, ERROR, WARN, INFO, DEBUG, DEBUG2 (case insensitive)
+# Note DEBUG and DEBUG2 require a build with (-DCMAKE_BUILD_TYPE=Debug)
+log_level: info
+num_polarizations: 2
+num_dishes: 1024
+num_elements: num_polarizations * num_dishes
+num_components: 2 # Re/Im
+num_freq_host_buf: 1
+{% set num_freq_gpu_buf = 16 %}
+num_freq_gpu_buf: {{ num_freq_gpu_buf }}
+num_ev_to_calculate: 4            # from n2 test case
+samples_per_data_set: 16384
+sample_period_ns: 2560
+network_frame_arrival_period: 16384 * sample_period_ns / 1e9
+baseband_buffer_depth: 3*272 # 3*272 = ~33 seconds after accounting for active frames
+# see where / if / how to use host_buffer_depth and gpu_buffer_depth
+host_buffer_depth: 12
+gpu_buffer_depth: 4
+num_gpus: 2
+cpu_affinity: [0, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
+
+# Constants
+sizeof_float: 4
+sizeof_float32: 4
+sizeof_int8: 1
+sizeof_int: 4
+sizeof_int32: 4
+sizeof_uint64: 8
+sizeof_short: 2
+
+use_hugepages: true
+
+# Telescope
+telescope:
+  name: CHIMETelescope
+  require_gps: true
+  query_gps: true # GPS time is provided via coco
+  query_frequency_map: true # Frequency map is provided via coco
+  require_frequency_map: true # Make sure we have the full frequency map
+  allow_default_frequency_map: false # Don't fall back on default map
+  eop_updatable_config: /earth_rotation_data
+
+earth_rotation_data:
+  kotekan_update_endpoint: json
+  earth_orientation_parameter_table:
+    - {time_inst_ns: 0, delta_UT1_inst: 0.0, x_pm: 0.0, y_pm: 0.0}
+
+dataset_manager:
+  use_dataset_broker: False
+
+main_pool:
+  kotekan_metadata_pool: chordMetadata
+  num_metadata_objects: 30 * host_buffer_depth + 5 * baseband_buffer_depth
+
+# Baseband metadata pool
+baseband_pool:
+  kotekan_metadata_pool: BasebandMetadata
+  num_metadata_objects: 30 * host_buffer_depth * 32
+
+n2_pool:
+    kotekan_metadata_pool: N2Metadata
+    num_metadata_objects: num_freq_gpu_buf * host_buffer_depth
+
+vis_pool:
+    kotekan_metadata_pool: VisMetadata
+    num_metadata_objects: num_freq_gpu_buf * gpu_buffer_depth # same as n2_pool
+
+
+################################################################################
+# Packet intake
+
+# Buffers
+
+host_voltage_buffers:
+  num_frames: baseband_buffer_depth
+  frame_size: samples_per_data_set * num_elements * num_freq_host_buf
+  metadata_pool: main_pool
+  numa_0:
+    numa_node: 0
+{%- for id in range(num_freq_gpu_buf) %}
+    host_voltage_buffer_{{ id }}:
+      kotekan_buffer: standard
+{%- endfor %}
+host_voltage_ringbuffer:
+  kotekan_buffer: ring
+  ring_buffer_size: gpu_buffer_depth * samples_per_data_set * num_elements * num_freq_gpu_buf
+  metadata_pool: main_pool
+
+{%- for id in range(num_freq_gpu_buf // 4) %}
+lost_samples_buffer_{{ id }}:
+  kotekan_buffer: standard
+  num_frames: 2 * host_buffer_depth
+  frame_size: samples_per_data_set
+  metadata_pool: main_pool
+{%- endfor %}
+
+# Stages
+
+# This configuration assumes that the system ports are ordered in as 4x10G
+# links for each QSFP+, and that each QSFP+ port comes from exactly one iceBoard
+# and that each iceBoard is in a _different_ crate pair, but also in the same
+# location in terms of slot, crate (within the crate pair), and link (on the board).
+dpdk:
+  kotekan_stage: dpdkCore
+  # Format is index = lcore, value = cpu core
+  lcore_cpu_map: [4,5,6,7,36,37,38,39]
+  main_lcore_cpu: 3
+  status_cadence: 60
+  max_rx_pkt_len: 5000
+  # Set to true when using a switch to replicate packets
+  using_switch: true
+  alignment: samples_per_data_set * 4
+  # List of PCIe devices we don't want to attach too
+  # Required to exclude the ConnectX 6 Lx output NICs.
+  # Excluded devices are listed by their PCIe address. 
+  pcie_block_list:
+    - 0d:00.0
+    - 0d:00.1
+    - 9f:00.0
+    - 9f:00.1
+  # Format is index = lcore, value = array of port IDs
+  # so [[0,1],[2,3]] maps lcore 0 to service ports 0 and 1,
+  # and lcore 1 to service ports 2 and 3.
+  lcore_port_map:
+    - [0, 4]
+    - [8, 12]
+    - [1, 5]
+    - [9, 13]
+    - [2, 6]
+    - [10, 14]
+    - [3, 7]
+    - [11, 15]
+
+  # One handler must be given per port, mapping is in port order.
+  handlers:
+{%- for id in range(4) %}
+    - dpdk_handler: iceBoardShuffle
+      link_group: 0
+      link_group_subid: {{ id }}
+      out_bufs:
+        - host_voltage_buffer_0
+        - host_voltage_buffer_1
+        - host_voltage_buffer_2
+        - host_voltage_buffer_3
+      lost_samples_buf: lost_samples_buffer_0
+
+    - dpdk_handler: iceBoardShuffle
+      link_group: 1
+      link_group_subid: {{ id }}
+      out_bufs:
+        - host_voltage_buffer_4
+        - host_voltage_buffer_5
+        - host_voltage_buffer_6
+        - host_voltage_buffer_7
+      lost_samples_buf: lost_samples_buffer_1
+
+    - dpdk_handler: iceBoardShuffle
+      link_group: 2
+      link_group_subid: {{ id }}
+      out_bufs:
+        - host_voltage_buffer_8
+        - host_voltage_buffer_9
+        - host_voltage_buffer_10
+        - host_voltage_buffer_11
+      lost_samples_buf: lost_samples_buffer_2
+
+    - dpdk_handler: iceBoardShuffle
+      link_group: 3
+      link_group_subid: {{ id }}
+      out_bufs:
+        - host_voltage_buffer_12
+        - host_voltage_buffer_13
+        - host_voltage_buffer_14
+        - host_voltage_buffer_15
+      lost_samples_buf: lost_samples_buffer_3
+{%- endfor %}
+
+# Zero out lost samples recorded at the DPDK stage
+zero_samples:
+  duplicate_ls_buffer: False
+{%- for id in range(num_freq_gpu_buf) %}
+  zero_{{ id }}:
+    kotekan_stage: zeroSamples
+    lost_samples_buf: lost_samples_buffer_{{ id // 4 }}
+    out_buf: host_voltage_buffer_{{ id }}
+{%- endfor %}
+
+################################################################################
+# Baseband capture and dump system
+
+# Buffers
+
+baseband_output_buffers:
+  # 32 times smaller frames, 32 times the number of frames
+  frame_size: samples_per_data_set * num_elements * num_freq_host_buf / 32
+  metadata_pool: baseband_pool
+{%- for id in range(num_freq_gpu_buf) %}
+  baseband_output_buffer_{{ id }}:
+    kotekan_buffer: standard
+    num_frames: 11 * 32 # baseband_buffer_depth
+{%- endfor %}
+  baseband_output_buffer_merged:
+    kotekan_buffer: standard
+    num_frames: 12
+
+# Stages
+
+baseband:
+  max_dump_samples: 300000 # 768ms
+  num_frames_buffer: baseband_buffer_depth - 10
+{%- for id in range(num_freq_gpu_buf) %}
+  baseband{{ id }}:
+    kotekan_stage: basebandReadout
+    in_buf: host_voltage_buffer_{{ id }}
+    out_buf: baseband_output_buffer_{{ id }}
+{%- endfor %}
+
+baseband_merge:
+  kotekan_stage: bufferMerge
+  timeout: 0.1
+  in_bufs:
+{%- for id in range(num_freq_gpu_buf) %}
+    - baseband_output_buffer_{{ id }}
+{%- endfor %}
+  out_buf: baseband_output_buffer_merged
+
+################################################################################
+# n2k incoming packet processing
+
+# Buffers
+
+host_bf_mask_buffer:
+    kotekan_buffer: standard
+    num_frames: 1
+    frame_size: sizeof_int8 * num_dishes * num_polarizations
+    metadata_pool: main_pool
+
+host_pl_mask_buffer:
+    kotekan_buffer: standard
+    num_frames: host_buffer_depth
+    frame_size: (64 / 8) * (num_dishes / 8) * num_polarizations * (num_freq_gpu_buf / 4) * (samples_per_data_set / 2 / 64)
+    metadata_pool: main_pool
+host_pl_mask_ringbuffer:
+    kotekan_buffer: ring
+    ring_buffer_size: gpu_buffer_depth * (64 / 8) * (num_dishes / 8) * num_polarizations * (num_freq_gpu_buf / 4) * (samples_per_data_set / 2 / 64)
+    metadata_pool: main_pool
+
+host_pl_expanded_mask_ringbuffer:
+    kotekan_buffer: ring
+    ring_buffer_size: gpu_buffer_depth * (64 / 8) * (num_dishes / 8) * num_polarizations * num_freq_gpu_buf * (samples_per_data_set / 64)
+    metadata_pool: main_pool
+
+# Stages
+
+# glue code to handle lost frames formats
+lostSamplesToPLMask:
+    kotekan_stage: lostSamplesToPLMask
+    pl_mask_buf: host_pl_mask_buffer
+    lost_samples_buffers:
+{%- for id in range(num_freq_gpu_buf // 4) %}
+      - lost_samples_buffer_{{ id }}
+{%- endfor %}
+
+kludge_constant_buffers:
+    set_bf_mask:
+        # no bad feeds, all feeds are good
+        kotekan_stage: testDataGen
+        out_buf: host_bf_mask_buffer
+        type: const8
+        value: 0x01
+
+run_send_pl_mask:
+    gpu_0:
+        kotekan_stage: cudaProcess
+        gpu_id: 0
+        buffer_depth: gpu_buffer_depth
+        frame_arrival_period: network_frame_arrival_period
+        num_times: samples_per_data_set
+        in_buffers:
+            host_pl_mask_buffer: host_pl_mask_buffer
+        out_buffers:
+            host_pl_mask_ringbuffer: host_pl_mask_ringbuffer
+        commands:
+        - name: cudaCopyToRingbuffer
+          input_size: (64 / 8) * (num_dishes / 8) * num_polarizations * (num_freq_gpu_buf / 4) * (samples_per_data_set / 2 / 64)
+          ring_buffer_size: gpu_buffer_depth * input_size
+          in_buf: host_pl_mask_buffer
+          signal_buf: host_pl_mask_ringbuffer
+          gpu_mem_output: pl_mask_buffer
+
+run_expand_pl_mask:
+    gpu_0:
+        kotekan_stage: cudaProcess
+        gpu_id: 0
+        buffer_depth: gpu_buffer_depth
+        frame_arrival_period: network_frame_arrival_period
+        num_times: samples_per_data_set
+        in_buffers:
+            host_pl_mask_ringbuffer: host_pl_mask_ringbuffer
+        out_buffers:
+            host_pl_expanded_mask_ringbuffer: host_pl_expanded_mask_ringbuffer
+        commands:
+        - name: cudaPLMaskExpander
+          num_frequencies: num_freq_gpu_buf
+          # num_polarizations: num_polarizations # global exists
+          # num_dishes: num_dishes # global exists
+          pl_mask_name: pl_mask
+          pl_expanded_mask_name: pl_expanded_mask
+
+run_send_voltage:
+    gpu_0:
+        kotekan_stage: cudaProcess
+        gpu_id: 0
+        buffer_depth: gpu_buffer_depth
+        frame_arrival_period: network_frame_arrival_period
+        num_times: samples_per_data_set
+        in_buffers:
+{%- for id in range(num_freq_gpu_buf) %}
+            host_voltage_buffer_{{ id }}: host_voltage_buffer_{{ id }}
+{%- endfor %}
+        out_buffers:
+            host_voltage_ringbuffer: host_voltage_ringbuffer
+        commands:
+        - name: cudaCopyNToRingbuffer
+          input_size: samples_per_data_set * num_elements * num_freq_gpu_buf
+          ring_buffer_size: gpu_buffer_depth * input_size
+          in_bufs: 
+{%- for id in range(num_freq_gpu_buf) %}
+            - host_voltage_buffer_{{ id }}
+{%- endfor %}
+          signal_buf: host_voltage_ringbuffer
+          gpu_mem_output: gpu_voltage_buffer
+
+################################################################################
+# transpose kernel to bring data into cylinder (cylinder, polarization, dish) order
+
+# this array of 2048 elements descibes to the xpose2048 kernel which adc input
+# (correlator index) should be put into which station index (cylinder order).
+# It is given as a list of desired adc inputs (correlator indices) ordered in
+# cylindar order (station index).
+# It can be obtained from the CHIME layout database by using the "cyl_ind"
+# column as the index and outputting the "corr_ind" column.
+set_scatter_indices:
+    kotekan_stage: parseReorderDefault
+    out_buf: host_scatter_indices_buffer
+    name: scatter_indices
+
+# Buffers
+
+host_scatter_indices_buffer:
+    kotekan_buffer: standard
+    num_frames: 1
+    frame_size: sizeof_int32 * num_dishes * num_polarizations
+    metadata_pool: main_pool
+
+host_xposed_voltage_ringbuffer:
+    kotekan_buffer: ring
+    ring_buffer_size: gpu_buffer_depth * num_dishes * num_polarizations * num_freq_gpu_buf * samples_per_data_set
+    metadata_pool: main_pool
+
+# Stages
+
+run_xpose2048:
+    gpu_0:
+        kotekan_stage: cudaProcess
+        gpu_id: 0
+        buffer_depth: gpu_buffer_depth
+        frame_arrival_period: network_frame_arrival_period
+        num_times: samples_per_data_set
+        in_buffers:
+            host_scatter_indices_buffer: host_scatter_indices_buffer
+            host_voltage_ringbuffer: host_voltage_ringbuffer
+        out_buffers:
+            host_xposed_voltage_ringbuffer: host_xposed_voltage_ringbuffer
+        commands:
+        - name: cudaInputData
+          do_once: true
+          in_buf: host_scatter_indices_buffer
+          gpu_mem: scatter_indices_buffer
+        - name: cudaSyncInput
+        - name: cudaTranspose2048_chime
+          input_voltage_name: voltage
+          scatter_indices_name: scatter_indices
+          output_voltage_name: xposed_voltage
+
+################################################################################
+# RFI setup
+
+# from 2.56 μs to 1.31072 ms
+rfi_downsampling_factor: 512
+# from 1.31072 ms to 41.94304 ms
+rfi_second_downsampling_factor: 32
+
+rfi_sk_rfimask_sigmas: 5.0
+rfi_single_feed_min_good_frac: 0.8
+rfi_feed_averaged_min_good_frac: 0.8
+rfi_mu_min: 2.0
+rfi_mu_max: 20.0
+
+# Buffers
+
+rfi_num_times: 256      # 1.31072 ms cadence
+rfi_num_times_bar: 32   # 41.94304 ms cadence
+
+host_rfi_S012_ringbuffer:
+    kotekan_buffer: ring
+    num_frames: gpu_buffer_depth
+    ring_buffer_size: gpu_buffer_depth * sizeof_uint64 * num_dishes * num_polarizations * 3 * num_freq_gpu_buf * rfi_num_times
+    type: uint64
+    dimnames: ["Trfi", "F", "S", "P", "D"]
+    shape: [buffer_depth * rfi_num_times, num_freq_gpu_buf, 3, num_polarizations, num_dishes]
+    metadata_pool: main_pool
+
+host_rfi_S012bar_ringbuffer:
+    kotekan_buffer: ring
+    num_frames: gpu_buffer_depth
+    ring_buffer_size: gpu_buffer_depth * sizeof_uint64 * num_dishes * num_polarizations * 3 * num_freq_gpu_buf * rfi_num_times_bar
+    type: uint64
+    dimnames: ["Trfibar", "F", "S", "P", "D"]
+    shape: [gpu_buffer_depth * rfi_num_times_bar, num_freq_gpu_buf, 3, num_polarizations, num_dishes]
+    metadata_pool: main_pool
+
+host_rfi_S012tilde_ringbuffer:
+    kotekan_buffer: ring
+    num_frames: gpu_buffer_depth
+    ring_buffer_size: gpu_buffer_depth * sizeof_uint64 * 3 * num_freq_gpu_buf * rfi_num_times
+    type: uint64
+    dimnames: ["Trfi", "F", "S"]
+    shape: [gpu_buffer_depth * rfi_num_times, num_freq_gpu_buf, 3]
+    metadata_pool: main_pool
+
+host_rfi_SKtilde_ringbuffer:
+    kotekan_buffer: ring
+    num_frames: gpu_buffer_depth
+    ring_buffer_size: gpu_buffer_depth * sizeof_float32 * 3 * num_freq_gpu_buf * rfi_num_times
+    type: float32
+    dimnames: ["Trfi", "F", "S"]
+    shape: [gpu_buffer_depth * rfi_num_times, num_freq_gpu_buf, 3]
+    metadata_pool: main_pool
+
+host_rfi_RFImask_buffer:
+    kotekan_buffer: standard
+    num_frames: gpu_buffer_depth
+    frame_size: num_freq_gpu_buf * samples_per_data_set / 8
+    type: uint1x8
+    dimnames: ["T8hi128", "F", "T8lo128"]
+    shape: [samples_per_data_set / 8 / 128, num_freq_gpu_buf, 128]
+    metadata_pool: main_pool
+host_rfi_RFImask_ringbuffer:
+    kotekan_buffer: ring
+    num_frames: gpu_buffer_depth
+    ring_buffer_size: gpu_buffer_depth * num_freq_gpu_buf * samples_per_data_set / 8
+    type: uint1x8
+    dimnames: ["T8hi128", "F", "T8lo128"]
+    shape: [gpu_buffer_depth * samples_per_data_set / 8 / 128, num_freq_gpu_buf, 128]
+    metadata_pool: main_pool
+
+host_rfi_SKbar_buffer:
+    kotekan_buffer: standard
+    num_frames: gpu_buffer_depth
+    frame_size: sizeof_float32 * num_dishes * num_polarizations * 3 * num_freq_gpu_buf * rfi_num_times_bar
+    type: float32
+    dimnames: ["Trfi", "F", "S", "P", "D"]
+    shape: [rfi_num_times_bar, num_freq_gpu_buf, 3, num_polarizaions, num_dishes]
+    metadata_pool: main_pool
+host_rfi_SKbar_ringbuffer:
+    kotekan_buffer: ring
+    num_frames: gpu_buffer_depth
+    ring_buffer_size: gpu_buffer_depth * sizeof_float32 * num_dishes * num_polarizations * 3 * num_freq_gpu_buf * rfi_num_times_bar
+    type: float32
+    dimnames: ["Trfi", "F", "S", "P", "D"]
+    shape: [gpu_buffer_depth * rfi_num_times_bar, num_freq_gpu_buf, 3, num_polarizaions, num_dishes]
+    metadata_pool: main_pool
+
+host_rfi_SKbartilde_buffer:
+    kotekan_buffer: standard
+    num_frames: gpu_buffer_depth
+    frame_size: sizeof_float32 * 3 * num_freq_gpu_buf * rfi_num_times_bar
+    type: float32
+    dimnames: ["Trfi", "F", "S"]
+    shape: [rfi_num_times_bar, num_freq_gpu_buf, 3]
+    metadata_pool: main_pool
+host_rfi_SKbartilde_ringbuffer:
+    kotekan_buffer: ring
+    num_frames: gpu_buffer_depth
+    ring_buffer_size: gpu_buffer_depth * sizeof_float32 * 3 * num_freq_gpu_buf * rfi_num_times_bar
+    type: float32
+    dimnames: ["Trfi", "F", "S"]
+    shape: [gpu_buffer_depth * rfi_num_times_bar, num_freq_gpu_buf, 3]
+    metadata_pool: main_pool
+
+# Stages
+
+run_rfi_S012:
+    gpu_0:
+        kotekan_stage: cudaProcess
+        gpu_id: 0
+        buffer_depth: gpu_buffer_depth
+        frame_arrival_period: network_frame_arrival_period
+        num_times: samples_per_data_set
+        in_buffers:
+            # TODO: transpose pl_mask
+            host_pl_mask_ringbuffer: host_pl_mask_ringbuffer
+            host_xposed_voltage_ringbuffer: host_xposed_voltage_ringbuffer
+        out_buffers:
+            host_rfi_S012_ringbuffer: host_rfi_S012_ringbuffer
+        commands:
+        - name: cudaRFIS012
+          num_frequencies: num_freq_gpu_buf
+          pl_mask_name: pl_mask
+          voltage_name: xposed_voltage
+          rfi_S012_name: rfi_S012
+
+run_rfi_S012tilde:
+    gpu_0:
+        kotekan_stage: cudaProcess
+        gpu_id: 0
+        buffer_depth: gpu_buffer_depth
+        # maybe? Depends on the chunking of the previous stage
+        frame_arrival_period: network_frame_arrival_period
+        num_times: samples_per_data_set
+        in_buffers:
+            host_bf_mask_buffer: host_bf_mask_buffer
+            host_rfi_S012_ringbuffer: host_rfi_S012_ringbuffer
+        out_buffers:
+            host_rfi_S012tilde_ringbuffer: host_rfi_S012tilde_ringbuffer
+        commands:
+        - name: cudaInputData
+          # TODO: Don't double-copy bf_mask
+          do_once: true
+          in_buf: host_bf_mask_buffer
+          gpu_mem: bf_mask_buffer
+        - name: cudaSyncInput
+        - name: cudaRFIS012tilde
+          num_frequencies: num_freq_gpu_buf
+          bf_mask_name: bf_mask
+          rfi_S012_name: rfi_S012
+          rfi_S012tilde_name: rfi_S012tilde
+
+run_rfi_S012bar:
+    gpu_0:
+        kotekan_stage: cudaProcess
+        gpu_id: 0
+        buffer_depth: gpu_buffer_depth
+        # maybe? Depends on the chunking of the previous stage
+        frame_arrival_period: network_frame_arrival_period
+        num_times: samples_per_data_set
+        in_buffers:
+            host_rfi_S012_ringbuffer: host_rfi_S012_ringbuffer
+        out_buffers:
+            host_rfi_S012bar_ringbuffer: host_rfi_S012bar_ringbuffer
+        commands:
+        - name: cudaRFIS012bar
+          num_frequencies: num_freq_gpu_buf
+          bf_mask_name: bf_mask
+          rfi_S012_name: rfi_S012
+          rfi_S012bar_name: rfi_S012bar
+
+run_rfi_SKtilde:
+    gpu_0:
+        kotekan_stage: cudaProcess
+        gpu_id: 0
+        buffer_depth: gpu_buffer_depth
+        # maybe? Depends on the chunking of the previous stage
+        frame_arrival_period: network_frame_arrival_period
+        num_times: samples_per_data_set
+        in_buffers:
+            host_bf_mask_buffer: host_bf_mask_buffer
+            host_rfi_S012_ringbuffer: host_rfi_S012_ringbuffer
+        out_buffers:
+            host_rfi_SKtilde_ringbuffer: host_rfi_SKtilde_ringbuffer
+            host_rfi_RFImask_ringbuffer: host_rfi_RFImask_ringbuffer
+        commands:
+        - name: cudaInputData
+          # TODO: Don't double-copy bf_mask
+          do_once: true
+          in_buf: host_bf_mask_buffer
+          gpu_mem: bf_mask_buffer
+        - name: cudaSyncInput
+        - name: cudaRFISKtilde
+          num_frequencies: num_freq_gpu_buf
+          bf_mask_name: bf_mask
+          rfi_S012_name: rfi_S012
+          rfi_SKtilde_name: rfi_SKtilde
+          rfi_RFImask_name: rfi_RFImask
+
+run_rfi_SKbar:
+    gpu_0:
+        kotekan_stage: cudaProcess
+        gpu_id: 0
+        buffer_depth: gpu_buffer_depth
+        # maybe? Depends on the chunking of the previous stage
+        frame_arrival_period: network_frame_arrival_period
+        num_times: samples_per_data_set
+        in_buffers:
+            host_bf_mask_buffer: host_bf_mask_buffer
+            host_rfi_S012bar_ringbuffer: host_rfi_S012bar_ringbuffer
+        out_buffers:
+            host_rfi_SKbar_ringbuffer: host_rfi_SKbar_ringbuffer
+            host_rfi_SKbartilde_ringbuffer: host_rfi_SKbartilde_ringbuffer
+        commands:
+        - name: cudaInputData
+          # TODO: Don't double-copy bf_mask
+          do_once: true
+          in_buf: host_bf_mask_buffer
+          gpu_mem: bf_mask_buffer
+        - name: cudaSyncInput
+        - name: cudaRFISKbar
+          num_frequencies: num_freq_gpu_buf
+          bf_mask_name: bf_mask
+          rfi_S012bar_name: rfi_S012bar
+          rfi_SKbar_name: rfi_SKbar
+          rfi_SKbartilde_name: rfi_SKbartilde
+
+################################################################################
+# n2k setup
+
+# Correlator setup
+n2k_sub_integration_ntime: samples_per_data_set
+# n2k_samples_per_data_set = max(samples_per_data_set, n2k_sub_integration_ntime)
+n2k_samples_per_data_set: samples_per_data_set
+
+# Buffers
+
+n2k_num_subintegrations: n2k_samples_per_data_set / n2k_sub_integration_ntime
+
+n2k_correlation_blocksize: 16
+n2k_correlation_num_elements: num_dishes * num_polarizations
+n2k_correlation_linear_num_blocks: (n2k_correlation_num_elements + 1) / n2k_correlation_blocksize
+n2k_correlation_triangle_num_blocks: n2k_correlation_linear_num_blocks * (n2k_correlation_linear_num_blocks + 1) / 2
+n2k_correlation_triangle_size: n2k_correlation_blocksize * n2k_correlation_blocksize * n2k_correlation_triangle_num_blocks
+
+n2k_counts_blocksize: 8
+n2k_counts_num_elements: num_dishes / 8 * num_polarizations
+n2k_counts_linear_num_blocks: (n2k_counts_num_elements + 1) / n2k_counts_blocksize
+n2k_counts_triangle_num_blocks: n2k_counts_linear_num_blocks * (n2k_counts_linear_num_blocks + 1) / 2
+n2k_counts_triangle_size: n2k_counts_blocksize * n2k_counts_blocksize * n2k_counts_triangle_num_blocks
+
+host_n2k_correlation_buffer:
+    kotekan_buffer: standard
+    num_frames: gpu_buffer_depth
+    frame_size: sizeof_int32 * num_components * n2k_correlation_triangle_size * num_freq_gpu_buf * n2k_num_subintegrations
+    metadata_pool: main_pool
+
+host_n2k_counts_buffer:
+    kotekan_buffer: standard
+    num_frames: gpu_buffer_depth
+    frame_size: sizeof_int32 * n2k_counts_triangle_size * num_freq_gpu_buf * n2k_num_subintegrations
+    metadata_pool: main_pool
+
+# Stages
+
+run_n2k_correlation:
+    gpu_0:
+        kotekan_stage: cudaProcess
+        gpu_id: 0
+        buffer_depth: gpu_buffer_depth
+        frame_arrival_period: network_frame_arrival_period
+        num_times: samples_per_data_set
+        in_buffers:
+            host_xposed_voltage_ringbuffer: host_xposed_voltage_ringbuffer
+            host_rfi_RFImask_ringbuffer: host_rfi_RFImask_ringbuffer
+        out_buffers:
+            host_n2k_correlation_buffer: host_n2k_correlation_buffer
+        commands:
+        - name: cudaCorrelator
+          num_elements: num_dishes * num_polarizations
+          num_local_freq: num_freq_gpu_buf
+          #samples_per_data_set: n2k_samples_per_data_set # global samples_per_data_set exists and is used in n2k_samples_per_data_set
+          sub_integration_ntime: n2k_sub_integration_ntime
+          voltage_name: xposed_voltage
+          rfi_RFImask_name: rfi_RFImask
+          n2k_correlation_name: n2k_correlation
+        - name: cudaSyncOutput
+        - name: cudaOutputData
+          gpu_mem: n2k_correlation_buffer
+          out_buf: host_n2k_correlation_buffer
+
+run_n2k_counts:
+    gpu_0:
+        kotekan_stage: cudaProcess
+        gpu_id: 0
+        buffer_depth: gpu_buffer_depth
+        # maybe? Depends on the chunking of the previous stage
+        frame_arrival_period: network_frame_arrival_period
+        num_times: samples_per_data_set
+        in_buffers:
+            host_pl_expanded_mask_ringbuffer: host_pl_expanded_mask_ringbuffer
+            host_rfi_RFImask_ringbuffer: host_rfi_RFImask_ringbuffer
+        out_buffers:
+            host_n2k_counts_buffer: host_n2k_counts_buffer
+        commands:
+        - name: cudaPL1bitCorrelator
+          num_elements: num_dishes * num_polarizations
+          num_frequencies: num_freq_gpu_buf
+          #samples_per_data_set: n2k_samples_per_data_set # global samples_per_data_set exists and is used in n2k_samples_per_data_set
+          sub_integration_ntime: n2k_sub_integration_ntime
+          pl_expanded_mask_name: pl_expanded_mask
+          rfi_RFImask_name: rfi_RFImask
+          n2k_counts_name: n2k_counts
+        - name: cudaSyncOutput
+        - name: cudaOutputData
+          gpu_mem: n2k_counts_buffer
+          out_buf: host_n2k_counts_buffer
+
+################################################################################
+# visibility matrix and eigendecomposition
+
+# Buffers
+
+vis_10s_buffer:
+    kotekan_buffer: N2
+    num_ev: 0
+    n2_layout: "FullUpperTri"
+    num_frames: gpu_buffer_depth * num_freq_gpu_buf
+    metadata_pool: n2_pool
+
+eig_10s_buffer:
+    kotekan_buffer: N2
+    num_ev: num_ev_to_calculate
+    n2_layout: "FullUpperTri"
+    num_frames: gpu_buffer_depth * num_freq_gpu_buf
+    metadata_pool: n2_pool
+
+vis_buffer:
+    kotekan_buffer: vis
+    num_ev: num_ev_to_calculate
+    num_frames: gpu_buffer_depth * num_freq_gpu_buf
+    metadata_pool: vis_pool
+
+# Stages
+
+run_recv_rfi_RFImask:
+    gpu_0:
+        kotekan_stage: cudaProcess
+        gpu_id: 0
+        buffer_depth: gpu_buffer_depth
+        # maybe? Depends on the chunking of the previous stage
+        frame_arrival_period: network_frame_arrival_period
+        num_times: samples_per_data_set
+        in_buffers:
+            host_rfi_RFImask_ringbuffer: host_rfi_RFImask_ringbuffer
+        out_buffers:
+            host_rfi_RFImask_buffer: host_rfi_RFImask_buffer
+        commands:
+        - name: cudaCopyFromRingbuffer
+          host_signal: host_rfi_RFImask_ringbuffer
+          gpu_mem_input: rfi_RFImask_buffer
+          output_size: num_freq_gpu_buf * samples_per_data_set / 8
+          ring_buffer_size: gpu_buffer_depth * output_size
+          out_buf: host_rfi_RFImask_buffer
+
+vis_accumulate:
+    kotekan_stage: N2Accumulate
+    in_buf: host_n2k_correlation_buffer
+    in_counts_buf: host_n2k_counts_buffer
+    in_rfimask_buf: host_rfi_RFImask_buffer
+    out_buf: vis_10s_buffer
+    packet_loss_is_scalar: True
+    num_workers: 3
+    # round_to_even(10e9 / ( n2k_samples_per_data_set * frame_arrival_period_ns ) * n2k_num_subintegrations)
+    # round_to_even(10s / ( 16384 * 2.56us ) * 1) = 238
+    # num_n2k_samples_to_accumulate_maybe_odd: 10e9 / ( n2k_samples_per_data_set * frame_arrival_period_ns ) * n2k_num_subintegrations)
+    # num_n2k_samples_to_accumulate: (num_n2k_samples_to_accumulate_maybe_odd + 1) / 2 * 2
+    num_n2k_samples_to_accumulate: 238
+    # these recap values from cudaCorrelator
+    num_freq_per_n2k_frame: num_freq_gpu_buf
+    #samples_per_data_set: n2k_samples_per_data_set # a global of this nam exists used by n2k_samples_per_data_set
+    sub_integration_ntime: n2k_sub_integration_ntime
+    # set as global variable of same name
+    #rfi_downsampling_factor: rfi_downsampling_factor
+    num_elements: n2k_correlation_num_elements
+    num_ev: 0 # only allowed value
+
+eigencalc:
+    kotekan_stage: EigenN2Iter
+    num_ev: num_ev_to_calculate
+    in_buf: vis_10s_buffer
+    out_buf: eig_10s_buffer
+    # Convergence config from chime science run
+    tol_eval: 0.00001
+    tol_evec: 0.0001
+    max_iterations: 19
+    num_ev_conv: 2
+    krylov: 2
+    subspace: 1
+
+vis_convert:
+    kotekan_stage: n2FrameToVisFrame
+    n2_buf: eig_10s_buffer
+    vis_buf: vis_buffer
+
+################################################################################
+# output to receivers
+
+# this will move to the baseband receiver eventually
+write_baseband:
+  root_path: baseband_raw
+  dump_timeout: 1200 # 20 Minutes
+  write_0:
+    samples_per_data_set: 512 # samples_per_data_set / 32 (which causes a recursion if used)
+    kotekan_stage: BasebandWriter
+    in_buf: baseband_output_buffer_merged
+
+## Transmit baseband data to the baseband receiver
+#baseband_send:
+#  server_ip: 10.5.60.2
+#  reconnect_time: 60
+#  send_timeout: 600 # 10 minutes
+#  log_level: warn
+#  # Keep data in memory even if the receiver node is down
+#  # Baseband readout handles back pressure management
+#  drop_frames: false
+#  use_config_tracker: false # not used by legacy CHIME kotekan code
+#  baseband_send_0:
+#    kotekan_stage: bufferSend
+#    server_port: 11027
+#    buf: baseband_output_buffer_merged
+
+write_vis:
+    kotekan_stage: VisWriter
+    root_path: vis_data
+    file_type: raw
+    in_buf: vis_buffer
+
+# Information for input reordering, packed as
+#   (adc_id, chan_id, correlator_input)
+# The first is for the reordering, the last two are for making the index map
+# Do not remove this entry since the FRB baseband_archiver.py script expects it here
+input_reorder:
+  - [ 128,    0, FCC000812]
+  - [ 129,    1, FCC000813]
+  - [ 130,    2, FCC000814]
+  - [ 131,    3, FCC000815]
+  - [ 132,    4, FCC000808]
+  - [ 133,    5, FCC000809]
+  - [ 134,    6, FCC000810]
+  - [ 135,    7, FCC000811]
+  - [ 136,    8, FCC000804]
+  - [ 137,    9, FCC000805]
+  - [ 138,   10, FCC000806]
+  - [ 139,   11, FCC000807]
+  - [ 140,   12, FCC000800]
+  - [ 141,   13, FCC000801]
+  - [ 142,   14, FCC000802]
+  - [ 143,   15, FCC000803]
+  - [ 160,   16, FCC001012]
+  - [ 161,   17, FCC001013]
+  - [ 162,   18, FCC001014]
+  - [ 163,   19, FCC001015]
+  - [ 164,   20, FCC001008]
+  - [ 165,   21, FCC001009]
+  - [ 166,   22, FCC001010]
+  - [ 167,   23, FCC001011]
+  - [ 168,   24, FCC001004]
+  - [ 169,   25, FCC001005]
+  - [ 170,   26, FCC001006]
+  - [ 171,   27, FCC001007]
+  - [ 172,   28, FCC001000]
+  - [ 173,   29, FCC001001]
+  - [ 174,   30, FCC001002]
+  - [ 175,   31, FCC001003]
+  - [ 192,   32, FCC001212]
+  - [ 193,   33, FCC001213]
+  - [ 194,   34, FCC001214]
+  - [ 195,   35, FCC001215]
+  - [ 196,   36, FCC001208]
+  - [ 197,   37, FCC001209]
+  - [ 198,   38, FCC001210]
+  - [ 199,   39, FCC001211]
+  - [ 200,   40, FCC001204]
+  - [ 201,   41, FCC001205]
+  - [ 202,   42, FCC001206]
+  - [ 203,   43, FCC001207]
+  - [ 204,   44, FCC001200]
+  - [ 205,   45, FCC001201]
+  - [ 206,   46, FCC001202]
+  - [ 207,   47, FCC001203]
+  - [ 224,   48, FCC001412]
+  - [ 225,   49, FCC001413]
+  - [ 226,   50, FCC001414]
+  - [ 227,   51, FCC001415]
+  - [ 228,   52, FCC001408]
+  - [ 229,   53, FCC001409]
+  - [ 230,   54, FCC001410]
+  - [ 231,   55, FCC001411]
+  - [ 232,   56, FCC001404]
+  - [ 233,   57, FCC001405]
+  - [ 234,   58, FCC001406]
+  - [ 235,   59, FCC001407]
+  - [ 236,   60, FCC001400]
+  - [ 237,   61, FCC001401]
+  - [ 238,   62, FCC001402]
+  - [ 239,   63, FCC001403]
+  - [ 384,   64, FCC010812]
+  - [ 385,   65, FCC010813]
+  - [ 386,   66, FCC010814]
+  - [ 387,   67, FCC010815]
+  - [ 388,   68, FCC010808]
+  - [ 389,   69, FCC010809]
+  - [ 390,   70, FCC010810]
+  - [ 391,   71, FCC010811]
+  - [ 392,   72, FCC010804]
+  - [ 393,   73, FCC010805]
+  - [ 394,   74, FCC010806]
+  - [ 395,   75, FCC010807]
+  - [ 396,   76, FCC010800]
+  - [ 397,   77, FCC010801]
+  - [ 398,   78, FCC010802]
+  - [ 399,   79, FCC010803]
+  - [ 416,   80, FCC011012]
+  - [ 417,   81, FCC011013]
+  - [ 418,   82, FCC011014]
+  - [ 419,   83, FCC011015]
+  - [ 420,   84, FCC011008]
+  - [ 421,   85, FCC011009]
+  - [ 422,   86, FCC011010]
+  - [ 423,   87, FCC011011]
+  - [ 424,   88, FCC011004]
+  - [ 425,   89, FCC011005]
+  - [ 426,   90, FCC011006]
+  - [ 427,   91, FCC011007]
+  - [ 428,   92, FCC011000]
+  - [ 429,   93, FCC011001]
+  - [ 430,   94, FCC011002]
+  - [ 431,   95, FCC011003]
+  - [ 448,   96, FCC011212]
+  - [ 449,   97, FCC011213]
+  - [ 450,   98, FCC011214]
+  - [ 451,   99, FCC011215]
+  - [ 452,  100, FCC011208]
+  - [ 453,  101, FCC011209]
+  - [ 454,  102, FCC011210]
+  - [ 455,  103, FCC011211]
+  - [ 456,  104, FCC011204]
+  - [ 457,  105, FCC011205]
+  - [ 458,  106, FCC011206]
+  - [ 459,  107, FCC011207]
+  - [ 460,  108, FCC011200]
+  - [ 461,  109, FCC011201]
+  - [ 462,  110, FCC011202]
+  - [ 463,  111, FCC011203]
+  - [ 480,  112, FCC011412]
+  - [ 481,  113, FCC011413]
+  - [ 482,  114, FCC011414]
+  - [ 483,  115, FCC011415]
+  - [ 484,  116, FCC011408]
+  - [ 485,  117, FCC011409]
+  - [ 486,  118, FCC011410]
+  - [ 487,  119, FCC011411]
+  - [ 488,  120, FCC011404]
+  - [ 489,  121, FCC011405]
+  - [ 490,  122, FCC011406]
+  - [ 491,  123, FCC011407]
+  - [ 492,  124, FCC011400]
+  - [ 493,  125, FCC011401]
+  - [ 494,  126, FCC011402]
+  - [ 495,  127, FCC011403]
+  - [ 268,  128, FCC010000]
+  - [ 269,  129, FCC010001]
+  - [ 270,  130, FCC010002]
+  - [ 271,  131, FCC010003]
+  - [ 264,  132, FCC010004]
+  - [ 265,  133, FCC010005]
+  - [ 266,  134, FCC010006]
+  - [ 267,  135, FCC010007]
+  - [ 260,  136, FCC010008]
+  - [ 261,  137, FCC010009]
+  - [ 262,  138, FCC010010]
+  - [ 263,  139, FCC010011]
+  - [ 256,  140, FCC010012]
+  - [ 257,  141, FCC010013]
+  - [ 258,  142, FCC010014]
+  - [ 259,  143, FCC010015]
+  - [ 300,  144, FCC010200]
+  - [ 301,  145, FCC010201]
+  - [ 302,  146, FCC010202]
+  - [ 303,  147, FCC010203]
+  - [ 296,  148, FCC010204]
+  - [ 297,  149, FCC010205]
+  - [ 298,  150, FCC010206]
+  - [ 299,  151, FCC010207]
+  - [ 292,  152, FCC010208]
+  - [ 293,  153, FCC010209]
+  - [ 294,  154, FCC010210]
+  - [ 295,  155, FCC010211]
+  - [ 288,  156, FCC010212]
+  - [ 289,  157, FCC010213]
+  - [ 290,  158, FCC010214]
+  - [ 291,  159, FCC010215]
+  - [ 332,  160, FCC010400]
+  - [ 333,  161, FCC010401]
+  - [ 334,  162, FCC010402]
+  - [ 335,  163, FCC010403]
+  - [ 328,  164, FCC010404]
+  - [ 329,  165, FCC010405]
+  - [ 330,  166, FCC010406]
+  - [ 331,  167, FCC010407]
+  - [ 324,  168, FCC010408]
+  - [ 325,  169, FCC010409]
+  - [ 326,  170, FCC010410]
+  - [ 327,  171, FCC010411]
+  - [ 320,  172, FCC010412]
+  - [ 321,  173, FCC010413]
+  - [ 322,  174, FCC010414]
+  - [ 323,  175, FCC010415]
+  - [ 364,  176, FCC010600]
+  - [ 365,  177, FCC010601]
+  - [ 366,  178, FCC010602]
+  - [ 367,  179, FCC010603]
+  - [ 360,  180, FCC010604]
+  - [ 361,  181, FCC010605]
+  - [ 362,  182, FCC010606]
+  - [ 363,  183, FCC010607]
+  - [ 356,  184, FCC010608]
+  - [ 357,  185, FCC010609]
+  - [ 358,  186, FCC010610]
+  - [ 359,  187, FCC010611]
+  - [ 352,  188, FCC010612]
+  - [ 353,  189, FCC010613]
+  - [ 354,  190, FCC010614]
+  - [ 355,  191, FCC010615]
+  - [  12,  192, FCC000000]
+  - [  13,  193, FCC000001]
+  - [  14,  194, FCC000002]
+  - [  15,  195, FCC000003]
+  - [   8,  196, FCC000004]
+  - [   9,  197, FCC000005]
+  - [  10,  198, FCC000006]
+  - [  11,  199, FCC000007]
+  - [   4,  200, FCC000008]
+  - [   5,  201, FCC000009]
+  - [   6,  202, FCC000010]
+  - [   7,  203, FCC000011]
+  - [   0,  204, FCC000012]
+  - [   1,  205, FCC000013]
+  - [   2,  206, FCC000014]
+  - [   3,  207, FCC000015]
+  - [  44,  208, FCC000200]
+  - [  45,  209, FCC000201]
+  - [  46,  210, FCC000202]
+  - [  47,  211, FCC000203]
+  - [  40,  212, FCC000204]
+  - [  41,  213, FCC000205]
+  - [  42,  214, FCC000206]
+  - [  43,  215, FCC000207]
+  - [  36,  216, FCC000208]
+  - [  37,  217, FCC000209]
+  - [  38,  218, FCC000210]
+  - [  39,  219, FCC000211]
+  - [  32,  220, FCC000212]
+  - [  34,  221, FCC000214]
+  - [  33,  222, FCC000213]
+  - [  35,  223, FCC000215]
+  - [  76,  224, FCC000400]
+  - [  77,  225, FCC000401]
+  - [  78,  226, FCC000402]
+  - [  79,  227, FCC000403]
+  - [  72,  228, FCC000404]
+  - [  73,  229, FCC000405]
+  - [  74,  230, FCC000406]
+  - [  75,  231, FCC000407]
+  - [  68,  232, FCC000408]
+  - [  69,  233, FCC000409]
+  - [  70,  234, FCC000410]
+  - [  71,  235, FCC000411]
+  - [  64,  236, FCC000412]
+  - [  65,  237, FCC000413]
+  - [  66,  238, FCC000414]
+  - [  67,  239, FCC000415]
+  - [ 108,  240, FCC000600]
+  - [ 109,  241, FCC000601]
+  - [ 110,  242, FCC000602]
+  - [ 111,  243, FCC000603]
+  - [ 104,  244, FCC000604]
+  - [ 105,  245, FCC000605]
+  - [ 106,  246, FCC000606]
+  - [ 107,  247, FCC000607]
+  - [ 100,  248, FCC000608]
+  - [ 101,  249, FCC000609]
+  - [ 102,  250, FCC000610]
+  - [ 103,  251, FCC000611]
+  - [  96,  252, FCC000612]
+  - [  97,  253, FCC000613]
+  - [  98,  254, FCC000614]
+  - [  99,  255, FCC000615]
+  - [ 144,  256, FCC000912]
+  - [ 145,  257, FCC000913]
+  - [ 146,  258, FCC000914]
+  - [ 147,  259, FCC000915]
+  - [ 148,  260, FCC000908]
+  - [ 149,  261, FCC000909]
+  - [ 150,  262, FCC000910]
+  - [ 151,  263, FCC000911]
+  - [ 152,  264, FCC000904]
+  - [ 153,  265, FCC000905]
+  - [ 154,  266, FCC000906]
+  - [ 155,  267, FCC000907]
+  - [ 156,  268, FCC000900]
+  - [ 157,  269, FCC000901]
+  - [ 158,  270, FCC000902]
+  - [ 159,  271, FCC000903]
+  - [ 176,  272, FCC001112]
+  - [ 177,  273, FCC001113]
+  - [ 178,  274, FCC001114]
+  - [ 179,  275, FCC001115]
+  - [ 180,  276, FCC001108]
+  - [ 181,  277, FCC001109]
+  - [ 182,  278, FCC001110]
+  - [ 183,  279, FCC001111]
+  - [ 184,  280, FCC001104]
+  - [ 185,  281, FCC001105]
+  - [ 186,  282, FCC001106]
+  - [ 187,  283, FCC001107]
+  - [ 188,  284, FCC001100]
+  - [ 189,  285, FCC001101]
+  - [ 190,  286, FCC001102]
+  - [ 191,  287, FCC001103]
+  - [ 208,  288, FCC001312]
+  - [ 209,  289, FCC001313]
+  - [ 210,  290, FCC001314]
+  - [ 211,  291, FCC001315]
+  - [ 212,  292, FCC001308]
+  - [ 213,  293, FCC001309]
+  - [ 214,  294, FCC001310]
+  - [ 215,  295, FCC001311]
+  - [ 216,  296, FCC001304]
+  - [ 217,  297, FCC001305]
+  - [ 218,  298, FCC001306]
+  - [ 219,  299, FCC001307]
+  - [ 220,  300, FCC001300]
+  - [ 221,  301, FCC001301]
+  - [ 222,  302, FCC001302]
+  - [ 223,  303, FCC001303]
+  - [ 240,  304, FCC001512]
+  - [ 241,  305, FCC001513]
+  - [ 242,  306, FCC001514]
+  - [ 243,  307, FCC001515]
+  - [ 244,  308, FCC001508]
+  - [ 245,  309, FCC001509]
+  - [ 246,  310, FCC001510]
+  - [ 247,  311, FCC001511]
+  - [ 248,  312, FCC001504]
+  - [ 249,  313, FCC001505]
+  - [ 250,  314, FCC001506]
+  - [ 251,  315, FCC001507]
+  - [ 252,  316, FCC001500]
+  - [ 253,  317, FCC001501]
+  - [ 254,  318, FCC001502]
+  - [ 255,  319, FCC001503]
+  - [ 400,  320, FCC010912]
+  - [ 401,  321, FCC010913]
+  - [ 402,  322, FCC010914]
+  - [ 403,  323, FCC010915]
+  - [ 404,  324, FCC010908]
+  - [ 405,  325, FCC010909]
+  - [ 406,  326, FCC010910]
+  - [ 407,  327, FCC010911]
+  - [ 408,  328, FCC010904]
+  - [ 409,  329, FCC010905]
+  - [ 410,  330, FCC010906]
+  - [ 411,  331, FCC010907]
+  - [ 412,  332, FCC010900]
+  - [ 413,  333, FCC010901]
+  - [ 414,  334, FCC010902]
+  - [ 415,  335, FCC010903]
+  - [ 432,  336, FCC011112]
+  - [ 433,  337, FCC011113]
+  - [ 434,  338, FCC011114]
+  - [ 435,  339, FCC011115]
+  - [ 436,  340, FCC011108]
+  - [ 437,  341, FCC011109]
+  - [ 438,  342, FCC011110]
+  - [ 439,  343, FCC011111]
+  - [ 440,  344, FCC011104]
+  - [ 441,  345, FCC011105]
+  - [ 442,  346, FCC011106]
+  - [ 443,  347, FCC011107]
+  - [ 444,  348, FCC011100]
+  - [ 445,  349, FCC011101]
+  - [ 446,  350, FCC011102]
+  - [ 447,  351, FCC011103]
+  - [ 464,  352, FCC011312]
+  - [ 465,  353, FCC011313]
+  - [ 466,  354, FCC011314]
+  - [ 467,  355, FCC011315]
+  - [ 468,  356, FCC011308]
+  - [ 469,  357, FCC011309]
+  - [ 470,  358, FCC011310]
+  - [ 471,  359, FCC011311]
+  - [ 472,  360, FCC011304]
+  - [ 473,  361, FCC011305]
+  - [ 474,  362, FCC011306]
+  - [ 475,  363, FCC011307]
+  - [ 476,  364, FCC011300]
+  - [ 477,  365, FCC011301]
+  - [ 478,  366, FCC011302]
+  - [ 479,  367, FCC011303]
+  - [ 496,  368, FCC011512]
+  - [ 497,  369, FCC011513]
+  - [ 498,  370, FCC011514]
+  - [ 499,  371, FCC011515]
+  - [ 500,  372, FCC011508]
+  - [ 501,  373, FCC011509]
+  - [ 502,  374, FCC011510]
+  - [ 503,  375, FCC011511]
+  - [ 504,  376, FCC011504]
+  - [ 505,  377, FCC011505]
+  - [ 506,  378, FCC011506]
+  - [ 507,  379, FCC011507]
+  - [ 508,  380, FCC011500]
+  - [ 509,  381, FCC011501]
+  - [ 510,  382, FCC011502]
+  - [ 511,  383, FCC011503]
+  - [ 287,  384, FCC010103]
+  - [ 286,  385, FCC010102]
+  - [ 285,  386, FCC010101]
+  - [ 284,  387, FCC010100]
+  - [ 280,  388, FCC010104]
+  - [ 281,  389, FCC010105]
+  - [ 282,  390, FCC010106]
+  - [ 283,  391, FCC010107]
+  - [ 276,  392, FCC010108]
+  - [ 277,  393, FCC010109]
+  - [ 278,  394, FCC010110]
+  - [ 279,  395, FCC010111]
+  - [ 272,  396, FCC010112]
+  - [ 273,  397, FCC010113]
+  - [ 274,  398, FCC010114]
+  - [ 275,  399, FCC010115]
+  - [ 316,  400, FCC010300]
+  - [ 317,  401, FCC010301]
+  - [ 318,  402, FCC010302]
+  - [ 319,  403, FCC010303]
+  - [ 312,  404, FCC010304]
+  - [ 313,  405, FCC010305]
+  - [ 314,  406, FCC010306]
+  - [ 315,  407, FCC010307]
+  - [ 308,  408, FCC010308]
+  - [ 309,  409, FCC010309]
+  - [ 310,  410, FCC010310]
+  - [ 311,  411, FCC010311]
+  - [ 304,  412, FCC010312]
+  - [ 305,  413, FCC010313]
+  - [ 306,  414, FCC010314]
+  - [ 307,  415, FCC010315]
+  - [ 348,  416, FCC010500]
+  - [ 349,  417, FCC010501]
+  - [ 350,  418, FCC010502]
+  - [ 351,  419, FCC010503]
+  - [ 344,  420, FCC010504]
+  - [ 345,  421, FCC010505]
+  - [ 346,  422, FCC010506]
+  - [ 347,  423, FCC010507]
+  - [ 343,  424, FCC010511]
+  - [ 342,  425, FCC010510]
+  - [ 341,  426, FCC010509]
+  - [ 340,  427, FCC010508]
+  - [ 336,  428, FCC010512]
+  - [ 337,  429, FCC010513]
+  - [ 338,  430, FCC010514]
+  - [ 339,  431, FCC010515]
+  - [ 380,  432, FCC010700]
+  - [ 381,  433, FCC010701]
+  - [ 382,  434, FCC010702]
+  - [ 383,  435, FCC010703]
+  - [ 376,  436, FCC010704]
+  - [ 377,  437, FCC010705]
+  - [ 378,  438, FCC010706]
+  - [ 379,  439, FCC010707]
+  - [ 372,  440, FCC010708]
+  - [ 373,  441, FCC010709]
+  - [ 374,  442, FCC010710]
+  - [ 375,  443, FCC010711]
+  - [ 368,  444, FCC010712]
+  - [ 369,  445, FCC010713]
+  - [ 370,  446, FCC010714]
+  - [ 371,  447, FCC010715]
+  - [  28,  448, FCC000100]
+  - [  29,  449, FCC000101]
+  - [  30,  450, FCC000102]
+  - [  31,  451, FCC000103]
+  - [  24,  452, FCC000104]
+  - [  25,  453, FCC000105]
+  - [  26,  454, FCC000106]
+  - [  27,  455, FCC000107]
+  - [  20,  456, FCC000108]
+  - [  21,  457, FCC000109]
+  - [  22,  458, FCC000110]
+  - [  23,  459, FCC000111]
+  - [  16,  460, FCC000112]
+  - [  17,  461, FCC000113]
+  - [  18,  462, FCC000114]
+  - [  19,  463, FCC000115]
+  - [  60,  464, FCC000300]
+  - [  61,  465, FCC000301]
+  - [  62,  466, FCC000302]
+  - [  63,  467, FCC000303]
+  - [  56,  468, FCC000304]
+  - [  57,  469, FCC000305]
+  - [  58,  470, FCC000306]
+  - [  59,  471, FCC000307]
+  - [  52,  472, FCC000308]
+  - [  53,  473, FCC000309]
+  - [  54,  474, FCC000310]
+  - [  55,  475, FCC000311]
+  - [  48,  476, FCC000312]
+  - [  49,  477, FCC000313]
+  - [  50,  478, FCC000314]
+  - [  51,  479, FCC000315]
+  - [  92,  480, FCC000500]
+  - [  93,  481, FCC000501]
+  - [  94,  482, FCC000502]
+  - [  95,  483, FCC000503]
+  - [  88,  484, FCC000504]
+  - [  89,  485, FCC000505]
+  - [  90,  486, FCC000506]
+  - [  91,  487, FCC000507]
+  - [  84,  488, FCC000508]
+  - [  85,  489, FCC000509]
+  - [  86,  490, FCC000510]
+  - [  87,  491, FCC000511]
+  - [  80,  492, FCC000512]
+  - [  81,  493, FCC000513]
+  - [  82,  494, FCC000514]
+  - [  83,  495, FCC000515]
+  - [ 124,  496, FCC000700]
+  - [ 125,  497, FCC000701]
+  - [ 126,  498, FCC000702]
+  - [ 127,  499, FCC000703]
+  - [ 120,  500, FCC000704]
+  - [ 121,  501, FCC000705]
+  - [ 122,  502, FCC000706]
+  - [ 123,  503, FCC000707]
+  - [ 116,  504, FCC000708]
+  - [ 117,  505, FCC000709]
+  - [ 118,  506, FCC000710]
+  - [ 119,  507, FCC000711]
+  - [ 112,  508, FCC000712]
+  - [ 113,  509, FCC000713]
+  - [ 114,  510, FCC000714]
+  - [ 115,  511, FCC000715]
+  - [ 608,  512, FCC020612]
+  - [ 609,  513, FCC020613]
+  - [ 610,  514, FCC020614]
+  - [ 611,  515, FCC020615]
+  - [ 612,  516, FCC020608]
+  - [ 613,  517, FCC020609]
+  - [ 614,  518, FCC020610]
+  - [ 615,  519, FCC020611]
+  - [ 616,  520, FCC020604]
+  - [ 617,  521, FCC020605]
+  - [ 618,  522, FCC020606]
+  - [ 619,  523, FCC020607]
+  - [ 620,  524, FCC020600]
+  - [ 621,  525, FCC020601]
+  - [ 622,  526, FCC020602]
+  - [ 623,  527, FCC020603]
+  - [ 576,  528, FCC020412]
+  - [ 577,  529, FCC020413]
+  - [ 578,  530, FCC020414]
+  - [ 579,  531, FCC020415]
+  - [ 580,  532, FCC020408]
+  - [ 581,  533, FCC020409]
+  - [ 582,  534, FCC020410]
+  - [ 583,  535, FCC020411]
+  - [ 584,  536, FCC020404]
+  - [ 585,  537, FCC020405]
+  - [ 586,  538, FCC020406]
+  - [ 587,  539, FCC020407]
+  - [ 588,  540, FCC020400]
+  - [ 589,  541, FCC020401]
+  - [ 590,  542, FCC020402]
+  - [ 591,  543, FCC020403]
+  - [ 544,  544, FCC020212]
+  - [ 545,  545, FCC020213]
+  - [ 546,  546, FCC020214]
+  - [ 547,  547, FCC020215]
+  - [ 548,  548, FCC020208]
+  - [ 549,  549, FCC020209]
+  - [ 550,  550, FCC020210]
+  - [ 551,  551, FCC020211]
+  - [ 553,  552, FCC020205]
+  - [ 552,  553, FCC020204]
+  - [ 554,  554, FCC020206]
+  - [ 555,  555, FCC020207]
+  - [ 556,  556, FCC020200]
+  - [ 557,  557, FCC020201]
+  - [ 558,  558, FCC020202]
+  - [ 559,  559, FCC020203]
+  - [ 512,  560, FCC020012]
+  - [ 513,  561, FCC020013]
+  - [ 514,  562, FCC020014]
+  - [ 515,  563, FCC020015]
+  - [ 516,  564, FCC020008]
+  - [ 517,  565, FCC020009]
+  - [ 518,  566, FCC020010]
+  - [ 519,  567, FCC020011]
+  - [ 520,  568, FCC020004]
+  - [ 521,  569, FCC020005]
+  - [ 522,  570, FCC020006]
+  - [ 523,  571, FCC020007]
+  - [ 524,  572, FCC020000]
+  - [ 525,  573, FCC020001]
+  - [ 526,  574, FCC020002]
+  - [ 527,  575, FCC020003]
+  - [ 864,  576, FCC030612]
+  - [ 865,  577, FCC030613]
+  - [ 866,  578, FCC030614]
+  - [ 867,  579, FCC030615]
+  - [ 868,  580, FCC030608]
+  - [ 869,  581, FCC030609]
+  - [ 870,  582, FCC030610]
+  - [ 871,  583, FCC030611]
+  - [ 872,  584, FCC030604]
+  - [ 873,  585, FCC030605]
+  - [ 874,  586, FCC030606]
+  - [ 875,  587, FCC030607]
+  - [ 876,  588, FCC030600]
+  - [ 877,  589, FCC030601]
+  - [ 878,  590, FCC030602]
+  - [ 879,  591, FCC030603]
+  - [ 832,  592, FCC030412]
+  - [ 833,  593, FCC030413]
+  - [ 834,  594, FCC030414]
+  - [ 835,  595, FCC030415]
+  - [ 836,  596, FCC030408]
+  - [ 837,  597, FCC030409]
+  - [ 838,  598, FCC030410]
+  - [ 839,  599, FCC030411]
+  - [ 840,  600, FCC030404]
+  - [ 841,  601, FCC030405]
+  - [ 842,  602, FCC030406]
+  - [ 843,  603, FCC030407]
+  - [ 844,  604, FCC030400]
+  - [ 845,  605, FCC030401]
+  - [ 846,  606, FCC030402]
+  - [ 847,  607, FCC030403]
+  - [ 800,  608, FCC030212]
+  - [ 801,  609, FCC030213]
+  - [ 802,  610, FCC030214]
+  - [ 803,  611, FCC030215]
+  - [ 804,  612, FCC030208]
+  - [ 805,  613, FCC030209]
+  - [ 806,  614, FCC030210]
+  - [ 807,  615, FCC030211]
+  - [ 808,  616, FCC030204]
+  - [ 809,  617, FCC030205]
+  - [ 810,  618, FCC030206]
+  - [ 811,  619, FCC030207]
+  - [ 812,  620, FCC030200]
+  - [ 813,  621, FCC030201]
+  - [ 814,  622, FCC030202]
+  - [ 815,  623, FCC030203]
+  - [ 768,  624, FCC030012]
+  - [ 769,  625, FCC030013]
+  - [ 770,  626, FCC030014]
+  - [ 771,  627, FCC030015]
+  - [ 772,  628, FCC030008]
+  - [ 773,  629, FCC030009]
+  - [ 774,  630, FCC030010]
+  - [ 775,  631, FCC030011]
+  - [ 776,  632, FCC030004]
+  - [ 777,  633, FCC030005]
+  - [ 778,  634, FCC030006]
+  - [ 779,  635, FCC030007]
+  - [ 780,  636, FCC030000]
+  - [ 781,  637, FCC030001]
+  - [ 782,  638, FCC030002]
+  - [ 783,  639, FCC030003]
+  - [1004,  640, FCC031400]
+  - [1005,  641, FCC031401]
+  - [1006,  642, FCC031402]
+  - [1007,  643, FCC031403]
+  - [1003,  644, FCC031407]
+  - [1002,  645, FCC031406]
+  - [1001,  646, FCC031405]
+  - [1000,  647, FCC031404]
+  - [ 996,  648, FCC031408]
+  - [ 997,  649, FCC031409]
+  - [ 934,  650, FCC031010]
+  - [ 935,  651, FCC031011]
+  - [ 992,  652, FCC031412]
+  - [ 993,  653, FCC031413]
+  - [ 994,  654, FCC031414]
+  - [ 995,  655, FCC031415]
+  - [ 972,  656, FCC031200]
+  - [ 973,  657, FCC031201]
+  - [ 974,  658, FCC031202]
+  - [ 975,  659, FCC031203]
+  - [ 968,  660, FCC031204]
+  - [ 969,  661, FCC031205]
+  - [ 970,  662, FCC031206]
+  - [ 971,  663, FCC031207]
+  - [ 964,  664, FCC031208]
+  - [ 965,  665, FCC031209]
+  - [ 966,  666, FCC031210]
+  - [ 967,  667, FCC031211]
+  - [ 960,  668, FCC031212]
+  - [ 961,  669, FCC031213]
+  - [ 962,  670, FCC031214]
+  - [ 963,  671, FCC031215]
+  - [ 943,  672, FCC031003]
+  - [ 942,  673, FCC031002]
+  - [ 941,  674, FCC031001]
+  - [ 940,  675, FCC031000]
+  - [ 936,  676, FCC031004]
+  - [ 937,  677, FCC031005]
+  - [ 938,  678, FCC031006]
+  - [ 939,  679, FCC031007]
+  - [ 932,  680, FCC031008]
+  - [ 933,  681, FCC031009]
+  - [ 998,  682, FCC031410]
+  - [ 999,  683, FCC031411]
+  - [ 928,  684, FCC031012]
+  - [ 929,  685, FCC031013]
+  - [ 930,  686, FCC031014]
+  - [ 931,  687, FCC031015]
+  - [ 908,  688, FCC030800]
+  - [ 909,  689, FCC030801]
+  - [ 910,  690, FCC030802]
+  - [ 911,  691, FCC030803]
+  - [ 904,  692, FCC030804]
+  - [ 905,  693, FCC030805]
+  - [ 906,  694, FCC030806]
+  - [ 907,  695, FCC030807]
+  - [ 900,  696, FCC030808]
+  - [ 901,  697, FCC030809]
+  - [ 902,  698, FCC030810]
+  - [ 903,  699, FCC030811]
+  - [ 896,  700, FCC030812]
+  - [ 897,  701, FCC030813]
+  - [ 898,  702, FCC030814]
+  - [ 899,  703, FCC030815]
+  - [ 748,  704, FCC021400]
+  - [ 749,  705, FCC021401]
+  - [ 750,  706, FCC021402]
+  - [ 751,  707, FCC021403]
+  - [ 744,  708, FCC021404]
+  - [ 745,  709, FCC021405]
+  - [ 746,  710, FCC021406]
+  - [ 747,  711, FCC021407]
+  - [ 740,  712, FCC021408]
+  - [ 741,  713, FCC021409]
+  - [ 742,  714, FCC021410]
+  - [ 743,  715, FCC021411]
+  - [ 736,  716, FCC021412]
+  - [ 737,  717, FCC021413]
+  - [ 738,  718, FCC021414]
+  - [ 739,  719, FCC021415]
+  - [ 716,  720, FCC021200]
+  - [ 717,  721, FCC021201]
+  - [ 718,  722, FCC021202]
+  - [ 719,  723, FCC021203]
+  - [ 712,  724, FCC021204]
+  - [ 713,  725, FCC021205]
+  - [ 714,  726, FCC021206]
+  - [ 715,  727, FCC021207]
+  - [ 708,  728, FCC021208]
+  - [ 709,  729, FCC021209]
+  - [ 710,  730, FCC021210]
+  - [ 711,  731, FCC021211]
+  - [ 704,  732, FCC021212]
+  - [ 705,  733, FCC021213]
+  - [ 706,  734, FCC021214]
+  - [ 707,  735, FCC021215]
+  - [ 684,  736, FCC021000]
+  - [ 685,  737, FCC021001]
+  - [ 686,  738, FCC021002]
+  - [ 687,  739, FCC021003]
+  - [ 680,  740, FCC021004]
+  - [ 681,  741, FCC021005]
+  - [ 682,  742, FCC021006]
+  - [ 683,  743, FCC021007]
+  - [ 676,  744, FCC021008]
+  - [ 677,  745, FCC021009]
+  - [ 678,  746, FCC021010]
+  - [ 679,  747, FCC021011]
+  - [ 672,  748, FCC021012]
+  - [ 673,  749, FCC021013]
+  - [ 674,  750, FCC021014]
+  - [ 675,  751, FCC021015]
+  - [ 652,  752, FCC020800]
+  - [ 653,  753, FCC020801]
+  - [ 654,  754, FCC020802]
+  - [ 655,  755, FCC020803]
+  - [ 648,  756, FCC020804]
+  - [ 649,  757, FCC020805]
+  - [ 650,  758, FCC020806]
+  - [ 651,  759, FCC020807]
+  - [ 644,  760, FCC020808]
+  - [ 645,  761, FCC020809]
+  - [ 646,  762, FCC020810]
+  - [ 647,  763, FCC020811]
+  - [ 640,  764, FCC020812]
+  - [ 641,  765, FCC020813]
+  - [ 642,  766, FCC020814]
+  - [ 643,  767, FCC020815]
+  - [ 624,  768, FCC020712]
+  - [ 625,  769, FCC020713]
+  - [ 626,  770, FCC020714]
+  - [ 627,  771, FCC020715]
+  - [ 628,  772, FCC020708]
+  - [ 629,  773, FCC020709]
+  - [ 630,  774, FCC020710]
+  - [ 631,  775, FCC020711]
+  - [ 632,  776, FCC020704]
+  - [ 633,  777, FCC020705]
+  - [ 634,  778, FCC020706]
+  - [ 635,  779, FCC020707]
+  - [ 636,  780, FCC020700]
+  - [ 637,  781, FCC020701]
+  - [ 638,  782, FCC020702]
+  - [ 639,  783, FCC020703]
+  - [ 592,  784, FCC020512]
+  - [ 593,  785, FCC020513]
+  - [ 594,  786, FCC020514]
+  - [ 595,  787, FCC020515]
+  - [ 596,  788, FCC020508]
+  - [ 597,  789, FCC020509]
+  - [ 598,  790, FCC020510]
+  - [ 599,  791, FCC020511]
+  - [ 600,  792, FCC020504]
+  - [ 601,  793, FCC020505]
+  - [ 602,  794, FCC020506]
+  - [ 603,  795, FCC020507]
+  - [ 604,  796, FCC020500]
+  - [ 605,  797, FCC020501]
+  - [ 606,  798, FCC020502]
+  - [ 607,  799, FCC020503]
+  - [ 560,  800, FCC020312]
+  - [ 561,  801, FCC020313]
+  - [ 562,  802, FCC020314]
+  - [ 563,  803, FCC020315]
+  - [ 564,  804, FCC020308]
+  - [ 565,  805, FCC020309]
+  - [ 566,  806, FCC020310]
+  - [ 567,  807, FCC020311]
+  - [ 568,  808, FCC020304]
+  - [ 569,  809, FCC020305]
+  - [ 570,  810, FCC020306]
+  - [ 571,  811, FCC020307]
+  - [ 572,  812, FCC020300]
+  - [ 573,  813, FCC020301]
+  - [ 574,  814, FCC020302]
+  - [ 575,  815, FCC020303]
+  - [ 528,  816, FCC020112]
+  - [ 529,  817, FCC020113]
+  - [ 530,  818, FCC020114]
+  - [ 531,  819, FCC020115]
+  - [ 532,  820, FCC020108]
+  - [ 533,  821, FCC020109]
+  - [ 534,  822, FCC020110]
+  - [ 535,  823, FCC020111]
+  - [ 536,  824, FCC020104]
+  - [ 537,  825, FCC020105]
+  - [ 538,  826, FCC020106]
+  - [ 539,  827, FCC020107]
+  - [ 540,  828, FCC020100]
+  - [ 541,  829, FCC020101]
+  - [ 542,  830, FCC020102]
+  - [ 543,  831, FCC020103]
+  - [ 880,  832, FCC030712]
+  - [ 881,  833, FCC030713]
+  - [ 882,  834, FCC030714]
+  - [ 883,  835, FCC030715]
+  - [ 884,  836, FCC030708]
+  - [ 885,  837, FCC030709]
+  - [ 886,  838, FCC030710]
+  - [ 887,  839, FCC030711]
+  - [ 888,  840, FCC030704]
+  - [ 889,  841, FCC030705]
+  - [ 890,  842, FCC030706]
+  - [ 891,  843, FCC030707]
+  - [ 892,  844, FCC030700]
+  - [ 893,  845, FCC030701]
+  - [ 894,  846, FCC030702]
+  - [ 895,  847, FCC030703]
+  - [ 848,  848, FCC030512]
+  - [ 849,  849, FCC030513]
+  - [ 850,  850, FCC030514]
+  - [ 851,  851, FCC030515]
+  - [ 852,  852, FCC030508]
+  - [ 853,  853, FCC030509]
+  - [ 854,  854, FCC030510]
+  - [ 855,  855, FCC030511]
+  - [ 856,  856, FCC030504]
+  - [ 857,  857, FCC030505]
+  - [ 858,  858, FCC030506]
+  - [ 859,  859, FCC030507]
+  - [ 860,  860, FCC030500]
+  - [ 861,  861, FCC030501]
+  - [ 862,  862, FCC030502]
+  - [ 863,  863, FCC030503]
+  - [ 816,  864, FCC030312]
+  - [ 817,  865, FCC030313]
+  - [ 818,  866, FCC030314]
+  - [ 819,  867, FCC030315]
+  - [ 820,  868, FCC030308]
+  - [ 821,  869, FCC030309]
+  - [ 822,  870, FCC030310]
+  - [ 823,  871, FCC030311]
+  - [ 824,  872, FCC030304]
+  - [ 825,  873, FCC030305]
+  - [ 826,  874, FCC030306]
+  - [ 827,  875, FCC030307]
+  - [ 828,  876, FCC030300]
+  - [ 829,  877, FCC030301]
+  - [ 830,  878, FCC030302]
+  - [ 831,  879, FCC030303]
+  - [ 784,  880, FCC030112]
+  - [ 785,  881, FCC030113]
+  - [ 786,  882, FCC030114]
+  - [ 787,  883, FCC030115]
+  - [ 788,  884, FCC030108]
+  - [ 789,  885, FCC030109]
+  - [ 790,  886, FCC030110]
+  - [ 791,  887, FCC030111]
+  - [ 792,  888, FCC030104]
+  - [ 793,  889, FCC030105]
+  - [ 794,  890, FCC030106]
+  - [ 795,  891, FCC030107]
+  - [ 796,  892, FCC030100]
+  - [ 797,  893, FCC030101]
+  - [ 798,  894, FCC030102]
+  - [ 799,  895, FCC030103]
+  - [1020,  896, FCC031500]
+  - [1021,  897, FCC031501]
+  - [1022,  898, FCC031502]
+  - [1023,  899, FCC031503]
+  - [1016,  900, FCC031504]
+  - [1017,  901, FCC031505]
+  - [1018,  902, FCC031506]
+  - [1019,  903, FCC031507]
+  - [1012,  904, FCC031508]
+  - [1013,  905, FCC031509]
+  - [1015,  906, FCC031511]
+  - [1014,  907, FCC031510]
+  - [1008,  908, FCC031512]
+  - [1009,  909, FCC031513]
+  - [1010,  910, FCC031514]
+  - [1011,  911, FCC031515]
+  - [ 988,  912, FCC031300]
+  - [ 989,  913, FCC031301]
+  - [ 990,  914, FCC031302]
+  - [ 991,  915, FCC031303]
+  - [ 984,  916, FCC031304]
+  - [ 985,  917, FCC031305]
+  - [ 986,  918, FCC031306]
+  - [ 987,  919, FCC031307]
+  - [ 980,  920, FCC031308]
+  - [ 981,  921, FCC031309]
+  - [ 982,  922, FCC031310]
+  - [ 983,  923, FCC031311]
+  - [ 976,  924, FCC031312]
+  - [ 977,  925, FCC031313]
+  - [ 978,  926, FCC031314]
+  - [ 979,  927, FCC031315]
+  - [ 956,  928, FCC031100]
+  - [ 957,  929, FCC031101]
+  - [ 958,  930, FCC031102]
+  - [ 959,  931, FCC031103]
+  - [ 952,  932, FCC031104]
+  - [ 953,  933, FCC031105]
+  - [ 954,  934, FCC031106]
+  - [ 955,  935, FCC031107]
+  - [ 948,  936, FCC031108]
+  - [ 949,  937, FCC031109]
+  - [ 950,  938, FCC031110]
+  - [ 951,  939, FCC031111]
+  - [ 944,  940, FCC031112]
+  - [ 945,  941, FCC031113]
+  - [ 946,  942, FCC031114]
+  - [ 947,  943, FCC031115]
+  - [ 924,  944, FCC030900]
+  - [ 925,  945, FCC030901]
+  - [ 926,  946, FCC030902]
+  - [ 927,  947, FCC030903]
+  - [ 920,  948, FCC030904]
+  - [ 921,  949, FCC030905]
+  - [ 922,  950, FCC030906]
+  - [ 923,  951, FCC030907]
+  - [ 916,  952, FCC030908]
+  - [ 917,  953, FCC030909]
+  - [ 918,  954, FCC030910]
+  - [ 919,  955, FCC030911]
+  - [ 912,  956, FCC030912]
+  - [ 913,  957, FCC030913]
+  - [ 914,  958, FCC030914]
+  - [ 915,  959, FCC030915]
+  - [ 764,  960, FCC021500]
+  - [ 765,  961, FCC021501]
+  - [ 766,  962, FCC021502]
+  - [ 767,  963, FCC021503]
+  - [ 760,  964, FCC021504]
+  - [ 761,  965, FCC021505]
+  - [ 762,  966, FCC021506]
+  - [ 763,  967, FCC021507]
+  - [ 756,  968, FCC021508]
+  - [ 757,  969, FCC021509]
+  - [ 758,  970, FCC021510]
+  - [ 759,  971, FCC021511]
+  - [ 752,  972, FCC021512]
+  - [ 753,  973, FCC021513]
+  - [ 754,  974, FCC021514]
+  - [ 755,  975, FCC021515]
+  - [ 732,  976, FCC021300]
+  - [ 733,  977, FCC021301]
+  - [ 734,  978, FCC021302]
+  - [ 735,  979, FCC021303]
+  - [ 728,  980, FCC021304]
+  - [ 729,  981, FCC021305]
+  - [ 730,  982, FCC021306]
+  - [ 731,  983, FCC021307]
+  - [ 724,  984, FCC021308]
+  - [ 725,  985, FCC021309]
+  - [ 726,  986, FCC021310]
+  - [ 727,  987, FCC021311]
+  - [ 720,  988, FCC021312]
+  - [ 721,  989, FCC021313]
+  - [ 722,  990, FCC021314]
+  - [ 723,  991, FCC021315]
+  - [ 700,  992, FCC021100]
+  - [ 701,  993, FCC021101]
+  - [ 702,  994, FCC021102]
+  - [ 703,  995, FCC021103]
+  - [ 696,  996, FCC021104]
+  - [ 697,  997, FCC021105]
+  - [ 698,  998, FCC021106]
+  - [ 699,  999, FCC021107]
+  - [ 692, 1000, FCC021108]
+  - [ 693, 1001, FCC021109]
+  - [ 694, 1002, FCC021110]
+  - [ 695, 1003, FCC021111]
+  - [ 688, 1004, FCC021112]
+  - [ 689, 1005, FCC021113]
+  - [ 690, 1006, FCC021114]
+  - [ 691, 1007, FCC021115]
+  - [ 668, 1008, FCC020900]
+  - [ 669, 1009, FCC020901]
+  - [ 670, 1010, FCC020902]
+  - [ 671, 1011, FCC020903]
+  - [ 664, 1012, FCC020904]
+  - [ 665, 1013, FCC020905]
+  - [ 666, 1014, FCC020906]
+  - [ 667, 1015, FCC020907]
+  - [ 660, 1016, FCC020908]
+  - [ 661, 1017, FCC020909]
+  - [ 662, 1018, FCC020910]
+  - [ 663, 1019, FCC020911]
+  - [ 656, 1020, FCC020912]
+  - [ 657, 1021, FCC020913]
+  - [ 658, 1022, FCC020914]
+  - [ 659, 1023, FCC020915]
+  - [1420, 1024, FCC050800]
+  - [1421, 1025, FCC050801]
+  - [1422, 1026, FCC050802]
+  - [1423, 1027, FCC050803]
+  - [1416, 1028, FCC050804]
+  - [1417, 1029, FCC050805]
+  - [1418, 1030, FCC050806]
+  - [1419, 1031, FCC050807]
+  - [1412, 1032, FCC050808]
+  - [1413, 1033, FCC050809]
+  - [1414, 1034, FCC050810]
+  - [1415, 1035, FCC050811]
+  - [1408, 1036, FCC050812]
+  - [1409, 1037, FCC050813]
+  - [1410, 1038, FCC050814]
+  - [1411, 1039, FCC050815]
+  - [1452, 1040, FCC051000]
+  - [1453, 1041, FCC051001]
+  - [1454, 1042, FCC051002]
+  - [1455, 1043, FCC051003]
+  - [1448, 1044, FCC051004]
+  - [1449, 1045, FCC051005]
+  - [1450, 1046, FCC051006]
+  - [1451, 1047, FCC051007]
+  - [1444, 1048, FCC051008]
+  - [1445, 1049, FCC051009]
+  - [1446, 1050, FCC051010]
+  - [1447, 1051, FCC051011]
+  - [1440, 1052, FCC051012]
+  - [1441, 1053, FCC051013]
+  - [1442, 1054, FCC051014]
+  - [1443, 1055, FCC051015]
+  - [1484, 1056, FCC051200]
+  - [1485, 1057, FCC051201]
+  - [1486, 1058, FCC051202]
+  - [1487, 1059, FCC051203]
+  - [1480, 1060, FCC051204]
+  - [1481, 1061, FCC051205]
+  - [1482, 1062, FCC051206]
+  - [1483, 1063, FCC051207]
+  - [1476, 1064, FCC051208]
+  - [1477, 1065, FCC051209]
+  - [1478, 1066, FCC051210]
+  - [1479, 1067, FCC051211]
+  - [1472, 1068, FCC051212]
+  - [1473, 1069, FCC051213]
+  - [1474, 1070, FCC051214]
+  - [1475, 1071, FCC051215]
+  - [1516, 1072, FCC051400]
+  - [1517, 1073, FCC051401]
+  - [1518, 1074, FCC051402]
+  - [1519, 1075, FCC051403]
+  - [1512, 1076, FCC051404]
+  - [1513, 1077, FCC051405]
+  - [1514, 1078, FCC051406]
+  - [1515, 1079, FCC051407]
+  - [1508, 1080, FCC051408]
+  - [1509, 1081, FCC051409]
+  - [1510, 1082, FCC051410]
+  - [1511, 1083, FCC051411]
+  - [1504, 1084, FCC051412]
+  - [1505, 1085, FCC051413]
+  - [1506, 1086, FCC051414]
+  - [1507, 1087, FCC051415]
+  - [1164, 1088, FCC040800]
+  - [1165, 1089, FCC040801]
+  - [1166, 1090, FCC040802]
+  - [1167, 1091, FCC040803]
+  - [1160, 1092, FCC040804]
+  - [1161, 1093, FCC040805]
+  - [1162, 1094, FCC040806]
+  - [1163, 1095, FCC040807]
+  - [1156, 1096, FCC040808]
+  - [1157, 1097, FCC040809]
+  - [1158, 1098, FCC040810]
+  - [1159, 1099, FCC040811]
+  - [1152, 1100, FCC040812]
+  - [1153, 1101, FCC040813]
+  - [1154, 1102, FCC040814]
+  - [1155, 1103, FCC040815]
+  - [1196, 1104, FCC041000]
+  - [1197, 1105, FCC041001]
+  - [1198, 1106, FCC041002]
+  - [1199, 1107, FCC041003]
+  - [1192, 1108, FCC041004]
+  - [1193, 1109, FCC041005]
+  - [1194, 1110, FCC041006]
+  - [1195, 1111, FCC041007]
+  - [1188, 1112, FCC041008]
+  - [1189, 1113, FCC041009]
+  - [1190, 1114, FCC041010]
+  - [1191, 1115, FCC041011]
+  - [1184, 1116, FCC041012]
+  - [1185, 1117, FCC041013]
+  - [1186, 1118, FCC041014]
+  - [1187, 1119, FCC041015]
+  - [1228, 1120, FCC041200]
+  - [1229, 1121, FCC041201]
+  - [1230, 1122, FCC041202]
+  - [1231, 1123, FCC041203]
+  - [1224, 1124, FCC041204]
+  - [1225, 1125, FCC041205]
+  - [1226, 1126, FCC041206]
+  - [1227, 1127, FCC041207]
+  - [1220, 1128, FCC041208]
+  - [1221, 1129, FCC041209]
+  - [1222, 1130, FCC041210]
+  - [1223, 1131, FCC041211]
+  - [1216, 1132, FCC041212]
+  - [1217, 1133, FCC041213]
+  - [1219, 1134, FCC041215]
+  - [1218, 1135, FCC041214]
+  - [1260, 1136, FCC041400]
+  - [1261, 1137, FCC041401]
+  - [1262, 1138, FCC041402]
+  - [1263, 1139, FCC041403]
+  - [1256, 1140, FCC041404]
+  - [1257, 1141, FCC041405]
+  - [1258, 1142, FCC041406]
+  - [1259, 1143, FCC041407]
+  - [1252, 1144, FCC041408]
+  - [1253, 1145, FCC041409]
+  - [1254, 1146, FCC041410]
+  - [1255, 1147, FCC041411]
+  - [1248, 1148, FCC041412]
+  - [1249, 1149, FCC041413]
+  - [1250, 1150, FCC041414]
+  - [1251, 1151, FCC041415]
+  - [1036, 1152, FCC040000]
+  - [1037, 1153, FCC040001]
+  - [1038, 1154, FCC040002]
+  - [1039, 1155, FCC040003]
+  - [1032, 1156, FCC040004]
+  - [1033, 1157, FCC040005]
+  - [1034, 1158, FCC040006]
+  - [1035, 1159, FCC040007]
+  - [1028, 1160, FCC040008]
+  - [1029, 1161, FCC040009]
+  - [1030, 1162, FCC040010]
+  - [1031, 1163, FCC040011]
+  - [1024, 1164, FCC040012]
+  - [1025, 1165, FCC040013]
+  - [1026, 1166, FCC040014]
+  - [1027, 1167, FCC040015]
+  - [1056, 1168, FCC040212]
+  - [1057, 1169, FCC040213]
+  - [1058, 1170, FCC040214]
+  - [1059, 1171, FCC040215]
+  - [1060, 1172, FCC040208]
+  - [1061, 1173, FCC040209]
+  - [1062, 1174, FCC040210]
+  - [1063, 1175, FCC040211]
+  - [1064, 1176, FCC040204]
+  - [1065, 1177, FCC040205]
+  - [1066, 1178, FCC040206]
+  - [1067, 1179, FCC040207]
+  - [1068, 1180, FCC040200]
+  - [1069, 1181, FCC040201]
+  - [1070, 1182, FCC040202]
+  - [1071, 1183, FCC040203]
+  - [1088, 1184, FCC040412]
+  - [1089, 1185, FCC040413]
+  - [1090, 1186, FCC040414]
+  - [1091, 1187, FCC040415]
+  - [1092, 1188, FCC040408]
+  - [1093, 1189, FCC040409]
+  - [1094, 1190, FCC040410]
+  - [1095, 1191, FCC040411]
+  - [1096, 1192, FCC040404]
+  - [1097, 1193, FCC040405]
+  - [1098, 1194, FCC040406]
+  - [1099, 1195, FCC040407]
+  - [1100, 1196, FCC040400]
+  - [1101, 1197, FCC040401]
+  - [1102, 1198, FCC040402]
+  - [1103, 1199, FCC040403]
+  - [1120, 1200, FCC040612]
+  - [1121, 1201, FCC040613]
+  - [1122, 1202, FCC040614]
+  - [1123, 1203, FCC040615]
+  - [1124, 1204, FCC040608]
+  - [1125, 1205, FCC040609]
+  - [1126, 1206, FCC040610]
+  - [1127, 1207, FCC040611]
+  - [1128, 1208, FCC040604]
+  - [1129, 1209, FCC040605]
+  - [1130, 1210, FCC040606]
+  - [1131, 1211, FCC040607]
+  - [1132, 1212, FCC040600]
+  - [1133, 1213, FCC040601]
+  - [1134, 1214, FCC040602]
+  - [1135, 1215, FCC040603]
+  - [1292, 1216, FCC050000]
+  - [1293, 1217, FCC050001]
+  - [1294, 1218, FCC050002]
+  - [1295, 1219, FCC050003]
+  - [1288, 1220, FCC050004]
+  - [1289, 1221, FCC050005]
+  - [1290, 1222, FCC050006]
+  - [1291, 1223, FCC050007]
+  - [1284, 1224, FCC050008]
+  - [1285, 1225, FCC050009]
+  - [1286, 1226, FCC050010]
+  - [1287, 1227, FCC050011]
+  - [1280, 1228, FCC050012]
+  - [1281, 1229, FCC050013]
+  - [1282, 1230, FCC050014]
+  - [1283, 1231, FCC050015]
+  - [1324, 1232, FCC050200]
+  - [1325, 1233, FCC050201]
+  - [1326, 1234, FCC050202]
+  - [1327, 1235, FCC050203]
+  - [1320, 1236, FCC050204]
+  - [1321, 1237, FCC050205]
+  - [1322, 1238, FCC050206]
+  - [1323, 1239, FCC050207]
+  - [1316, 1240, FCC050208]
+  - [1317, 1241, FCC050209]
+  - [1318, 1242, FCC050210]
+  - [1319, 1243, FCC050211]
+  - [1312, 1244, FCC050212]
+  - [1313, 1245, FCC050213]
+  - [1314, 1246, FCC050214]
+  - [1315, 1247, FCC050215]
+  - [1356, 1248, FCC050400]
+  - [1357, 1249, FCC050401]
+  - [1358, 1250, FCC050402]
+  - [1359, 1251, FCC050403]
+  - [1352, 1252, FCC050404]
+  - [1353, 1253, FCC050405]
+  - [1354, 1254, FCC050406]
+  - [1355, 1255, FCC050407]
+  - [1348, 1256, FCC050408]
+  - [1349, 1257, FCC050409]
+  - [1350, 1258, FCC050410]
+  - [1351, 1259, FCC050411]
+  - [1344, 1260, FCC050412]
+  - [1345, 1261, FCC050413]
+  - [1346, 1262, FCC050414]
+  - [1347, 1263, FCC050415]
+  - [1388, 1264, FCC050600]
+  - [1389, 1265, FCC050601]
+  - [1390, 1266, FCC050602]
+  - [1391, 1267, FCC050603]
+  - [1384, 1268, FCC050604]
+  - [1385, 1269, FCC050605]
+  - [1386, 1270, FCC050606]
+  - [1387, 1271, FCC050607]
+  - [1380, 1272, FCC050608]
+  - [1381, 1273, FCC050609]
+  - [1382, 1274, FCC050610]
+  - [1383, 1275, FCC050611]
+  - [1376, 1276, FCC050612]
+  - [1377, 1277, FCC050613]
+  - [1378, 1278, FCC050614]
+  - [1379, 1279, FCC050615]
+  - [1436, 1280, FCC050900]
+  - [1437, 1281, FCC050901]
+  - [1438, 1282, FCC050902]
+  - [1439, 1283, FCC050903]
+  - [1432, 1284, FCC050904]
+  - [1433, 1285, FCC050905]
+  - [1434, 1286, FCC050906]
+  - [1435, 1287, FCC050907]
+  - [1428, 1288, FCC050908]
+  - [1429, 1289, FCC050909]
+  - [1430, 1290, FCC050910]
+  - [1431, 1291, FCC050911]
+  - [1424, 1292, FCC050912]
+  - [1425, 1293, FCC050913]
+  - [1426, 1294, FCC050914]
+  - [1427, 1295, FCC050915]
+  - [1468, 1296, FCC051100]
+  - [1469, 1297, FCC051101]
+  - [1470, 1298, FCC051102]
+  - [1471, 1299, FCC051103]
+  - [1464, 1300, FCC051104]
+  - [1465, 1301, FCC051105]
+  - [1466, 1302, FCC051106]
+  - [1467, 1303, FCC051107]
+  - [1460, 1304, FCC051108]
+  - [1461, 1305, FCC051109]
+  - [1462, 1306, FCC051110]
+  - [1463, 1307, FCC051111]
+  - [1456, 1308, FCC051112]
+  - [1457, 1309, FCC051113]
+  - [1458, 1310, FCC051114]
+  - [1459, 1311, FCC051115]
+  - [1500, 1312, FCC051300]
+  - [1501, 1313, FCC051301]
+  - [1502, 1314, FCC051302]
+  - [1503, 1315, FCC051303]
+  - [1496, 1316, FCC051304]
+  - [1497, 1317, FCC051305]
+  - [1498, 1318, FCC051306]
+  - [1499, 1319, FCC051307]
+  - [1492, 1320, FCC051308]
+  - [1493, 1321, FCC051309]
+  - [1494, 1322, FCC051310]
+  - [1495, 1323, FCC051311]
+  - [1488, 1324, FCC051312]
+  - [1489, 1325, FCC051313]
+  - [1490, 1326, FCC051314]
+  - [1491, 1327, FCC051315]
+  - [1532, 1328, FCC051500]
+  - [1533, 1329, FCC051501]
+  - [1534, 1330, FCC051502]
+  - [1535, 1331, FCC051503]
+  - [1528, 1332, FCC051504]
+  - [1529, 1333, FCC051505]
+  - [1530, 1334, FCC051506]
+  - [1531, 1335, FCC051507]
+  - [1524, 1336, FCC051508]
+  - [1525, 1337, FCC051509]
+  - [1526, 1338, FCC051510]
+  - [1527, 1339, FCC051511]
+  - [1520, 1340, FCC051512]
+  - [1521, 1341, FCC051513]
+  - [1522, 1342, FCC051514]
+  - [1523, 1343, FCC051515]
+  - [1180, 1344, FCC040900]
+  - [1181, 1345, FCC040901]
+  - [1182, 1346, FCC040902]
+  - [1183, 1347, FCC040903]
+  - [1176, 1348, FCC040904]
+  - [1177, 1349, FCC040905]
+  - [1178, 1350, FCC040906]
+  - [1179, 1351, FCC040907]
+  - [1172, 1352, FCC040908]
+  - [1173, 1353, FCC040909]
+  - [1174, 1354, FCC040910]
+  - [1175, 1355, FCC040911]
+  - [1168, 1356, FCC040912]
+  - [1169, 1357, FCC040913]
+  - [1170, 1358, FCC040914]
+  - [1171, 1359, FCC040915]
+  - [1212, 1360, FCC041100]
+  - [1213, 1361, FCC041101]
+  - [1214, 1362, FCC041102]
+  - [1215, 1363, FCC041103]
+  - [1208, 1364, FCC041104]
+  - [1209, 1365, FCC041105]
+  - [1210, 1366, FCC041106]
+  - [1211, 1367, FCC041107]
+  - [1204, 1368, FCC041108]
+  - [1205, 1369, FCC041109]
+  - [1206, 1370, FCC041110]
+  - [1207, 1371, FCC041111]
+  - [1200, 1372, FCC041112]
+  - [1201, 1373, FCC041113]
+  - [1202, 1374, FCC041114]
+  - [1203, 1375, FCC041115]
+  - [1244, 1376, FCC041300]
+  - [1245, 1377, FCC041301]
+  - [1246, 1378, FCC041302]
+  - [1247, 1379, FCC041303]
+  - [1240, 1380, FCC041304]
+  - [1241, 1381, FCC041305]
+  - [1242, 1382, FCC041306]
+  - [1243, 1383, FCC041307]
+  - [1236, 1384, FCC041308]
+  - [1237, 1385, FCC041309]
+  - [1238, 1386, FCC041310]
+  - [1239, 1387, FCC041311]
+  - [1232, 1388, FCC041312]
+  - [1233, 1389, FCC041313]
+  - [1234, 1390, FCC041314]
+  - [1235, 1391, FCC041315]
+  - [1276, 1392, FCC041500]
+  - [1277, 1393, FCC041501]
+  - [1278, 1394, FCC041502]
+  - [1279, 1395, FCC041503]
+  - [1272, 1396, FCC041504]
+  - [1273, 1397, FCC041505]
+  - [1274, 1398, FCC041506]
+  - [1275, 1399, FCC041507]
+  - [1268, 1400, FCC041508]
+  - [1269, 1401, FCC041509]
+  - [1270, 1402, FCC041510]
+  - [1271, 1403, FCC041511]
+  - [1264, 1404, FCC041512]
+  - [1265, 1405, FCC041513]
+  - [1266, 1406, FCC041514]
+  - [1267, 1407, FCC041515]
+  - [1052, 1408, FCC040100]
+  - [1053, 1409, FCC040101]
+  - [1054, 1410, FCC040102]
+  - [1055, 1411, FCC040103]
+  - [1048, 1412, FCC040104]
+  - [1049, 1413, FCC040105]
+  - [1050, 1414, FCC040106]
+  - [1051, 1415, FCC040107]
+  - [1044, 1416, FCC040108]
+  - [1045, 1417, FCC040109]
+  - [1046, 1418, FCC040110]
+  - [1047, 1419, FCC040111]
+  - [1040, 1420, FCC040112]
+  - [1041, 1421, FCC040113]
+  - [1042, 1422, FCC040114]
+  - [1043, 1423, FCC040115]
+  - [1072, 1424, FCC040312]
+  - [1073, 1425, FCC040313]
+  - [1074, 1426, FCC040314]
+  - [1075, 1427, FCC040315]
+  - [1076, 1428, FCC040308]
+  - [1077, 1429, FCC040309]
+  - [1078, 1430, FCC040310]
+  - [1079, 1431, FCC040311]
+  - [1080, 1432, FCC040304]
+  - [1081, 1433, FCC040305]
+  - [1082, 1434, FCC040306]
+  - [1083, 1435, FCC040307]
+  - [1084, 1436, FCC040300]
+  - [1085, 1437, FCC040301]
+  - [1086, 1438, FCC040302]
+  - [1087, 1439, FCC040303]
+  - [1104, 1440, FCC040512]
+  - [1105, 1441, FCC040513]
+  - [1106, 1442, FCC040514]
+  - [1107, 1443, FCC040515]
+  - [1108, 1444, FCC040508]
+  - [1109, 1445, FCC040509]
+  - [1110, 1446, FCC040510]
+  - [1111, 1447, FCC040511]
+  - [1112, 1448, FCC040504]
+  - [1113, 1449, FCC040505]
+  - [1114, 1450, FCC040506]
+  - [1115, 1451, FCC040507]
+  - [1116, 1452, FCC040500]
+  - [1117, 1453, FCC040501]
+  - [1118, 1454, FCC040502]
+  - [1119, 1455, FCC040503]
+  - [1136, 1456, FCC040712]
+  - [1137, 1457, FCC040713]
+  - [1138, 1458, FCC040714]
+  - [1139, 1459, FCC040715]
+  - [1140, 1460, FCC040708]
+  - [1141, 1461, FCC040709]
+  - [1142, 1462, FCC040710]
+  - [1143, 1463, FCC040711]
+  - [1144, 1464, FCC040704]
+  - [1145, 1465, FCC040705]
+  - [1146, 1466, FCC040706]
+  - [1147, 1467, FCC040707]
+  - [1148, 1468, FCC040700]
+  - [1149, 1469, FCC040701]
+  - [1150, 1470, FCC040702]
+  - [1151, 1471, FCC040703]
+  - [1308, 1472, FCC050100]
+  - [1309, 1473, FCC050101]
+  - [1310, 1474, FCC050102]
+  - [1311, 1475, FCC050103]
+  - [1304, 1476, FCC050104]
+  - [1305, 1477, FCC050105]
+  - [1306, 1478, FCC050106]
+  - [1307, 1479, FCC050107]
+  - [1300, 1480, FCC050108]
+  - [1301, 1481, FCC050109]
+  - [1302, 1482, FCC050110]
+  - [1303, 1483, FCC050111]
+  - [1296, 1484, FCC050112]
+  - [1297, 1485, FCC050113]
+  - [1298, 1486, FCC050114]
+  - [1299, 1487, FCC050115]
+  - [1340, 1488, FCC050300]
+  - [1341, 1489, FCC050301]
+  - [1342, 1490, FCC050302]
+  - [1343, 1491, FCC050303]
+  - [1336, 1492, FCC050304]
+  - [1337, 1493, FCC050305]
+  - [1338, 1494, FCC050306]
+  - [1339, 1495, FCC050307]
+  - [1332, 1496, FCC050308]
+  - [1333, 1497, FCC050309]
+  - [1334, 1498, FCC050310]
+  - [1335, 1499, FCC050311]
+  - [1328, 1500, FCC050312]
+  - [1329, 1501, FCC050313]
+  - [1330, 1502, FCC050314]
+  - [1331, 1503, FCC050315]
+  - [1372, 1504, FCC050500]
+  - [1373, 1505, FCC050501]
+  - [1374, 1506, FCC050502]
+  - [1375, 1507, FCC050503]
+  - [1368, 1508, FCC050504]
+  - [1369, 1509, FCC050505]
+  - [1370, 1510, FCC050506]
+  - [1371, 1511, FCC050507]
+  - [1364, 1512, FCC050508]
+  - [1365, 1513, FCC050509]
+  - [1366, 1514, FCC050510]
+  - [1367, 1515, FCC050511]
+  - [1360, 1516, FCC050512]
+  - [1361, 1517, FCC050513]
+  - [1362, 1518, FCC050514]
+  - [1363, 1519, FCC050515]
+  - [1404, 1520, FCC050700]
+  - [1405, 1521, FCC050701]
+  - [1406, 1522, FCC050702]
+  - [1407, 1523, FCC050703]
+  - [1400, 1524, FCC050704]
+  - [1401, 1525, FCC050705]
+  - [1402, 1526, FCC050706]
+  - [1403, 1527, FCC050707]
+  - [1396, 1528, FCC050708]
+  - [1397, 1529, FCC050709]
+  - [1398, 1530, FCC050710]
+  - [1399, 1531, FCC050711]
+  - [1392, 1532, FCC050712]
+  - [1393, 1533, FCC050713]
+  - [1394, 1534, FCC050714]
+  - [1395, 1535, FCC050715]
+  - [1632, 1536, FCC060612]
+  - [1633, 1537, FCC060613]
+  - [1634, 1538, FCC060614]
+  - [1635, 1539, FCC060615]
+  - [1636, 1540, FCC060608]
+  - [1637, 1541, FCC060609]
+  - [1638, 1542, FCC060610]
+  - [1639, 1543, FCC060611]
+  - [1640, 1544, FCC060604]
+  - [1641, 1545, FCC060605]
+  - [1642, 1546, FCC060606]
+  - [1643, 1547, FCC060607]
+  - [1644, 1548, FCC060600]
+  - [1645, 1549, FCC060601]
+  - [1646, 1550, FCC060602]
+  - [1647, 1551, FCC060603]
+  - [1600, 1552, FCC060412]
+  - [1601, 1553, FCC060413]
+  - [1602, 1554, FCC060414]
+  - [1603, 1555, FCC060415]
+  - [1604, 1556, FCC060408]
+  - [1605, 1557, FCC060409]
+  - [1606, 1558, FCC060410]
+  - [1607, 1559, FCC060411]
+  - [1608, 1560, FCC060404]
+  - [1609, 1561, FCC060405]
+  - [1610, 1562, FCC060406]
+  - [1611, 1563, FCC060407]
+  - [1612, 1564, FCC060400]
+  - [1613, 1565, FCC060401]
+  - [1614, 1566, FCC060402]
+  - [1615, 1567, FCC060403]
+  - [1568, 1568, FCC060212]
+  - [1569, 1569, FCC060213]
+  - [1570, 1570, FCC060214]
+  - [1571, 1571, FCC060215]
+  - [1572, 1572, FCC060208]
+  - [1573, 1573, FCC060209]
+  - [1574, 1574, FCC060210]
+  - [1575, 1575, FCC060211]
+  - [1576, 1576, FCC060204]
+  - [1577, 1577, FCC060205]
+  - [1578, 1578, FCC060206]
+  - [1579, 1579, FCC060207]
+  - [1580, 1580, FCC060200]
+  - [1581, 1581, FCC060201]
+  - [1582, 1582, FCC060202]
+  - [1583, 1583, FCC060203]
+  - [1536, 1584, FCC060012]
+  - [1537, 1585, FCC060013]
+  - [1538, 1586, FCC060014]
+  - [1539, 1587, FCC060015]
+  - [1540, 1588, FCC060008]
+  - [1541, 1589, FCC060009]
+  - [1542, 1590, FCC060010]
+  - [1543, 1591, FCC060011]
+  - [1544, 1592, FCC060004]
+  - [1545, 1593, FCC060005]
+  - [1546, 1594, FCC060006]
+  - [1547, 1595, FCC060007]
+  - [1548, 1596, FCC060000]
+  - [1549, 1597, FCC060001]
+  - [1550, 1598, FCC060002]
+  - [1551, 1599, FCC060003]
+  - [1888, 1600, FCC070612]
+  - [1889, 1601, FCC070613]
+  - [1890, 1602, FCC070614]
+  - [1891, 1603, FCC070615]
+  - [1892, 1604, FCC070608]
+  - [1893, 1605, FCC070609]
+  - [1894, 1606, FCC070610]
+  - [1895, 1607, FCC070611]
+  - [1896, 1608, FCC070604]
+  - [1897, 1609, FCC070605]
+  - [1898, 1610, FCC070606]
+  - [1899, 1611, FCC070607]
+  - [1900, 1612, FCC070600]
+  - [1901, 1613, FCC070601]
+  - [1902, 1614, FCC070602]
+  - [1903, 1615, FCC070603]
+  - [1856, 1616, FCC070412]
+  - [1857, 1617, FCC070413]
+  - [1858, 1618, FCC070414]
+  - [1859, 1619, FCC070415]
+  - [1860, 1620, FCC070408]
+  - [1861, 1621, FCC070409]
+  - [1862, 1622, FCC070410]
+  - [1863, 1623, FCC070411]
+  - [1864, 1624, FCC070404]
+  - [1865, 1625, FCC070405]
+  - [1866, 1626, FCC070406]
+  - [1867, 1627, FCC070407]
+  - [1868, 1628, FCC070400]
+  - [1869, 1629, FCC070401]
+  - [1870, 1630, FCC070402]
+  - [1871, 1631, FCC070403]
+  - [1824, 1632, FCC070212]
+  - [1825, 1633, FCC070213]
+  - [1826, 1634, FCC070214]
+  - [1827, 1635, FCC070215]
+  - [1828, 1636, FCC070208]
+  - [1829, 1637, FCC070209]
+  - [1830, 1638, FCC070210]
+  - [1831, 1639, FCC070211]
+  - [1832, 1640, FCC070204]
+  - [1833, 1641, FCC070205]
+  - [1834, 1642, FCC070206]
+  - [1835, 1643, FCC070207]
+  - [1836, 1644, FCC070200]
+  - [1837, 1645, FCC070201]
+  - [1838, 1646, FCC070202]
+  - [1839, 1647, FCC070203]
+  - [1792, 1648, FCC070012]
+  - [1793, 1649, FCC070013]
+  - [1794, 1650, FCC070014]
+  - [1795, 1651, FCC070015]
+  - [1796, 1652, FCC070008]
+  - [1797, 1653, FCC070009]
+  - [1798, 1654, FCC070010]
+  - [1799, 1655, FCC070011]
+  - [1800, 1656, FCC070004]
+  - [1801, 1657, FCC070005]
+  - [1802, 1658, FCC070006]
+  - [1803, 1659, FCC070007]
+  - [1804, 1660, FCC070000]
+  - [1805, 1661, FCC070001]
+  - [1806, 1662, FCC070002]
+  - [1807, 1663, FCC070003]
+  - [1760, 1664, FCC061412]
+  - [1761, 1665, FCC061413]
+  - [1762, 1666, FCC061414]
+  - [1763, 1667, FCC061415]
+  - [1764, 1668, FCC061408]
+  - [1765, 1669, FCC061409]
+  - [1766, 1670, FCC061410]
+  - [1767, 1671, FCC061411]
+  - [1768, 1672, FCC061404]
+  - [1769, 1673, FCC061405]
+  - [1770, 1674, FCC061406]
+  - [1771, 1675, FCC061407]
+  - [1772, 1676, FCC061400]
+  - [1773, 1677, FCC061401]
+  - [1774, 1678, FCC061402]
+  - [1775, 1679, FCC061403]
+  - [1728, 1680, FCC061212]
+  - [1729, 1681, FCC061213]
+  - [1730, 1682, FCC061214]
+  - [1731, 1683, FCC061215]
+  - [1732, 1684, FCC061208]
+  - [1733, 1685, FCC061209]
+  - [1734, 1686, FCC061210]
+  - [1735, 1687, FCC061211]
+  - [1736, 1688, FCC061204]
+  - [1737, 1689, FCC061205]
+  - [1738, 1690, FCC061206]
+  - [1739, 1691, FCC061207]
+  - [1740, 1692, FCC061200]
+  - [1741, 1693, FCC061201]
+  - [1742, 1694, FCC061202]
+  - [1743, 1695, FCC061203]
+  - [1696, 1696, FCC061012]
+  - [1697, 1697, FCC061013]
+  - [1698, 1698, FCC061014]
+  - [1699, 1699, FCC061015]
+  - [1700, 1700, FCC061008]
+  - [1701, 1701, FCC061009]
+  - [1702, 1702, FCC061010]
+  - [1703, 1703, FCC061011]
+  - [1704, 1704, FCC061004]
+  - [1705, 1705, FCC061005]
+  - [1706, 1706, FCC061006]
+  - [1707, 1707, FCC061007]
+  - [1708, 1708, FCC061000]
+  - [1709, 1709, FCC061001]
+  - [1710, 1710, FCC061002]
+  - [1711, 1711, FCC061003]
+  - [1664, 1712, FCC060812]
+  - [1665, 1713, FCC060813]
+  - [1666, 1714, FCC060814]
+  - [1667, 1715, FCC060815]
+  - [1668, 1716, FCC060808]
+  - [1669, 1717, FCC060809]
+  - [1670, 1718, FCC060810]
+  - [1671, 1719, FCC060811]
+  - [1672, 1720, FCC060804]
+  - [1673, 1721, FCC060805]
+  - [1674, 1722, FCC060806]
+  - [1675, 1723, FCC060807]
+  - [1676, 1724, FCC060800]
+  - [1677, 1725, FCC060801]
+  - [1678, 1726, FCC060802]
+  - [1679, 1727, FCC060803]
+  - [2016, 1728, FCC071412]
+  - [2017, 1729, FCC071413]
+  - [2018, 1730, FCC071414]
+  - [2019, 1731, FCC071415]
+  - [2020, 1732, FCC071408]
+  - [2021, 1733, FCC071409]
+  - [2022, 1734, FCC071410]
+  - [2023, 1735, FCC071411]
+  - [2024, 1736, FCC071404]
+  - [2025, 1737, FCC071405]
+  - [2026, 1738, FCC071406]
+  - [2027, 1739, FCC071407]
+  - [2028, 1740, FCC071400]
+  - [2029, 1741, FCC071401]
+  - [2030, 1742, FCC071402]
+  - [2031, 1743, FCC071403]
+  - [1984, 1744, FCC071212]
+  - [1985, 1745, FCC071213]
+  - [1986, 1746, FCC071214]
+  - [1987, 1747, FCC071215]
+  - [1988, 1748, FCC071208]
+  - [1989, 1749, FCC071209]
+  - [1990, 1750, FCC071210]
+  - [1991, 1751, FCC071211]
+  - [1992, 1752, FCC071204]
+  - [1993, 1753, FCC071205]
+  - [1994, 1754, FCC071206]
+  - [1995, 1755, FCC071207]
+  - [1996, 1756, FCC071200]
+  - [1997, 1757, FCC071201]
+  - [1998, 1758, FCC071202]
+  - [1999, 1759, FCC071203]
+  - [1952, 1760, FCC071012]
+  - [1953, 1761, FCC071013]
+  - [1954, 1762, FCC071014]
+  - [1955, 1763, FCC071015]
+  - [1956, 1764, FCC071008]
+  - [1957, 1765, FCC071009]
+  - [1958, 1766, FCC071010]
+  - [1959, 1767, FCC071011]
+  - [1960, 1768, FCC071004]
+  - [1961, 1769, FCC071005]
+  - [1962, 1770, FCC071006]
+  - [1963, 1771, FCC071007]
+  - [1964, 1772, FCC071000]
+  - [1965, 1773, FCC071001]
+  - [1966, 1774, FCC071002]
+  - [1967, 1775, FCC071003]
+  - [1920, 1776, FCC070812]
+  - [1921, 1777, FCC070813]
+  - [1922, 1778, FCC070814]
+  - [1923, 1779, FCC070815]
+  - [1924, 1780, FCC070808]
+  - [1925, 1781, FCC070809]
+  - [1926, 1782, FCC070810]
+  - [1927, 1783, FCC070811]
+  - [1928, 1784, FCC070804]
+  - [1929, 1785, FCC070805]
+  - [1930, 1786, FCC070806]
+  - [1931, 1787, FCC070807]
+  - [1932, 1788, FCC070800]
+  - [1933, 1789, FCC070801]
+  - [1934, 1790, FCC070802]
+  - [1935, 1791, FCC070803]
+  - [1648, 1792, FCC060712]
+  - [1649, 1793, FCC060713]
+  - [1650, 1794, FCC060714]
+  - [1651, 1795, FCC060715]
+  - [1652, 1796, FCC060708]
+  - [1653, 1797, FCC060709]
+  - [1654, 1798, FCC060710]
+  - [1655, 1799, FCC060711]
+  - [1656, 1800, FCC060704]
+  - [1657, 1801, FCC060705]
+  - [1658, 1802, FCC060706]
+  - [1659, 1803, FCC060707]
+  - [1660, 1804, FCC060700]
+  - [1661, 1805, FCC060701]
+  - [1662, 1806, FCC060702]
+  - [1663, 1807, FCC060703]
+  - [1616, 1808, FCC060512]
+  - [1617, 1809, FCC060513]
+  - [1618, 1810, FCC060514]
+  - [1619, 1811, FCC060515]
+  - [1620, 1812, FCC060508]
+  - [1621, 1813, FCC060509]
+  - [1622, 1814, FCC060510]
+  - [1623, 1815, FCC060511]
+  - [1624, 1816, FCC060504]
+  - [1625, 1817, FCC060505]
+  - [1626, 1818, FCC060506]
+  - [1627, 1819, FCC060507]
+  - [1628, 1820, FCC060500]
+  - [1629, 1821, FCC060501]
+  - [1630, 1822, FCC060502]
+  - [1631, 1823, FCC060503]
+  - [1584, 1824, FCC060312]
+  - [1585, 1825, FCC060313]
+  - [1586, 1826, FCC060314]
+  - [1587, 1827, FCC060315]
+  - [1588, 1828, FCC060308]
+  - [1589, 1829, FCC060309]
+  - [1590, 1830, FCC060310]
+  - [1591, 1831, FCC060311]
+  - [1592, 1832, FCC060304]
+  - [1593, 1833, FCC060305]
+  - [1594, 1834, FCC060306]
+  - [1595, 1835, FCC060307]
+  - [1596, 1836, FCC060300]
+  - [1597, 1837, FCC060301]
+  - [1598, 1838, FCC060302]
+  - [1599, 1839, FCC060303]
+  - [1552, 1840, FCC060112]
+  - [1553, 1841, FCC060113]
+  - [1554, 1842, FCC060114]
+  - [1555, 1843, FCC060115]
+  - [1556, 1844, FCC060108]
+  - [1557, 1845, FCC060109]
+  - [1558, 1846, FCC060110]
+  - [1559, 1847, FCC060111]
+  - [1560, 1848, FCC060104]
+  - [1561, 1849, FCC060105]
+  - [1562, 1850, FCC060106]
+  - [1563, 1851, FCC060107]
+  - [1564, 1852, FCC060100]
+  - [1565, 1853, FCC060101]
+  - [1566, 1854, FCC060102]
+  - [1567, 1855, FCC060103]
+  - [1904, 1856, FCC070712]
+  - [1905, 1857, FCC070713]
+  - [1906, 1858, FCC070714]
+  - [1907, 1859, FCC070715]
+  - [1908, 1860, FCC070708]
+  - [1909, 1861, FCC070709]
+  - [1910, 1862, FCC070710]
+  - [1911, 1863, FCC070711]
+  - [1912, 1864, FCC070704]
+  - [1913, 1865, FCC070705]
+  - [1914, 1866, FCC070706]
+  - [1915, 1867, FCC070707]
+  - [1916, 1868, FCC070700]
+  - [1917, 1869, FCC070701]
+  - [1918, 1870, FCC070702]
+  - [1919, 1871, FCC070703]
+  - [1872, 1872, FCC070512]
+  - [1873, 1873, FCC070513]
+  - [1874, 1874, FCC070514]
+  - [1875, 1875, FCC070515]
+  - [1876, 1876, FCC070508]
+  - [1877, 1877, FCC070509]
+  - [1878, 1878, FCC070510]
+  - [1879, 1879, FCC070511]
+  - [1880, 1880, FCC070504]
+  - [1881, 1881, FCC070505]
+  - [1882, 1882, FCC070506]
+  - [1883, 1883, FCC070507]
+  - [1884, 1884, FCC070500]
+  - [1885, 1885, FCC070501]
+  - [1886, 1886, FCC070502]
+  - [1887, 1887, FCC070503]
+  - [1840, 1888, FCC070312]
+  - [1841, 1889, FCC070313]
+  - [1842, 1890, FCC070314]
+  - [1843, 1891, FCC070315]
+  - [1844, 1892, FCC070308]
+  - [1845, 1893, FCC070309]
+  - [1846, 1894, FCC070310]
+  - [1847, 1895, FCC070311]
+  - [1848, 1896, FCC070304]
+  - [1849, 1897, FCC070305]
+  - [1850, 1898, FCC070306]
+  - [1851, 1899, FCC070307]
+  - [1852, 1900, FCC070300]
+  - [1853, 1901, FCC070301]
+  - [1854, 1902, FCC070302]
+  - [1855, 1903, FCC070303]
+  - [1808, 1904, FCC070112]
+  - [1809, 1905, FCC070113]
+  - [1810, 1906, FCC070114]
+  - [1811, 1907, FCC070115]
+  - [1812, 1908, FCC070108]
+  - [1813, 1909, FCC070109]
+  - [1815, 1910, FCC070111]
+  - [1814, 1911, FCC070110]
+  - [1816, 1912, FCC070104]
+  - [1817, 1913, FCC070105]
+  - [1818, 1914, FCC070106]
+  - [1819, 1915, FCC070107]
+  - [1820, 1916, FCC070100]
+  - [1821, 1917, FCC070101]
+  - [1822, 1918, FCC070102]
+  - [1823, 1919, FCC070103]
+  - [1776, 1920, FCC061512]
+  - [1777, 1921, FCC061513]
+  - [1778, 1922, FCC061514]
+  - [1779, 1923, FCC061515]
+  - [1780, 1924, FCC061508]
+  - [1781, 1925, FCC061509]
+  - [1782, 1926, FCC061510]
+  - [1783, 1927, FCC061511]
+  - [1784, 1928, FCC061504]
+  - [1785, 1929, FCC061505]
+  - [1786, 1930, FCC061506]
+  - [1787, 1931, FCC061507]
+  - [1788, 1932, FCC061500]
+  - [1789, 1933, FCC061501]
+  - [1790, 1934, FCC061502]
+  - [1791, 1935, FCC061503]
+  - [1744, 1936, FCC061312]
+  - [1745, 1937, FCC061313]
+  - [1746, 1938, FCC061314]
+  - [1747, 1939, FCC061315]
+  - [1748, 1940, FCC061308]
+  - [1749, 1941, FCC061309]
+  - [1750, 1942, FCC061310]
+  - [1751, 1943, FCC061311]
+  - [1752, 1944, FCC061304]
+  - [1753, 1945, FCC061305]
+  - [1754, 1946, FCC061306]
+  - [1755, 1947, FCC061307]
+  - [1756, 1948, FCC061300]
+  - [1757, 1949, FCC061301]
+  - [1759, 1950, FCC061303]
+  - [1758, 1951, FCC061302]
+  - [1712, 1952, FCC061112]
+  - [1713, 1953, FCC061113]
+  - [1714, 1954, FCC061114]
+  - [1715, 1955, FCC061115]
+  - [1716, 1956, FCC061108]
+  - [1717, 1957, FCC061109]
+  - [1718, 1958, FCC061110]
+  - [1719, 1959, FCC061111]
+  - [1720, 1960, FCC061104]
+  - [1721, 1961, FCC061105]
+  - [1722, 1962, FCC061106]
+  - [1723, 1963, FCC061107]
+  - [1724, 1964, FCC061100]
+  - [1725, 1965, FCC061101]
+  - [1726, 1966, FCC061102]
+  - [1727, 1967, FCC061103]
+  - [1680, 1968, FCC060912]
+  - [1681, 1969, FCC060913]
+  - [1682, 1970, FCC060914]
+  - [1683, 1971, FCC060915]
+  - [1684, 1972, FCC060908]
+  - [1685, 1973, FCC060909]
+  - [1686, 1974, FCC060910]
+  - [1687, 1975, FCC060911]
+  - [1688, 1976, FCC060904]
+  - [1689, 1977, FCC060905]
+  - [1690, 1978, FCC060906]
+  - [1691, 1979, FCC060907]
+  - [1692, 1980, FCC060900]
+  - [1693, 1981, FCC060901]
+  - [1694, 1982, FCC060902]
+  - [1695, 1983, FCC060903]
+  - [2032, 1984, FCC071512]
+  - [2033, 1985, FCC071513]
+  - [2034, 1986, FCC071514]
+  - [2035, 1987, FCC071515]
+  - [2036, 1988, FCC071508]
+  - [2037, 1989, FCC071509]
+  - [2038, 1990, FCC071510]
+  - [2039, 1991, FCC071511]
+  - [2040, 1992, FCC071504]
+  - [2041, 1993, FCC071505]
+  - [2042, 1994, FCC071506]
+  - [2043, 1995, FCC071507]
+  - [2044, 1996, FCC071500]
+  - [2045, 1997, FCC071501]
+  - [2046, 1998, FCC071502]
+  - [2047, 1999, FCC071503]
+  - [2000, 2000, FCC071312]
+  - [2001, 2001, FCC071313]
+  - [2002, 2002, FCC071314]
+  - [2003, 2003, FCC071315]
+  - [2004, 2004, FCC071308]
+  - [2005, 2005, FCC071309]
+  - [2006, 2006, FCC071310]
+  - [2007, 2007, FCC071311]
+  - [2008, 2008, FCC071304]
+  - [2009, 2009, FCC071305]
+  - [2010, 2010, FCC071306]
+  - [2011, 2011, FCC071307]
+  - [2012, 2012, FCC071300]
+  - [2013, 2013, FCC071301]
+  - [2014, 2014, FCC071302]
+  - [2015, 2015, FCC071303]
+  - [1968, 2016, FCC071112]
+  - [1969, 2017, FCC071113]
+  - [1970, 2018, FCC071114]
+  - [1971, 2019, FCC071115]
+  - [1972, 2020, FCC071108]
+  - [1973, 2021, FCC071109]
+  - [1974, 2022, FCC071110]
+  - [1975, 2023, FCC071111]
+  - [1976, 2024, FCC071104]
+  - [1977, 2025, FCC071105]
+  - [1978, 2026, FCC071106]
+  - [1979, 2027, FCC071107]
+  - [1980, 2028, FCC071100]
+  - [1981, 2029, FCC071101]
+  - [1982, 2030, FCC071102]
+  - [1983, 2031, FCC071103]
+  - [1936, 2032, FCC070912]
+  - [1937, 2033, FCC070913]
+  - [1938, 2034, FCC070914]
+  - [1939, 2035, FCC070915]
+  - [1940, 2036, FCC070908]
+  - [1941, 2037, FCC070909]
+  - [1942, 2038, FCC070910]
+  - [1943, 2039, FCC070911]
+  - [1944, 2040, FCC070904]
+  - [1945, 2041, FCC070905]
+  - [1946, 2042, FCC070906]
+  - [1947, 2043, FCC070907]
+  - [1948, 2044, FCC070900]
+  - [1949, 2045, FCC070901]
+  - [1950, 2046, FCC070902]
+  - [1951, 2047, FCC070903]

--- a/lib/stages/CMakeLists.txt
+++ b/lib/stages/CMakeLists.txt
@@ -103,6 +103,7 @@ add_library(
     N2TimeDownsample.cpp
     N2FringeStop.cpp
     dropAllFrames.cpp
+    N2FrameToVisFrame.cpp
     # Julia
     $<$<BOOL:${Julia_FOUND}>:juliaHelloWorld.cpp>)
 

--- a/lib/stages/N2FrameToVisFrame.cpp
+++ b/lib/stages/N2FrameToVisFrame.cpp
@@ -1,0 +1,219 @@
+#include "N2FrameToVisFrame.hpp"
+
+#include "Config.hpp" // for Config
+#include "N2FrameView.hpp"
+#include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
+#include "buffer.hpp"          // for Buffer
+#include "bufferContainer.hpp" // for bufferContainer
+#include "datasetState.hpp"
+#include "gateSpec.hpp"
+#include "visBuffer.hpp"
+#include "visUtil.hpp"
+
+#include <cassert> // for assert
+#include <complex>
+
+using kotekan::bufferContainer;
+using kotekan::Config;
+using kotekan::Stage;
+
+REGISTER_KOTEKAN_STAGE(n2FrameToVisFrame);
+
+n2FrameToVisFrame::n2FrameToVisFrame(Config& config, const std::string& unique_name,
+                                     bufferContainer& buffer_container) :
+    Stage(config, unique_name, buffer_container, std::bind(&n2FrameToVisFrame::main_thread, this)),
+    dm(datasetManager::instance()) {
+
+    n2_buf = get_buffer("n2_buf");
+    n2_buf->register_consumer(unique_name);
+
+    vis_buf = get_buffer("vis_buf");
+    vis_buf->register_producer(unique_name);
+
+    // TODO: add any sanity checks required
+    if (n2_buf->frame_size != vis_buf->frame_size) {
+        FATAL_ERROR(
+            "Frame sizes between N2FrameView and VisFrameView must be identical, but got {} and {}",
+            n2_buf->frame_size, vis_buf->frame_size);
+    }
+
+    // Get everything we need for registering dataset states
+
+    const auto& tel = Telescope::instance();
+
+    // --> get metadata
+    std::string instrument_name =
+        config.get_default<std::string>(unique_name, "instrument_name", "chime");
+
+    // Get the frequency IDs that are on this stream, check the config or just
+    // assume all CHIME channels
+    std::vector<uint32_t> freq_ids;
+    if (config.exists(unique_name, "freq_ids")) {
+        freq_ids = config.get<std::vector<uint32_t>>(unique_name, "freq_ids");
+    } else {
+        freq_ids.resize(tel.num_freq());
+        std::iota(std::begin(freq_ids), std::end(freq_ids), 0);
+    }
+
+    // Create the frequency specification
+    std::vector<std::pair<uint32_t, freq_ctype>> freqs;
+    std::transform(std::begin(freq_ids), std::end(freq_ids), std::back_inserter(freqs),
+                   [&tel](uint32_t id) -> std::pair<uint32_t, freq_ctype> {
+                       return {id, {tel.to_freq_MHz(id), tel.freq_width_MHz(id)}};
+                   });
+
+    // The input specification from the config
+    const auto& input_reorder = parse_reorder_default(config, unique_name);
+    std::vector<input_ctype> inputs = std::get<1>(input_reorder);
+
+    size_t num_elements = inputs.size();
+
+    // Create the product specification
+    std::vector<prod_ctype> prods;
+    prods.reserve(num_elements * (num_elements + 1) / 2);
+    for (uint16_t i = 0; i < num_elements; i++) {
+        for (uint16_t j = i; j < num_elements; j++) {
+            prods.push_back({i, j});
+        }
+    }
+
+    // register base dataset states to prepare for getting dataset IDs for out frames
+    register_base_dataset_states(instrument_name, freqs, inputs, prods);
+}
+
+n2FrameToVisFrame::~n2FrameToVisFrame() {}
+
+void n2FrameToVisFrame::main_thread() {
+
+    // base dataset_id of visAcummulate (before gating)
+    dset_id_t base_dataset_id;
+    // added state of eigenVis
+    state_id_t evState_id;
+    // incoming dataset_id
+    dset_id_t ds_id_n2;
+    // outgoing dataset_id (could be visibility or eigenvalues)
+    dset_id_t ds_id_vis;
+
+    // sanity checks
+    uint32_t num_ev_first_time;
+
+    frameID n2_buf_frame_id(n2_buf);
+    frameID vis_buf_frame_id(vis_buf);
+    bool first_time = true;
+    while (!stop_thread) {
+
+        if (n2_buf->wait_for_full_frame(unique_name, n2_buf_frame_id) == nullptr)
+            return;
+        const N2FrameView n2_frame(n2_buf, n2_buf_frame_id);
+
+        if (vis_buf->wait_for_empty_frame(unique_name, vis_buf_frame_id) == nullptr)
+            return;
+        auto vis_frame = VisFrameView::create_frame_view(
+            vis_buf, vis_buf_frame_id, n2_frame.num_elements, n2_frame.num_prod, n2_frame.num_ev);
+
+        // items set in VisFrameView::fill_metadata
+        vis_frame.freq_id = n2_frame.freq_id;
+        const uint64_t fpga_seq = n2_frame.fpga_start_tick;
+        const timespec ts = {.tv_sec = time_t(n2_frame.frame_start_time_ns / 1'000'000'000),
+                             .tv_nsec = time_t(n2_frame.frame_start_time_ns % 1'000'000'000)};
+        vis_frame.time = std::tuple(fpga_seq, ts);
+
+        // items set in visAccumulate::initialise_output
+
+        // dataset_id
+        dset_id_t ds_id_n2_new = n2_frame.dataset_id;
+        // in CHIME's visAccumulate the dataset id also changes due to state
+        // changes via the REST endpoint for gated datasets. Since there is no
+        // gating yet in N2Accumulate we do not worry about this here.
+        if (first_time || (ds_id_n2_new != ds_id_n2)) {
+            ds_id_n2 = ds_id_n2_new;
+
+            // Register base dataset. If no dataset ID was was set in the incoming frame,
+            // ds_id_in will be dset_id_t::null and thus cause a root dataset to
+            // be registered.
+            base_dataset_id = dm.add_dataset(base_dataset_states, ds_id_n2);
+            DEBUG("Registered base dataset: {}", base_dataset_id);
+
+            // no gating supported by N2Accumulate, only main visibility
+            // from visAccumulate's maint_thread and register_gate_dataset
+            const auto visSpec =
+                gateSpec::create("uniform", "vis", kotekan::logLevel(_member_log_level));
+            const state_id_t visState_id = dm.create_state<gatingState>(*visSpec).first;
+            ds_id_vis = dm.add_dataset(visState_id, base_dataset_id);
+
+            // eigenVis creates a new state by adding the number of eigenVectors
+            if (vis_frame.num_ev > 0) {
+                if (first_time) {
+                    evState_id = dm.create_state<eigenvalueState>(vis_frame.num_ev).first;
+                    num_ev_first_time = vis_frame.num_ev;
+                } else {
+                    (void)num_ev_first_time, /* pacify unused warning */
+                        assert(vis_frame.num_ev == num_ev_first_time
+                               && "Number of eigenvectors changed unexpectedly.");
+                }
+                ds_id_vis = dm.add_dataset(evState_id, ds_id_vis);
+            }
+
+            first_time = false;
+        }
+        vis_frame.dataset_id = ds_id_vis;
+
+        vis_frame.fpga_seq_length = n2_frame.frame_length_fpga_ticks;
+
+        // items set in visAccumulate::main_thread
+        vis_frame.fpga_seq_total = n2_frame.n_valid_fpga_ticks;
+        vis_frame.rfi_total = n2_frame.n_rfi_fpga_ticks;
+
+        // CHIME and n2k use different conventions for the visiblity matrix,
+        // with CHIME using the unusual choice V_ij = < x_i*(nu) x_j(nu) >
+        // (CHIME_signs_conventions_note.pdf, Eq. (2)) with n2 using the
+        // conventional V_ij = < x_i(nu) x*_j(nu) >.
+        assert(n2_frame.vis.size() == vis_frame.vis.size());
+        for (auto it_n2 = n2_frame.vis.begin(), it_vis = vis_frame.vis.begin();
+             it_n2 != n2_frame.vis.end(); ++it_n2, ++it_vis)
+            *it_vis = std::conj(*it_n2);
+
+        assert(n2_frame.weight.size() == vis_frame.weight.size());
+        for (auto it_n2 = n2_frame.weight.begin(), it_vis = vis_frame.weight.begin();
+             it_n2 != n2_frame.weight.end(); ++it_n2, ++it_vis)
+            *it_vis = *it_n2;
+
+        assert(n2_frame.flags.size() == vis_frame.flags.size());
+        for (auto it_n2 = n2_frame.flags.begin(), it_vis = vis_frame.flags.begin();
+             it_n2 != n2_frame.flags.end(); ++it_n2, ++it_vis)
+            *it_vis = *it_n2;
+
+        assert(n2_frame.eval.size() == vis_frame.eval.size());
+        for (auto it_n2 = n2_frame.eval.begin(), it_vis = vis_frame.eval.begin();
+             it_n2 != n2_frame.eval.end(); ++it_n2, ++it_vis)
+            *it_vis = *it_n2;
+
+        vis_frame.erms = n2_frame.erms;
+
+        assert(n2_frame.gain.size() == vis_frame.gain.size());
+        for (auto it_n2 = n2_frame.gain.begin(), it_vis = vis_frame.gain.begin();
+             it_n2 != n2_frame.gain.end(); ++it_n2, ++it_vis)
+            *it_vis = std::conj(*it_n2);
+
+        vis_buf->mark_frame_full(unique_name, vis_buf_frame_id++);
+        n2_buf->mark_frame_empty(unique_name, n2_buf_frame_id++);
+    }
+}
+
+// from visAccumulate
+void n2FrameToVisFrame::register_base_dataset_states(
+    std::string& instrument_name, std::vector<std::pair<uint32_t, freq_ctype>>& freqs,
+    std::vector<input_ctype>& inputs, std::vector<prod_ctype>& prods) {
+    // weight calculation is hardcoded, so is the weight type name
+    // TODO: check if this is still true
+    const std::string weight_type = "inverse_var";
+    const std::string git_tag = get_git_commit_hash();
+
+    // create all the states
+    base_dataset_states.push_back(dm.create_state<freqState>(freqs).first);
+    base_dataset_states.push_back(dm.create_state<inputState>(inputs).first);
+    base_dataset_states.push_back(dm.create_state<prodState>(prods).first);
+    base_dataset_states.push_back(dm.create_state<eigenvalueState>(0).first);
+    base_dataset_states.push_back(
+        dm.create_state<metadataState>(weight_type, instrument_name, git_tag).first);
+}

--- a/lib/stages/N2FrameToVisFrame.hpp
+++ b/lib/stages/N2FrameToVisFrame.hpp
@@ -1,0 +1,66 @@
+#ifndef N2FRAME_TO_VISFRAME_HPP
+#define N2FRAME_TO_VISFRAME_HPP
+
+#include "Config.hpp"          // for Config
+#include "Stage.hpp"           // for Stage
+#include "buffer.hpp"          // for Buffer
+#include "bufferContainer.hpp" // for bufferContainer
+#include "datasetManager.hpp"
+#include "version.h"
+#include "visUtil.hpp"
+
+#include <stdint.h> // for int32_t, uint32_t, uint8_t
+#include <string>   // for string
+#include <vector>   // for vector
+
+/**
+ * @brief Translates a N2FrameView buffer to a VisFrameView buffer by complex
+ * conjugating the visibility matrix and quantities derived from the
+ * eigenvectors as needed. Also adds dataset ids as if the VisFrameView had been
+ * passed along CHIME's hfa pipeline instead.
+ *
+ * @par Buffers
+ * @buffer n2_buf The accumulated and tagged data.
+ *         @buffer_format VisBuffer structured.
+ *         @buffer_metadata N2Metadata
+ * @buffer vis_buf Output buffer.
+ *         @buffer_format VisBuffer structured.
+ *         @buffer_metadata VisMetadata
+ *
+ * @conf  n2_buf  Buffers to hold the N2FrameView
+ * @conf  vis_buf Buffers to hold the VisFrameView
+ *
+ * @author Roland Haas
+ */
+class n2FrameToVisFrame : public kotekan::Stage {
+public:
+    /// Standard constructor
+    n2FrameToVisFrame(kotekan::Config& config, const std::string& unique_name,
+                      kotekan::bufferContainer& buffer_container);
+
+    /// Destructor
+    ~n2FrameToVisFrame();
+
+    /// Main thead which zeros the data from the lost_samples_buf
+    void main_thread() override;
+
+private:
+    void register_base_dataset_states(std::string& instrument_name,
+                                      std::vector<std::pair<uint32_t, freq_ctype>>& freqs,
+                                      std::vector<input_ctype>& inputs,
+                                      std::vector<prod_ctype>& prods);
+
+private:
+    datasetManager& dm;
+
+    // the base states (input, prod, freq, meta)
+    std::vector<state_id_t> base_dataset_states;
+
+    /// The buffer with the output of N2Accumulate
+    Buffer* n2_buf;
+
+    /// The target buffer for a visFrame
+    Buffer* vis_buf;
+};
+
+#endif /* N2FRAME_TO_VISFRAME_HPP */


### PR DESCRIPTION
This introduces a converter stage from N2FrameView to CHIME's VisFrameView expected by the science receivers. Adds a trial set of input files (quite kludgy right now since they borrow from the fengine tests).