### PR TITLE
minor fixes and updates

### DIFF
--- a/config/chime_upgrade_n2.j2
+++ b/config/chime_upgrade_n2.j2
@@ -346,7 +346,7 @@ run_send_voltage:
             host_voltage_ringbuffer: host_voltage_ringbuffer
         commands:
         - name: cudaCopyNToRingbuffer
-          input_size: samples_per_data_set * num_elements * num_freq_gpu_buf
+          input_size: samples_per_data_set * num_elements * num_freq_host_buf
           ring_buffer_size: gpu_buffer_depth * input_size
           in_bufs: 
 {%- for id in range(num_freq_gpu_buf) %}

--- a/config/chime_upgrade_n2.j2
+++ b/config/chime_upgrade_n2.j2
@@ -33,7 +33,10 @@ sample_period_ns: 2560
 network_frame_arrival_period: 16384 * sample_period_ns / 1e9
 baseband_buffer_depth: 3*272 # 3*272 = ~33 seconds after accounting for active frames
 # see where / if / how to use host_buffer_depth and gpu_buffer_depth
+# must be at least size of gpu_buffer_depth
 host_buffer_depth: 12
+# this must be 4 since cudaTranspose2048_chime.cpp hard-codes the outermost
+# size of the voltage ring-buffer as 4
 gpu_buffer_depth: 4
 num_gpus: 2
 cpu_affinity: [0, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]

--- a/lib/metadata/NDArray.cpp
+++ b/lib/metadata/NDArray.cpp
@@ -107,7 +107,7 @@ bool GenericNDArray::operator==(const FrameDesc& other_desc) const {
         bool is_simple_stride = true;
         auto const& strides = this->get_strides();
         auto const& extents = this->get_extents();
-        for (ssize_t d = 0, simple_stride = 1; d < ssize_t(strides.size()); ++d) {
+        for (ssize_t d = ssize_t(strides.size())-1, simple_stride = 1; d >= 0 ; --d) {
             if (simple_stride != strides[d]) {
                 is_simple_stride = false;
                 break;
@@ -118,7 +118,7 @@ bool GenericNDArray::operator==(const FrameDesc& other_desc) const {
             std::ostringstream buf;
             buf << "NDArray " << this->get_quantity_name()
                 << " does not have simple stride. Strides " << format_vector(strides)
-                << " are no simple for extents " << format_vector(extents)
+                << " are not simple for extents " << format_vector(extents)
                 << " and cannot be compared.";
             // cannot use ERROR since I don't derive from kotekan_loging
             throw std::runtime_error(buf.str());

--- a/lib/stages/bufferDelay.cpp
+++ b/lib/stages/bufferDelay.cpp
@@ -90,9 +90,11 @@ void bufferDelay::main_thread() {
                 }
                 in_buf->copy_metadata(in_frame_release_id, out_buf, out_frame_id);
                 std::memcpy(output_frame, in_buf->frames[in_frame_release_id], in_buf->frame_size);
+                out_buf->set_frame_desc(in_buf->get_frame_description());
             } else {
                 in_buf->pass_metadata(in_frame_release_id, out_buf, out_frame_id);
                 in_buf->swap_frames(in_frame_release_id, out_buf, out_frame_id);
+                out_buf->set_frame_desc(in_buf->get_frame_description());
             }
 
             DEBUG("Reached maximum no. of frames to hold. Releasing oldest frame... in_frame_id: "


### PR DESCRIPTION
* 13057a469 - chime_upgrade_n2: correct size for voltage array being sent GPU
* 711057fc8 - chime_upgrade_n2: document constraints on GPU buffer depth
* bd6bd98a0 - bufferDelay: forward frame description when forwarding frame
* 2d785983c - NDArray: correct stride checking

you will want the NDArray fix. bufferDelay is exotic I would say (but used in some CHIME production yaml files). the others are CHIME specific, though the constraint is generic.