### PR TITLE
Add DUT1 updatable config to chime_keep_gpu_warm.yaml

### DIFF
--- a/config/chime_keep_gpu_warm.yaml
+++ b/config/chime_keep_gpu_warm.yaml
@@ -114,6 +114,9 @@ updatable_config:
   frb_gain:
     kotekan_update_endpoint: json
     frb_gain_dir: /invalid
+  DUT1:
+    kotekan_update_endpoint: json
+    DUT1: -0.01771538093532198585
   tracking_gain:
     0:
       kotekan_update_endpoint: json


### PR DESCRIPTION
The top of this file points out that this is the same config as the `no_output` config except without the DPDK packet capture.

But that's not quite true anymore: a few differences other than the one I fix here have evolved over time.  I wonder if we should do a more thorough review of the differences at some point.