### PR TITLE
Minor tweaks to `bufferBadInputs`

### DIFF
--- a/lib/stages/bufferBadInputs.cpp
+++ b/lib/stages/bufferBadInputs.cpp
@@ -1,5 +1,3 @@
-#define DONTUSECHIMEMETA 1
-
 #include "bufferBadInputs.hpp"
 
 #include "Config.hpp"         // for Config
@@ -8,15 +6,10 @@
 #include "chordMetadata.hpp"  // for get_chord_metadata, chordMetadata
 #include "configUpdater.hpp"  // for configUpdater
 #include "kotekanLogging.hpp" // for DEBUG, ERROR
-#include "visUtil.hpp"        // for parse_reorder_default
 
-#include "fmt.hpp" // for compile_string_to_view
-
-#include <algorithm>  // for copy, max
 #include <exception>  // for exception
 #include <functional> // for bind, function, _1
 #include <memory>     // for __shared_ptr_access, shared_ptr
-#include <tuple>      // for get
 
 using kotekan::bufferContainer;
 using kotekan::Config;
@@ -27,71 +20,57 @@ REGISTER_KOTEKAN_STAGE(bufferBadInputs);
 
 bufferBadInputs::bufferBadInputs(Config& config_, const std::string& unique_name,
                                  bufferContainer& buffer_container) :
-    Stage(config_, unique_name, buffer_container, std::bind(&bufferBadInputs::main_thread, this)) {
+    Stage(config_, unique_name, buffer_container, std::bind(&bufferBadInputs::main_thread, this)),
+    // Required since `frame_id` is used outside of the main loop
+    frame_id(get_buffer("out_buf")) {
 
-    uint32_t num_elements = config.get<uint32_t>(unique_name, "num_elements");
-    input_mask_len = sizeof(uint8_t) * num_elements;
-
-    auto input_reorder = parse_reorder_default(config, unique_name);
-    input_remap = std::get<0>(input_reorder);
+    num_elements = config.get<size_t>(unique_name, "num_elements");
 
     out_buf = get_buffer("out_buf");
     out_buf->register_producer(unique_name);
-
-    out_buffer_ID = 0;
 }
 
 bufferBadInputs::~bufferBadInputs() {}
 
 bool bufferBadInputs::update_bad_inputs_callback(nlohmann::json& json) {
-
     DEBUG("update_bad_inputs_callback(): Update to bad inputs list.");
 
-    // Get the first output buffer which will always be id = 0 to start.
-    uint8_t* host_mask = out_buf->wait_for_empty_frame(unique_name, out_buffer_ID);
+    // Get the next output frame
+    uint8_t* host_mask = (uint8_t*)out_buf->wait_for_empty_frame(unique_name, frame_id);
+    // Reset the mask (1 == good)
+    std::memset(host_mask, 1U, num_elements);
+
+    bool all_good = true;
 
     try {
-        bad_inputs_cylinder = json["bad_inputs"].get<std::vector<int>>();
+        bad_inputs = json["bad_inputs"].get<std::vector<int>>();
     } catch (std::exception const& e) {
-        ERROR("Failed to parse bad input list {:s}", e.what());
+        ERROR("Failed to parse bad input list:\n{:s}", e.what());
         return false;
     }
 
-    // Reorder list
-    bad_inputs_correlator.clear();
-    for (auto element : bad_inputs_cylinder)
-        bad_inputs_correlator.push_back(input_remap[element]);
-
-    // Zero bad inputs mask
-    for (uint32_t i = 0; i < input_mask_len; ++i) {
-        host_mask[i] = 1;
-    }
-
-    // Add current bad input mask
-    for (auto element : bad_inputs_correlator) {
-        if (element < (int)input_mask_len && element >= 0) {
+    // Add current bad input to the mask
+    for (int element : bad_inputs) {
+        if (element < (int)num_elements && element >= 0) {
             host_mask[element] = 0;
         } else {
-            ERROR("Got a bad input with invalid index");
-            return false;
+            ERROR("Got input with invalid index: {:d}", element);
+            all_good = false;
         }
     }
 
     // Create new metadata
-    out_buf->allocate_new_metadata_object(out_buffer_ID);
-
+    out_buf->allocate_new_metadata_object(frame_id);
     // Set no. of bad inputs in the metadata
-    get_chord_metadata(out_buf, out_buffer_ID)
-        ->set_rfi_num_bad_inputs(bad_inputs_correlator.size());
+    get_chord_metadata(out_buf, frame_id)->set_rfi_num_bad_inputs(bad_inputs.size());
 
-    out_buf->mark_frame_full(unique_name, out_buffer_ID);
+    out_buf->mark_frame_full(unique_name, frame_id);
 
     DEBUG("update_bad_inputs_callback(): Bad inputs reordered and buffered.");
 
-    // Increment frame ID
-    out_buffer_ID = (out_buffer_ID + 1) % out_buf->num_frames;
+    frame_id++;
 
-    return true;
+    return all_good;
 }
 
 void bufferBadInputs::main_thread() {

--- a/lib/stages/bufferBadInputs.hpp
+++ b/lib/stages/bufferBadInputs.hpp
@@ -8,21 +8,22 @@
 #define BUFFER_BAD_INPUT_DATA
 
 #include "Config.hpp"          // for Config
+#include "N2Util.hpp"          // for frameID
 #include "Stage.hpp"           // for Stage
 #include "buffer.hpp"          // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
 
 #include "json.hpp" // for json
 
-#include <stdint.h> // for uint32_t
-#include <string>   // for string
-#include <vector>   // for vector
+#include <string> // for string
+#include <vector> // for vector
 
 /**
  * @class bufferBadInputs
  * @brief Buffers updates to the bad input list.
  *
- * This engine reorders, inverts and generates a mask of bad inputs then stores the mask in a buffer
+ * Copies a list of bad inputs into a mask buffer, which is 0 if
+ * an element is bad and 1 if it is good.
  *
  * @par Buffers
  * @buffer out_buf Kotekan buffer of bad inputs.
@@ -32,8 +33,7 @@
  *                                      config block containing the following properties:
  *                                      "bad_inputs"  An array of bad inputs in cylinder order.
  *
- * @author James Willis
- *
+ * @author James Willis & Liam Gray
  */
 
 class bufferBadInputs : public kotekan::Stage {
@@ -52,22 +52,13 @@ public:
 
 private:
     Buffer* out_buf;
-
-    /// Stage variables
-
-    /// List of current bad inputs in cylinder order
-    std::vector<int> bad_inputs_cylinder;
-
-    /// List of current bad inputs in correlator order.
-    std::vector<int> bad_inputs_correlator;
-
+    /// List of current bad inputs in received order, which
+    // is expected to be cylinder order
+    std::vector<int> bad_inputs;
     /// The size of the bad input mask.
-    uint32_t input_mask_len;
-
-    /// The mapping from correlator to cylinder element indexing.
-    std::vector<uint32_t> input_remap;
-
-    uint32_t out_buffer_ID = 0;
+    size_t num_elements;
+    // Need to use the frame_id outside of the main thread
+    N2::frameID frame_id;
 };
 
 #endif


### PR DESCRIPTION
This was originally made under the assumption that we would no longer need to reorder the bad input list before passing it to the SK kernels. That no longer seems to be the case, so now this PR just makes a couple of minor tweaks without changing any functionality. 