### PR TITLE
Rhaas/metadata catchup

### DIFF
--- a/lib/dpdk/iceBoardShuffle.hpp
+++ b/lib/dpdk/iceBoardShuffle.hpp
@@ -277,7 +277,7 @@ iceBoardShuffle::iceBoardShuffle(kotekan::Config& config, const std::string& uni
         out_bufs[i]
             ->allocate_ndarray_frame_desc<
                 kotekan::GetType<kotekan::int4x2_swapped_withoffset>::type, 3>(
-                "E", {ptrdiff_t(out_bufs[i]->frame_size) / sample_size, sample_size},
+                "E", {1, ptrdiff_t(out_bufs[i]->frame_size) / sample_size, sample_size},
                 {"F", "T", "E"});
     }
 


### PR DESCRIPTION
correct missing first dimension size in dpdk metadata. :-( 

C++ does not enforce the size of the list used to initalize a `std::array` to match the array's size 