### PR TITLE
Extra RFI plumbing in pathfinder config

### DIFF
--- a/config/chord_pathfinder.j2
+++ b/config/chord_pathfinder.j2
@@ -54,7 +54,9 @@
 
 # RFI Detection Parameters
 {% set rfi_downsampling_factor = 256 %}
+{% set rfi_second_downsampling_factor = 32 %}
 {% set rfi_num_times = samples_per_data_set // rfi_downsampling_factor %}  {# = 32 #}
+{% set rfi_num_times_bar = rfi_num_times //  rfi_second_downsampling_factor %}  {# = 1 #}
 
 # RFI SK Thresholds
 {% set rfi_sk_rfimask_sigmas = 5.0 %}
@@ -97,7 +99,9 @@ sizeof_float32: 4
 sub_integration_ntime: {{ sub_integration_ntime }}
 samples_per_data_set: {{ samples_per_data_set }}
 rfi_downsampling_factor: {{ rfi_downsampling_factor }}
+rfi_second_downsampling_factor: {{ rfi_second_downsampling_factor }}
 rfi_num_times: {{ rfi_num_times }}
+rfi_num_times_bar: {{ rfi_num_times_bar }}
 rfi_sk_rfimask_sigmas: {{ rfi_sk_rfimask_sigmas }}
 rfi_single_feed_min_good_frac: {{ rfi_single_feed_min_good_frac }}
 rfi_feed_averaged_min_good_frac: {{ rfi_feed_averaged_min_good_frac }}
@@ -118,9 +122,6 @@ time_short: 16
 time_long: samples_per_data_set / time_short
 element_short: 8
 element_long: num_elements / element_short
-
-# GIGA: 1000000000
-# start_time_s: 1760000000 # ~ 2025-10-09
 
 telescope:
   name: CHORDTelescope
@@ -230,6 +231,18 @@ host_rfi_RFImask_buffer:
     frame_size: num_local_freq * samples_per_data_set / 8
     zero_new_frames: true
     zero_value: 0xFF
+    metadata_pool: main_pool
+
+host_rfi_SKtilde_buffer:
+    kotekan_buffer: standard
+    num_frames: host_side_buffer_depth
+    frame_size: sizeof_float32 * 3 * num_local_freq * rfi_num_times
+    metadata_pool: main_pool
+
+host_rfi_SKbar_buffer:
+    kotekan_buffer: standard
+    num_frames: host_side_buffer_depth
+    frame_size: sizeof_float32 * num_polarizations * num_dishes * 3 * num_local_freq * rfi_num_times_bar
     metadata_pool: main_pool
 
 # Note this is the expanded version of the pl_mask used for correlator input
@@ -354,6 +367,27 @@ host_pl_mask_ringbuffer:
 host_rfi_S012_ringbuffer:
     kotekan_buffer: ring
     ring_buffer_size: buffer_depth * sizeof_uint64 * num_dishes * num_polarizations * 3 * num_local_freq * rfi_num_times
+    metadata_pool: main_pool
+
+# RFI S012bar statistics ringbuffer (time-downsampled)
+# Shape: [Trfibar, F, S, P, D] = [rfi_num_times_bar, num_local_freq, 3, 2, num_dishes]
+host_rfi_S012bar_ringbuffer:
+    kotekan_buffer: ring
+    ring_buffer_size: buffer_depth * sizeof_uint64 * num_dishes * num_polarizations * 3 * num_local_freq * rfi_num_times_bar
+    metadata_pool: main_pool
+
+# RFI SKbar statistics ringbuffer (time-downsampled SK)
+# Shape: [Trfibar, F, SK, P, D] = [rfi_num_times_bar, num_local_freq, 3, 2, num_dishes]
+host_rfi_SKbar_ringbuffer:
+    kotekan_buffer: ring
+    ring_buffer_size: buffer_depth * sizeof_float32 * num_dishes * num_polarizations * 3 * num_local_freq * rfi_num_times_bar
+    metadata_pool: main_pool
+
+# RFI SKbartilde statistics ringbuffer (time-downsampled and feed-averaged SK)
+# Shape: [Trfibar, F, SK] = [rfi_num_times_bar, num_local_freq, 3]
+host_rfi_SKbar_ringbuffer:
+    kotekan_buffer: ring
+    ring_buffer_size: buffer_depth * sizeof_float32 * 3 * num_local_freq * rfi_num_times_bar
     metadata_pool: main_pool
 
 # RFI SKtilde statistics ringbuffer (feed-averaged SK)
@@ -575,6 +609,45 @@ run_rfi_SKtilde:
           rfi_SKtilde_name: rfi_SKtilde
           rfi_RFImask_name: rfi_RFImask
 
+# Downsample S0, S1, S2 statistics by rfi_second_downsampling_factor
+run_rfi_S012bar:
+    num_frequencies: num_local_freq
+    gpu_0:
+        kotekan_stage: cudaProcess
+        gpu_id: 0
+        in_buffers:
+            host_rfi_S012_ringbuffer: host_rfi_S012_ringbuffer
+        out_buffers:
+            host_rfi_S012bar_ringbuffer: host_rfi_S012bar_ringbuffer
+        commands:
+        - name: cudaRFIS012bar
+          rfi_S012_name: rfi_S012
+          rfi_S012bar_name: rfi_S012bar
+
+# Compute SK statistics from S012bar + bf_mask
+run_rfi_SKbar:
+    num_frequencies: num_local_freq
+    gpu_0:
+        kotekan_stage: cudaProcess
+        gpu_id: 0
+        in_buffers:
+            host_bf_mask_buffer: host_bf_mask_buffer
+            host_rfi_S012bar_ringbuffer: host_rfi_S012bar_ringbuffer
+        out_buffers:
+            host_rfi_SKbar_ringbuffer: host_rfi_SKbar_ringbuffer
+            host_rfi_SKbartilde_ringbuffer: host_rfi_SKbartilde_ringbuffer
+        commands:
+        - name: cudaInputData
+          do_once: true
+          in_buf: host_bf_mask_buffer
+          gpu_mem: bf_mask_buffer
+        - name: cudaSyncInput
+        - name: cudaRFISKbar
+          bf_mask_name: bf_mask
+          rfi_S012bar_name: rfi_S012bar
+          rfi_SKbar_name: rfi_SKbartilde
+          rfi_SKbartilde_name: rfi_SKbartilde
+
 # Packet-loss correlator to produce counts for N2Accumulate
 
 run_pl_corr:
@@ -618,6 +691,57 @@ run_n2k:
         - name: cudaOutputData
           gpu_mem: correlation_buffer
           out_buf: host_correlation
+
+# Copy RFI mask back to CPU
+run_recv_rfi_mask:
+    gpu_0:
+        kotekan_stage: cudaProcess
+        gpu_id: 0
+        in_buffers:
+            host_rfi_RFImask_ringbuffer_in: host_rfi_RFImask_ringbuffer
+        out_buffers:
+            host_rfi_RFImask_buffer_out: host_rfi_RFImask_buffer
+        commands:
+        - name: cudaCopyFromRingbuffer
+          host_signal: host_rfi_RFImask_ringbuffer_in
+          gpu_mem_input: rfi_RFImask_buffer
+          output_size: samples_per_data_set * num_local_freq / 8
+          ring_buffer_size: buffer_depth * output_size
+          out_buf: host_rfi_RFImask_buffer_out
+
+# Copy RFI feed-averaged SK statistics back to CPU
+run_recv_SKtilde:
+    gpu_0:
+        kotekan_stage: cudaProcess
+        gpu_id: 0
+        in_buffers:
+            host_rfi_SKtilde_ringbuffer_in: host_rfi_SKtilde_ringbuffer
+        out_buffers:
+            host_rfi_SKtilde_buffer_out: host_rfi_SKtilde_buffer
+        commands:
+        - name: cudaCopyFromRingbuffer
+          host_signal: host_rfi_SKtilde_ringbuffer_in
+          gpu_mem_input: rfi_SKtilde_buffer
+          output_size: sizeof_float32 * 3 * num_local_freq * rfi_num_times
+          ring_buffer_size: buffer_depth * output_size
+          out_buf: host_rfi_SKtilde_buffer_out
+
+# Copy RFI time-downsampled SK statistics back to CPU
+run_recv_SKbar:
+    gpu_0:
+        kotekan_stage: cudaProcess
+        gpu_id: 0
+        in_buffers:
+            host_rfi_SKbar_ringbuffer_in: host_rfi_SKbar_ringbuffer
+        out_buffers:
+            host_rfi_SKbar_buffer_out: host_rfi_SKbar_buffer
+        commands:
+        - name: cudaCopyFromRingbuffer
+          host_signal: host_rfi_SKbar_ringbuffer_in
+          gpu_mem_input: rfi_SKbar_buffer
+          output_size: sizeof_float32 * num_dishes * num_polarizations * 3 * num_local_freq * rfi_num_time_bar
+          ring_buffer_size: buffer_depth * output_size
+          out_buf: host_rfi_SKbar_buffer_out
 
 
 # Accumulate N2K visibilities on CPU

--- a/config/chord_pathfinder.j2
+++ b/config/chord_pathfinder.j2
@@ -385,7 +385,7 @@ host_rfi_SKbar_ringbuffer:
 
 # RFI SKbartilde statistics ringbuffer (time-downsampled and feed-averaged SK)
 # Shape: [Trfibar, F, SK] = [rfi_num_times_bar, num_local_freq, 3]
-host_rfi_SKbar_ringbuffer:
+host_rfi_SKbartilde_ringbuffer:
     kotekan_buffer: ring
     ring_buffer_size: buffer_depth * sizeof_float32 * 3 * num_local_freq * rfi_num_times_bar
     metadata_pool: main_pool
@@ -645,7 +645,7 @@ run_rfi_SKbar:
         - name: cudaRFISKbar
           bf_mask_name: bf_mask
           rfi_S012bar_name: rfi_S012bar
-          rfi_SKbar_name: rfi_SKbartilde
+          rfi_SKbar_name: rfi_SKbar
           rfi_SKbartilde_name: rfi_SKbartilde
 
 # Packet-loss correlator to produce counts for N2Accumulate
@@ -739,7 +739,7 @@ run_recv_SKbar:
         - name: cudaCopyFromRingbuffer
           host_signal: host_rfi_SKbar_ringbuffer_in
           gpu_mem_input: rfi_SKbar_buffer
-          output_size: sizeof_float32 * num_dishes * num_polarizations * 3 * num_local_freq * rfi_num_time_bar
+          output_size: sizeof_float32 * num_dishes * num_polarizations * 3 * num_local_freq * rfi_num_times_bar
           ring_buffer_size: buffer_depth * output_size
           out_buf: host_rfi_SKbar_buffer_out
 

--- a/config/chord_pathfinder.j2
+++ b/config/chord_pathfinder.j2
@@ -836,3 +836,29 @@ hdf5_N2_write_eigen:
     num_ev: num_ev_to_calculate
     n2_layout: "FullUpperTri"
     num_file_t: 20
+
+# Write out (some) SKtilde statistics
+hdf5_write_SKtilde:
+    log_level: INFO
+    kotekanStage: hdf5FileWrite
+    cpu_affinity: [13]
+    in_buf: host_rfi_SKtilde_buffer
+    base_dir: /mnt/cs00/data/kotekan_vis_files/SKtilde/
+    filename: pipeline_SKtilde
+    prefix_hostname: false
+    create_single_file: true
+    write_x_frames: 32  # 1 frame is ~42 ms, so this is ~1.3 s of writing
+    per_y_frames: 16384 # 2048 = 32 * 64 ~ 1.3 minutes  16384 ~ 11 minutes
+
+# Write out (some) SKbar statistics
+hdf5_write_SKtilde:
+    log_level: INFO
+    kotekanStage: hdf5FileWrite
+    cpu_affinity: [13]
+    in_buf: host_rfi_SKbar_buffer
+    base_dir: /mnt/cs00/data/kotekan_vis_files/SKbar/
+    filename: pipeline_SKbar
+    prefix_hostname: false
+    create_single_file: true
+    write_x_frames: 32  # 1 frame is ~42 ms, so this is ~1.3 s of writing
+    per_y_frames: 16384 # 2048 = 32 * 64 ~ 1.3 minutes  16384 ~ 11 minutes

--- a/lib/stages/hdf5FileWrite.cpp
+++ b/lib/stages/hdf5FileWrite.cpp
@@ -501,6 +501,7 @@ public:
             INFO("Received buffer {} frame {} (duration {} sec)", unique_name, frame_counter,
                  elapsed_time);
 
+            // Optionally, only write every X out of Y frames.
             bool do_write = true;
             if (write_x_frames >= 0 && per_y_frames > 0) {
                 if (frame_counter % per_y_frames > write_x_frames) {

--- a/lib/stages/hdf5FileWrite.cpp
+++ b/lib/stages/hdf5FileWrite.cpp
@@ -81,6 +81,10 @@ class hdf5FileWrite : public kotekan::Stage {
     const bool skip_writing = config.get_default<bool>(unique_name, "skip_writing", false);
     const bool create_single_file =
         config.get_default<bool>(unique_name, "create_single_file", false);
+    const int64_t write_x_frames =
+        config.get_default<int64_t>(unique_name, "write_x_frames", -1);
+    const int64_t per_y_frames =
+        config.get_default<int64_t>(unique_name, "per_y_frames", -1);
 
     Buffer* const buffer;
 
@@ -497,7 +501,14 @@ public:
             INFO("Received buffer {} frame {} (duration {} sec)", unique_name, frame_counter,
                  elapsed_time);
 
-            if (!skip_writing) {
+            bool do_write = true;
+            if (write_x_frames >= 0 && per_y_frames > 0) {
+                if (frame_counter % per_y_frames > write_x_frames) {
+                    do_write = false;
+                }
+            }
+
+            if (!skip_writing && do_write) {
                 // Fetch metadata
                 const std::shared_ptr<const metadataObject> mc = buffer->get_metadata(frame_id);
                 if (!mc)


### PR DESCRIPTION
- RFImask is now copied from GPU to host (so N2Accumulate can get correct count of rfi-dropped samples)
- Added buffers and stages for running time-downsampled SK statistics, and added stages copying feed-averaged SK (SKtilde) and time-downsampled SK (SKbar) back to CPU.
- Did not add file writers for SKbar and SKtilde buffers.