### PR TITLE
Replicate correlator counts from CHIME lost_samples buffer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 build-*
 docs/sphinx/html/*
 .ccache/*
+.cache/*
 scratch/*
 Manifest*.toml
 *.log

--- a/lib/stages/CMakeLists.txt
+++ b/lib/stages/CMakeLists.txt
@@ -82,6 +82,7 @@ add_library(
     HFBAccumulate.cpp
     compressLostSamples.cpp
     lostSamplesToPLMask.cpp
+    lostSamplesToN2Counts.cpp
     bufferBadInputs.cpp
     RfiFrameDrop.cpp
     VisSharedMemWriter.cpp

--- a/lib/stages/lostSamplesToN2Counts.cpp
+++ b/lib/stages/lostSamplesToN2Counts.cpp
@@ -1,0 +1,240 @@
+#include "lostSamplesToN2Counts.hpp"
+
+#include "Config.hpp" // for Config
+#include "DataType.hpp"
+#include "N2Util.hpp"          // for frameID
+#include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
+#include "buffer.hpp"          // for Buffer
+#include "bufferContainer.hpp" // for bufferContainer
+#include "chordMetadata.hpp"   // for get_chord_metadata, chordMetadata
+
+#include "json.hpp" // for basic_json, json, iter_impl
+
+#include <memory>
+#include <string>
+#include <sys/types.h>
+
+using kotekan::bufferContainer;
+using kotekan::Config;
+using kotekan::Stage;
+using nlohmann::json;
+
+
+REGISTER_KOTEKAN_STAGE(lostSamplesToN2Counts);
+
+// Random helpers for clarity
+#define BITS_PER_BYTE 8
+// Counts ALWAYS have tile size of 8
+#define COUNTS_BLOCK_SIZE 8
+#define COUNTS_ELEMENT_DOWNSAMPLE 8
+
+
+lostSamplesToN2Counts::lostSamplesToN2Counts(Config& config, const std::string& unique_name,
+                                             bufferContainer& buffer_container) :
+    Stage(config, unique_name, buffer_container,
+          std::bind(&lostSamplesToN2Counts::main_thread, this)),
+    num_elements(config.get<size_t>(unique_name, "num_elements")),
+    num_n2k_freq(config.get<size_t>(unique_name, "num_n2k_freq")),
+    samples_per_data_set(config.get<size_t>(unique_name, "samples_per_data_set")),
+    sub_integration_ntime(config.get<size_t>(unique_name, "sub_integration_ntime")) {
+
+    // Set up for n2 counts buffer. One buffer containing all
+    // frequencies on this node
+    n2k_counts_buf = get_buffer("n2k_counts_buf");
+    n2k_counts_buf->register_producer(unique_name);
+
+    // Register as a consumer for the rfi mask buffer, which should
+    // also be a single buffer for all frequencies
+    rfi_mask_buf = get_buffer("rfi_mask_buf");
+    rfi_mask_buf->register_consumer(unique_name);
+
+    // Register as a consumer for all the lost samples buffers
+    json ls_in_bufs = config.get_value(unique_name, "lost_samples_buffers");
+
+    for (json::iterator it = ls_in_bufs.begin(); it != ls_in_bufs.end(); ++it) {
+        Buffer* buf = buffer_container.get_buffer(it.value());
+
+        lost_samples_buffers.push_back(buf);
+        buf->register_consumer(unique_name);
+
+        if (buf->frame_size != lost_samples_buffers.at(0)->frame_size)
+            FATAL_ERROR("Input lost_samples buffers have different frame sizes: {:d} != {:d}",
+                        buf->frame_size, lost_samples_buffers.at(0)->frame_size);
+
+        if (buf->num_frames != lost_samples_buffers.at(0)->num_frames)
+            FATAL_ERROR("Input lost_samples buffers have different number of frames: {:d} != {:d}",
+                        buf->num_frames, lost_samples_buffers.at(0)->num_frames);
+    }
+
+    // Check counts size against both inputs
+    // lost_samples->frame_size == samples_per_data_set
+    // rfi_mask->frame_size == nfreq * samples_per_data_set / 8
+    // counts->frame_size == nfreq * subintegrations * _counts_stride * sizeof(int32_t)
+    if (samples_per_data_set != lost_samples_buffers.at(0)->frame_size)
+        FATAL_ERROR("lost_samples_buf does not have the expected number of samples. Expected {:d}, "
+                    "got {:d}",
+                    samples_per_data_set, lost_samples_buffers.at(0)->frame_size);
+
+    size_t _nbufs = lost_samples_buffers.size();
+    // Can't have a fractional number of frequencies
+    // rfi_mask is a bitmap, so frame size is reduced by a factor of 8
+    if ((BITS_PER_BYTE * rfi_mask_buf->frame_size) % samples_per_data_set != 0)
+        FATAL_ERROR("rfi_mask_buf and lost_samples_buf frame sizes are incompatable. rfi_mask: "
+                    "{:d}; lost_samples: {:d}",
+                    rfi_mask_buf->frame_size, samples_per_data_set);
+
+    if (num_n2k_freq % _nbufs != 0)
+        FATAL_ERROR(
+            "Number of lost_samples buffers ({:d}) does not evenly divide total frequencies ({:d})",
+            _nbufs, num_n2k_freq);
+
+    // Check rfi make frame size against expectation
+    size_t _expected_rfi_frame_size = num_n2k_freq * samples_per_data_set / BITS_PER_BYTE;
+    if (rfi_mask_buf->frame_size != _expected_rfi_frame_size)
+        FATAL_ERROR("Unexpected frame size for rfi_mask {:d} - expected {:d}",
+                    rfi_mask_buf->frame_size, _expected_rfi_frame_size);
+
+    // This is a bit of a misnomer - the lost_samples buffer does not _include_
+    // multiple frequencies, but information may be shared by multiple frequencies
+    _num_freq_per_lost_samples_buffer = num_n2k_freq / _nbufs;
+    // Number of subintegrations - i.e., time dimension of counts
+    // Integers, so no remainder
+    _num_subintegrations = samples_per_data_set / sub_integration_ntime;
+    // Number of instrument elements and the corresponding stride
+    // to take in the `counts` array
+    _counts_ntiles = (num_elements / (COUNTS_BLOCK_SIZE * COUNTS_ELEMENT_DOWNSAMPLE))
+                     * (1 + num_elements / (COUNTS_BLOCK_SIZE * COUNTS_ELEMENT_DOWNSAMPLE)) / 2;
+    _counts_stride = _counts_ntiles * COUNTS_BLOCK_SIZE * COUNTS_BLOCK_SIZE;
+
+    // Check counts frame size against expectations. counts has type int32
+    size_t _expected_counts_frame_size =
+        _num_subintegrations * num_n2k_freq * _counts_stride * sizeof(int32_t);
+
+    if (n2k_counts_buf->frame_size != _expected_counts_frame_size)
+        FATAL_ERROR("Unexpected frame sizes for n2_counts {:d} - expected {:d}",
+                    n2k_counts_buf->frame_size, _expected_counts_frame_size);
+
+    // Set the frame description
+    // The buffer name and axis names are the same as those set in
+    // cudaPL1butCorrelator
+    n2k_counts_buf->allocate_ndarray_frame_desc<kotekan::GetType_t<kotekan::int32>, 5>(
+        "n2k_counts",
+        {static_cast<long>(_num_subintegrations), static_cast<long>(num_n2k_freq),
+         static_cast<long>(_counts_ntiles), COUNTS_BLOCK_SIZE, COUNTS_BLOCK_SIZE},
+        {"Tc", "F", "D8Phi", "D8Plo1", "D8Plo2"});
+}
+
+lostSamplesToN2Counts::~lostSamplesToN2Counts() {}
+
+void lostSamplesToN2Counts::main_thread() {
+
+    // Create frame IDs for input and output buffers
+    N2::frameID n2k_counts_buf_frame_id(n2k_counts_buf);
+    N2::frameID rfi_mask_buf_frame_id(rfi_mask_buf);
+    // Get one for each lost_samples buffer
+    std::vector<N2::frameID> lost_samples_frame_ids;
+    for (size_t iter = 0; iter < lost_samples_buffers.size(); ++iter) {
+        lost_samples_frame_ids.emplace_back(lost_samples_buffers.at(iter));
+    }
+
+    while (!stop_thread) {
+        // Just need one complete frame with all frequencies here
+        DEBUG("Waiting on empty n2k_counts frame.");
+        int32_t* n2k_count_frame =
+            (int32_t*)n2k_counts_buf->wait_for_empty_frame(unique_name, n2k_counts_buf_frame_id);
+        if (n2k_count_frame == nullptr)
+            break;
+
+        DEBUG("Waiting on full RFI mask frame.");
+        uint8_t* rfi_mask_frame =
+            (uint8_t*)rfi_mask_buf->wait_for_full_frame(unique_name, rfi_mask_buf_frame_id);
+        if (rfi_mask_frame == nullptr)
+            break;
+
+        // Get the RFI mask low num samples, which is the last dimension
+        std::shared_ptr<chordMetadata> rfi_meta =
+            get_chord_metadata(rfi_mask_buf, rfi_mask_buf_frame_id);
+        // rfi_mask fine time samples (last dimension)
+        size_t _rfi_t_lo = rfi_meta->dim[rfi_meta->dims - 1];
+        // Stride between coarse time samples
+        size_t _rfi_f_stride = _rfi_t_lo;
+        size_t _rfi_t_hi_stride = num_n2k_freq * _rfi_f_stride;
+
+        // Iterate through the lost sample buffers
+        for (size_t fouter = 0; fouter < lost_samples_buffers.size(); ++fouter) {
+            auto lost_samples_buf = lost_samples_buffers.at(fouter);
+            N2::frameID& lost_samples_frame_id = lost_samples_frame_ids.at(fouter);
+
+            DEBUG("Waiting on full lost_samples frame from buffer {:d}.", fouter);
+            uint8_t* lost_samples_frame =
+                lost_samples_buf->wait_for_full_frame(unique_name, lost_samples_frame_id);
+            if (lost_samples_frame == nullptr)
+                break;
+
+            // Indices in counts and rfi_mask corresponding to the first
+            // frequency in the current lost_samples buffer
+            // Note that the rfi mask index is constructed per-bit (i.e. for
+            // a uint1 array) and converted to a uint8 index immediately
+            // before accessing the index in the array
+            size_t cidx_f = fouter * _num_freq_per_lost_samples_buffer * _counts_stride;
+            size_t ridx_f = fouter * _num_freq_per_lost_samples_buffer * _rfi_f_stride;
+
+            // Iterate the frequencies covered by this lost_samples buf
+            for (size_t f = 0; f < _num_freq_per_lost_samples_buffer; ++f) {
+                // Iterate subintegrations
+                for (size_t tau = 0; tau < _num_subintegrations; ++tau) {
+                    // Linear time index in the lost_samples buffer
+                    size_t t0 = tau * sub_integration_ntime;
+                    // Accumulate for this subintegration
+                    int32_t _sum = 0;
+                    for (size_t ts = t0; ts < t0 + sub_integration_ntime; ++ts) {
+                        // base offset + coarse_time * stride + fine_time
+                        size_t tsr =
+                            ridx_f + (ts / _rfi_t_lo) * _rfi_t_hi_stride + (ts % _rfi_t_lo);
+                        // Convert bit index in a uint1 buffer to byte index in a uint8 buffer
+                        tsr /= BITS_PER_BYTE;
+                        // Assume that this is a uint1 stream viewed as uint8, meaning
+                        // that the MSB is the first sample in a given byte
+                        uint8_t shiftval = (BITS_PER_BYTE - 1) - ts % BITS_PER_BYTE;
+                        // tsr only increments every 8 iterations -
+                        // accumulate individual bits
+                        _sum += (lost_samples_frame[ts] ^ 1u)
+                                & ((rfi_mask_frame[tsr] >> shiftval) & 1u);
+                    }
+                    // Set the current subintegration and freq in counts. Only
+                    // set the 0th value of each stride. If we wanted to set the
+                    // entire block, just add an extra loop here
+                    size_t idx = cidx_f + tau * num_n2k_freq * _counts_stride;
+                    n2k_count_frame[idx] = _sum;
+                }
+                // Shift frequency offset
+                ridx_f += _rfi_f_stride;
+                cidx_f += _counts_stride;
+            }
+            // Release the current lost_samples frame
+            lost_samples_buf->mark_frame_empty(unique_name, lost_samples_frame_id);
+            lost_samples_frame_id++;
+        }
+
+        // Set metadata from the frame description
+        n2k_counts_buf->allocate_new_metadata_object(n2k_counts_buf_frame_id);
+        std::shared_ptr<chordMetadata> meta =
+            get_chord_metadata(n2k_counts_buf, n2k_counts_buf_frame_id);
+        meta->set_from_frame_desc(n2k_counts_buf->get_ndarray_frame_desc());
+
+        // Set additional metadata not handled by the helper, including
+        // the name and FPGA time-sample downsampling
+        meta->set_name("n2k_counts");
+        meta->set_time_downsampling_fpga(sub_integration_ntime);
+
+        // Check that frame desc and metadata match
+        meta->check_frame_desc(n2k_counts_buf->get_ndarray_frame_desc());
+
+        // Release the current frames and increment to the next frame ID
+        n2k_counts_buf->mark_frame_full(unique_name, n2k_counts_buf_frame_id);
+        rfi_mask_buf->mark_frame_empty(unique_name, rfi_mask_buf_frame_id);
+
+        n2k_counts_buf_frame_id++;
+        rfi_mask_buf_frame_id++;
+    }
+}

--- a/lib/stages/lostSamplesToN2Counts.hpp
+++ b/lib/stages/lostSamplesToN2Counts.hpp
@@ -1,0 +1,82 @@
+#ifndef LOST_SAMPLES_TO_N2_COUNTS
+#define LOST_SAMPLES_TO_N2_COUNTS
+
+#include "Config.hpp"          // for Config
+#include "Stage.hpp"           // for Stage
+#include "buffer.hpp"          // for Buffer
+#include "bufferContainer.hpp" // for bufferContainer
+
+#include <string> // for string
+#include <vector> // for vector
+
+/**
+ * @brief Converts CHIME lost samples and rfi masks to counts expected by N2Accumulate
+ *
+ * This stage will accumulate the logical AND of the lost samples and RFI masks, based
+ * on the convention that a value of 1 correpsonds to a good sample and 0 to a flagged
+ * samples in the RFI mask, and a value of corresponds to a _missing_ sample in the
+ * lost samples mask.
+ *
+ * This stage is specific to CHIME - others should likely use cudaPL1bitCorrelator and
+ * do this operation on GPU. Because CHIME's lost sample (equivalent to packet loss) mask
+ * is one-dimensions (i.e., all elements are flagged if any packet is lost for a given
+ * frequency and time), only the 0th element index is actually set. Thus, this requires
+ * that the N2Accumulate config value `_packet_loss_is_scalar` is True.
+ *
+ * @par Buffers
+ * @buffer rfi_mask_buf Array of flags indicating samples affected by RFI
+ *     @buffer_format [num_times / 8 / 128][freq][128]
+ *     @buffer_metadata chordMetadata
+ * @buffer lost_samples_buf Array of flags which indicate if a sample in a given location is lost
+ *     @buffer_format [num_times]
+ *     @buffer_metadata chordMetadata
+ * @buffer n2k_counts_buf Array counting the number of good samples per subintegration
+ *     @buffer_format [num_subintegrations][freq][tiles][blocksize][blocksize]
+ *     @buffer_metadata chordMetadata
+ *
+ * @conf num_elements                        Int. Number of instrument elements. In CHIME, this
+ *                                           is the number of inputs times polarisations.
+ * @conf num_n2k_freq                        Int. The number of frequencies in each GPU frame.
+ * @conf samples_per_data_set                Int. The number of FPGA samples per frame.
+ * @conf sub_integration_ntime               Int. The number of FPGA samples to accumulate for.
+ *                                           This must correspond to the number of samples
+ *                                           accumulated by the correlator.
+ *
+ * @author Liam Gray
+ */
+class lostSamplesToN2Counts : public kotekan::Stage {
+public:
+    // Standard constructor
+    lostSamplesToN2Counts(kotekan::Config& config, const std::string& unique_name,
+                          kotekan::bufferContainer& buffer_container);
+
+    // Destructor
+    ~lostSamplesToN2Counts();
+
+    // Main thread accumulates lost_samples and rfi_mask
+    void main_thread() override;
+
+private:
+    // RFI mask buffer
+    Buffer* rfi_mask_buf;
+
+    // PL mask buffer. One buffer per frequency
+    std::vector<Buffer*> lost_samples_buffers;
+
+    // Buffer with the reshaped counts array
+    Buffer* n2k_counts_buf;
+
+    // Set from config file
+    size_t num_elements;          // number of instrument elements
+    size_t num_n2k_freq;          // number of freqs per N2 frame
+    size_t samples_per_data_set;  // number of fpga samples per input buffer
+    size_t sub_integration_ntime; // number of fpga samples per subintegration
+
+    // Private attrs for internal use
+    size_t _num_freq_per_lost_samples_buffer;
+    size_t _num_subintegrations; // tau_bar
+    size_t _counts_ntiles;
+    size_t _counts_stride;
+};
+
+#endif /* LOST_SAMPLES_TO_N2_COUNTS */

