### PR TITLE
misc fixes and updates

### DIFF
--- a/config/chime_upgrade_n2.j2
+++ b/config/chime_upgrade_n2.j2
@@ -741,9 +741,22 @@ eig_10s_buffer:
     num_frames: gpu_buffer_depth * num_freq_gpu_buf
     metadata_pool: n2_pool
 
+failed_10s_buffer:
+    kotekan_buffer: N2
+    num_ev: 0
+    n2_layout: "FullUpperTri"
+    num_frames: gpu_buffer_depth * num_freq_gpu_buf
+    metadata_pool: n2_pool
+
 vis_buffer:
     kotekan_buffer: vis
     num_ev: num_ev_to_calculate
+    num_frames: gpu_buffer_depth * num_freq_gpu_buf
+    metadata_pool: vis_pool
+
+failed_vis_buffer:
+    kotekan_buffer: vis
+    num_ev: 0
     num_frames: gpu_buffer_depth * num_freq_gpu_buf
     metadata_pool: vis_pool
 
@@ -796,6 +809,7 @@ eigencalc:
     num_ev: num_ev_to_calculate
     in_buf: vis_10s_buffer
     out_buf: eig_10s_buffer
+    failed_buf: failed_10s_buffer
     # Convergence config from chime science run
     tol_eval: 0.00001
     tol_evec: 0.0001
@@ -808,6 +822,11 @@ vis_convert:
     kotekan_stage: n2FrameToVisFrame
     n2_buf: eig_10s_buffer
     vis_buf: vis_buffer
+
+failed_vis_convert:
+    kotekan_stage: n2FrameToVisFrame
+    n2_buf: failed_10s_buffer
+    vis_buf: failed_vis_buffer
 
 ################################################################################
 # output to receivers
@@ -841,6 +860,12 @@ write_vis:
     root_path: vis_data
     file_type: raw
     in_buf: vis_buffer
+
+write_failed_vis:
+    kotekan_stage: VisWriter
+    root_path: failed_eig
+    file_type: raw
+    in_buf: failed_vis_buffer
 
 # Information for input reordering, packed as
 #   (adc_id, chan_id, correlator_input)

--- a/config/chime_upgrade_n2.j2
+++ b/config/chime_upgrade_n2.j2
@@ -274,6 +274,8 @@ host_pl_expanded_mask_ringbuffer:
 # glue code to handle lost frames formats
 lostSamplesToPLMask:
     kotekan_stage: lostSamplesToPLMask
