### PR TITLE
skip common extraneous directories in clang-format

### DIFF
--- a/tools/lint.sh
+++ b/tools/lint.sh
@@ -127,7 +127,7 @@ fi
 
 # clang-format
 echo "Running clang-format..."
-find $KOTEKAN_DIR -type d \( -name "build-iwyu" -o -name "build" -o -name "external" \) -prune -o -type f -regex '.*\.\(cpp\|hpp\|c\|h\)' -exec $CLANG_FORMAT -style=file -i {} \;
+find $KOTEKAN_DIR -type d \( -name "build-iwyu" -o -name "build" -o -name "external" -o -name ".venv" -o -name "scratch" \) -prune -o -type f -regex '.*\.\(cpp\|hpp\|c\|h\)' -exec $CLANG_FORMAT -style=file -i {} \;
 if ! git diff --exit-code; then
     echo "Error: clang-format found formatting issues" >&2
     ERROR=1


### PR DESCRIPTION
Just a small modification to `tools/lint.sh` to improve run speed in some environments. In addition to directories skipped already, clang-format will skip:
- `.venv/`  (created by Python virtual envionments, can include a lot of C/C++ code)
- `scratch/` (common work directory for quick scripts and tests)