--- a/lib/stages/testDataGen.cpp
+++ b/lib/stages/testDataGen.cpp
@@ -298,6 +298,9 @@ void testDataGen::main_thread() {
             frameu64 = (uint64_t*)frame;
             if (chordmeta)
                 chordmeta->type = kotekan::uint64;
+        } else if (type == "random") {
+            if (chordmeta)
+                chordmeta->type = kotekan::uint4x2;
         } else if (type == "random_signed") {
             if (chordmeta)
                 chordmeta->type = kotekan::int4x2;
@@ -307,6 +310,9 @@ void testDataGen::main_thread() {
         } else if (type == "random1x8") {
             if (chordmeta)
                 chordmeta->type = kotekan::uint1x8;
+        } else if (type == "ramp") {
+            if (chordmeta)
+                chordmeta->type = kotekan::uint8;
         } else if (type == "tpluse") {
             if (chordmeta)
                 chordmeta->type = kotekan::uint1x8;
@@ -319,8 +325,11 @@ void testDataGen::main_thread() {
         } else if (type == "square") {
             if (chordmeta)
                 chordmeta->type = kotekan::int4x2;
+        } else if (type == "onehot") {
+            if (chordmeta)
+                chordmeta->type = kotekan::uint8;
         } else {
-            ERROR("unexpected type: {s}", type);
+            ERROR("unexpected type: {:s}", type);
             throw std::runtime_error("unexpected type: " + type);
         }
 
@@ -489,7 +498,7 @@ void testDataGen::main_thread() {
                 temp_output = ((new_real << 4) & 0xF0) + (new_imaginary & 0x0F);
                 frame[j] = temp_output;
             } else {
-                ERROR("unexpected type: {s}", type);
+                ERROR("unexpected type: {:s}", type);
                 throw std::runtime_error("unexpected type: " + type);
             }
         }

--- a/tests/test_lostsamples_to_n2counts.py
+++ b/tests/test_lostsamples_to_n2counts.py
@@ -1,0 +1,417 @@
+"""Tests for `lostSampesToN2Counts` stage."""
+
+import pytest
+
+from kotekan import runner
+
+# TODO: should this be a skip or a fail?
+if not runner.has_hdf5():
+    pytest.skip("HDF5 support not available; skipping...")
+
+import h5py
+import numpy as np
+
+from pathlib import Path
+
+global_params: dict = {
+    "log_level": "DEBUG",
+    "num_elements": 2048,  # CHIME
+    "counts_ntiles": (2048 / 64) * (1 + 2048 / 64) / 2,
+    "sizeof_int": 4,
+}
+
+
+class FakeRFIBuffer(runner.InputBuffer):
+    """Create an input rfi mask using `testDataGen`.
+
+    Parameters
+    ----------
+    samples_per_data_set : int
+        Number of FPGA time samples per dataset.
+    num_local_freq : int
+        Number of frequencies present in this buffer.
+    **kwargs : dict
+        Parameters fed straight into the stage config.
+    """
+
+    _buf_ind: int = 0
+
+    def __init__(self, samples_per_data_set: int, num_local_freq: int, **kwargs: dict):
+
+        self.name = f"fake_rfi_buf_{self._buf_ind:,}"
+        stage_name = f"fake_gen_rfi_{self._buf_ind:,}"
+
+        self.__class__._buf_ind += 1
+
+        self.buffer_block = {
+            self.name: {
+                "kotekan_buffer": "standard",
+                "metadata_pool": "main_pool",
+                "num_frames": "buffer_depth",
+                "frame_size": "(samples_per_data_set * num_local_freq) / 8",
+            }
+        }
+
+        stage_config = {
+            "kotekan_stage": "testDataGen",
+            "out_buf": self.name,
+            "type": "const1x8",
+            "value": 255,
+            "name": stage_name,
+            "array_shape": [samples_per_data_set // 128 // 8, num_local_freq, 128],
+            "dim_name": ["T8hi128", "F", "T8lo128"],
+        }
+
+        stage_config.update(**kwargs)
+
+        self.stage_block = {stage_name: stage_config}
+
+
+class FakeLostSamplesN2Buffer(runner.InputBuffer):
+    """Create input `lost_samples` buffer using `testDataGen`.
+
+    This is specific to the N2 pipeline and produces a single mask
+    value per FPGA time sample.
+
+    Parameters
+    ----------
+    samples_per_data_set : int
+        Number of FPGA time samples.
+    **kwargs : dict
+        Additional parameters fed to the stage config.
+    """
+
+    _buf_ind: int = 0
+
+    def __init__(self, samples_per_data_set: int, **kwargs: dict):
+        self.name = f"fake_lost_samples_buf_{self._buf_ind}"
+        stage_name = f"fake_gen_lost_samples_{self._buf_ind}"
+
+        self.__class__._buf_ind += 1
+
+        self.buffer_block = {
+            self.name: {
+                "kotekan_buffer": "standard",
+                "metadata_pool": "main_pool",
+                "num_frames": "buffer_depth",
+                "frame_size": "samples_per_data_set",
+            }
+        }
+
+        stage_config = {
+            "kotekan_stage": "testDataGen",
+            "out_buf": self.name,
+            "type": "const8",
+            "value": 1,
+            "name": stage_name,
+            "array_shape": [samples_per_data_set],
+            "dim_name": ["T"],
+        }
+
+        stage_config.update(**kwargs)
+
+        self.stage_block = {stage_name: stage_config}
+
+
+class DumpCountsBuffer(runner.OutputBuffer):
+    """Consume a N2 Counts buffer and provide its content as `CountsBuffer` objects.
+
+    Parameters
+    ----------
+    output_dir : str
+        Temp. directory to output to. Dumped files are not removed.
+    """
+
+    _buf_ind = 0
+
+    name = None
+
+    def __init__(self, output_dir, num_elements=None):
+        self.name = f"dumpcounts_buf{self._buf_ind}"
+        stage_name = f"dump{self._buf_ind}"
+
+        self.__class__._buf_ind += 1
+
+        self.output_dir = output_dir
+        self.num_elements = num_elements
+
+        self.buffer_block = {
+            self.name: {
+                "kotekan_buffer": "standard",
+                "metadata_pool": "main_pool",
+                "num_frames": "buffer_depth",
+                "frame_size": "sizeof_int * num_local_freq * counts_ntiles * 8 * 8 * samples_per_data_set / sub_integration_ntime",
+            }
+        }
+
+        self.stage_block = {
+            stage_name: {
+                "kotekan_stage": "hdf5FileWrite",
+                "in_buf": self.name,
+                "file_name": self.name,
+                "base_dir": output_dir,
+                "prefix_hostname": False,
+                "max_frames": "buffer_depth",
+            }
+        }
+
+    def load(self):
+        """Load the output data from the buffer.
+
+        Returns
+        -------
+        dumps : lost of buffers
+            Buffer output.
+        """
+        import glob
+
+        files = glob.glob(f"{self.output_dir}/*{self.name}*.h5")
+
+        dsets = []
+
+        for file in files:
+            # HDF5 file write produces a file called
+            # <file_name>.<_buf_ind>.h5, so strip off
+            # the number when accessing the dataset name
+            dset_name = Path(file).stem.split(".")[0]
+
+            dsets.append(h5py.File(file, "r")[dset_name])
+
+        return dsets
+
+
+def _generate_input_rfibuf(
+    nsamples: int, nfreq: int
+) -> tuple[FakeRFIBuffer, np.ndarray]:
+    """Buffer (and matching array) representing a `uint1` RFI mask.
+
+    Has shape (nsamples // 128 // 8, nfreq, 128).
+
+    Parameters
+    ----------
+    nsamples
+        Number of FPGA time samples
+    nfreq
+        Number of frequencies per node
+
+    Returns
+    -------
+    buf : runner.FakeRFIBuffer
+        Buffer instance filled with ones.
+    arr : np.ndarray
+        Numpy array of same size filled with ones.
+    """
+    buf = FakeRFIBuffer(samples_per_data_set=nsamples, num_local_freq=nfreq)
+
+    arr = np.ones(nsamples * nfreq, dtype=np.uint8)
+    arr = np.packbits(arr, axis=-1, bitorder="big")
+
+    return buf, arr
+
+
+def _generate_input_lost_samples_bufs(
+    nsamples: int, nbufs: int
+) -> tuple[list[FakeLostSamplesN2Buffer], list[np.ndarray]]:
+    """Buffers (and matching arrays) representing `uint8` lost samples masks.
+
+    `nbufs` buffers of size `nsamples`.
+
+    Parameters
+    ----------
+    nsamples
+        Number of FPGA time samples
+    nbufs
+        Number of individual buffers to produce
+
+    Returns
+    -------
+    buffers : list
+        List of `FakeLostSamplesN2Buffer` objects.
+    arrays : list
+        List of numpy arrays matching the buffer data.
+    """
+    buffers = []
+
+    # This is set to match the corresponding numpy array.
+    # If this is changed, must change the array as well
+    fill_type_args: dict = {"type": "ramp", "value": 1}
+
+    for n in range(nbufs):
+        buffers.append(
+            FakeLostSamplesN2Buffer(samples_per_data_set=nsamples, **fill_type_args)
+        )
+
+    # Create the matching numpy array
+    arr = (np.arange(nsamples) % 256).astype(np.uint8)
+
+    return buffers, [arr.copy() for _ in range(nbufs)]
+
+
+def accumulate_numpy(
+    nsamples: int,
+    nfreq: int,
+    sub_integration_time: int,
+    rfiarr: np.ndarray,
+    lost_samples_arrs: list[np.ndarray],
+) -> np.ndarray:
+    """Combine and integrate array copies of input buffers.
+
+    This should be used to test against the result of `accumulate`.
+    Parameters
+    ----------
+    nsamples
+        Number of FPGA time samples per frame
+    nfreq
+        Number of frequencies per RFI buffer
+    sub_integration_time
+        Number of time samples per subintegration
+    rfiarr
+        Array corresponding to the RFI mask
+    lost_samples_arrs
+        List of 1D arrays corresponding to lost_samples masks
+
+    Returns
+    -------
+    expected_output : np.ndarray
+        Array created by multiplying and accumulating the input masks
+    """
+    # Sort out the expected RFI buffer dimensions
+    t_hi = nsamples // 128
+    # Unpack and reshape the rfi array to shape [freq, subintegrations]
+    ra = np.unpackbits(rfiarr, axis=-1, bitorder="big")
+
+    # Split the array into coarse time samples and concatenate into
+    # a single contiguous time axis
+    rtc = []
+    for arr in np.array_split(ra, t_hi):
+        rtc.append(arr.reshape(nfreq, -1))
+
+    rtc = np.concatenate(rtc, axis=-1)
+
+    # Sort out the expected number of frequencies represented
+    # by each lost_samples buffer
+    nbufs = len(lost_samples_arrs)
+
+    if nfreq % nbufs:
+        raise RuntimeError(
+            f"Number of lost_samples buffers ({nbufs}) does not evenly divide frequencies ({nfreq})."
+        )
+
+    nfreq_per_buf = nfreq // nbufs
+
+    expected_output = np.zeros(
+        (nsamples // sub_integration_time, nfreq), dtype=np.int32
+    )
+
+    for ii, buf in enumerate(lost_samples_arrs):
+        # reshape to sum over the last axis for accumulation
+        ea = buf.reshape(-1, sub_integration_time)
+        sl = slice(ii * nfreq_per_buf, (ii + 1) * nfreq_per_buf)
+        eb = rtc[sl].reshape(-1, sub_integration_time)
+        # Should automatically broadcast length-1 axis in ea against
+        # freq slice in eb
+        expected_output[:, ii] = ((ea ^ 1) & eb).astype(np.int32).sum(axis=-1)
+
+    return expected_output
+
+
+def accumulate(
+    tmpdir: str,
+    nsamples: int,
+    nfreq: int,
+    sub_integration_ntime: int,
+    rfibuf: FakeRFIBuffer,
+    lost_samples_bufs: list[FakeLostSamplesN2Buffer],
+) -> list[h5py.File]:
+    """Get and process a combination of input buffers.
+
+    Parameters
+    ----------
+    nsamples
+        Number of FPGA time samples
+    nfreq
+        Number of frequencies
+    nbufs
+        Number of lost samples buffer to produce
+    """
+    # This needs to be in the global config to calculate the
+    # counts buffer tile size
+    gp = {
+        **global_params,
+        "sub_integration_ntime": sub_integration_ntime,
+        "samples_per_data_set": nsamples,
+        "num_local_freq": nfreq,
+    }
+
+    output_buf = DumpCountsBuffer(
+        str(tmpdir), num_elements=global_params["num_elements"]
+    )
+
+    run_params = {
+        "num_n2k_freq": nfreq,  # This has a different name from num_local_freq in the stage
+        "sub_integration_ntime": sub_integration_ntime,
+        "samples_per_data_set": nsamples,
+        "num_elements": global_params["num_elements"],
+        "rfi_mask_buf": rfibuf.name,
+        "lost_samples_buffers": [buf.name for buf in lost_samples_bufs],
+        "n2k_counts_buf": output_buf.name,
+    }
+
+    test = runner.KotekanStageTester(
+        "lostSamplesToN2Counts",
+        run_params,
+        [rfibuf, *lost_samples_bufs],
+        output_buf,
+        gp,
+    )
+
+    test.run()
+
+    return output_buf.load()
+
+
+@pytest.mark.parametrize("nsamples", [2048])
+@pytest.mark.parametrize("nfreq", [1, 3, 4])
+@pytest.mark.parametrize("sub_integration_ntime", [1, 8, 128, 512])
+def test_accumulate(tmpdir_factory, nsamples, nfreq, sub_integration_ntime):
+    """Test the numerical correctness of the stage accumulation.
+
+    These are integers and should be an exact match.
+    """
+    rfibuf, rfiarr = _generate_input_rfibuf(nsamples, nfreq)
+    lost_samples_bufs, lost_samples_arrs = _generate_input_lost_samples_bufs(
+        nsamples, nfreq
+    )
+
+    arr_accum = accumulate_numpy(
+        nsamples, nfreq, sub_integration_ntime, rfiarr, lost_samples_arrs
+    )
+
+    tmpdir = tmpdir_factory.mktemp(f"tmp_{nsamples}_{nfreq}_{sub_integration_ntime}")
+
+    _expected_shape = [
+        nsamples // sub_integration_ntime,
+        nfreq,
+        global_params["counts_ntiles"],
+        8,
+        8,
+    ]
+    _expected_dim_names = ["Tc", "F", "D8Phi", "D8Plo1", "D8Plo2"]
+
+    # This is a generator, so use a loop even if returning a single dset
+    for dset in accumulate(
+        tmpdir, nsamples, nfreq, sub_integration_ntime, rfibuf, lost_samples_bufs
+    ):
+        # Check that metadata is correct
+        assert dset.attrs["name"] == "n2k_counts"
+        assert dset.attrs["type"] == "int32"
+        assert dset.attrs["time_downsampling_fpga"] == sub_integration_ntime
+        assert (dset.attrs["dim_names"] == _expected_dim_names).all()
+
+        # Check the payload
+        arr = dset[:]
+        assert arr.dtype == np.int32
+        assert np.all([arrs == es for arrs, es in zip(arr.shape, _expected_shape)])
+        # Check that the payload is as-expected and non-zero
+        assert np.any(arr > 0)
+        assert (arr[:, :, 0, 0, 0] == arr_accum).all()


### PR DESCRIPTION
Creates the `counts` buffer required by `N2Accumulate` using the CHIME lost_samples and rfi masks.

I've _assumed_ that the masking convention is 0 == bad, 1 == good (based on a couple of comments I've found), but if this isn't the case then it's a simple fix.

Probably some missing metadata