### PR TITLE
add stage to parse input reorder table for chime_xpos2048

### DIFF
--- a/lib/stages/CMakeLists.txt
+++ b/lib/stages/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(
     integratePowerStream.cpp
     monitorBuffer.cpp
     networkInputPowerStream.cpp
+    parseReorderDefault.cpp
     pyPlotN2.cpp
     rawFileRead.cpp
     rawFileWrite.cpp

--- a/lib/stages/parseReorderDefault.cpp
+++ b/lib/stages/parseReorderDefault.cpp
@@ -26,13 +26,19 @@ parseReorderDefault::parseReorderDefault(Config& config, const std::string& uniq
           std::bind(&parseReorderDefault::main_thread, this)),
     _out_buf(get_buffer("out_buf")), _name(config.get<std::string>(unique_name, "name")),
     _input_reorder(std::get<0>(parse_reorder_default(config, unique_name))),
-    _invert_mapping(config.get_default<bool>(unique_name, "invert_mapping", true)) {
-
+    _invert_mapping(config.get_default<bool>(unique_name, "invert_mapping", true)),
+    _num_polarizations(config.get<int>(unique_name, "num_polarizations")),
+    _num_dishes(config.get<int>(unique_name, "num_dishes")) {
     _out_buf->register_producer(unique_name);
 
     if (_out_buf->frame_size != _input_reorder.size() * sizeof(_input_reorder[0])) {
         throw std::invalid_argument("parseReorderDefault: incorrect frame size");
     }
+
+    // TODO: this is not quite correct. Really if going to cylinder order
+    // the array is {4,2,256} {"C", "P", "D"}
+    _out_buf->allocate_ndarray_frame_desc(kotekan::int32, _name, {_num_polarizations, _num_dishes},
+                                          {"P", "D"});
 }
 
 
@@ -72,9 +78,6 @@ void parseReorderDefault::main_thread() {
 
         chordmeta->set_frame_counter(0); // these do not actually change with time
 
-        // TODO: this is not quite correct. Really if going to cylinder order
-        // the array is {4,2,256} {"C", "P", "D"}
-        _out_buf->allocate_ndarray_frame_desc(kotekan::int32, _name, {2, 1024}, {"P", "D"});
         chordmeta->set_from_frame_desc(_out_buf->get_ndarray_frame_desc());
         chordmeta->check_frame_desc(_out_buf->get_ndarray_frame_desc());
 

--- a/lib/stages/parseReorderDefault.cpp
+++ b/lib/stages/parseReorderDefault.cpp
@@ -1,0 +1,87 @@
+#include "parseReorderDefault.hpp"
+
+#include "DataType.hpp"        // for DataType, KOTEKAN_FLOAT16, float16_t
+#include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
+#include "bufferContainer.hpp" // for bufferContainer
+#include "chordMetadata.hpp"   // for chordMetadata, get_chord_metadata, CHORD_META_MAX_FREQ
+#include "kotekanLogging.hpp"  // for INFO, DEBUG, ERROR
+
+#include <assert.h>  // for assert
+#include <stdint.h>  // for int8_t, uint32_t, uint8_t, int16_t, int32_t, uint64_t
+#include <string>    // for std::string
+#include <strings.h> // for bzero
+#include <unistd.h>  // for sleep
+#include <vector>    // for vector
+
+
+using kotekan::bufferContainer;
+using kotekan::Config;
+using kotekan::Stage;
+
+REGISTER_KOTEKAN_STAGE(parseReorderDefault);
+
+parseReorderDefault::parseReorderDefault(Config& config, const std::string& unique_name,
+                                         bufferContainer& buffer_container) :
+    Stage(config, unique_name, buffer_container,
+          std::bind(&parseReorderDefault::main_thread, this)),
+    _out_buf(get_buffer("out_buf")), _name(config.get<std::string>(unique_name, "name")),
+    _input_reorder(std::get<0>(parse_reorder_default(config, unique_name))),
+    _invert_mapping(config.get_default<bool>(unique_name, "invert_mapping", true)) {
+
+    _out_buf->register_producer(unique_name);
+
+    if (_out_buf->frame_size != _input_reorder.size() * sizeof(_input_reorder[0])) {
+        throw std::invalid_argument("parseReorderDefault: incorrect frame size");
+    }
+}
+
+
+void parseReorderDefault::main_thread() {
+    int abs_frame_id = 0;
+
+    bool first_time = true;
+    while (!stop_thread) {
+
+        if (first_time && abs_frame_id > 0) {
+            sleep(1);
+            continue;
+        }
+
+        const int frame_id = abs_frame_id % _out_buf->num_frames;
+        int32_t* const frame =
+            reinterpret_cast<int32_t*>(_out_buf->wait_for_empty_frame(unique_name, frame_id));
+        if (frame == nullptr)
+            break;
+
+        for (size_t i = 0; i < _input_reorder.size(); ++i) {
+            if (_invert_mapping) {
+                // the (ptrdiff_t) cast is just there to pacify a warning about
+                // comparing unsigned >= 0 being always true. The assert is to
+                // future proof this in case anyone ever changes the type of
+                // _input_reorder to be signed.
+                assert((ptrdiff_t)_input_reorder.at(i) >= 0
+                       && _input_reorder.at(i) < _input_reorder.size());
+                frame[_input_reorder.at(i)] = static_cast<int32_t>(i);
+            } else {
+                frame[i] = _input_reorder.at(i);
+            }
+        }
+
+        _out_buf->allocate_new_metadata_object(frame_id);
+        std::shared_ptr<chordMetadata> chordmeta = get_chord_metadata(_out_buf, frame_id);
+
+        chordmeta->set_frame_counter(0); // these do not actually change with time
+
+        // TODO: this is not quite correct. Really if going to cylinder order
+        // the array is {4,2,256} {"C", "P", "D"}
+        _out_buf->allocate_ndarray_frame_desc(kotekan::int32, _name, {2, 1024}, {"P", "D"});
+        chordmeta->set_from_frame_desc(_out_buf->get_ndarray_frame_desc());
+        chordmeta->check_frame_desc(_out_buf->get_ndarray_frame_desc());
+
+        _out_buf->mark_frame_full(unique_name, frame_id);
+
+        abs_frame_id += 1;
+
+        first_time = false;
+    }
+}

--- a/lib/stages/parseReorderDefault.hpp
+++ b/lib/stages/parseReorderDefault.hpp
@@ -23,6 +23,10 @@
  * @conf  invert_mapping        Bool. Default: true. Invert the input reorder
  *                              table, that is store the target indices instead
  *                              of the source indices consecutively.
+ * @conf  num_polarizations     Int. Number of polarizations. Used only to
+ *                              compute number of elements.
+ * @conf  num_dishes            Int. Number of dishes in telescope. Used only to
+ *                              compute number of elements.
  *
  * @author Roland Haas
  */
@@ -38,6 +42,8 @@ private:
     const std::string _name;
     const std::vector<uint32_t> _input_reorder;
     const bool _invert_mapping;
+    const int _num_polarizations;
+    const int _num_dishes;
 };
 
 #endif

--- a/lib/stages/parseReorderDefault.hpp
+++ b/lib/stages/parseReorderDefault.hpp
@@ -1,0 +1,43 @@
+#ifndef GIVEN_DATA_GEN_H
+#define GIVEN_DATA_GEN_H
+
+#include "Config.hpp"  // for Config
+#include "Stage.hpp"   // for Stage
+#include "buffer.hpp"  // for Buffer
+#include "visUtil.hpp" // for input_ctype
+
+#include <stdint.h> // for uint32_t
+#include <string>   // for string
+#include <vector>   // for vector
+
+/**
+ * @class parseReorderDefault
+ * @brief Parse the reordering configuration section
+ *
+ * @par Buffers
+ * @buffer out_buf Buffer to with reorder table column
+ *         @buffer_metadata chordMetadata
+ *
+ * @conf  name                  String. Name of the quantity being set.
+ * @conf  input_reorder         Table. The input reorder table to parse.
+ * @conf  invert_mapping        Bool. Default: true. Invert the input reorder
+ *                              table, that is store the target indices instead
+ *                              of the source indices consecutively.
+ *
+ * @author Roland Haas
+ */
+class parseReorderDefault : public kotekan::Stage {
+public:
+    parseReorderDefault(kotekan::Config& config, const std::string& unique_name,
+                        kotekan::bufferContainer& buffer_container);
+    ~parseReorderDefault() = default;
+    void main_thread() override;
+
+private:
+    Buffer* const _out_buf;
+    const std::string _name;
+    const std::vector<uint32_t> _input_reorder;
+    const bool _invert_mapping;
+};
+
+#endif

--- a/tests/test_parseReorderDefault.py
+++ b/tests/test_parseReorderDefault.py
@@ -1,0 +1,93 @@
+import pytest
+import numpy as np
+import numpy.random as random
+import h5py
+
+from kotekan import runner
+
+if not runner.has_hdf5():
+    pytest.fail("HDF5 support not available; unable to run tests!")
+
+parseReorderDefault_params = {
+    "out_buf": "reorder_buffer",
+    "name": "scatter_indices",
+}
+
+global_params = {
+    "type": "config",
+    "log_level": "INFO",
+    "cpu_affinity": [0, 1],
+    "num_elements": 2048,
+    # KotekanStageTester adds a "main_pool" section
+    # Buffers
+    "reorder_buffer": {
+        "kotekan_buffer": "standard",
+        "num_frames": 1,
+        "frame_size": 2048 * 4,
+        "metadata_pool": "main_pool",
+    },
+    # dump to disk to inspect manually
+    "write_reorder_buffer": {
+        "kotekan_stage": "hdf5FileWrite",
+        "base_dir": None,  # set by Python code
+        "prefix_hostname": False,
+        "max_frames": "1",
+        "file_name": "reorder_buffer",
+        "in_buf": "reorder_buffer",
+    },
+    "input_reorder": None,  # set by Python code
+}
+
+
+@pytest.fixture(scope="module")
+def scatter_indices(tmpdir_factory):
+
+    tmpdir = tmpdir_factory.mktemp("parseReorderDefault")
+
+    global_params["write_reorder_buffer"]["base_dir"] = str(tmpdir)
+    # file name of produced file
+    fname = (
+        global_params["write_reorder_buffer"]["base_dir"]
+        + "/"
+        + global_params["write_reorder_buffer"]["file_name"]
+        + ".00000000.h5"
+    )
+
+    # make up some dummy data
+    seed = 17
+    rnd = random.Generator(random.PCG64(seed))
+
+    station_ids = list(range(global_params["num_elements"]))
+    adc_ids = [int(id) for id in rnd.permuted(station_ids)]
+    feed_labels = ["FCC%06d" % id for id in rnd.permuted(station_ids)]
+
+    input_reorder = list(zip(adc_ids, station_ids, feed_labels))
+    global_params["input_reorder"] = input_reorder
+
+    test = runner.KotekanStageTester(
+        "parseReorderDefault", parseReorderDefault_params, None, None, global_params
+    )
+    test.run()
+
+    yield h5py.File(fname, "r")["reorder_buffer"], adc_ids
+
+
+def test_scatter_indices(scatter_indices):
+
+    reorder_buffer, adc_ids = scatter_indices
+
+    # metadata and array description
+    assert reorder_buffer.attrs["name"] == "scatter_indices"
+    assert np.all(reorder_buffer.shape == (2, 1024))
+    assert np.all(reorder_buffer.attrs["dim_names"] == ("P", "D"))
+    assert reorder_buffer.attrs["type"] == "int32"
+    assert reorder_buffer.dtype == np.int32
+
+    # payload
+    inverse_mapping = np.empty_like(reorder_buffer)
+    inverse_mapping[:] = -1
+    for el in range(2048):
+        adc_id = adc_ids[el]
+        inverse_mapping[adc_id // 1024][adc_id % 1024] = el
+    assert np.all(inverse_mapping != -1)
+    assert np.all(inverse_mapping == reorder_buffer)

--- a/tests/test_parseReorderDefault.py
+++ b/tests/test_parseReorderDefault.py
@@ -18,6 +18,8 @@ global_params = {
     "log_level": "INFO",
     "cpu_affinity": [0, 1],
     "num_elements": 2048,
+    "num_dishes": 1024,
+    "num_polarizations": 2,
     # KotekanStageTester adds a "main_pool" section
     # Buffers
     "reorder_buffer": {


### PR DESCRIPTION
This parses the yaml file member that is also used by (say) the FRB baseband archiver, so that there is a single source of truth for this. 