+    # num_dishes: num_dishes # set via a global
+    # num_polarizations: num_polarizations # set via a global
     pl_mask_buf: host_pl_mask_buffer
     lost_samples_buffers:
 {%- for id in range(num_freq_gpu_buf // 4) %}

--- a/config/ci-tests/cpu_batch/test_lostSamplesToPLMask.yaml
+++ b/config/ci-tests/cpu_batch/test_lostSamplesToPLMask.yaml
@@ -48,6 +48,8 @@ pl_mask_buffers:
 gen_test_data:
     log_level: WARN
     kotekan_stage: testLostSamplesToPLMask
+    # num_dishes: num_dishes # set via global
+    # num_polarizations: num_polarizations # set via global
     pl_mask_buf: cmp_pl_mask_buffer
     lost_samples_buffers:
       - lost_samples_buffer_0
@@ -56,6 +58,8 @@ gen_test_data:
 
 lostSamplesToPLMask:
     kotekan_stage: lostSamplesToPLMask
+    # num_dishes: num_dishes # set via global
+    # num_polarizations: num_polarizations # set via global
     pl_mask_buf: out_pl_mask_buffer
     lost_samples_buffers:
       - lost_samples_buffer_0

--- a/lib/core/buffer.cpp
+++ b/lib/core/buffer.cpp
@@ -439,7 +439,7 @@ void Buffer::print_full_status() {
 
     DEBUG2("{:<40} : {:}", "Full Frames (X)", std::string(status_string));
 
-    DEBUG2("---- Producers ----");
+    DEBUG2("---- Producers ({:d}) ----", producers.size());
     for (auto& xit : producers) {
         auto& x = xit.second;
         for (int i = 0; i < num_frames; ++i) {
@@ -452,7 +452,7 @@ void Buffer::print_full_status() {
                x.last_frame_acquired, x.last_frame_released);
     }
 
-    DEBUG2("---- Consumers ----");
+    DEBUG2("---- Consumers ({:d}) ----", consumers.size());
     for (auto& xit : consumers) {
         auto& x = xit.second;
         for (int i = 0; i < num_frames; ++i) {

--- a/lib/core/buffer.hpp
+++ b/lib/core/buffer.hpp
@@ -545,7 +545,7 @@ public:
             frames_desc =
                 std::make_shared<kotekan::NDArray<T, D>>(quantity_name, extents, dimnames, nullptr);
         else {
-            auto nd_desc = std::dynamic_pointer_cast<kotekan::GenericNDArray>(frames_desc);
+            auto nd_desc = std::dynamic_pointer_cast<const kotekan::GenericNDArray>(frames_desc);
             if (!nd_desc) {
                 ERROR("Frame desc mismatch: existing desc is not an NDArray");
                 return;
@@ -584,7 +584,7 @@ public:
             frames_desc = kotekan::GenericNDArray::create(value_type, quantity_name, extents,
                                                           dimnames, nullptr);
         } else {
-            auto nd_desc = std::dynamic_pointer_cast<kotekan::GenericNDArray>(frames_desc);
+            auto nd_desc = std::dynamic_pointer_cast<const kotekan::GenericNDArray>(frames_desc);
             if (!nd_desc) {
                 ERROR("Frame desc mismatch: existing desc is not an NDArray");
                 return;
@@ -630,7 +630,7 @@ public:
     /**
      * @brief Sets the frame description
      */
-    void set_frame_desc(std::shared_ptr<kotekan::FrameDesc> new_desc) {
+    void set_frame_desc(std::shared_ptr<const kotekan::FrameDesc> new_desc) {
         buffer_lock lock(mutex);
 
         if (new_desc->get_byte_size() != frame_size) {
@@ -689,7 +689,7 @@ public:
     std::vector<uint8_t*> frames;
 
     /// Metdata describing the shape of the data stored in frames
-    std::shared_ptr<kotekan::FrameDesc> frames_desc;
+    std::shared_ptr<const kotekan::FrameDesc> frames_desc;
 
     /**
      * @brief Flag variables to say which frames are full

--- a/lib/core/ringbuffer.cpp
+++ b/lib/core/ringbuffer.cpp
@@ -277,14 +277,14 @@ void RingBuffer::print_full_status() {
            (first_write_head - last_read_tail) / 1.0e+6);
     DEBUG2("{:<40} : {:13.6f} MB", "free space to write",
            (size - (first_write_head - last_read_tail)) / 1.0e+6);
-    DEBUG2("---- Producers ----");
+    DEBUG2("---- Producers ({:d}) ----", producers.size());
     for (auto& it : producers) {
         const auto& name = it.second.name;
         DEBUG2("{:<40} : {:13.6f} MB ... {:.6f} MB ({:.6f} MB)", name.c_str(),
                write_heads[name] / 1.0e+6, write_next[name] / 1.0e+6,
                (write_next[name] - write_heads[name]) / 1.0e+6);
     }
-    DEBUG2("---- Consumers ----");
+    DEBUG2("---- Consumers ({:d}) ----", consumers.size());
     for (auto& it : consumers) {
         const auto& name = it.second.name;
         DEBUG2("{:<40} : {:13.6f} MB ... {:.6f} MB ({:.6f} MB)", name.c_str(),

--- a/lib/stages/CMakeLists.txt
+++ b/lib/stages/CMakeLists.txt
@@ -64,6 +64,7 @@ add_library(
     bufferCopy.cpp
     bufferSwitch.cpp
     bufferDelay.cpp
+    bufferQuiet.cpp
     BufferSplit.cpp
     InputSubset.cpp
     setScatterIndices.cpp

--- a/lib/stages/CMakeLists.txt
+++ b/lib/stages/CMakeLists.txt
@@ -91,6 +91,7 @@ add_library(
     BeamExtract.cpp
     BeamInspect.cpp
     configTrackerWriter.cpp
+    givenDataGen.cpp
     testDataGen.cpp
     DPDKShuffleSimulate.cpp
     BadInputFlag.cpp

--- a/lib/stages/EigenN2Iter.cpp
+++ b/lib/stages/EigenN2Iter.cpp
@@ -9,7 +9,7 @@
 #include "StageFactory.hpp"      // for REGISTER_KOTEKAN_STAGE, StageMakerTemplate
 #include "buffer.hpp"            // for allocate_new_metadata_object, mark_frame_empty, mark_fr...
 #include "kotekanLogging.hpp"    // for DEBUG
-#include "prometheusMetrics.hpp" // for Gauge, Metrics, MetricFamily
+#include "prometheusMetrics.hpp" // for Counter, Gauge, Metrics, MetricFamily
 
 #include "fmt.hpp"      // for format, fmt
 #include "gsl-lite.hpp" // for span
@@ -41,6 +41,7 @@ EigenN2Iter::EigenN2Iter(Config& config, const std::string& unique_name,
     Stage(config, unique_name, buffer_container, std::bind(&EigenN2Iter::main_thread, this)),
 
     in_buf(get_buffer("in_buf")), out_buf(get_buffer("out_buf")),
+    failed_buf(config.exists(unique_name, "failed_buf") ? get_buffer("failed_buf") : nullptr),
 
     _num_eigenvectors(config.get<size_t>(unique_name, "num_ev")),
 
@@ -67,7 +68,9 @@ EigenN2Iter::EigenN2Iter(Config& config, const std::string& unique_name,
     eigenvalue_convergence_metric(Metrics::instance().add_gauge(
         "kotekan_eigenN2iter_eigenvalue_convergence", unique_name, {"freq_id"})),
     eigenvector_convergence_metric(Metrics::instance().add_gauge(
-        "kotekan_eigenN2iter_eigenvector_convergence", unique_name, {"freq_id"})) {
+        "kotekan_eigenN2iter_eigenvector_convergence", unique_name, {"freq_id"})),
+    num_failed_eigencalc(
+        Metrics::instance().add_counter("kotekan_eigenN2iter_num_failed_eigencalc", unique_name)) {
 
     in_buf->register_consumer(unique_name);
     out_buf->register_producer(unique_name);
@@ -96,6 +99,34 @@ EigenN2Iter::EigenN2Iter(Config& config, const std::string& unique_name,
                     out_desc->get_num_ev(), _num_eigenvectors);
     }
 
+    if (failed_buf) {
+        failed_buf->register_producer(unique_name);
+        // this replicates some of the tests on in_buf to not rely on previous tests
+        if (in_buf->buffer_type != "N2" || failed_buf->buffer_type != "N2")
+            FATAL_ERROR("EigenN2Iter stage requires 'N2' buffers as input and failed.");
+
+        // Validate that input and failed buffers have N2 frame descriptors set
+        auto in_desc =
+            std::dynamic_pointer_cast<const kotekan::N2FrameDesc>(in_buf->get_frame_description());
+        auto failed_desc = std::dynamic_pointer_cast<const kotekan::N2FrameDesc>(
+            failed_buf->get_frame_description());
+        if (!in_desc || !failed_desc) {
+            FATAL_ERROR("EigenN2Iter: Input and failed buffers must have N2FrameDesc set");
+        }
+        // Validate num_elements and layout match
+        if (in_desc->get_num_elements() != failed_desc->get_num_elements()) {
+            FATAL_ERROR("EigenN2Iter: Input and failed buffer num_elements must match");
+        }
+        if (in_desc->get_n2_layout() != failed_desc->get_n2_layout()) {
+            FATAL_ERROR("EigenN2Iter: Input and failed buffer n2_layout must match");
+        }
+        // Validate failed buffer has correct num_ev for this stage
+        if (failed_desc->get_num_ev() != 0) {
+            FATAL_ERROR("EigenN2Iter: Failed buffer num_ev ({:d}) not 0",
+                        failed_desc->get_num_ev());
+        }
+    }
+
     if (_num_ev_conv > _num_eigenvectors)
         FATAL_ERROR("The `num_ev_conv` config parameter ({:d}) must be less than or equal to "
                     "`num_ev` ({:d}).",
@@ -114,6 +145,9 @@ void EigenN2Iter::main_thread() {
 
     frameID input_frame_id(in_buf);
     frameID output_frame_id(out_buf);
+    // need to pass a valid buffer to avoid a segfault, even if failed_frame_id
+    // is not used afterwards
+    frameID failed_frame_id(failed_buf != nullptr ? failed_buf : out_buf);
 
     DynamicHermitian<float> mask;
     uint32_t num_elements = 0;
@@ -156,9 +190,30 @@ void EigenN2Iter::main_thread() {
         DynamicHermitian<cfloat> vis = to_blaze_herm(input_frame.vis);
 
         // Perform the actual eigen-decomposition
-        std::tie(eigpair, stats) =
-            eigen_masked_subspace(vis, mask, _num_eigenvectors, _tol_eval, _tol_evec,
-                                  _max_iterations, _num_ev_conv, _krylov, _subspace);
+        try {
+            std::tie(eigpair, stats) =
+                eigen_masked_subspace(vis, mask, _num_eigenvectors, _tol_eval, _tol_evec,
+                                      _max_iterations, _num_ev_conv, _krylov, _subspace);
+        } catch (const std::runtime_error& e) {
+            ERROR("Could not find eigenvalues after {:d} for frame fpga_seq {:d}: {:s}",
+                  _max_iterations, input_frame.fpga_start_tick, e.what());
+
+            num_failed_eigencalc.inc(1);
+
+            if (failed_buf != nullptr) {
+                if (failed_buf->wait_for_empty_frame(unique_name, failed_frame_id) == nullptr) {
+                    break;
+                }
+
+                in_buf->pass_metadata(input_frame_id, failed_buf, failed_frame_id);
+                N2FrameView failed_frame(failed_buf, failed_frame_id);
+                failed_frame.copy_data(input_frame, {N2Field::eval, N2Field::evec, N2Field::erms});
+
+                failed_buf->mark_frame_full(unique_name, failed_frame_id++);
+            }
+            in_buf->mark_frame_empty(unique_name, input_frame_id++);
+            continue;
+        }
         auto& evals = eigpair.first;
         auto& evecs = eigpair.second;
 

--- a/lib/stages/EigenN2Iter.hpp
+++ b/lib/stages/EigenN2Iter.hpp
@@ -44,6 +44,10 @@
  * @buffer out_buf Output stream with the calculated eigen-pairs.
  *         @buffer_format N2Buffer structured
  *         @buffer_metadata N2Metadata
+ * @buffer failed_buf Output stream to which buffers for which eigenvalues
+ *         cannot be computed are sent. Leave empty to drop these frames.
+ *         @buffer_format N2Buffer structured
+ *         @buffer_metadata N2Metadata
  *
  * @conf  num_elements     Int. The number of elements (i.e. inputs) in the
  *                         correlator data.
@@ -82,6 +86,9 @@
  *         Eigenvalue convergence parameter of the last sample.
  * @metric kotekan_eigenN2iter_eigenvector_convergence
  *         Eigenvector convergence parameter of the last sample.
+ * @metric kotekan_eigenN2iter_num_failed_eigencalc
+ *         The number of failed eigenvector decompositions.
+ *
  *
  * @author Richard Shaw, Kiyoshi Masui
  */
@@ -103,6 +110,7 @@ private:
 
     Buffer* in_buf;
     Buffer* out_buf;
+    Buffer* failed_buf;
 
     const size_t _num_eigenvectors;
 
@@ -127,6 +135,7 @@ private:
     kotekan::prometheus::MetricFamily<kotekan::prometheus::Gauge>& iterations_metric;
     kotekan::prometheus::MetricFamily<kotekan::prometheus::Gauge>& eigenvalue_convergence_metric;
     kotekan::prometheus::MetricFamily<kotekan::prometheus::Gauge>& eigenvector_convergence_metric;
+    kotekan::prometheus::Counter& num_failed_eigencalc;
 };
 
 #endif

--- a/lib/stages/N2FrameToVisFrame.cpp
+++ b/lib/stages/N2FrameToVisFrame.cpp
@@ -30,7 +30,8 @@ n2FrameToVisFrame::n2FrameToVisFrame(Config& config, const std::string& unique_n
     vis_buf = get_buffer("vis_buf");
     vis_buf->register_producer(unique_name);
 
-    // TODO: add any sanity checks required
+    // cannot check on num_ev, num_elements, or num_prod which are used only to
+    // calculate the frame size in BufferFactory but not stored
     if (n2_buf->frame_size != vis_buf->frame_size) {
         FATAL_ERROR(
             "Frame sizes between N2FrameView and VisFrameView must be identical, but got {} and {}",

--- a/lib/stages/bufferQuiet.cpp
+++ b/lib/stages/bufferQuiet.cpp
@@ -1,0 +1,129 @@
+#include "bufferQuiet.hpp"
+
+#include "StageFactory.hpp"   // for REGISTER_KOTEKAN_STAGE
+#include "buffer.hpp"         // for Buffer
+#include "kotekanLogging.hpp" // for DEBUG
+#include "metadata.hpp"       // for metadataObject
+#include "visUtil.hpp"        // for frameID, modulo
+
+#include "fmt.hpp" // for compile_string_to_view, format, fmt
+
+#include <cstring>    // for memcpy
+#include <functional> // for bind, function
+#include <stdexcept>  // for runtime_error, invalid_argument
+#include <time.h>     // for clock_gettime
+
+
+using kotekan::bufferContainer;
+using kotekan::Config;
+using kotekan::Stage;
+
+REGISTER_KOTEKAN_STAGE(bufferQuiet);
+
+bufferQuiet::bufferQuiet(Config& config, const std::string& unique_name,
+                         bufferContainer& buffer_container) :
+    Stage(config, unique_name, buffer_container, std::bind(&bufferQuiet::main_thread, this)) {
+
+    in_buf = get_buffer("in_buf");
+    in_buf->register_consumer(unique_name);
+
+    out_buf = get_buffer("out_buf");
+    out_buf->register_producer(unique_name);
+
+    // Frame sizes must match exactly
+    if (in_buf->frame_size != out_buf->frame_size) {
+        throw std::runtime_error(
+            fmt::format(fmt("Buffer sizes must match for direct copy (src {:d} != dest {:d})."),
+                        in_buf->frame_size, out_buf->frame_size));
+    }
+
+    _copy_frame = config.get_default<bool>(unique_name, "copy_frame", false);
+    _quiet_time = config.get<double>(unique_name, "quiet_time");
+    _num_reserve_frames = config.get_default<int>(unique_name, "num_reserve_frames", 0);
+}
+
+void bufferQuiet::main_thread() {
+
+    frameID in_frame_id(in_buf);
+    frameID in_frame_release_id(in_buf);
+    frameID out_frame_id(out_buf);
+    int in_frame_hold_ctr = 0;
+
+    uint8_t* output_frame = nullptr;
+
+    while (!stop_thread) {
+
+        timespec now;
+        clock_gettime(CLOCK_MONOTONIC, &now);
+        const timespec timeout = add_nsec(now, _quiet_time * 1e9);
+
+        const int reason = in_buf->wait_for_full_frame_timeout(unique_name, in_frame_id, timeout);
+        if (reason == -1) // thread exit signal
+            return;
+
+        if (reason == 0) { // got a frame before timeout
+            DEBUG("Got new input frame {:d}", in_frame_id);
+            in_frame_hold_ctr += 1;
+            in_frame_id += 1;
+        }
+
+        int frames_to_release = -1;
+        if (reason == 1) { // timeout, release all frames
+            frames_to_release = in_frame_hold_ctr;
+        } else if (in_frame_hold_ctr + _num_reserve_frames
+                   >= out_buf->num_frames) { // emergency release a frame since buffer is full
+            assert(reason == 0);
+            assert(in_frame_hold_ctr + _num_reserve_frames
+                   == out_buf->num_frames); // we count up be ones, we cannot miss equality
+            frames_to_release = 1;
+        } else { // got a frame, no timeout, no full buffer. Wait.
+            assert(reason == 0);
+            frames_to_release = 0;
+        }
+        while (frames_to_release-- > 0) {
+
+            // Get a new output frame
+            output_frame = out_buf->wait_for_empty_frame(unique_name, out_frame_id);
+            if (output_frame == nullptr)
+                return;
+
+            if (_copy_frame || in_buf->get_num_consumers() > 1) {
+                out_buf->allocate_new_metadata_object(out_frame_id);
+                // Metadata sizes must match exactly
+                if (in_buf->metadata[in_frame_release_id]->get_object_size()
+                    != out_buf->metadata[out_frame_id]->get_object_size()) {
+                    throw std::runtime_error(fmt::format(
+                        fmt("Metadata sizes must match for direct copy (src {:d} != dest {:d})."),
+                        in_buf->metadata[in_frame_release_id]->get_object_size(),
+                        out_buf->metadata[out_frame_id]->get_object_size()));
+                }
+                in_buf->copy_metadata(in_frame_release_id, out_buf, out_frame_id);
+                std::memcpy(output_frame, in_buf->frames[in_frame_release_id], in_buf->frame_size);
+                // this just copies the shared pointer, and is only valid since
+                // a frame description must never change
+                out_buf->set_frame_desc(in_buf->get_frame_description());
+            } else {
+                in_buf->pass_metadata(in_frame_release_id, out_buf, out_frame_id);
+                in_buf->swap_frames(in_frame_release_id, out_buf, out_frame_id);
+                // this just copies the shared pointer, and is only valid since
+                // a frame description must never change
+                out_buf->set_frame_desc(in_buf->get_frame_description());
+            }
+
+            DEBUG("Releasing frame... in_frame_id: {:d}, in_frame_hold_ctr: {:d}, "
+                  "in_frame_release_id: {:d}",
+                  in_frame_id, in_frame_release_id);
+
+            out_buf->mark_frame_full(unique_name, out_frame_id);
+            out_frame_id++;
+
+            // Release the input buffer frame.
+            in_buf->mark_frame_empty(unique_name, in_frame_release_id);
+            in_frame_release_id++;
+
+            in_frame_hold_ctr--;
+        }
+
+        DEBUG("Holding {:d} frames", in_frame_hold_ctr);
+    }
+}

--- a/lib/stages/bufferQuiet.hpp
+++ b/lib/stages/bufferQuiet.hpp
@@ -1,0 +1,64 @@
+#ifndef BUFFER_QUIET_HPP
+#define BUFFER_QUIET_HPP
+
+#include "Config.hpp"          // for Config
+#include "Stage.hpp"           // for Stage
+#include "buffer.hpp"          // for Buffer
+#include "bufferContainer.hpp" // for bufferContainer
+
+#include <string> // for string
+
+
+/**
+ * @brief Waits for a quiet period without new input frames or imminent buffer
+ * overflow before releasing of frames of the buffer.
+ *
+ *
+ * @par Buffer
+ * @buffer in_buf Buffer to release frames from
+ *        @buffer_format Matches the output buffer
+ *        @buffer_metadata Matches the output buffer
+ * @buffer out_buf Buffer to release frames to
+ *        @buffer_format Matches the input buffer
+ *        @buffer_metadata Matches the input buffer
+ *
+ * @conf   copy_frame Bool. Flag to copy or swap frames
+ * @conf   quiet_time Double. Seconds in of quiet before staring to relase
+ *         frames.
+ * @conf   num_reserve_frames Int. Optional. Start releasing frames if buffer
+ *         has less than this many empty frames even when there are still
+ *         incoming frames.
+ *
+ * @author Roland Haas
+ */
+class bufferQuiet : public kotekan::Stage {
+public:
+    /// Constructor
+    bufferQuiet(kotekan::Config& config, const std::string& unique_name,
+                kotekan::bufferContainer& buffer_container);
+
+    /// Destructor
+    ~bufferQuiet() = default;
+
+    /// Thread for merging the frames.
+    void main_thread() override;
+
+protected:
+    /// The input buffer to release frames from
+    Buffer* in_buf;
+
+    /// The output buffer to release frames to
+    Buffer* out_buf;
+
+    /// Config variables
+    /// Flag to copy or swap frames
+    bool _copy_frame;
+
+    /// Seconds of quiet before releasing frames.
+    double _quiet_time;
+
+    /// Savety marging of empty frames
+    int _num_reserve_frames;
+};
+
+#endif

--- a/lib/stages/givenDataGen.cpp
+++ b/lib/stages/givenDataGen.cpp
@@ -1,0 +1,118 @@
+#include "givenDataGen.hpp"
+
+#include "DataType.hpp"        // for DataType, KOTEKAN_FLOAT16, float16_t
+#include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
+#include "bufferContainer.hpp" // for bufferContainer
+#include "chordMetadata.hpp"   // for chordMetadata, get_chord_metadata, CHORD_META_MAX_FREQ
+#include "kotekanLogging.hpp"  // for INFO, DEBUG, ERROR
+
+#include <assert.h>  // for assert
+#include <stdint.h>  // for int8_t, uint32_t, uint8_t, int16_t, int32_t, uint64_t
+#include <string>    // for std::string
+#include <strings.h> // for bzero
+#include <unistd.h>  // for sleep
+#include <vector>    // for vector
+
+
+using kotekan::bufferContainer;
+using kotekan::Config;
+using kotekan::Stage;
+
+REGISTER_KOTEKAN_STAGE(givenDataGen);
+
+givenDataGen::givenDataGen(Config& config, const std::string& unique_name,
+                           bufferContainer& buffer_container) :
+    Stage(config, unique_name, buffer_container, std::bind(&givenDataGen::main_thread, this)),
+    _out_buf(get_buffer("out_buf")), _values(config.get<std::vector<int>>(unique_name, "values")),
+    _name(config.get<kotekan::Symbol>(unique_name, "name")),
+    _datatype(kotekan::string_to_type(config.get<std::string>(unique_name, "datatype"))),
+    _array_shape(config.get<std::vector<ptrdiff_t>>(unique_name, "array_shape")),
+    _dim_name(config.get<std::vector<kotekan::Symbol>>(unique_name, "dim_name")),
+    _do_once(config.get<bool>(unique_name, "do_once")) {
+
+    _out_buf->register_producer(unique_name);
+
+    if (_datatype == kotekan::unknown_type) {
+        throw std::invalid_argument("givenDataGen: unknown datatype for 'datatype' option");
+    }
+
+    if (_array_shape.size() != _dim_name.size()) {
+        throw std::invalid_argument("givenDataGen: 'array_shape' and 'dim_name' config "
+                                    "settings must be the same length!");
+    }
+
+    size_t num_elemns = 1;
+    for (const auto sz : _array_shape)
+        num_elemns *= sz;
+    if (_out_buf->frame_size != num_elemns * kotekan::type_total_bytes(_datatype)) {
+        throw std::invalid_argument("givenDataGen: product of 'array_shape' config setting must "
+                                    "equal the buffer frame size");
+    }
+
+    if (num_elemns != _values.size()) {
+        throw std::invalid_argument(
+            "givenDataGen: size of 'values' config setting must equal the buffer frame size");
+    }
+}
+
+
+void givenDataGen::main_thread() {
+
+    int abs_frame_id = 0;
+    while (!stop_thread) {
+
+        if (_do_once && abs_frame_id > 0) {
+            sleep(1);
+            continue;
+        }
+
+        const int frame_id = abs_frame_id % _out_buf->num_frames;
+        uint8_t* const frame = _out_buf->wait_for_empty_frame(unique_name, frame_id);
+        if (frame == nullptr)
+            break;
+
+        const size_t type_size = kotekan::type_total_bytes(_datatype);
+        for (size_t i = 0; i < _values.size(); ++i) {
+            // this really makes all kinds of asusmptions
+            // only works for integers
+            // only works on little endian machines
+            assert((i + 1) * type_size <= _out_buf->frame_size && "Out of bounds access");
+            std::memcpy(frame + i * type_size, &_values.at(i), type_size);
+        }
+
+        _out_buf->allocate_new_metadata_object(frame_id);
+        std::shared_ptr<chordMetadata> chordmeta = get_chord_metadata(_out_buf, frame_id);
+
+        chordmeta->set_frame_counter(abs_frame_id);
+
+        const int name_written =
+            std::snprintf(chordmeta->name, sizeof chordmeta->name, "%s", _name.get_c_string());
+        if (!(name_written < (int)sizeof chordmeta->name)) {
+            throw std::runtime_error("Name too long");
+        }
+
+        chordmeta->type = _datatype;
+
+        chordmeta->dims = _array_shape.size();
+        assert(chordmeta->dims <= CHORD_META_MAX_DIM);
+
+        for (int d = 0; d < chordmeta->dims; ++d) {
+            const int dim_written =
+                std::snprintf(chordmeta->dim_name[d], sizeof chordmeta->dim_name[d], "%s",
+                              _dim_name.at(d).get_c_string());
+            if (!(dim_written < (int)sizeof chordmeta->dim_name[d])) {
+                throw std::runtime_error("Dimension label too long");
+            }
+            chordmeta->dim[d] = _array_shape.at(d);
+        }
+        chordmeta->set_strides_simple();
+
+        _out_buf->allocate_ndarray_frame_desc(chordmeta->type, _name, _array_shape, _dim_name);
+        /* test that things are consistent */
+        chordmeta->check_frame_desc(_out_buf->get_ndarray_frame_desc());
+
+        _out_buf->mark_frame_full(unique_name, frame_id);
+
+        abs_frame_id += 1;
+    }
+}

--- a/lib/stages/givenDataGen.hpp
+++ b/lib/stages/givenDataGen.hpp
@@ -1,0 +1,47 @@
+#ifndef GIVEN_DATA_GEN_H
+#define GIVEN_DATA_GEN_H
+
+#include "Config.hpp" // for Config
+#include "Stage.hpp"  // for Stage
+#include "Symbol.hpp" // for Symbol
+#include "buffer.hpp" // for Buffer
+
+#include <stdint.h> // for uint32_t
+#include <vector>   // for vector
+
+/**
+ * @class givenDataGen
+ * @brief Present given data as a kotekan buffer.
+ *
+ * @par Buffers
+ * @buffer out_buf Buffer to fill
+ *         @buffer_format any format
+ *         @buffer_metadata chordMetadata
+ *
+ * @conf  values                Vector of ints.
+ * @conf  name                  String. Name of the quantity being set.
+ * @conf  datatype              String. Kotekan datatype name.
+ * @conf  array_shape           Vector of ints. Size of each dimension.
+ * @conf  dim_name              Vector of strings. Name of each dimension.
+ * @conf  do_once               Bool. Set data only once, for a single frame.
+ *
+ * @author Roland Haas, based on testDataGen
+ */
+class givenDataGen : public kotekan::Stage {
+public:
+    givenDataGen(kotekan::Config& config, const std::string& unique_name,
+                 kotekan::bufferContainer& buffer_container);
+    ~givenDataGen() = default;
+    void main_thread() override;
+
+private:
+    Buffer* const _out_buf;
+    const std::vector<int> _values;
+    const kotekan::Symbol _name;
+    const kotekan::DataType _datatype;
+    const std::vector<std::ptrdiff_t> _array_shape;
+    const std::vector<kotekan::Symbol> _dim_name;
+    const bool _do_once;
+};
+
+#endif

--- a/lib/stages/lostSamplesToPLMask.cpp
+++ b/lib/stages/lostSamplesToPLMask.cpp
@@ -33,14 +33,12 @@ REGISTER_KOTEKAN_STAGE(lostSamplesToPLMask);
 
 #define BITS_PER_BYTE 8
 
-// CHIME parameters, actually
-#define NUM_DISHES 1024
-#define NUM_POLARIZATIONS 2
-
 lostSamplesToPLMask::lostSamplesToPLMask(Config& config, const std::string& unique_name,
                                          bufferContainer& buffer_container) :
     Stage(config, unique_name, buffer_container,
-          std::bind(&lostSamplesToPLMask::main_thread, this)) {
+          std::bind(&lostSamplesToPLMask::main_thread, this)),
+    num_polarizations(config.get<int>(unique_name, "num_polarizations")),
+    num_dishes(config.get<int>(unique_name, "num_dishes")) {
 
     pl_mask_buf = get_buffer("pl_mask_buf");
     pl_mask_buf->register_producer(unique_name);
@@ -61,8 +59,8 @@ lostSamplesToPLMask::lostSamplesToPLMask(Config& config, const std::string& uniq
     const int num_freq_bins = int(lost_samples_bufs.size());
 
     if (pl_mask_buf->frame_size
-        != lost_samples_bufs.at(0)->frame_size / PL_MASK_DOWNSAMPLING_FACTOR * NUM_DISHES
-               / PL_MASK_DISHES_PER_BIN * NUM_POLARIZATIONS / BITS_PER_BYTE * num_freq_bins)
+        != lost_samples_bufs.at(0)->frame_size / PL_MASK_DOWNSAMPLING_FACTOR * num_dishes
+               / PL_MASK_DISHES_PER_BIN * num_polarizations / BITS_PER_BYTE * num_freq_bins)
         FATAL_ERROR("Unexpected frames sizes for pl_mask {:d} and lost_samples {:d}",
                     pl_mask_buf->frame_size, lost_samples_bufs.at(0)->frame_size);
 }
@@ -120,10 +118,10 @@ void lostSamplesToPLMask::main_thread() {
                 // frequencies
                 size_t idx =
                     (ihi / PL_MASK_DOWNSAMPLING_FACTOR / PL_MASK_HILO_SPLIT * num_freq_bins + f)
-                    * NUM_POLARIZATIONS * NUM_DISHES / PL_MASK_DISHES_PER_BIN * PL_MASK_HILO_SPLIT
+                    * num_polarizations * num_dishes / PL_MASK_DISHES_PER_BIN * PL_MASK_HILO_SPLIT
                     / BITS_PER_BYTE;
-                for (int dbin = 0; dbin < NUM_DISHES / PL_MASK_DISHES_PER_BIN; ++dbin) {
-                    for (int polr = 0; polr < NUM_POLARIZATIONS; ++polr) {
+                for (int dbin = 0; dbin < num_dishes / PL_MASK_DISHES_PER_BIN; ++dbin) {
+                    for (int polr = 0; polr < num_polarizations; ++polr) {
                         std::memcpy(&pl_mask_frame[idx], buf, sizeof(buf));
                         idx += sizeof(buf);
                     }
@@ -150,8 +148,8 @@ void lostSamplesToPLMask::main_thread() {
                 pl_mask_meta->dim[0] = lost_samples_bufs.at(0)->frame_size
                                        / PL_MASK_DOWNSAMPLING_FACTOR / PL_MASK_HILO_SPLIT;
                 pl_mask_meta->dim[1] = lost_samples_bufs.size();
-                pl_mask_meta->dim[2] = NUM_POLARIZATIONS;
-                pl_mask_meta->dim[3] = NUM_DISHES / PL_MASK_DISHES_PER_BIN;
+                pl_mask_meta->dim[2] = num_polarizations;
+                pl_mask_meta->dim[3] = num_dishes / PL_MASK_DISHES_PER_BIN;
                 pl_mask_meta->dim[4] =
                     PL_MASK_HILO_SPLIT / BITS_PER_BYTE; // because we count uint1x8, not uint1
                 for (int d = pl_mask_meta->dims - 1; d >= 0; --d)
@@ -202,8 +200,8 @@ void lostSamplesToPLMask::main_thread() {
             "pl_mask",
             {ptrdiff_t(lost_samples_bufs.at(0)->frame_size / PL_MASK_DOWNSAMPLING_FACTOR
                        / PL_MASK_HILO_SPLIT),
-             ptrdiff_t(lost_samples_bufs.size()), NUM_POLARIZATIONS,
-             NUM_DISHES / PL_MASK_DISHES_PER_BIN,
+             ptrdiff_t(lost_samples_bufs.size()), num_polarizations,
+             num_dishes / PL_MASK_DISHES_PER_BIN,
              PL_MASK_HILO_SPLIT / BITS_PER_BYTE /* because we count uint1x8, not uint1 */},
             {"T2hi64", "F4", "P", "D8", "T2lo64"});
         pl_mask_meta->check_frame_desc(pl_mask_buf->get_ndarray_frame_desc());

--- a/lib/stages/lostSamplesToPLMask.hpp
+++ b/lib/stages/lostSamplesToPLMask.hpp
@@ -29,6 +29,8 @@
  *                                        - lost_samples_buffer_1
  *                                        - lost_samples_buffer_2
  *                                        - lost_samples_buffer_3
+ * @conf  num_polarizations         Number of polarizations present in data set.
+ * @conf  num_dishes                Number of dishes present in data set.
  *
  * @author Roland Haas
  */
@@ -45,6 +47,12 @@ public:
     void main_thread() override;
 
 private:
+    /// The number of polarizations in data set
+    const int num_polarizations;
+
+    /// The number of dishes in data set
+    const int num_dishes;
+
     /// The buffer with the package loss data
     Buffer* pl_mask_buf;
 

--- a/lib/testing/testLostSamplesToPLMask.cpp
+++ b/lib/testing/testLostSamplesToPLMask.cpp
@@ -33,14 +33,12 @@ REGISTER_KOTEKAN_STAGE(testLostSamplesToPLMask);
 
 #define BITS_PER_BYTE 8
 
-// CHIME parameters, actually
-#define NUM_DISHES 1024
-#define NUM_POLARIZATIONS 2
-
 testLostSamplesToPLMask::testLostSamplesToPLMask(Config& config, const std::string& unique_name,
                                                  bufferContainer& buffer_container) :
     Stage(config, unique_name, buffer_container,
-          std::bind(&testLostSamplesToPLMask::main_thread, this)) {
+          std::bind(&testLostSamplesToPLMask::main_thread, this)),
+    num_polarizations(config.get<int>(unique_name, "num_polarizations")),
+    num_dishes(config.get<int>(unique_name, "num_dishes")) {
 
     pl_mask_buf = get_buffer("pl_mask_buf");
     pl_mask_buf->register_producer(unique_name);
@@ -61,8 +59,8 @@ testLostSamplesToPLMask::testLostSamplesToPLMask(Config& config, const std::stri
     const int num_freq_bins = int(lost_samples_bufs.size());
 
     if (pl_mask_buf->frame_size
-        != lost_samples_bufs.at(0)->frame_size / PL_MASK_DOWNSAMPLING_FACTOR * NUM_DISHES
-               / PL_MASK_DISHES_PER_BIN * NUM_POLARIZATIONS / BITS_PER_BYTE * num_freq_bins)
+        != lost_samples_bufs.at(0)->frame_size / PL_MASK_DOWNSAMPLING_FACTOR * num_dishes
+               / PL_MASK_DISHES_PER_BIN * num_polarizations / BITS_PER_BYTE * num_freq_bins)
         FATAL_ERROR("Unexpected frames sizes for pl_mask {:d} and lost_samples {:d}",
                     pl_mask_buf->frame_size, lost_samples_bufs.at(0)->frame_size);
 }
@@ -98,8 +96,8 @@ void testLostSamplesToPLMask::main_thread() {
         for (int thi = 0;
              thi < samples_in_dataset / PL_MASK_DOWNSAMPLING_FACTOR / PL_MASK_HILO_SPLIT; ++thi)
             for (int fbin = 0; fbin < num_freq_bins; ++fbin)
-                for (int polr = 0; polr < NUM_POLARIZATIONS; ++polr)
-                    for (int dbin = 0; dbin < NUM_DISHES / PL_MASK_DISHES_PER_BIN; ++dbin)
+                for (int polr = 0; polr < num_polarizations; ++polr)
+                    for (int dbin = 0; dbin < num_dishes / PL_MASK_DISHES_PER_BIN; ++dbin)
                         for (int tlo = 0; tlo < PL_MASK_HILO_SPLIT; ++tlo) {
                             bool lost = false;
                             for (int ds = 0; ds < PL_MASK_DOWNSAMPLING_FACTOR; ++ds)
@@ -110,8 +108,8 @@ void testLostSamplesToPLMask::main_thread() {
                             assert(size_t(pl_idx / BITS_PER_BYTE) < pl_mask_buf->frame_size);
                             // indexing is a bit annoying due to bits and downsampling
                             assert(pl_idx
-                                   == (((thi * num_freq_bins + fbin) * NUM_POLARIZATIONS + polr)
-                                           * NUM_DISHES / PL_MASK_DISHES_PER_BIN
+                                   == (((thi * num_freq_bins + fbin) * num_polarizations + polr)
+                                           * num_dishes / PL_MASK_DISHES_PER_BIN
                                        + dbin) * PL_MASK_HILO_SPLIT
                                           + tlo);
                             pl_mask_frame[pl_idx / BITS_PER_BYTE] |= (!lost)
@@ -151,8 +149,8 @@ void testLostSamplesToPLMask::main_thread() {
         pl_mask_meta->dim[0] =
             lost_samples_bufs.at(0)->frame_size / PL_MASK_DOWNSAMPLING_FACTOR / PL_MASK_HILO_SPLIT;
         pl_mask_meta->dim[1] = lost_samples_bufs.size();
-        pl_mask_meta->dim[2] = NUM_POLARIZATIONS;
-        pl_mask_meta->dim[3] = NUM_DISHES / PL_MASK_DISHES_PER_BIN;
+        pl_mask_meta->dim[2] = num_polarizations;
+        pl_mask_meta->dim[3] = num_dishes / PL_MASK_DISHES_PER_BIN;
         pl_mask_meta->dim[4] =
             PL_MASK_HILO_SPLIT / BITS_PER_BYTE; // because we count uint1x8, not uint1
         for (int d = pl_mask_meta->dims - 1; d >= 0; --d)
@@ -165,8 +163,8 @@ void testLostSamplesToPLMask::main_thread() {
             "pl_mask",
             {ptrdiff_t(lost_samples_bufs.at(0)->frame_size / PL_MASK_DOWNSAMPLING_FACTOR
                        / PL_MASK_HILO_SPLIT),
-             ptrdiff_t(lost_samples_bufs.size()), NUM_POLARIZATIONS,
-             NUM_DISHES / PL_MASK_DISHES_PER_BIN,
+             ptrdiff_t(lost_samples_bufs.size()), num_polarizations,
+             num_dishes / PL_MASK_DISHES_PER_BIN,
              PL_MASK_HILO_SPLIT / BITS_PER_BYTE /* because we count uint1x8, not uint1 */},
             {"T2hi64", "F4", "P", "D8", "T2lo64"});
         pl_mask_meta->check_frame_desc(pl_mask_buf->get_ndarray_frame_desc());

--- a/lib/testing/testLostSamplesToPLMask.hpp
+++ b/lib/testing/testLostSamplesToPLMask.hpp
@@ -20,6 +20,8 @@
  * @buffer lost_samples_buf Array of flags which indicate if a sample in a given location is lost
  *     @buffer_format Array of flags uint8_t flags which are either 0 (unset) or 1 (set)
  *     @buffer_metadata chordMetadata
+ * @conf  num_polarizations         Number of polarizations present in data set.
+ * @conf  num_dishes                Number of dishes present in data set.
  *
  * @author Roland Haas
  */
@@ -36,6 +38,12 @@ public:
     void main_thread() override;
 
 private:
+    /// The number of polarizations in data set
+    const int num_polarizations;
+
+    /// The number of dishes in data set
+    const int num_dishes;
+
     /// The buffer with the package loss data
     Buffer* pl_mask_buf;
 

--- a/lib/utils/visBuffer.cpp
+++ b/lib/utils/visBuffer.cpp
@@ -11,6 +11,7 @@
 #include <algorithm> // for copy
 #include <assert.h>  // for assert
 #include <complex>   // for complex
+#include <cstddef>   // for offsetof
 #include <cstdint>   // for uint64_t // IWYU pragma: keep
 #include <cstring>   // for memset
 #include <ctime>     // for gmtime
@@ -37,7 +38,12 @@ struct VisMetadataFormat {
     uint32_t num_elements;
     uint32_t num_prod;
     uint32_t num_ev;
+    uint32_t pad; // automatically inserted by compiler
 };
+// there are only 84 bytes of member data, but the struct gets padded to 8 bytes
+// this means that adding a 4 byte member will not change the struct size
+static_assert(sizeof(VisMetadataFormat) == 88, "Unexpected change in sizeof(VisMetadataFormat), "
+                                               "this will break binary data send to receivers");
 
 size_t VisMetadata::get_serialized_size() {
     return sizeof(VisMetadataFormat);
@@ -57,6 +63,8 @@ size_t VisMetadata::set_from_bytes(const char* bytes, [[maybe_unused]] size_t le
     num_elements = fmt->num_elements;
     num_prod = fmt->num_prod;
     num_ev = fmt->num_ev;
+    // cannot check pad value here, since the input bytes may be from an old
+    // file on disk
     return sz;
 }
 
@@ -73,6 +81,7 @@ size_t VisMetadata::serialize(char* bytes) {
     fmt->num_elements = num_elements;
     fmt->num_prod = num_prod;
     fmt->num_ev = num_ev;
+    fmt->pad = 0xdeadbeef; // initialize padding
     return sz;
 }
 


### PR DESCRIPTION
* 10f74d3a - EigenN2Iter: correct use of optional buffer for failures
* e3eebba8 - chime_upgrade_n2: add buffer for failed eigenvalues
* b3c376d0 - bufferQuiet: utility stage to hold frames until no new ones arrive anymore
* bcc65fc3 - ringbuffer: output number of producers / consumers
* 9a0f0e6c - buffer: output number of producers / consumers
* 94c70381 - givenDataGen: create a kotekan buffer with data given as config inputs
* a120aac9 - EigenN2Iter: catch eigenvalue calculation errors from blaze

none of these are actually required by anything. Some are "nice to have", some are "would this make sense"? 
