### PR TITLE
EOP quality of life updates

### DIFF
--- a/config/chime_upgrade_n2.j2
+++ b/config/chime_upgrade_n2.j2
@@ -72,7 +72,7 @@ telescope:
 earth_rotation_data:
   kotekan_update_endpoint: json
   earth_orientation_parameter_table:
-    - {time_inst_ns: 0, delta_UT1_inst: 0.0, x_pm: 0.0, y_pm: 0.0}
+    - {t_inst_ns: 0, delta_UT1_inst: 0.0, xp_as: 0.0, yp_as: 0.0}
 
 # these are to trigger visibility dumps while starting kotekan early to avoid
 # packet sync hickups

--- a/config/ci-tests/cpu_batch/run_n2accum.yaml
+++ b/config/ci-tests/cpu_batch/run_n2accum.yaml
@@ -64,15 +64,15 @@ earth_rotation_data:
   kotekan_update_endpoint: json
   earth_orientation_parameter_table: [
     {
-      time_inst_ns: 1750000000000000000,
+      t_inst_ns: 1750000000000000000,
       delta_UT1_inst: 0.5,
-      x_pm: 0.1,
-      y_pm: 0.2
+      xp_as: 0.1,
+      yp_as: 0.2
     }, {
-      time_inst_ns: 1770000000000000000,
+      t_inst_ns: 1770000000000000000,
       delta_UT1_inst: -0.5,
-      x_pm: 0.3,
-      y_pm: 0.4
+      xp_as: 0.3,
+      yp_as: 0.4
     }]
 
   

--- a/config/ci-tests/cpu_batch/test_send_recv.yaml
+++ b/config/ci-tests/cpu_batch/test_send_recv.yaml
@@ -29,10 +29,10 @@ telescope:
 earth_rotation_data:
     kotekan_update_endpoint: json
     earth_orientation_parameter_table:
-      - time_inst_ns: 0
-        delta_UT1_inst: 0.0
-        x_pm: 0.0
-        y_pm: 0.0
+      - t_inst_ns: 0
+        delta_UT1_inst: 0.1
+        xp_as: -0.5
+        yp_as: 0.6
 
 # Pools
 main_pool:

--- a/config/ci-tests/standalone/test_pipeline.j2
+++ b/config/ci-tests/standalone/test_pipeline.j2
@@ -124,15 +124,15 @@ earth_rotation_data:
   kotekan_update_endpoint: json
   earth_orientation_parameter_table: [
     {
-      time_inst_ns: 1750000000000000000,
+      t_inst_ns: 1750000000000000000,
       delta_UT1_inst: 0.5,
-      x_pm: 0.1,
-      y_pm: 0.2
+      xp_as: 0.1,
+      yp_as: 0.2
     }, {
-      time_inst_ns: 1770000000000000000,
+      t_inst_ns: 1770000000000000000,
       delta_UT1_inst: -0.5,
-      x_pm: 0.3,
-      y_pm: 0.4
+      xp_as: 0.3,
+      yp_as: 0.4
     }]
 
 

--- a/config/fengine/include/fengine_chime.j2
+++ b/config/fengine/include/fengine_chime.j2
@@ -31,7 +31,7 @@ telescope:
     dish_vert_axis: [0.0, 0.0, 1.0]
     dish_coelev_deg: 0.0
 
-    eop_updatable_config: "/earth_rotation_data"
+    require_eop: false
 
     dish_separation_x_m: 20.0
     dish_separation_y_m: 0.390625
@@ -48,11 +48,6 @@ telescope:
       label: CHIME-{{"ABCD"[x]}}{{"{:04d}".format(y+1)}}
 {%   endfor %}
 {% endfor %}
-
-earth_rotation_data:
-    kotekan_update_endpoint: json
-    earth_orientation_parameter_table:
-    - {time_inst_ns: 0, delta_UT1_inst: 0.0, x_pm: 0.0, y_pm: 0.0}
 
 ################################################################################
 

--- a/config/fengine/include/fengine_chord.j2
+++ b/config/fengine/include/fengine_chord.j2
@@ -31,7 +31,7 @@ telescope:
     dish_vert_axis: [0.0, 0.0, 1.0]
     dish_coelev_deg: 0.0
 
-    eop_updatable_config: "/earth_rotation_data"
+    require_eop: false
 
     dish_separation_x_m: 6.3
     dish_separation_y_m: 8.5
@@ -50,11 +50,6 @@ telescope:
 {%     endif %}
 {%   endfor %}
 {% endfor %}
-
-earth_rotation_data:
-    kotekan_update_endpoint: json
-    earth_orientation_parameter_table:
-    - {time_inst_ns: 0, delta_UT1_inst: 0.0, x_pm: 0.0, y_pm: 0.0}
 
 ################################################################################
 

--- a/config/fengine/include/fengine_hirax.j2
+++ b/config/fengine/include/fengine_hirax.j2
@@ -31,7 +31,7 @@ telescope:
     dish_vert_axis: [0.0, 0.0, 1.0]
     dish_coelev_deg: 0.0
 
-    eop_updatable_config: "/earth_rotation_data"
+    require_eop: false
 
     dish_separation_x_m: 6.3    # TODO: check
     dish_separation_y_m: 8.5    # TODO: check
@@ -48,11 +48,6 @@ telescope:
       label: HIRAX-{{"ABCDEFGHIJKLMNOPQRSTUVWXYZ"[y]}}{{"{:02d}".format(x+1)}}
 {%   endfor %}
 {% endfor %}
-
-earth_rotation_data:
-    kotekan_update_endpoint: json
-    earth_orientation_parameter_table:
-    - {time_inst_ns: 0, delta_UT1_inst: 0.0, x_pm: 0.0, y_pm: 0.0}
 
 ################################################################################
 

--- a/config/fengine/include/fengine_pathfinder.j2
+++ b/config/fengine/include/fengine_pathfinder.j2
@@ -31,7 +31,7 @@ telescope:
     dish_vert_axis: [0.0, 0.0, 1.0]
     dish_coelev_deg: 0.0
 
-    eop_updatable_config: "/earth_rotation_data"
+    require_eop: false
 
     dish_separation_x_m: 6.3
     dish_separation_y_m: 8.5
@@ -61,11 +61,6 @@ telescope:
 {%     endif %}
 {%   endfor %}
 {% endfor %}
-
-earth_rotation_data:
-    kotekan_update_endpoint: json
-    earth_orientation_parameter_table:
-    - {time_inst_ns: 0, delta_UT1_inst: 0.0, x_pm: 0.0, y_pm: 0.0}
 
 ################################################################################
 

--- a/config/tests/fringestop.yaml
+++ b/config/tests/fringestop.yaml
@@ -134,15 +134,15 @@ earth_rotation_data:
   kotekan_update_endpoint: json
   earth_orientation_parameter_table: [
     {
-      time_inst_ns: 1417910401000000000,
+      t_inst_ns: 1417910401000000000,
       delta_UT1_inst: 0.5,
-      x_pm: 0.1,
-      y_pm: 0.2
+      xp_as: 0.1,
+      yp_as: 0.2
     }, {
-      time_inst_ns: 1418910418000000000,
+      t_inst_ns: 1418910418000000000,
       delta_UT1_inst: 0.5,
-      x_pm: 0.1,
-      y_pm: 0.2
+      xp_as: 0.1,
+      yp_as: 0.2
     }]
 
 fakevis0:

--- a/config/tests/point_source.yaml
+++ b/config/tests/point_source.yaml
@@ -54,15 +54,15 @@ earth_rotation_data:
   kotekan_update_endpoint: json
   earth_orientation_parameter_table: [
     {
-      time_inst_ns: 1764575999000000000,
+      t_inst_ns: 1764575999000000000,
       delta_UT1_inst: 0.08,
-      x_pm: 0.13,
-      y_pm: 0.32
+      xp_as: 0.13,
+      yp_as: 0.32
     }, {
-      time_inst_ns: 1764676000000000000,
+      t_inst_ns: 1764676000000000000,
       delta_UT1_inst: 0.08,
-      x_pm: 0.13,
-      y_pm: 0.32
+      xp_as: 0.13,
+      yp_as: 0.32
     }]
 
 gps_time:

--- a/config/tests/testCHORDTelescope.yaml
+++ b/config/tests/testCHORDTelescope.yaml
@@ -19,24 +19,18 @@ nsec_in_day: sec_in_day * giga
 earth_rotation_data:
   kotekan_update_endpoint: "json"
   earth_orientation_parameter_table: [
+# (Un)comment out to use a particular EOP table.
 #      {
 #        t_inst_ns: 1578010000000000300,
 #        delta_UT1_inst: 0.5,
 #        xp_as: 0.1,
 #        yp_as: 0.2
-#      }
+#      }, {
+#        t_inst_ns: 1578040000000000380,
+#        delta_UT1_inst: 0.801234,
+#        xp_as: 3.0,
+#        yp_as: 4.0,
     ]
-# #, {
-#  t_inst_ns: 1578040000000000380,
-#  delta_UT1_inst: 0.801234,
-#  xp_as: 3.0,
-#  yp_as: 4.0,
-#}, {
-#  t_inst_ns: 1578030000000000350,
-#  delta_UT1_inst: 0.1,
-#  xp_as: -0.5,
-#  yp_as: -0.6,
-#}]
 
 
 telescope:
@@ -69,8 +63,9 @@ telescope:
     {dish_idx: 9, grid_x_idx: 15, grid_y_idx: 15, feed_pos_disp_m: [0.0, 0.0, 0.0], coelev_disp_deg: 0.0, type: ArrayDish, label: CHORD-P16}
   ]
 
-  # gps_time:
-  # frame0_nano: 50 * nsec_in_jyear
+# (Un)comment out this block to test a particular GPS time
+# gps_time:
+#   frame0_nano: 50 * nsec_in_jyear
 
 num_dishes: 32
 num_dishes_x: 16

--- a/config/tests/testCHORDTelescope.yaml
+++ b/config/tests/testCHORDTelescope.yaml
@@ -51,7 +51,7 @@ telescope:
   dish_coelev_deg: 0.0
 
   eop_updatable_config: "/earth_rotation_data"
-  require_eop: true
+  require_eop: false
 
   dish_separation_x_m: 6.3
   dish_separation_y_m: 8.5

--- a/config/tests/testCHORDTelescope.yaml
+++ b/config/tests/testCHORDTelescope.yaml
@@ -19,12 +19,12 @@ nsec_in_day: sec_in_day * giga
 earth_rotation_data:
   kotekan_update_endpoint: "json"
   earth_orientation_parameter_table: [
-     {
-       time_inst_ns: 1578010000000000300,
-       delta_UT1_inst: 0.5,
-       x_pm: 0.1,
-       y_pm: 0.2
-     }
+#      {
+#        time_inst_ns: 1578010000000000300,
+#        delta_UT1_inst: 0.5,
+#        x_pm: 0.1,
+#        y_pm: 0.2
+#      }
     ]
 # #, {
 #  time_inst_ns: 1578040000000000380,
@@ -51,6 +51,7 @@ telescope:
   dish_coelev_deg: 0.0
 
   eop_updatable_config: "/earth_rotation_data"
+  require_eop: true
 
   dish_separation_x_m: 6.3
   dish_separation_y_m: 8.5

--- a/config/tests/testCHORDTelescope.yaml
+++ b/config/tests/testCHORDTelescope.yaml
@@ -20,22 +20,22 @@ earth_rotation_data:
   kotekan_update_endpoint: "json"
   earth_orientation_parameter_table: [
 #      {
-#        time_inst_ns: 1578010000000000300,
+#        t_inst_ns: 1578010000000000300,
 #        delta_UT1_inst: 0.5,
-#        x_pm: 0.1,
-#        y_pm: 0.2
+#        xp_as: 0.1,
+#        yp_as: 0.2
 #      }
     ]
 # #, {
-#  time_inst_ns: 1578040000000000380,
+#  t_inst_ns: 1578040000000000380,
 #  delta_UT1_inst: 0.801234,
-#  x_pm: 3.0,
-#  y_pm: 4.0,
+#  xp_as: 3.0,
+#  yp_as: 4.0,
 #}, {
-#  time_inst_ns: 1578030000000000350,
+#  t_inst_ns: 1578030000000000350,
 #  delta_UT1_inst: 0.1,
-#  x_pm: -0.5,
-#  y_pm: -0.6,
+#  xp_as: -0.5,
+#  yp_as: -0.6,
 #}]
 
 

--- a/config/tests/testCHORDTelescope.yaml
+++ b/config/tests/testCHORDTelescope.yaml
@@ -19,13 +19,14 @@ nsec_in_day: sec_in_day * giga
 earth_rotation_data:
   kotekan_update_endpoint: "json"
   earth_orientation_parameter_table: [
-    {
-      time_inst_ns: 1578010000000000300,
-      delta_UT1_inst: 0.5,
-      x_pm: 0.1,
-      y_pm: 0.2
-    }]
-#, {
+     {
+       time_inst_ns: 1578010000000000300,
+       delta_UT1_inst: 0.5,
+       x_pm: 0.1,
+       y_pm: 0.2
+     }
+    ]
+# #, {
 #  time_inst_ns: 1578040000000000380,
 #  delta_UT1_inst: 0.801234,
 #  x_pm: 3.0,
@@ -67,8 +68,8 @@ telescope:
     {dish_idx: 9, grid_x_idx: 15, grid_y_idx: 15, feed_pos_disp_m: [0.0, 0.0, 0.0], coelev_disp_deg: 0.0, type: ArrayDish, label: CHORD-P16}
   ]
 
-gps_time:
-  frame0_nano: 50 * nsec_in_jyear
+  # gps_time:
+  # frame0_nano: 50 * nsec_in_jyear
 
 num_dishes: 32
 num_dishes_x: 16

--- a/lib/stages/N2Accumulate.cpp
+++ b/lib/stages/N2Accumulate.cpp
@@ -301,8 +301,7 @@ void N2Accumulate::main_thread() {
         }
 
         // Record the current frame time being processed.
-        comp_time_seconds_metric.set(
-            timespec_to_nanosec_i64(_tel.to_time(frame_metadata->get_fpga_seq_num())) / 1e9);
+        comp_time_seconds_metric.set(_tel.to_time_ns(frame_metadata->get_fpga_seq_num()) / 1e9);
 
         // Accumulate each visibility sample in the in_frame
         // t_outer

--- a/lib/stages/N2FringeStop.cpp
+++ b/lib/stages/N2FringeStop.cpp
@@ -73,8 +73,8 @@ void N2FringeStop::main_thread() {
 
     int64_t ut1 = get_UT1_from_ERA(num_rot_target, era_target_deg);
 
-    struct EOP eop_target = {.t_inst = ut1,
-                             .t_ut1 = ut1,
+    struct EOP eop_target = {.t_inst_ns = ut1,
+                             .t_ut1_ns = ut1,
                              .delta_UT1_inst = 0.0,
                              .ERA_deg = era_target_deg,
                              .xp_as = xp_target_as,

--- a/lib/stages/N2TimeDownsample.cpp
+++ b/lib/stages/N2TimeDownsample.cpp
@@ -96,7 +96,7 @@ void N2TimeDownsample::main_thread() {
 
     uint64_t era_bin_idx_startup = (uint64_t)(eop_startup.ERA_deg / era_bin_width);
     int64_t num_rotations_startup;
-    get_ERA_from_UT1(eop_startup.t_ut1, &num_rotations_startup);
+    get_ERA_from_UT1(eop_startup.t_ut1_ns, &num_rotations_startup);
 
     uint64_t prev_abs_time_idx = 0;
 
@@ -132,13 +132,13 @@ void N2TimeDownsample::main_thread() {
             double era_deg_target = 0.5 * (era_deg_lo + era_deg_hi);
 
             // Initialize num_rotations from first frame.
-            get_ERA_from_UT1(frame.bin_eop.t_ut1, &num_rotations);
+            get_ERA_from_UT1(frame.bin_eop.t_ut1_ns, &num_rotations);
 
             // Get UT1 time at target ERA
-            int64_t t_ut1 = get_UT1_from_ERA(num_rotations, era_deg_target);
+            int64_t t_ut1_ns = get_UT1_from_ERA(num_rotations, era_deg_target);
 
             // Set EOP at target ERA
-            eop_target = tel.get_EOP_at_UT1(t_ut1);
+            eop_target = tel.get_EOP_at_UT1(t_ut1_ns);
 
             // Check ERA at the beginning of the frame. If it's earlier than
             // the bin edge, we'll fill the bin and can start integrating
@@ -167,8 +167,9 @@ void N2TimeDownsample::main_thread() {
             wait_for_alignment = false;
 
 
-        DEBUG("T:   {:d}s + {:d}ns", frame.bin_eop.t_inst / GIGA, frame.bin_eop.t_inst % GIGA);
-        DEBUG("UT1: {:d}s + {:d}ns", frame.bin_eop.t_ut1 / GIGA, frame.bin_eop.t_ut1 % GIGA);
+        DEBUG("T:   {:d}s + {:d}ns", frame.bin_eop.t_inst_ns / GIGA,
+              frame.bin_eop.t_inst_ns % GIGA);
+        DEBUG("UT1: {:d}s + {:d}ns", frame.bin_eop.t_ut1_ns / GIGA, frame.bin_eop.t_ut1_ns % GIGA);
         DEBUG("ERA: {:f}; ERA_target: {:f}; ERA_bin_lo: {:f}; ERA_bin_hi: {:f}",
               frame.bin_eop.ERA_deg, eop_target.ERA_deg, era_deg_lo, era_deg_hi);
 
@@ -191,13 +192,13 @@ void N2TimeDownsample::main_thread() {
             double era_deg_target = 0.5 * (era_deg_lo + era_deg_hi);
 
             // Get the current num_rotations from frame.
-            get_ERA_from_UT1(frame.bin_eop.t_ut1, &num_rotations);
+            get_ERA_from_UT1(frame.bin_eop.t_ut1_ns, &num_rotations);
 
             // Get UT1 time at target ERA
-            int64_t t_ut1 = get_UT1_from_ERA(num_rotations, era_deg_target);
+            int64_t t_ut1_ns = get_UT1_from_ERA(num_rotations, era_deg_target);
 
             // Set EOP at target ERA / UT1
-            eop_target = tel.get_EOP_at_UT1(t_ut1);
+            eop_target = tel.get_EOP_at_UT1(t_ut1_ns);
 
             // Wait for an empty frame
             if (out_buf->wait_for_empty_frame(unique_name, output_frame_id) == nullptr) {
@@ -390,10 +391,10 @@ void N2TimeDownsample::main_thread() {
             }
 
             DEBUG("Output frame - num_elements: {:d}", output_frame.num_elements);
-            DEBUG("Output T:   {:d}s + {:d}ns", output_frame.bin_eop.t_inst / GIGA,
-                  output_frame.bin_eop.t_inst % GIGA);
-            DEBUG("Output UT1: {:d}s + {:d}ns", output_frame.bin_eop.t_ut1 / GIGA,
-                  output_frame.bin_eop.t_ut1 % GIGA);
+            DEBUG("Output T:   {:d}s + {:d}ns", output_frame.bin_eop.t_inst_ns / GIGA,
+                  output_frame.bin_eop.t_inst_ns % GIGA);
+            DEBUG("Output UT1: {:d}s + {:d}ns", output_frame.bin_eop.t_ut1_ns / GIGA,
+                  output_frame.bin_eop.t_ut1_ns % GIGA);
             DEBUG("Output ERA: {:f}", output_frame.bin_eop.ERA_deg);
 
             char* addr0 = (char*)&(output_frame.vis[0]);

--- a/lib/stages/asdfFileWrite.cpp
+++ b/lib/stages/asdfFileWrite.cpp
@@ -312,8 +312,8 @@ public:
                         group->emplace("fpga_seq_num",
                                        std::make_shared<ASDF::int_entry>(meta->get_fpga_seq_num()));
                         group->emplace("fpga_seq_time_nsec",
-                                       std::make_shared<ASDF::int_entry>(timespec_to_nanosec_i64(
-                                           telescope.to_time(meta->get_fpga_seq_num()))));
+                                       std::make_shared<ASDF::int_entry>(
+                                           telescope.to_time_ns(meta->get_fpga_seq_num())));
                     }
 
                     if (meta->has_time_downsampling_fpga())

--- a/lib/stages/gdalFileWrite.cpp
+++ b/lib/stages/gdalFileWrite.cpp
@@ -295,7 +295,7 @@ public:
 
                 if (meta->has_fpga_seq_num()) {
                     const auto fpga_seq_time_nsec_value =
-                        timespec_to_nanosec_i64(telescope.to_time(meta->get_fpga_seq_num()));
+                        telescope.to_time_ns(meta->get_fpga_seq_num());
                     const auto fpga_seq_time_nsec = group->CreateAttribute(
                         "fpga_seq_time_nsec", std::vector<GUInt64>{},
                         GDALExtendedDataType::Create(get_gdal_datatype(fpga_seq_time_nsec_value)));

--- a/lib/stages/hdf5FileWrite.cpp
+++ b/lib/stages/hdf5FileWrite.cpp
@@ -253,9 +253,8 @@ public:
 
             if (meta->has_fpga_seq_num()) {
                 dataset.createAttribute("fpga_seq_num", meta->get_fpga_seq_num());
-                dataset.createAttribute(
-                    "fpga_seq_time_nsec",
-                    timespec_to_nanosec_i64(telescope.to_time(meta->get_fpga_seq_num())));
+                dataset.createAttribute("fpga_seq_time_nsec",
+                                        telescope.to_time_ns(meta->get_fpga_seq_num()));
             }
 
             if (meta->has_time_downsampling_fpga())
@@ -398,15 +397,15 @@ public:
         file.createAttribute("freq_id", frame.freq_id);
         file.createAttribute("freq_MHz", frame.freq_MHz);
         file.createAttribute("abs_time_idx", frame.abs_time_idx);
-        file.createAttribute("time_center_eop.t_inst", frame.time_center_eop.t_inst);
-        file.createAttribute("time_center_eop.t_ut1", frame.time_center_eop.t_ut1);
+        file.createAttribute("time_center_eop.t_inst_ns", frame.time_center_eop.t_inst_ns);
+        file.createAttribute("time_center_eop.t_ut1_ns", frame.time_center_eop.t_ut1_ns);
         file.createAttribute("time_center_eop.delta_UT1_inst",
                              frame.time_center_eop.delta_UT1_inst);
         file.createAttribute("time_center_eop.ERA_deg", frame.time_center_eop.ERA_deg);
         file.createAttribute("time_center_eop.xp_as", frame.time_center_eop.xp_as);
         file.createAttribute("time_center_eop.yp_as", frame.time_center_eop.yp_as);
-        file.createAttribute("bin_eop.t_inst", frame.bin_eop.t_inst);
-        file.createAttribute("bin_eop.t_ut1", frame.bin_eop.t_ut1);
+        file.createAttribute("bin_eop.t_inst_ns", frame.bin_eop.t_inst_ns);
+        file.createAttribute("bin_eop.t_ut1_ns", frame.bin_eop.t_ut1_ns);
         file.createAttribute("bin_eop.delta_UT1_inst", frame.bin_eop.delta_UT1_inst);
         file.createAttribute("bin_eop.ERA_deg", frame.bin_eop.ERA_deg);
         file.createAttribute("bin_eop.xp_as", frame.bin_eop.xp_as);

--- a/lib/stages/hdf5N2Write.cpp
+++ b/lib/stages/hdf5N2Write.cpp
@@ -321,24 +321,24 @@ std::unique_ptr<HighFive::File> N2FileData::_open_or_create_file(const std::stri
             std::vector<EOP> eop_table = telescope.get_current_EOP_table();
             const int eop_len = eop_table.size();
             if (eop_len > 0) {
-                std::vector<int64_t> eop_t_inst(eop_len);
-                std::vector<int64_t> eop_t_ut1(eop_len);
-                std::vector<int64_t> eop_delta_UT1_inst(eop_len);
+                std::vector<int64_t> eop_t_inst_ns(eop_len);
+                std::vector<int64_t> eop_t_ut1_ns(eop_len);
+                std::vector<double> eop_delta_UT1_inst(eop_len);
                 std::vector<double> eop_ERA_deg(eop_len);
                 std::vector<double> eop_xp_as(eop_len);
                 std::vector<double> eop_yp_as(eop_len);
 
                 for (int i = 0; i < eop_len; i++) {
                     EOP eop = eop_table[i];
-                    eop_t_inst[i] = eop.t_inst;
-                    eop_t_ut1[i] = eop.t_ut1;
+                    eop_t_inst_ns[i] = eop.t_inst_ns;
+                    eop_t_ut1_ns[i] = eop.t_ut1_ns;
                     eop_delta_UT1_inst[i] = eop.delta_UT1_inst;
                     eop_ERA_deg[i] = eop.ERA_deg;
                     eop_xp_as[i] = eop.xp_as;
                     eop_yp_as[i] = eop.yp_as;
                 }
-                _check_create_attribute(*file, "EOP_t_inst", eop_t_inst);
-                _check_create_attribute(*file, "EOP_t_ut1", eop_t_ut1);
+                _check_create_attribute(*file, "EOP_t_inst_ns", eop_t_inst_ns);
+                _check_create_attribute(*file, "EOP_t_ut1_ns", eop_t_ut1_ns);
                 _check_create_attribute(*file, "EOP_delta_UT1_inst", eop_delta_UT1_inst);
                 _check_create_attribute(*file, "EOP_ERA_deg", eop_ERA_deg);
                 _check_create_attribute(*file, "EOP_xp_as", eop_xp_as);
@@ -613,8 +613,8 @@ N2FileData::AddFrameStatus N2FileData::add_frame(const N2FrameView& fv, size_t t
         || (frame_length_fpga_ticks[t_index] > 0
             && frame_length_fpga_ticks[t_index] != fv.frame_length_fpga_ticks)
         || (time_center_ut1[t_index] > 0
-            && !ns_close(time_center_ut1[t_index], fv.time_center_eop.t_ut1))
-        || (bin_ut1[t_index] > 0 && !ns_close(bin_ut1[t_index], fv.bin_eop.t_ut1))
+            && !ns_close(time_center_ut1[t_index], fv.time_center_eop.t_ut1_ns))
+        || (bin_ut1[t_index] > 0 && !ns_close(bin_ut1[t_index], fv.bin_eop.t_ut1_ns))
         || (bin_start_ERA_deg[t_index] < 0) || (bin_start_ERA_deg[t_index] > 360)
         || (bin_end_ERA_deg[t_index] < 0) || (bin_end_ERA_deg[t_index] > 360)) {
         // TODO: Don't check these yet, but do when we have LAST values
@@ -626,14 +626,14 @@ N2FileData::AddFrameStatus N2FileData::add_frame(const N2FrameView& fv, size_t t
             "fv.gain.size()={}, fv.flags.size()={}, fv.num_elements={}, fv.num_prod={}, "
             "fv.num_ev={}, fpga_start_tick[t_index]={}, fv.fpga_start_tick={}, "
             "fv.frame_length_fpga_ticks={}, frame_length_fpga_ticks[t_index]={}, "
-            "time_center_ut1[t_index]={}, fv.time_center_eop.t_ut1={}, bin_ut1[t_index]={}, "
-            "fv.bin_eop.t_ut1={}, bin_start_ERA_deg[t_index]={}, bin_end_ERA_deg[t_index]={}, "
+            "time_center_ut1[t_index]={}, fv.time_center_eop.t_ut1_ns={}, bin_ut1[t_index]={}, "
+            "fv.bin_eop.t_ut1_ns={}, bin_start_ERA_deg[t_index]={}, bin_end_ERA_deg[t_index]={}, "
             "bin_start_LAST[t_index]={}, bin_end_LAST[t_index]={}",
             f_index, t_index, fv.vis.size(), fv.weight.size(), fv.eval.size(), fv.evec.size(),
             fv.gain.size(), fv.flags.size(), fv.num_elements, fv.num_prod, fv.num_ev,
             fpga_start_tick[t_index], fv.fpga_start_tick, fv.frame_length_fpga_ticks,
-            frame_length_fpga_ticks[t_index], time_center_ut1[t_index], fv.time_center_eop.t_ut1,
-            bin_ut1[t_index], fv.bin_eop.t_ut1, bin_start_ERA_deg[t_index],
+            frame_length_fpga_ticks[t_index], time_center_ut1[t_index], fv.time_center_eop.t_ut1_ns,
+            bin_ut1[t_index], fv.bin_eop.t_ut1_ns, bin_start_ERA_deg[t_index],
             bin_end_ERA_deg[t_index], bin_start_LAST[t_index], bin_end_LAST[t_index]);
         return AddFrameStatus::MetadataMismatch;
     }
@@ -668,8 +668,8 @@ N2FileData::AddFrameStatus N2FileData::add_frame(const N2FrameView& fv, size_t t
     // Store per-time metadata
     fpga_start_tick[t_index] = fv.fpga_start_tick;
     frame_length_fpga_ticks[t_index] = fv.frame_length_fpga_ticks;
-    time_center_ut1[t_index] = fv.time_center_eop.t_ut1;
-    bin_ut1[t_index] = fv.bin_eop.t_ut1;
+    time_center_ut1[t_index] = fv.time_center_eop.t_ut1_ns;
+    bin_ut1[t_index] = fv.bin_eop.t_ut1_ns;
     bin_start_ERA_deg[t_index] = fv.bin_start_ERA_deg;
     bin_end_ERA_deg[t_index] = fv.bin_end_ERA_deg;
     bin_start_LAST[t_index] = fv.bin_start_LAST;

--- a/lib/testing/fakeGpu.cpp
+++ b/lib/testing/fakeGpu.cpp
@@ -177,6 +177,7 @@ void FakeGpu::main_thread() {
 
 FakeTelescope::FakeTelescope(const kotekan::Config& config, const std::string& path) :
     Telescope(path, config.get<std::string>(path, "log_level"),
+              config.get_default<bool>(path, "require_eop", false),
               config.get_default<std::string>(path, "eop_updatable_config", "")) {
     _num_local_freq = config.get_default<size_t>(path, "num_local_freq", 1);
 }

--- a/lib/testing/testCHORDTelescope.cpp
+++ b/lib/testing/testCHORDTelescope.cpp
@@ -93,10 +93,11 @@ void TestCHORDTelescope::main_thread() {
         INFO("            EOP entries: {:d}", eop_tab.size());
         for (i = 0; i < eop_tab.size(); i++) {
             struct EOP eop = eop_tab[i];
-            eop_times.push_back(eop.t_inst);
-            INFO("            {0:02d} - t_inst: {1:d} s + {2:d} ns", i, eop.t_inst / GIGA,
-                 eop.t_inst % GIGA);
-            INFO("               - t_ut1:  {0:d} s + {1:d} ns", eop.t_ut1 / GIGA, eop.t_ut1 % GIGA);
+            eop_times.push_back(eop.t_inst_ns);
+            INFO("            {0:02d} - t_inst: {1:d} s + {2:d} ns", i, eop.t_inst_ns / GIGA,
+                 eop.t_inst_ns % GIGA);
+            INFO("               - t_ut1:  {0:d} s + {1:d} ns", eop.t_ut1_ns / GIGA,
+                 eop.t_ut1_ns % GIGA);
             INFO("               - dut1:   {:f} s", eop.delta_UT1_inst);
             INFO("               - era:    {:f} deg", eop.ERA_deg);
             INFO("               - xp:     {:f} arcsec", eop.xp_as);
@@ -133,32 +134,33 @@ void TestCHORDTelescope::main_thread() {
                     timespec ts = {.tv_sec = (time_t)(t / GIGA), .tv_nsec = t % GIGA};
 
                     struct EOP eop = tel.get_EOP_at_time(ts);
-                    INFO("               - t_inst: {1:d} s + {2:d} ns", i, eop.t_inst / GIGA,
-                         eop.t_inst % GIGA);
-                    INFO("               - t_ut1:  {0:d} s + {1:d} ns", eop.t_ut1 / GIGA,
-                         eop.t_ut1 % GIGA);
+                    INFO("               - t_inst: {1:d} s + {2:d} ns", i, eop.t_inst_ns / GIGA,
+                         eop.t_inst_ns % GIGA);
+                    INFO("               - t_ut1:  {0:d} s + {1:d} ns", eop.t_ut1_ns / GIGA,
+                         eop.t_ut1_ns % GIGA);
                     INFO("               - dut1:   {:f} s", eop.delta_UT1_inst);
                     INFO("               - era:    {:f} deg", eop.ERA_deg);
                     INFO("               - xp:     {:f} arcsec", eop.xp_as);
                     INFO("               - yp:     {:f} arcsec", eop.yp_as);
 
-                    timespec ts_inst2 = get_time_from_UT1(eop.t_ut1, eop.delta_UT1_inst);
+                    timespec ts_inst2 = get_time_from_UT1(eop.t_ut1_ns, eop.delta_UT1_inst);
                     int64_t n_rot;
-                    double era = get_ERA_from_UT1(eop.t_ut1, &n_rot);
-                    int64_t t_ut12 = get_UT1_from_ERA(n_rot, eop.ERA_deg);
+                    double era = get_ERA_from_UT1(eop.t_ut1_ns, &n_rot);
+                    int64_t t_ut1_ns2 = get_UT1_from_ERA(n_rot, eop.ERA_deg);
 
                     INFO("               -t_inst2: {0:d} s + {1:d} ns", ts_inst2.tv_sec,
                          ts_inst2.tv_nsec);
                     INFO("               -diff:    {0:d} s + {1:d} ns",
-                         ts_inst2.tv_sec - eop.t_inst / GIGA, ts_inst2.tv_nsec - eop.t_inst % GIGA);
-                    INFO("               -t_ut12:  {0:d} s + {1:d} ns", t_ut12 / GIGA,
-                         t_ut12 % GIGA);
-                    INFO("               -diff:    {0:d} s + {1:d} ns", (t_ut12 - eop.t_ut1) / GIGA,
-                         (t_ut12 - eop.t_ut1) % GIGA);
+                         ts_inst2.tv_sec - eop.t_inst_ns / GIGA,
+                         ts_inst2.tv_nsec - eop.t_inst_ns % GIGA);
+                    INFO("               -t_ut12:  {0:d} s + {1:d} ns", t_ut1_ns2 / GIGA,
+                         t_ut1_ns2 % GIGA);
+                    INFO("               -diff:    {0:d} s + {1:d} ns",
+                         (t_ut1_ns2 - eop.t_ut1_ns) / GIGA, (t_ut1_ns2 - eop.t_ut1_ns) % GIGA);
 
 
                     int64_t n_rot2;
-                    double era2 = get_ERA_from_UT1(t_ut12, &n_rot2);
+                    double era2 = get_ERA_from_UT1(t_ut1_ns2, &n_rot2);
 
                     INFO("               -era:  {0:f} deg + {1:d}", era, n_rot);
                     INFO("               -diff: {0:e} deg + {1:d}", era2 - era, n_rot2 - n_rot);

--- a/lib/utils/CHIMETelescope.cpp
+++ b/lib/utils/CHIMETelescope.cpp
@@ -18,6 +18,7 @@ REGISTER_TELESCOPE(CHIMETelescope, "CHIMETelescope");
 
 CHIMETelescope::CHIMETelescope(const kotekan::Config& config, const std::string& path) :
     ICETelescope(path, config.get<std::string>(path, "log_level"),
+                 config.get_default<bool>(path, "require_eop", false),
                  config.get_default<std::string>(path, "eop_updatable_config", "")) {
     INFO("Building CHIMETelescope");
 

--- a/lib/utils/CHORDTelescope.cpp
+++ b/lib/utils/CHORDTelescope.cpp
@@ -10,6 +10,7 @@
 
 #include <algorithm>  // for lower_bound, copy, sort, max
 #include <assert.h>   // for assert
+#include <chrono>     // for system_clock, duration_cast, nanoseconds
 #include <exception>  // for exception
 #include <functional> // for bind, _1, function
 #include <math.h>     // for sin, cos, M_PI
@@ -325,8 +326,10 @@ GPSTimeParams GPSTimeParams::from_config(const kotekan::Config& config, const st
 
     if (gps.gps_enabled)
         INFO_NON_OO("Telescope configured with GPS time0: {:d} ns", gps.time0_ns);
-    else
-        INFO_NON_OO("Telescope GPS time not enabled.");
+    else {
+        INFO_NON_OO("Telescope GPS time not enabled, using system time.");
+        set_gps_time_params_from_system(gps); // sets gps_enabled, time0_ns
+    }
 
     return gps;
 }
@@ -372,6 +375,13 @@ void GPSTimeParams::set_gps_time_params_from_remote(GPSTimeParams& gps) {
     gps.time0_ns = time0_ns;
     gps.gps_enabled = true;
     INFO_NON_OO("GPS frame0 time set to {:d}", gps.time0_ns);
+}
+
+void GPSTimeParams::set_gps_time_params_from_system(GPSTimeParams& gps) {
+    gps.time0_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                       std::chrono::system_clock::now().time_since_epoch())
+                       .count();
+    gps.gps_enabled = false;
 }
 
 bool GPSTimeParams::get_gps_time0_ns_from_remote(const GPSTimeParams& gps, uint64_t& time0_ns,
@@ -452,6 +462,7 @@ bool GPSTimeParams::get_gps_time0_ns_from_remote(const GPSTimeParams& gps, uint6
 
 CHORDTelescope::CHORDTelescope(const kotekan::Config& config, const std::string& path) :
     Telescope(path, config.get<std::string>(path, "log_level"),
+              config.get_default<bool>(path, "require_eop", false),
               config.get_default<std::string>(path, "eop_updatable_config", "")),
     // Frequency sampling parameters
     _freq_params(FreqParams::from_config(config, path)),

--- a/lib/utils/CHORDTelescope.hpp
+++ b/lib/utils/CHORDTelescope.hpp
@@ -416,6 +416,9 @@ private:
 
     /// Set the GPS time parameters (gps_enabled, time0_ns) from a remote server (fpga_master)
     static void set_gps_time_params_from_remote(GPSTimeParams& gps);
+
+    /// Set the GPS time parameters (gps_enabled, time0_ns) from the system clock.
+    static void set_gps_time_params_from_system(GPSTimeParams& gps);
 };
 
 

--- a/lib/utils/ICETelescope.cpp
+++ b/lib/utils/ICETelescope.cpp
@@ -17,6 +17,7 @@ REGISTER_TELESCOPE(ICETelescope, "ICETelescope");
 
 ICETelescope::ICETelescope(const kotekan::Config& config, const std::string& path) :
     Telescope(path, config.get<std::string>(path, "log_level"),
+              config.get_default<bool>(path, "require_eop", false),
               config.get_default<std::string>(path, "eop_updatable_config", "")) {
     INFO("Building ICETelescope");
 

--- a/lib/utils/Telescope.cpp
+++ b/lib/utils/Telescope.cpp
@@ -16,11 +16,11 @@ using kotekan::restServer;
 #define GIGA 1'000'000'000L
 
 static constexpr BareEOP dummy_bare_eop_first = {
-    .time_inst_ns = 0, .delta_UT1_inst = 0.0, .x_pm = 0.0, .y_pm = 0.0};
-static constexpr BareEOP dummy_bare_eop_last = {.time_inst_ns = std::numeric_limits<int64_t>::max(),
+    .t_inst_ns = 0, .delta_UT1_inst = 0.0, .xp_as = 0.0, .yp_as = 0.0};
+static constexpr BareEOP dummy_bare_eop_last = {.t_inst_ns = std::numeric_limits<int64_t>::max(),
                                                 .delta_UT1_inst = 0.0,
-                                                .x_pm = 0.0,
-                                                .y_pm = 0.0};
+                                                .xp_as = 0.0,
+                                                .yp_as = 0.0};
 
 Telescope::Telescope(const std::string& tel_path, const std::string& log_level, bool require_eop,
                      const std::string& eop_updatable_config_path) :

--- a/lib/utils/Telescope.cpp
+++ b/lib/utils/Telescope.cpp
@@ -15,20 +15,8 @@ using kotekan::restServer;
 
 #define GIGA 1'000'000'000L
 
-void to_json(nlohmann::json& j, const BareEOP& eop) {
-    j = {};
-    j.emplace("time_inst_ns", eop.time_inst_ns);
-    j.emplace("delta_UT1_inst", eop.delta_UT1_inst);
-    j.emplace("x_pm", eop.x_pm);
-    j.emplace("y_pm", eop.y_pm);
-}
-
-void from_json(const nlohmann::json& j, BareEOP& eop) {
-    eop.time_inst_ns = j.at("time_inst_ns");
-    eop.delta_UT1_inst = j.at("delta_UT1_inst");
-    eop.x_pm = j.at("x_pm");
-    eop.y_pm = j.at("y_pm");
-}
+static constexpr BareEOP dummy_bare_eop_first = {.time_inst_ns=0, .delta_UT1_inst=0.0, .x_pm=0.0, .y_pm=0.0};
+static constexpr BareEOP dummy_bare_eop_last = {.time_inst_ns=std::numeric_limits<int64_t>::max(), .delta_UT1_inst=0.0, .x_pm=0.0, .y_pm=0.0};
 
 Telescope::Telescope(const std::string& tel_path, const std::string& log_level, bool require_eop,
                      const std::string& eop_updatable_config_path) :
@@ -39,9 +27,11 @@ Telescope::Telescope(const std::string& tel_path, const std::string& log_level, 
     DEBUG("Building Telescope");
 
     // Initializing EOP table with dummy values
-    _eop_table = {build_EOP_from_update(0, 0.0, 0.0, 0.0),
-                  build_EOP_from_update(std::numeric_limits<int64_t>::max(), 0.0, 0.0, 0.0)};
-
+    /*
+    _eop_table = {BareEOP(0, 0.0, 0.0, 0.0).to_EOP(),
+                  BareEOP(std::numeric_limits<int64_t>::max(), 0.0, 0.0, 0.0).to_EOP()};
+    */
+    _eop_table = {dummy_bare_eop_first.to_EOP(), dummy_bare_eop_last.to_EOP()};
 
     // Set up callbacks for updating EOP and sending time0_ns
     using namespace std::placeholders;
@@ -129,19 +119,11 @@ bool Telescope::receive_eop_updates(nlohmann::json& json) {
         }
         std::vector<BareEOP> bare_eop_table = json.at("earth_orientation_parameter_table");
         
-        std::vector<EOP> tmp_eop_table(bare_eop_table.size());
-        for (size_t i = 0; i < tmp_eop_table.size(); i++)
+        size_t N = bare_eop_table.size(); 
+        std::vector<EOP> tmp_eop_table(N);
+
+        for (size_t i = 0; i < N; i++)
             tmp_eop_table.at(i) = bare_eop_table.at(i).to_EOP();
-        /*
-        for (const auto& elem : json.at("earth_orientation_parameter_table")) {
-            INFO("Telescope EOP update: {:s}", elem.dump());
-            int64_t t_ns = elem.at("time_inst_ns").get<int64_t>();
-            double dut1 = elem.at("delta_UT1_inst").get<double>();
-            double x_pm = elem.at("x_pm").get<double>();
-            double y_pm = elem.at("y_pm").get<double>();
-            tmp_eop_table.push_back(build_EOP_from_update(t_ns, dut1, x_pm, y_pm));
-        }
-        */
 
         if (tmp_eop_table.empty()) {
             // If table was empty, we're done here.
@@ -149,7 +131,7 @@ bool Telescope::receive_eop_updates(nlohmann::json& json) {
             if (_require_eop) {
                 // If table was required. Report an error.
                 ERROR(
-                    "Telescope {}: earth_orientation_parameter_table update contained no entries.",
+                    "earth_orientation_parameter_table update contained no entries.",
                     _unique_name);
                 return false;
             }
@@ -194,23 +176,6 @@ void Telescope::send_time0_ns(connectionInstance& conn) {
     nlohmann::json reply;
     reply["time0_ns"] = to_time_ns(0);
     conn.send_json_reply(reply);
-}
-
-EOP Telescope::build_EOP_from_update(int64_t time_ns, double delta_ut1_inst, double xp_as,
-                                     double yp_as) {
-
-    struct timespec ts_inst = nanosec_i64_to_timespec(time_ns);
-    int64_t ut1 = get_UT1_from_time(ts_inst, delta_ut1_inst);
-    double era = get_ERA_from_UT1(ut1, nullptr);
-
-    EOP eop{.t_inst = time_ns,
-            .t_ut1 = ut1,
-            .delta_UT1_inst = delta_ut1_inst,
-            .ERA_deg = era,
-            .xp_as = xp_as,
-            .yp_as = yp_as};
-
-    return eop;
 }
 
 std::vector<EOP> Telescope::get_current_EOP_table() const {

--- a/lib/utils/Telescope.cpp
+++ b/lib/utils/Telescope.cpp
@@ -31,10 +31,6 @@ Telescope::Telescope(const std::string& tel_path, const std::string& log_level, 
     DEBUG("Building Telescope");
 
     // Initializing EOP table with dummy values
-    /*
-    _eop_table = {BareEOP(0, 0.0, 0.0, 0.0).to_EOP(),
-                  BareEOP(std::numeric_limits<int64_t>::max(), 0.0, 0.0, 0.0).to_EOP()};
-    */
     _eop_table = {dummy_bare_eop_first.to_EOP(), dummy_bare_eop_last.to_EOP()};
 
     // Set up callbacks for updating EOP and sending time0_ns
@@ -117,7 +113,7 @@ bool Telescope::receive_eop_updates(nlohmann::json& json) {
 
         if (!json.contains("earth_orientation_parameter_table") && !_require_eop) {
             // If EOP is not required, say we succeeded and do nothing.
-            INFO("EOP update did not contain `earth_orientation_parameter_table`, igoring. EOP "
+            WARN("EOP update did not contain `earth_orientation_parameter_table`, ignoring. EOP "
                  "table is unchanged.");
             return true;
         }

--- a/lib/utils/Telescope.cpp
+++ b/lib/utils/Telescope.cpp
@@ -192,19 +192,24 @@ std::vector<EOP> Telescope::get_current_EOP_table() const {
 }
 
 EOP Telescope::get_EOP_at_time(const timespec& ts_target) const {
-    // Interpolate on the EOP table to find EOP for the given instrument time.
+    // extract the time in nanoseconds and then use the time_ns function.
+    int64_t ts_target_ns = timespec_to_nanosec_i64(ts_target);
+    return get_EOP_at_time_ns(ts_target_ns);
+}
 
+EOP Telescope::get_EOP_at_time_ns(int64_t t_target_ns) const {
+    // Interpolate on the EOP table to find EOP for the given instrument time.
     EOP eop;
 
-    int64_t t_target = timespec_to_nanosec_i64(ts_target);
-    eop.t_inst_ns = t_target;
+    eop.t_inst_ns = t_target_ns;
 
+    // thread-safety: acquire lock on EOP table
     {
         std::shared_lock lock(_eop_lock);
 
         if (_eop_table.empty()) {
             WARN("EOP table is empty, cannot interpolate EOP at instrument time {:d} s + {:d} ns.",
-                 t_target / GIGA, t_target % GIGA);
+                 t_target_ns / GIGA, t_target_ns % GIGA);
             return eop_null;
         }
 
@@ -220,11 +225,11 @@ EOP Telescope::get_EOP_at_time(const timespec& ts_target) const {
             eop.delta_UT1_inst = eop_b->delta_UT1_inst;
             eop.xp_as = eop_b->xp_as;
             eop.yp_as = eop_b->yp_as;
-            if (t_target < eop_b->t_inst_ns) {
+            if (t_target_ns < eop_b->t_inst_ns) {
                 WARN("Requesting EOP earlier than in table. Requested time = {:d} s + {:d} ns. "
                      "Earliest "
                      "time = {:d} s + {:d} ns.",
-                     t_target / GIGA, t_target % GIGA, eop_b->t_inst_ns / GIGA,
+                     t_target_ns / GIGA, t_target_ns % GIGA, eop_b->t_inst_ns / GIGA,
                      eop_b->t_inst_ns % GIGA);
             }
         } else if (eop_b == _eop_table.end()) {
@@ -233,21 +238,21 @@ EOP Telescope::get_EOP_at_time(const timespec& ts_target) const {
             eop.delta_UT1_inst = eop_last->delta_UT1_inst;
             eop.xp_as = eop_last->xp_as;
             eop.yp_as = eop_last->yp_as;
-            if (t_target > eop_last->t_inst_ns) {
+            if (t_target_ns > eop_last->t_inst_ns) {
                 WARN(
                     "Requesting EOP later than in table. Requested time = {:d} s + {:d} ns. Latest "
                     "UT1 = "
                     "{:d} s + {:d} ns.",
-                    t_target / GIGA, t_target % GIGA, eop_last->t_inst_ns / GIGA,
+                    t_target_ns / GIGA, t_target_ns % GIGA, eop_last->t_inst_ns / GIGA,
                     eop_last->t_inst_ns % GIGA);
             }
         } else {
             // Interpolate!
             auto eop_a = eop_b - 1;
             // t - ta in ns. Should be > 0
-            int64_t diff_ns_a = t_target - eop_a->t_inst_ns;
+            int64_t diff_ns_a = t_target_ns - eop_a->t_inst_ns;
             // t - tb in ns. Should be < 0
-            int64_t diff_ns_b = t_target - eop_b->t_inst_ns;
+            int64_t diff_ns_b = t_target_ns - eop_b->t_inst_ns;
             // tb - ta in ns.
             int64_t diff_ns = diff_ns_a - diff_ns_b;
 
@@ -260,10 +265,10 @@ EOP Telescope::get_EOP_at_time(const timespec& ts_target) const {
             eop.xp_as = wa * eop_a->xp_as + wb * eop_b->xp_as;
             eop.yp_as = wa * eop_a->yp_as + wb * eop_b->yp_as;
         }
-    }
+    } // eop_lock
 
     // now that we have a delta_UT1, can compute UT1 and ERA
-    int64_t ut1 = get_UT1_from_time(ts_target, eop.delta_UT1_inst);
+    int64_t ut1 = get_UT1_from_time_ns(t_target_ns, eop.delta_UT1_inst);
     double era = get_ERA_from_UT1(ut1, nullptr);
 
     eop.t_ut1_ns = ut1;
@@ -278,6 +283,7 @@ EOP Telescope::get_EOP_at_UT1(int64_t t_ut1_ns) const {
     EOP eop;
     eop.t_ut1_ns = t_ut1_ns;
 
+    // thread-safety: acquire lock on EOP table
     {
         std::shared_lock lock(_eop_lock);
 
@@ -338,7 +344,7 @@ EOP Telescope::get_EOP_at_UT1(int64_t t_ut1_ns) const {
             eop.xp_as = wa * eop_a->xp_as + wb * eop_b->xp_as;
             eop.yp_as = wa * eop_a->yp_as + wb * eop_b->yp_as;
         }
-    }
+    } // eop_lock
 
     // Now that we have a delta_UT1, can get t_inst and the ERA
     eop.t_inst_ns = get_time_ns_from_UT1(t_ut1_ns, eop.delta_UT1_inst);

--- a/lib/utils/Telescope.cpp
+++ b/lib/utils/Telescope.cpp
@@ -15,12 +15,18 @@ using kotekan::restServer;
 
 #define GIGA 1'000'000'000L
 
-Telescope::Telescope(const std::string& tel_path, const std::string& log_level,
-                     const std::string& eop_updatable_config_path) : _unique_name(tel_path) {
+Telescope::Telescope(const std::string& tel_path, const std::string& log_level, bool require_eop,
+                     const std::string& eop_updatable_config_path) :
+    _unique_name(tel_path), _require_eop(require_eop) {
     set_log_level(log_level);
     set_log_prefix("/telescope");
 
     DEBUG("Building Telescope");
+
+    // Initializing EOP table with dummy values
+    _eop_table = {build_EOP_from_update(0, 0.0, 0.0, 0.0),
+                  build_EOP_from_update(std::numeric_limits<int64_t>::max(), 0.0, 0.0, 0.0)};
+
 
     // Set up callbacks for updating EOP and sending time0_ns
     using namespace std::placeholders;
@@ -100,6 +106,13 @@ bool Telescope::receive_eop_updates(nlohmann::json& json) {
     try {
         // Fill a temporary table with the updated values.
         std::vector<EOP> tmp_eop_table;
+
+        if (!json.contains("earth_orientation_parameter_table") && !_require_eop) {
+            // If EOP is not required, say we succeeded and do nothing.
+            INFO("EOP update did not contain `earth_orientation_parameter_table`, igoring. EOP "
+                 "table is unchanged.");
+            return true;
+        }
         for (const auto& elem : json.at("earth_orientation_parameter_table")) {
             INFO("Telescope EOP update: {:s}", elem.dump());
             int64_t t_ns = elem.at("time_inst_ns").get<int64_t>();
@@ -110,10 +123,23 @@ bool Telescope::receive_eop_updates(nlohmann::json& json) {
         }
 
         if (tmp_eop_table.empty()) {
-            ERROR("Telescope {}: earth_orientation_parameter_table update contained no entries.",
-                  _unique_name);
-            return false;
+            // If table was empty, we're done here.
+
+            if (_require_eop) {
+                // If table was required. Report an error.
+                ERROR(
+                    "Telescope {}: earth_orientation_parameter_table update contained no entries.",
+                    _unique_name);
+                return false;
+            }
+
+            // If table is not required, signal success and ignore the update.
+            INFO("Ignoring `earth_orientation_parameter_table` update, it contained no entries. "
+                 "EOP Table is unchanged.");
+            return true;
         }
+
+        // There's at least one entry in the table, sort it and replace the current table.
 
         // Sort chronologically
         std::sort(tmp_eop_table.begin(), tmp_eop_table.end(), EOP_comp_time);
@@ -150,7 +176,7 @@ void Telescope::send_time0_ns(connectionInstance& conn) {
 }
 
 EOP Telescope::build_EOP_from_update(int64_t time_ns, double delta_ut1_inst, double xp_as,
-                                     double yp_as) const {
+                                     double yp_as) {
 
     struct timespec ts_inst = nanosec_i64_to_timespec(time_ns);
     int64_t ut1 = get_UT1_from_time(ts_inst, delta_ut1_inst);
@@ -205,21 +231,26 @@ EOP Telescope::get_EOP_at_time(const timespec& ts_target) const {
             eop.delta_UT1_inst = eop_b->delta_UT1_inst;
             eop.xp_as = eop_b->xp_as;
             eop.yp_as = eop_b->yp_as;
-            WARN(
-                "Requesting EOP earlier than in table. Requested time = {:d} s + {:d} ns. Earliest "
-                "time = {:d} s + {:d} ns.",
-                t_target / GIGA, t_target % GIGA, eop_b->t_inst / GIGA, eop_b->t_inst % GIGA);
+            if (t_target < eop_b->t_inst) {
+                WARN("Requesting EOP earlier than in table. Requested time = {:d} s + {:d} ns. "
+                     "Earliest "
+                     "time = {:d} s + {:d} ns.",
+                     t_target / GIGA, t_target % GIGA, eop_b->t_inst / GIGA, eop_b->t_inst % GIGA);
+            }
         } else if (eop_b == _eop_table.end()) {
             // Time is later than covered by the table, use the last value.
             auto eop_last = eop_b - 1;
             eop.delta_UT1_inst = eop_last->delta_UT1_inst;
             eop.xp_as = eop_last->xp_as;
             eop.yp_as = eop_last->yp_as;
-            WARN("Requesting EOP later than in table. Requested time = {:d} s + {:d} ns. Latest "
-                 "UT1 = "
-                 "{:d} s + {:d} ns.",
-                 t_target / GIGA, t_target % GIGA, eop_last->t_inst / GIGA,
-                 eop_last->t_inst % GIGA);
+            if (t_target > eop_last->t_inst) {
+                WARN(
+                    "Requesting EOP later than in table. Requested time = {:d} s + {:d} ns. Latest "
+                    "UT1 = "
+                    "{:d} s + {:d} ns.",
+                    t_target / GIGA, t_target % GIGA, eop_last->t_inst / GIGA,
+                    eop_last->t_inst % GIGA);
+            }
         } else {
             // Interpolate!
             auto eop_a = eop_b - 1;

--- a/lib/utils/Telescope.cpp
+++ b/lib/utils/Telescope.cpp
@@ -15,6 +15,21 @@ using kotekan::restServer;
 
 #define GIGA 1'000'000'000L
 
+void to_json(nlohmann::json& j, const BareEOP& eop) {
+    j = {};
+    j.emplace("time_inst_ns", eop.time_inst_ns);
+    j.emplace("delta_UT1_inst", eop.delta_UT1_inst);
+    j.emplace("x_pm", eop.x_pm);
+    j.emplace("y_pm", eop.y_pm);
+}
+
+void from_json(const nlohmann::json& j, BareEOP& eop) {
+    eop.time_inst_ns = j.at("time_inst_ns");
+    eop.delta_UT1_inst = j.at("delta_UT1_inst");
+    eop.x_pm = j.at("x_pm");
+    eop.y_pm = j.at("y_pm");
+}
+
 Telescope::Telescope(const std::string& tel_path, const std::string& log_level, bool require_eop,
                      const std::string& eop_updatable_config_path) :
     _unique_name(tel_path), _require_eop(require_eop) {
@@ -105,7 +120,6 @@ timespec Telescope::seq_length() const {
 bool Telescope::receive_eop_updates(nlohmann::json& json) {
     try {
         // Fill a temporary table with the updated values.
-        std::vector<EOP> tmp_eop_table;
 
         if (!json.contains("earth_orientation_parameter_table") && !_require_eop) {
             // If EOP is not required, say we succeeded and do nothing.
@@ -113,6 +127,12 @@ bool Telescope::receive_eop_updates(nlohmann::json& json) {
                  "table is unchanged.");
             return true;
         }
+        std::vector<BareEOP> bare_eop_table = json.at("earth_orientation_parameter_table");
+        
+        std::vector<EOP> tmp_eop_table(bare_eop_table.size());
+        for (size_t i = 0; i < tmp_eop_table.size(); i++)
+            tmp_eop_table.at(i) = bare_eop_table.at(i).to_EOP();
+        /*
         for (const auto& elem : json.at("earth_orientation_parameter_table")) {
             INFO("Telescope EOP update: {:s}", elem.dump());
             int64_t t_ns = elem.at("time_inst_ns").get<int64_t>();
@@ -121,6 +141,7 @@ bool Telescope::receive_eop_updates(nlohmann::json& json) {
             double y_pm = elem.at("y_pm").get<double>();
             tmp_eop_table.push_back(build_EOP_from_update(t_ns, dut1, x_pm, y_pm));
         }
+        */
 
         if (tmp_eop_table.empty()) {
             // If table was empty, we're done here.

--- a/lib/utils/Telescope.cpp
+++ b/lib/utils/Telescope.cpp
@@ -197,7 +197,7 @@ EOP Telescope::get_EOP_at_time(const timespec& ts_target) const {
     EOP eop;
 
     int64_t t_target = timespec_to_nanosec_i64(ts_target);
-    eop.t_inst = t_target;
+    eop.t_inst_ns = t_target;
 
     {
         std::shared_lock lock(_eop_lock);
@@ -220,11 +220,12 @@ EOP Telescope::get_EOP_at_time(const timespec& ts_target) const {
             eop.delta_UT1_inst = eop_b->delta_UT1_inst;
             eop.xp_as = eop_b->xp_as;
             eop.yp_as = eop_b->yp_as;
-            if (t_target < eop_b->t_inst) {
+            if (t_target < eop_b->t_inst_ns) {
                 WARN("Requesting EOP earlier than in table. Requested time = {:d} s + {:d} ns. "
                      "Earliest "
                      "time = {:d} s + {:d} ns.",
-                     t_target / GIGA, t_target % GIGA, eop_b->t_inst / GIGA, eop_b->t_inst % GIGA);
+                     t_target / GIGA, t_target % GIGA, eop_b->t_inst_ns / GIGA,
+                     eop_b->t_inst_ns % GIGA);
             }
         } else if (eop_b == _eop_table.end()) {
             // Time is later than covered by the table, use the last value.
@@ -232,21 +233,21 @@ EOP Telescope::get_EOP_at_time(const timespec& ts_target) const {
             eop.delta_UT1_inst = eop_last->delta_UT1_inst;
             eop.xp_as = eop_last->xp_as;
             eop.yp_as = eop_last->yp_as;
-            if (t_target > eop_last->t_inst) {
+            if (t_target > eop_last->t_inst_ns) {
                 WARN(
                     "Requesting EOP later than in table. Requested time = {:d} s + {:d} ns. Latest "
                     "UT1 = "
                     "{:d} s + {:d} ns.",
-                    t_target / GIGA, t_target % GIGA, eop_last->t_inst / GIGA,
-                    eop_last->t_inst % GIGA);
+                    t_target / GIGA, t_target % GIGA, eop_last->t_inst_ns / GIGA,
+                    eop_last->t_inst_ns % GIGA);
             }
         } else {
             // Interpolate!
             auto eop_a = eop_b - 1;
             // t - ta in ns. Should be > 0
-            int64_t diff_ns_a = t_target - eop_a->t_inst;
+            int64_t diff_ns_a = t_target - eop_a->t_inst_ns;
             // t - tb in ns. Should be < 0
-            int64_t diff_ns_b = t_target - eop_b->t_inst;
+            int64_t diff_ns_b = t_target - eop_b->t_inst_ns;
             // tb - ta in ns.
             int64_t diff_ns = diff_ns_a - diff_ns_b;
 
@@ -265,24 +266,24 @@ EOP Telescope::get_EOP_at_time(const timespec& ts_target) const {
     int64_t ut1 = get_UT1_from_time(ts_target, eop.delta_UT1_inst);
     double era = get_ERA_from_UT1(ut1, nullptr);
 
-    eop.t_ut1 = ut1;
+    eop.t_ut1_ns = ut1;
     eop.ERA_deg = era;
 
     return eop;
 }
 
-EOP Telescope::get_EOP_at_UT1(int64_t t_ut1) const {
+EOP Telescope::get_EOP_at_UT1(int64_t t_ut1_ns) const {
     // Interpolate on the EOP table to find EOP for the given UT1 time.
 
     EOP eop;
-    eop.t_ut1 = t_ut1;
+    eop.t_ut1_ns = t_ut1_ns;
 
     {
         std::shared_lock lock(_eop_lock);
 
         if (_eop_table.empty()) {
             WARN("EOP table is empty, cannot interpolate EOP at UT1 time {:d} s + {:d} ns.",
-                 t_ut1 / GIGA, t_ut1 % GIGA);
+                 t_ut1_ns / GIGA, t_ut1_ns % GIGA);
             return eop_null;
         }
 
@@ -303,7 +304,7 @@ EOP Telescope::get_EOP_at_UT1(int64_t t_ut1) const {
             WARN("Requesting EOP earlier than in table. Requested UT1 = {:d} s + {:d} ns. Earliest "
                  "UT1 "
                  "= {:d} s + {:d} ns.",
-                 t_ut1 / GIGA, t_ut1 % GIGA, eop_b->t_ut1 / GIGA, eop_b->t_ut1 % GIGA);
+                 t_ut1_ns / GIGA, t_ut1_ns % GIGA, eop_b->t_ut1_ns / GIGA, eop_b->t_ut1_ns % GIGA);
         } else if (eop_b == _eop_table.end()) {
             // Time is later than covered by the table, use the last value.
             auto eop_last = eop_b - 1;
@@ -313,15 +314,16 @@ EOP Telescope::get_EOP_at_UT1(int64_t t_ut1) const {
             WARN("Requesting EOP later than in table. Requested UT1 = {:d} s + {:d} ns. Latest UT1 "
                  "= "
                  "{:d} s + {:d} ns.",
-                 t_ut1 / GIGA, t_ut1 % GIGA, eop_last->t_ut1 / GIGA, eop_last->t_ut1 % GIGA);
+                 t_ut1_ns / GIGA, t_ut1_ns % GIGA, eop_last->t_ut1_ns / GIGA,
+                 eop_last->t_ut1_ns % GIGA);
         } else {
             // Interpolate! Target time = t, in table interval [ta, tb]
             auto eop_a = eop_b - 1;
 
             // t - ta in ns. Should be > 0
-            int64_t diff_ns_a = t_ut1 - eop_a->t_ut1;
+            int64_t diff_ns_a = t_ut1_ns - eop_a->t_ut1_ns;
             // t - tb in ns. Should be < 0
-            int64_t diff_ns_b = t_ut1 - eop_b->t_ut1;
+            int64_t diff_ns_b = t_ut1_ns - eop_b->t_ut1_ns;
 
             // tb - ta in ns.
             int64_t diff_ns = diff_ns_a - diff_ns_b;
@@ -339,11 +341,9 @@ EOP Telescope::get_EOP_at_UT1(int64_t t_ut1) const {
     }
 
     // Now that we have a delta_UT1, can get t_inst and the ERA
-    timespec ts_inst = get_time_from_UT1(t_ut1, eop.delta_UT1_inst);
-    double era = get_ERA_from_UT1(t_ut1, nullptr);
+    eop.t_inst_ns = get_time_ns_from_UT1(t_ut1_ns, eop.delta_UT1_inst);
+    eop.ERA_deg = get_ERA_from_UT1(t_ut1_ns, nullptr);
 
-    eop.t_inst = timespec_to_nanosec_i64(ts_inst);
-    eop.ERA_deg = era;
 
     return eop;
 }

--- a/lib/utils/Telescope.cpp
+++ b/lib/utils/Telescope.cpp
@@ -15,8 +15,12 @@ using kotekan::restServer;
 
 #define GIGA 1'000'000'000L
 
-static constexpr BareEOP dummy_bare_eop_first = {.time_inst_ns=0, .delta_UT1_inst=0.0, .x_pm=0.0, .y_pm=0.0};
-static constexpr BareEOP dummy_bare_eop_last = {.time_inst_ns=std::numeric_limits<int64_t>::max(), .delta_UT1_inst=0.0, .x_pm=0.0, .y_pm=0.0};
+static constexpr BareEOP dummy_bare_eop_first = {
+    .time_inst_ns = 0, .delta_UT1_inst = 0.0, .x_pm = 0.0, .y_pm = 0.0};
+static constexpr BareEOP dummy_bare_eop_last = {.time_inst_ns = std::numeric_limits<int64_t>::max(),
+                                                .delta_UT1_inst = 0.0,
+                                                .x_pm = 0.0,
+                                                .y_pm = 0.0};
 
 Telescope::Telescope(const std::string& tel_path, const std::string& log_level, bool require_eop,
                      const std::string& eop_updatable_config_path) :
@@ -118,8 +122,8 @@ bool Telescope::receive_eop_updates(nlohmann::json& json) {
             return true;
         }
         std::vector<BareEOP> bare_eop_table = json.at("earth_orientation_parameter_table");
-        
-        size_t N = bare_eop_table.size(); 
+
+        size_t N = bare_eop_table.size();
         std::vector<EOP> tmp_eop_table(N);
 
         for (size_t i = 0; i < N; i++)
@@ -130,9 +134,8 @@ bool Telescope::receive_eop_updates(nlohmann::json& json) {
 
             if (_require_eop) {
                 // If table was required. Report an error.
-                ERROR(
-                    "earth_orientation_parameter_table update contained no entries.",
-                    _unique_name);
+                ERROR("earth_orientation_parameter_table update contained no entries.",
+                      _unique_name);
                 return false;
             }
 

--- a/lib/utils/Telescope.hpp
+++ b/lib/utils/Telescope.hpp
@@ -297,6 +297,15 @@ public:
     EOP get_EOP_at_time(const timespec& ts) const;
 
     /**
+     * @brief   Return the EOP at the desired instrument time. Will interpolate
+     *          over table, use first or last entry if target time is out of
+     *          table range.
+     *
+     * @param   t_ns  Target instrument time in nanoseconds.
+     **/
+    EOP get_EOP_at_time_ns(int64_t t_ns) const;
+
+    /**
      * @brief   Return the EOP at the desired UT1 time. Will interpolate
      *          over table, using the first or last entry if target time is
      *          out of table range.

--- a/lib/utils/Telescope.hpp
+++ b/lib/utils/Telescope.hpp
@@ -39,33 +39,6 @@ struct stream_t {
     uint64_t id;
 };
 
-struct BareEOP {
-    int64_t time_inst_ns;
-    double delta_UT1_inst;
-    double x_pm;
-    double y_pm;
-
-    inline BareEOP() : time_inst_ns(0), delta_UT1_inst(0.0), x_pm(0.0), y_pm(0.0) {}
-    
-    inline BareEOP(int64_t t_inst, double dut1, double xp, double yp) : time_inst_ns(t_inst), delta_UT1_inst(dut1), x_pm(xp), y_pm(yp) {}
-
-    inline BareEOP(const EOP& eop) : time_inst_ns(eop.t_inst), delta_UT1_inst(eop.delta_UT1_inst),
-        x_pm(eop.xp_as), y_pm(eop.xp_as) {}
-
-    inline EOP to_EOP() const {
-        int64_t ut1 = get_UT1_from_time(nanosec_i64_to_timespec(time_inst_ns), delta_UT1_inst);
-        double era = get_ERA_from_UT1(ut1, nullptr);
-        return {.t_inst=time_inst_ns, .t_ut1=ut1, .delta_UT1_inst=delta_UT1_inst, .ERA_deg=era, .xp_as=x_pm, .yp_as=y_pm};
-    }
-};
-
-inline bool operator==(const BareEOP& lhs, const BareEOP& rhs) {
-    return (lhs.time_inst_ns == rhs.time_inst_ns && lhs.delta_UT1_inst == rhs.delta_UT1_inst && lhs.x_pm == rhs.x_pm && lhs.y_pm == rhs.y_pm);
-}
-
-void to_json(nlohmann::json& j, const BareEOP& eop);
-void from_json(const nlohmann::json& j, BareEOP& eop);
-
 /**
  * @brief A class to hold telescope specific functionality.
  *
@@ -375,17 +348,6 @@ protected:
      * @param   conn    Kotekan connection.
      */
     void send_time0_ns(kotekan::connectionInstance& conn);
-
-    /**
-     * @brief   Build a single EOP struct from config values
-     *
-     * @param   t_ns    Instrument time in nanoseconds.
-     * @param   delta_ut1_inst  Diff between UT1 and Instrument time in seconds
-     * @param   xp_as   Polar Motion x' coordinate in arcseconds
-     * @param   yp_as   Polar Motion y' coordinate in arcseconds
-     **/
-    static EOP build_EOP_from_update(int64_t t_ns, double delta_ut1_inst, double xp_as,
-                                     double yp_as);
 
     /**
      * The telescope's name in the config

--- a/lib/utils/Telescope.hpp
+++ b/lib/utils/Telescope.hpp
@@ -39,6 +39,33 @@ struct stream_t {
     uint64_t id;
 };
 
+struct BareEOP {
+    int64_t time_inst_ns;
+    double delta_UT1_inst;
+    double x_pm;
+    double y_pm;
+
+    inline BareEOP() : time_inst_ns(0), delta_UT1_inst(0.0), x_pm(0.0), y_pm(0.0) {}
+    
+    inline BareEOP(int64_t t_inst, double dut1, double xp, double yp) : time_inst_ns(t_inst), delta_UT1_inst(dut1), x_pm(xp), y_pm(yp) {}
+
+    inline BareEOP(const EOP& eop) : time_inst_ns(eop.t_inst), delta_UT1_inst(eop.delta_UT1_inst),
+        x_pm(eop.xp_as), y_pm(eop.xp_as) {}
+
+    inline EOP to_EOP() const {
+        int64_t ut1 = get_UT1_from_time(nanosec_i64_to_timespec(time_inst_ns), delta_UT1_inst);
+        double era = get_ERA_from_UT1(ut1, nullptr);
+        return {.t_inst=time_inst_ns, .t_ut1=ut1, .delta_UT1_inst=delta_UT1_inst, .ERA_deg=era, .xp_as=x_pm, .yp_as=y_pm};
+    }
+};
+
+inline bool operator==(const BareEOP& lhs, const BareEOP& rhs) {
+    return (lhs.time_inst_ns == rhs.time_inst_ns && lhs.delta_UT1_inst == rhs.delta_UT1_inst && lhs.x_pm == rhs.x_pm && lhs.y_pm == rhs.y_pm);
+}
+
+void to_json(nlohmann::json& j, const BareEOP& eop);
+void from_json(const nlohmann::json& j, BareEOP& eop);
+
 /**
  * @brief A class to hold telescope specific functionality.
  *

--- a/lib/utils/Telescope.hpp
+++ b/lib/utils/Telescope.hpp
@@ -320,11 +320,12 @@ protected:
      *
      * @param   tel_path    Path to the telescope in the Config (e.g. /telescope)
      * @param   log_level   The level to set logging at.
+     * @param   require_eop Whether to require a valid EOP table.
      * @param   eop_updatable_config_path   The value of "eop_updatable_config" in
      *          the telescope Config, pointing to the updatable field which
      *          contains "earth_orientation_parameter_table"
      **/
-    Telescope(const std::string& tel_path, const std::string& log_level,
+    Telescope(const std::string& tel_path, const std::string& log_level, bool require_eop,
               const std::string& eop_updatable_config_path);
 
     /**
@@ -356,13 +357,19 @@ protected:
      * @param   xp_as   Polar Motion x' coordinate in arcseconds
      * @param   yp_as   Polar Motion y' coordinate in arcseconds
      **/
-    EOP build_EOP_from_update(int64_t t_ns, double delta_ut1_inst, double xp_as,
-                              double yp_as) const;
+    static EOP build_EOP_from_update(int64_t t_ns, double delta_ut1_inst, double xp_as,
+                                     double yp_as);
 
     /**
      * The telescope's name in the config
      */
     const std::string _unique_name;
+
+    /**
+     * Whether to require an EOP table. If false and no (or an empty) EOP table
+     * is provided, the telescope will return a 0 EOP when queried.
+     */
+    const bool _require_eop;
 
     /**
      * This is the Earth Orientation Parameter (EOP) table used to determine

--- a/lib/utils/Telescope.hpp
+++ b/lib/utils/Telescope.hpp
@@ -60,8 +60,8 @@ struct stream_t {
  * @endpoint    /eop_table  GET     Returns a JSON object with a single field "eop_table" which
  *                                  contains a list of EOP objects. Each EOP object contains 6
  *                                  fields:
- *                                  - t_inst            int64   Instrument time in nanoseconds.
- *                                  - t_ut1             int64   UT1 time in nanoseconds since
+ *                                  - t_inst_ns            int64   Instrument time in nanoseconds.
+ *                                  - t_ut1_ns             int64   UT1 time in nanoseconds since
  *                                                              2451545.0 JD(UT1).
  *                                  - delta_UT1_inst    double  Difference in seconds between
  *                                                              UT1 and Instrument time.

--- a/lib/utils/Telescope.hpp
+++ b/lib/utils/Telescope.hpp
@@ -71,19 +71,19 @@ struct stream_t {
  *
  * Updatable Config
  *
- * @conf    eop_updatable_config    Optional. If not present, EOP table will be empty and only
+ * @conf    eop_updatable_config    Optional. If not present, EOP table will be a dummy and only
  *                                  null values (all 0s) will be returned by get_EOP functions.
  *                                  If present, the config path to an updatable config field
  *                                  containing the field "earth_orientation_parameter_table",
- *                                  which is a list of EOP Update objects. Each contains 4
+ *                                  which is a list of BareEOP objects. Each contains 4
  *                                  fields:
- *                                  - time_inst_ns      int     Instrument time in nanoseconds.
+ *                                  - t_inst_ns      int     Instrument time in nanoseconds.
  *                                  - delta_UT1_inst    double  As in EOP.
- *                                  - x_pm              double  As in EOP.
- *                                  - y_pm              double  As in EOP.
+ *                                  - xp_as             double  As in EOP.
+ *                                  - yp_as             double  As in EOP.
  *                                  Upon receiving an update, the entire EOP table is replaced
  *                                  with the new table. UT1 and ERA values are calculated from
- *                                  the given time_inst_ns and delta_UT1_inst.
+ *                                  the given t_inst_ns and delta_UT1_inst.
  *
  * To maintain continuity, tools updating the EOP table should first GET the current table, and
  * only update or add values at least two entries in the future.  The table is linearly

--- a/lib/utils/timeUtil.cpp
+++ b/lib/utils/timeUtil.cpp
@@ -227,12 +227,20 @@ void from_json(const nlohmann::json& j, EOP& m) {
     m.yp_as = j.at("yp_as");                   // Polar Motion y', in arcseconds.
 }
 
+std::string EOP::to_string() const {
+    return fmt::format("EOP{{t_inst_ns: {}, t_ut1_ns: {}, delta_UT1_inst: {}, ERA_deg: {}, xp_as: {}, yp_as: {}}}",
+              t_inst_ns, t_ut1_ns, delta_UT1_inst, ERA_deg, xp_as, yp_as);
+}
+
+
 std::ostream& operator<<(std::ostream& os, const EOP& eop) {
-    os << "EOP{t_inst_ns: " << eop.t_inst_ns << ", t_ut1_ns: " << eop.t_ut1_ns
-       << ", delta_UT1_inst: " << eop.delta_UT1_inst << ", ERA_deg: " << eop.ERA_deg
-       << ", xp_as: " << eop.xp_as << ", yp_as: " << eop.yp_as << "}";
+    os << eop.to_string();
 
     return os;
+}
+
+std::string format_as(const EOP &eop) {
+    return eop.to_string(); 
 }
 
 void to_json(nlohmann::json& j, const BareEOP& eop) {
@@ -250,9 +258,17 @@ void from_json(const nlohmann::json& j, BareEOP& eop) {
     eop.yp_as = j.at("yp_as");
 }
 
+std::string BareEOP::to_string() const {
+    return fmt::format("BareEOP{{t_inst_ns: {}, delta_UT1_inst: {}, xp_as: {}, yp_as: {}}}",
+              t_inst_ns, delta_UT1_inst, xp_as, yp_as);
+}
+
+std::string format_as(const BareEOP &eop) {
+    return eop.to_string(); 
+}
+
 std::ostream& operator<<(std::ostream& os, const BareEOP& eop) {
-    os << "BareEOP{t_inst_ns: " << eop.t_inst_ns << ", delta_UT1_inst: " << eop.delta_UT1_inst
-       << ", xp_as: " << eop.xp_as << ", yp_as: " << eop.yp_as << "}";
+    os << eop.to_string();
 
     return os;
 }

--- a/lib/utils/timeUtil.cpp
+++ b/lib/utils/timeUtil.cpp
@@ -227,22 +227,22 @@ std::ostream& operator<<(std::ostream& os, const EOP& eop) {
 
 void to_json(nlohmann::json& j, const BareEOP& eop) {
     j = {};
-    j.emplace("time_inst_ns", eop.time_inst_ns);
+    j.emplace("t_inst_ns", eop.t_inst_ns);
     j.emplace("delta_UT1_inst", eop.delta_UT1_inst);
-    j.emplace("x_pm", eop.x_pm);
-    j.emplace("y_pm", eop.y_pm);
+    j.emplace("xp_as", eop.xp_as);
+    j.emplace("yp_as", eop.yp_as);
 }
 
 void from_json(const nlohmann::json& j, BareEOP& eop) {
-    eop.time_inst_ns = j.at("time_inst_ns");
+    eop.t_inst_ns = j.at("t_inst_ns");
     eop.delta_UT1_inst = j.at("delta_UT1_inst");
-    eop.x_pm = j.at("x_pm");
-    eop.y_pm = j.at("y_pm");
+    eop.xp_as = j.at("xp_as");
+    eop.yp_as = j.at("yp_as");
 }
 
 std::ostream& operator<<(std::ostream& os, const BareEOP& eop) {
-    os << "BareEOP{time_inst_ns: " << eop.time_inst_ns << ", delta_UT1_inst: " << eop.delta_UT1_inst
-       << ", x_pm: " << eop.x_pm << ", y_pm: " << eop.y_pm << "}";
+    os << "BareEOP{t_inst_ns: " << eop.t_inst_ns << ", delta_UT1_inst: " << eop.delta_UT1_inst
+       << ", xp_as: " << eop.xp_as << ", yp_as: " << eop.yp_as << "}";
 
     return os;
 }

--- a/lib/utils/timeUtil.cpp
+++ b/lib/utils/timeUtil.cpp
@@ -86,7 +86,7 @@ int64_t get_UT1_from_time(const timespec& t, double delta_UT1_inst) {
     return ut1_ns;
 }
 
-timespec get_time_from_UT1(int64_t t_ut1, double delta_UT1_inst) {
+timespec get_time_from_UT1(int64_t t_ut1_ns, double delta_UT1_inst) {
 
     int64_t t0_ut1_s_jd = 2'451'545L * 86400L;
 
@@ -104,12 +104,22 @@ timespec get_time_from_UT1(int64_t t_ut1, double delta_UT1_inst) {
 
     // Convert UT1 to SI seconds (subtract dUT1), and re-base to J2000
     // (by subtracting J2000 in jy)
-    int64_t t_J2000_ns = t_ut1 - dUT1_ns - J2000_ns_jd + GIGA * (t0_ut1_s_jd - J2000_s_jd);
+    int64_t t_J2000_ns = t_ut1_ns - dUT1_ns - J2000_ns_jd + GIGA * (t0_ut1_s_jd - J2000_s_jd);
 
     // Now re-base to the unix epoch for instrument time.
     int64_t t_ns = t_J2000_ns + J2000_ns_unix + GIGA * J2000_s_unix;
 
     return nanosec_i64_to_timespec(t_ns);
+}
+
+int64_t get_UT1_from_time_ns(int64_t t_ns, double delta_UT1_inst) {
+    timespec ts = nanosec_i64_to_timespec(t_ns);
+    return get_UT1_from_time(ts, delta_UT1_inst);
+}
+
+int64_t get_time_ns_from_UT1(int64_t t_ut1_ns, double delta_UT1_inst) {
+    timespec ts = get_time_from_UT1(t_ut1_ns, delta_UT1_inst);
+    return timespec_to_nanosec_i64(ts);
 }
 
 double get_ERA_from_UT1(int64_t ut1, int64_t* n_rot) {
@@ -200,8 +210,8 @@ double get_ERA_from_time(const timespec& time, double dUT) {
 void to_json(nlohmann::json& j, const EOP& m) {
     assert(j.empty());
 
-    j.emplace("t_inst", m.t_inst);                 // Instrument time, nanoseconds, UNIX epoch.
-    j.emplace("t_ut1", m.t_ut1);                   // UT1 time, nanoseconds, J2000(UT1) epoch.
+    j.emplace("t_inst_ns", m.t_inst_ns);           // Instrument time, nanoseconds, UNIX epoch.
+    j.emplace("t_ut1_ns", m.t_ut1_ns);             // UT1 time, nanoseconds, J2000(UT1) epoch.
     j.emplace("delta_UT1_inst", m.delta_UT1_inst); // Diff between UT1 and Instrument time, seconds
     j.emplace("ERA_deg", m.ERA_deg);               // Earth Rotation Angle, degrees
     j.emplace("xp_as", m.xp_as);                   // Polar Motion x', in arcseconds.
@@ -209,8 +219,8 @@ void to_json(nlohmann::json& j, const EOP& m) {
 }
 
 void from_json(const nlohmann::json& j, EOP& m) {
-    m.t_inst = j.at("t_inst");                 // Instrument time, nanoseconds, UNIX epoch.
-    m.t_ut1 = j.at("t_ut1");                   // UT1 time, nanoseconds, J2000(UT1) epoch.
+    m.t_inst_ns = j.at("t_inst_ns");           // Instrument time, nanoseconds, UNIX epoch.
+    m.t_ut1_ns = j.at("t_ut1_ns");             // UT1 time, nanoseconds, J2000(UT1) epoch.
     m.delta_UT1_inst = j.at("delta_UT1_inst"); // Diff between UT1 and Instrument time, seconds
     m.ERA_deg = j.at("ERA_deg");               // Earth Rotation Angle, degrees
     m.xp_as = j.at("xp_as");                   // Polar Motion x', in arcseconds.
@@ -218,7 +228,7 @@ void from_json(const nlohmann::json& j, EOP& m) {
 }
 
 std::ostream& operator<<(std::ostream& os, const EOP& eop) {
-    os << "EOP{t_inst: " << eop.t_inst << ", t_ut1: " << eop.t_ut1
+    os << "EOP{t_inst_ns: " << eop.t_inst_ns << ", t_ut1_ns: " << eop.t_ut1_ns
        << ", delta_UT1_inst: " << eop.delta_UT1_inst << ", ERA_deg: " << eop.ERA_deg
        << ", xp_as: " << eop.xp_as << ", yp_as: " << eop.yp_as << "}";
 

--- a/lib/utils/timeUtil.cpp
+++ b/lib/utils/timeUtil.cpp
@@ -228,8 +228,9 @@ void from_json(const nlohmann::json& j, EOP& m) {
 }
 
 std::string EOP::to_string() const {
-    return fmt::format("EOP{{t_inst_ns: {}, t_ut1_ns: {}, delta_UT1_inst: {}, ERA_deg: {}, xp_as: {}, yp_as: {}}}",
-              t_inst_ns, t_ut1_ns, delta_UT1_inst, ERA_deg, xp_as, yp_as);
+    return fmt::format(
+        "EOP{{t_inst_ns: {}, t_ut1_ns: {}, delta_UT1_inst: {}, ERA_deg: {}, xp_as: {}, yp_as: {}}}",
+        t_inst_ns, t_ut1_ns, delta_UT1_inst, ERA_deg, xp_as, yp_as);
 }
 
 
@@ -239,8 +240,8 @@ std::ostream& operator<<(std::ostream& os, const EOP& eop) {
     return os;
 }
 
-std::string format_as(const EOP &eop) {
-    return eop.to_string(); 
+std::string format_as(const EOP& eop) {
+    return eop.to_string();
 }
 
 void to_json(nlohmann::json& j, const BareEOP& eop) {
@@ -260,11 +261,11 @@ void from_json(const nlohmann::json& j, BareEOP& eop) {
 
 std::string BareEOP::to_string() const {
     return fmt::format("BareEOP{{t_inst_ns: {}, delta_UT1_inst: {}, xp_as: {}, yp_as: {}}}",
-              t_inst_ns, delta_UT1_inst, xp_as, yp_as);
+                       t_inst_ns, delta_UT1_inst, xp_as, yp_as);
 }
 
-std::string format_as(const BareEOP &eop) {
-    return eop.to_string(); 
+std::string format_as(const BareEOP& eop) {
+    return eop.to_string();
 }
 
 std::ostream& operator<<(std::ostream& os, const BareEOP& eop) {

--- a/lib/utils/timeUtil.cpp
+++ b/lib/utils/timeUtil.cpp
@@ -218,7 +218,9 @@ void from_json(const nlohmann::json& j, EOP& m) {
 }
 
 std::ostream& operator<<(std::ostream& os, const EOP& eop) {
-    os << "EOP{t_inst: " << eop.t_inst << ", t_ut1: " << eop.t_ut1 << ", delta_UT1_inst: " << eop.delta_UT1_inst << ", ERA_deg: " << eop.ERA_deg << ", xp_as: " << eop.xp_as << ", yp_as: " << eop.yp_as << "}";
+    os << "EOP{t_inst: " << eop.t_inst << ", t_ut1: " << eop.t_ut1
+       << ", delta_UT1_inst: " << eop.delta_UT1_inst << ", ERA_deg: " << eop.ERA_deg
+       << ", xp_as: " << eop.xp_as << ", yp_as: " << eop.yp_as << "}";
 
     return os;
 }
@@ -239,7 +241,8 @@ void from_json(const nlohmann::json& j, BareEOP& eop) {
 }
 
 std::ostream& operator<<(std::ostream& os, const BareEOP& eop) {
-    os << "BareEOP{time_inst_ns: " << eop.time_inst_ns << ", delta_UT1_inst: " << eop.delta_UT1_inst << ", x_pm: " << eop.x_pm << ", y_pm: " << eop.y_pm << "}";
+    os << "BareEOP{time_inst_ns: " << eop.time_inst_ns << ", delta_UT1_inst: " << eop.delta_UT1_inst
+       << ", x_pm: " << eop.x_pm << ", y_pm: " << eop.y_pm << "}";
 
     return os;
 }

--- a/lib/utils/timeUtil.cpp
+++ b/lib/utils/timeUtil.cpp
@@ -216,3 +216,30 @@ void from_json(const nlohmann::json& j, EOP& m) {
     m.xp_as = j.at("xp_as");                   // Polar Motion x', in arcseconds.
     m.yp_as = j.at("yp_as");                   // Polar Motion y', in arcseconds.
 }
+
+std::ostream& operator<<(std::ostream& os, const EOP& eop) {
+    os << "EOP{t_inst: " << eop.t_inst << ", t_ut1: " << eop.t_ut1 << ", delta_UT1_inst: " << eop.delta_UT1_inst << ", ERA_deg: " << eop.ERA_deg << ", xp_as: " << eop.xp_as << ", yp_as: " << eop.yp_as << "}";
+
+    return os;
+}
+
+void to_json(nlohmann::json& j, const BareEOP& eop) {
+    j = {};
+    j.emplace("time_inst_ns", eop.time_inst_ns);
+    j.emplace("delta_UT1_inst", eop.delta_UT1_inst);
+    j.emplace("x_pm", eop.x_pm);
+    j.emplace("y_pm", eop.y_pm);
+}
+
+void from_json(const nlohmann::json& j, BareEOP& eop) {
+    eop.time_inst_ns = j.at("time_inst_ns");
+    eop.delta_UT1_inst = j.at("delta_UT1_inst");
+    eop.x_pm = j.at("x_pm");
+    eop.y_pm = j.at("y_pm");
+}
+
+std::ostream& operator<<(std::ostream& os, const BareEOP& eop) {
+    os << "BareEOP{time_inst_ns: " << eop.time_inst_ns << ", delta_UT1_inst: " << eop.delta_UT1_inst << ", x_pm: " << eop.x_pm << ", y_pm: " << eop.y_pm << "}";
+
+    return os;
+}

--- a/lib/utils/timeUtil.hpp
+++ b/lib/utils/timeUtil.hpp
@@ -115,6 +115,7 @@ int64_t get_UT1_from_ERA(int64_t num_rot, double ERA_deg);
  */
 double get_ERA_from_time(const timespec& t_inst, double delta_UT1_inst);
 
+
 /**
  * @brief   Simple struct for containing Earth Orientation Parameter (EOP) data
  *
@@ -204,6 +205,14 @@ struct BareEOP {
                 .ERA_deg = era,
                 .xp_as = xp_as,
                 .yp_as = yp_as};
+    }
+
+    /// Produce a BareEOP from an EOP, stripping the redundant fields.
+    static inline BareEOP from_EOP(const EOP& eop) {
+        return {.t_inst_ns = eop.t_inst_ns,
+                .delta_UT1_inst = eop.delta_UT1_inst,
+                .xp_as = eop.xp_as,
+                .yp_as = eop.yp_as};
     }
 
     /// Return a simple string representation of the BareEOP for printing purposes

--- a/lib/utils/timeUtil.hpp
+++ b/lib/utils/timeUtil.hpp
@@ -124,7 +124,9 @@ void to_json(nlohmann::json& j, const EOP& m);
 void from_json(const nlohmann::json& j, EOP& m);
 
 inline bool operator==(const EOP& lhs, const EOP& rhs) {
-    return (lhs.t_inst == rhs.t_inst && lhs.t_ut1 == rhs.t_ut1 && lhs.delta_UT1_inst == rhs.delta_UT1_inst && lhs.ERA_deg == rhs.ERA_deg && lhs.xp_as == rhs.xp_as && lhs.yp_as == rhs.yp_as);
+    return (lhs.t_inst == rhs.t_inst && lhs.t_ut1 == rhs.t_ut1
+            && lhs.delta_UT1_inst == rhs.delta_UT1_inst && lhs.ERA_deg == rhs.ERA_deg
+            && lhs.xp_as == rhs.xp_as && lhs.yp_as == rhs.yp_as);
 }
 
 std::ostream& operator<<(std::ostream& os, const EOP& eop);
@@ -152,20 +154,22 @@ inline bool EOP_comp_ut1(const EOP& eop1, const EOP& eop2) {
 }
 
 /**
- * @brief A struct used for updating the EOP Table via REST which contains minimal EOP data. A full EOP can be produced from a BareEOP.
+ * @brief A struct used for updating the EOP Table via REST which contains minimal EOP data. A full
+ * EOP can be produced from a BareEOP.
  */
 struct BareEOP {
-    int64_t time_inst_ns;   /// Instrument time INST in nanoseconds for this moment.
-    double delta_UT1_inst;  /// UT1 - INST at this moment.
-    double x_pm;            /// x polar motion parameter at this moment, arcseconds.
-    double y_pm;            /// y polar motion parameter at this moment, arcseconds.
+    int64_t time_inst_ns;  /// Instrument time INST in nanoseconds for this moment.
+    double delta_UT1_inst; /// UT1 - INST at this moment.
+    double x_pm;           /// x polar motion parameter at this moment, arcseconds.
+    double y_pm;           /// y polar motion parameter at this moment, arcseconds.
 
     /*
     /// Constuct a null BareEOP.
     inline BareEOP() : time_inst_ns(0), delta_UT1_inst(0.0), x_pm(0.0), y_pm(0.0) {}
-   
+
     /// Construct a BareEOP with given parameters.
-    inline BareEOP(int64_t t_inst, double dut1, double xp, double yp) : time_inst_ns(t_inst), delta_UT1_inst(dut1), x_pm(xp), y_pm(yp) {}
+    inline BareEOP(int64_t t_inst, double dut1, double xp, double yp) : time_inst_ns(t_inst),
+    delta_UT1_inst(dut1), x_pm(xp), y_pm(yp) {}
 
     /// Construct a BareEOP from given EOP.
     inline BareEOP(const EOP& eop) : time_inst_ns(eop.t_inst), delta_UT1_inst(eop.delta_UT1_inst),
@@ -176,15 +180,22 @@ struct BareEOP {
     inline EOP to_EOP() const {
         int64_t ut1 = get_UT1_from_time(nanosec_i64_to_timespec(time_inst_ns), delta_UT1_inst);
         double era = get_ERA_from_UT1(ut1, nullptr);
-        return {.t_inst=time_inst_ns, .t_ut1=ut1, .delta_UT1_inst=delta_UT1_inst, .ERA_deg=era, .xp_as=x_pm, .yp_as=y_pm};
+        return {.t_inst = time_inst_ns,
+                .t_ut1 = ut1,
+                .delta_UT1_inst = delta_UT1_inst,
+                .ERA_deg = era,
+                .xp_as = x_pm,
+                .yp_as = y_pm};
     }
 };
 
-static constexpr BareEOP bare_eop_null = {.time_inst_ns=0, .delta_UT1_inst=0, .x_pm=0, .y_pm=0};
+static constexpr BareEOP bare_eop_null = {
+    .time_inst_ns = 0, .delta_UT1_inst = 0, .x_pm = 0, .y_pm = 0};
 
 /// Simple equality for BareEOP
 inline bool operator==(const BareEOP& lhs, const BareEOP& rhs) {
-    return (lhs.time_inst_ns == rhs.time_inst_ns && lhs.delta_UT1_inst == rhs.delta_UT1_inst && lhs.x_pm == rhs.x_pm && lhs.y_pm == rhs.y_pm);
+    return (lhs.time_inst_ns == rhs.time_inst_ns && lhs.delta_UT1_inst == rhs.delta_UT1_inst
+            && lhs.x_pm == rhs.x_pm && lhs.y_pm == rhs.y_pm);
 }
 
 std::ostream& operator<<(std::ostream& os, const BareEOP& eop);

--- a/lib/utils/timeUtil.hpp
+++ b/lib/utils/timeUtil.hpp
@@ -32,8 +32,8 @@ back to UT1.
 #ifndef TIME_UTIL_HPP
 #define TIME_UTIL_HPP
 
-#include "json.hpp" // for json
 #include "fmt.hpp"
+#include "json.hpp" // for json
 
 #include <inttypes.h>
 #include <time.h> // for timespec

--- a/lib/utils/timeUtil.hpp
+++ b/lib/utils/timeUtil.hpp
@@ -140,18 +140,22 @@ static constexpr EOP eop_null = {.t_inst_ns = 0,
                                  .xp_as = 0.0,
                                  .yp_as = 0.0};
 
+/// JSON serialization functions
 void to_json(nlohmann::json& j, const EOP& m);
 void from_json(const nlohmann::json& j, EOP& m);
 
+/// Simple equality comparison
 inline bool operator==(const EOP& lhs, const EOP& rhs) {
     return (lhs.t_inst_ns == rhs.t_inst_ns && lhs.t_ut1_ns == rhs.t_ut1_ns
             && lhs.delta_UT1_inst == rhs.delta_UT1_inst && lhs.ERA_deg == rhs.ERA_deg
             && lhs.xp_as == rhs.xp_as && lhs.yp_as == rhs.yp_as);
 }
 
+/// Simple string printing.
 std::ostream& operator<<(std::ostream& os, const EOP& eop);
+
 /**
- * @brief   Comparison function for searching/sorting the EOP table. Compares
+ * @brief   Comparison function for searching/sorting an EOP table. Compares
  *          EOP based on t_inst, orders chronologically.
  *
  * @params  eop1    First EOP to compare.
@@ -162,7 +166,7 @@ inline bool EOP_comp_time(const EOP& eop1, const EOP& eop2) {
 }
 
 /**
- * @brief   Comparison function for searching/sorting the EOP table. Compares
+ * @brief   Comparison function for searching/sorting an EOP table. Compares
  *          EOP based on t_ut1, orders by increasing rotation. Will produce the
  *          same order as t_inst, unless something is apocalyptically wrong.
  *
@@ -182,19 +186,6 @@ struct BareEOP {
     double delta_UT1_inst; /// UT1 - INST at this moment.
     double xp_as;          /// x polar motion parameter at this moment, arcseconds.
     double yp_as;          /// y polar motion parameter at this moment, arcseconds.
-
-    /*
-    /// Constuct a null BareEOP.
-    inline BareEOP() : t_inst_ns(0), delta_UT1_inst(0.0), xp_as(0.0), yp_as(0.0) {}
-
-    /// Construct a BareEOP with given parameters.
-    inline BareEOP(int64_t t_inst, double dut1, double xp, double yp) : t_inst_ns(t_inst),
-    delta_UT1_inst(dut1), xp_as(xp), yp_as(yp) {}
-
-    /// Construct a BareEOP from given EOP.
-    inline BareEOP(const EOP& eop) : t_inst_ns(eop.t_inst), delta_UT1_inst(eop.delta_UT1_inst),
-        xp_as(eop.xp_as), yp_as(eop.xp_as) {}
-    */
 
     /// Produce an EOP from this BareEOP, computing the redundant fields in the full EOP.
     inline EOP to_EOP() const {
@@ -218,8 +209,11 @@ inline bool operator==(const BareEOP& lhs, const BareEOP& rhs) {
             && lhs.xp_as == rhs.xp_as && lhs.yp_as == rhs.yp_as);
 }
 
+/// Simple printing to string
 std::ostream& operator<<(std::ostream& os, const BareEOP& eop);
 
+
+/// JSON serialization
 void to_json(nlohmann::json& j, const BareEOP& eop);
 void from_json(const nlohmann::json& j, BareEOP& eop);
 

--- a/lib/utils/timeUtil.hpp
+++ b/lib/utils/timeUtil.hpp
@@ -33,6 +33,7 @@ back to UT1.
 #define TIME_UTIL_HPP
 
 #include "json.hpp" // for json
+#include "fmt.hpp"
 
 #include <inttypes.h>
 #include <time.h> // for timespec
@@ -131,6 +132,9 @@ struct EOP {
     double ERA_deg;        // Earth Rotation Angle, degrees
     double xp_as;          // Polar Motion x', in arcseconds.
     double yp_as;          // Polar Motion y', in arcseconds.
+
+    /// Return a simple string representation of the EOP for printing purposes
+    std::string to_string() const;
 };
 
 static constexpr EOP eop_null = {.t_inst_ns = 0,
@@ -153,6 +157,9 @@ inline bool operator==(const EOP& lhs, const EOP& rhs) {
 
 /// Simple string printing.
 std::ostream& operator<<(std::ostream& os, const EOP& eop);
+
+/// Printing with fmt {}
+std::string format_as(const EOP& eop);
 
 /**
  * @brief   Comparison function for searching/sorting an EOP table. Compares
@@ -198,6 +205,9 @@ struct BareEOP {
                 .xp_as = xp_as,
                 .yp_as = yp_as};
     }
+
+    /// Return a simple string representation of the BareEOP for printing purposes
+    std::string to_string() const;
 };
 
 static constexpr BareEOP bare_eop_null = {
@@ -212,6 +222,8 @@ inline bool operator==(const BareEOP& lhs, const BareEOP& rhs) {
 /// Simple printing to string
 std::ostream& operator<<(std::ostream& os, const BareEOP& eop);
 
+/// Printing with fmt {}
+std::string format_as(const BareEOP& eop);
 
 /// JSON serialization
 void to_json(nlohmann::json& j, const BareEOP& eop);

--- a/lib/utils/timeUtil.hpp
+++ b/lib/utils/timeUtil.hpp
@@ -72,6 +72,22 @@ int64_t get_UT1_from_time(const timespec& t, double delta_UT1_inst);
 timespec get_time_from_UT1(int64_t t_ut1, double delta_UT1_inst);
 
 /**
+ * @brief   Compute UT1 time (J2000(UT1) epoch, nanoseconds) from instrument time.
+ * @param   t_ns The instrument time to convert in nanoseconds
+ * @param   delta_UT1_inst Value of UT1-INST at t, seconds
+ * @return  UT1 time (int64_t nanoseconds since J2000(UT1))
+ */
+int64_t get_UT1_from_time_ns(int64_t t_ns, double delta_UT1_inst);
+
+/**
+ * @brief   Compute instrument time from UT1 time (J2000(UT1) epoch, nanoseconds).
+ * @param   t_ut1 The instrument time to convert, const reference timespec
+ * @param   delta_UT1_inst Value of UT1-INST at ut1, seconds
+ * @return  Instrument time in nanoseconds
+ */
+int64_t get_time_ns_from_UT1(int64_t t_ut1, double delta_UT1_inst);
+
+/**
  * @brief   Compute Earth Rotation Angle (ERA) from UT1
  * @param   ut1  The UT1 time to convert, nanoseconds since J2000(UT1)
  * @param   num_rot int64_t pointer, optional location to store number of rotations since UT1
@@ -101,30 +117,34 @@ double get_ERA_from_time(const timespec& t_inst, double delta_UT1_inst);
 /**
  * @brief   Simple struct for containing Earth Orientation Parameter (EOP) data
  *
- * @param   t_inst          int64_t Instrument time, nanoseconds, UNIX epoch.
- * @param   t_ut1           int64_t UT1 time, nanoseconds, J2000(UT1) epoch.
+ * @param   t_inst_ns       int64_t Instrument time, nanoseconds, UNIX epoch.
+ * @param   t_ut1_ns        int64_t UT1 time, nanoseconds, J2000(UT1) epoch.
  * @param   delta_UT1_inst  double  Difference between UT1 and Instrument time, seconds.
  * @param   ERA_deg         double  Earth Rotation Angle, degrees.
  * @param   xp_as           double  Polar Motion x', arcseconds.
  * @param   yp_as           double  Polar Motion y', arcseconds.
  */
 struct EOP {
-    int64_t t_inst;        // Instrument time, nanoseconds, UNIX epoch.
-    int64_t t_ut1;         // UT1 time, nanoseconds, J2000(UT1) epoch.
+    int64_t t_inst_ns;     // Instrument time, nanoseconds, UNIX epoch.
+    int64_t t_ut1_ns;      // UT1 time, nanoseconds, J2000(UT1) epoch.
     double delta_UT1_inst; // Diff between UT1 and Instrument time, seconds
     double ERA_deg;        // Earth Rotation Angle, degrees
     double xp_as;          // Polar Motion x', in arcseconds.
     double yp_as;          // Polar Motion y', in arcseconds.
 };
 
-static constexpr EOP eop_null = {
-    .t_inst = 0, .t_ut1 = 0, .delta_UT1_inst = 0.0, .ERA_deg = 0.0, .xp_as = 0.0, .yp_as = 0.0};
+static constexpr EOP eop_null = {.t_inst_ns = 0,
+                                 .t_ut1_ns = 0,
+                                 .delta_UT1_inst = 0.0,
+                                 .ERA_deg = 0.0,
+                                 .xp_as = 0.0,
+                                 .yp_as = 0.0};
 
 void to_json(nlohmann::json& j, const EOP& m);
 void from_json(const nlohmann::json& j, EOP& m);
 
 inline bool operator==(const EOP& lhs, const EOP& rhs) {
-    return (lhs.t_inst == rhs.t_inst && lhs.t_ut1 == rhs.t_ut1
+    return (lhs.t_inst_ns == rhs.t_inst_ns && lhs.t_ut1_ns == rhs.t_ut1_ns
             && lhs.delta_UT1_inst == rhs.delta_UT1_inst && lhs.ERA_deg == rhs.ERA_deg
             && lhs.xp_as == rhs.xp_as && lhs.yp_as == rhs.yp_as);
 }
@@ -138,7 +158,7 @@ std::ostream& operator<<(std::ostream& os, const EOP& eop);
  * @params  eop2    Second EOP to compare.
  **/
 inline bool EOP_comp_time(const EOP& eop1, const EOP& eop2) {
-    return eop1.t_inst < eop2.t_inst;
+    return eop1.t_inst_ns < eop2.t_inst_ns;
 }
 
 /**
@@ -150,7 +170,7 @@ inline bool EOP_comp_time(const EOP& eop1, const EOP& eop2) {
  * @params  eop2    Second EOP to compare.
  **/
 inline bool EOP_comp_ut1(const EOP& eop1, const EOP& eop2) {
-    return eop1.t_ut1 < eop2.t_ut1;
+    return eop1.t_ut1_ns < eop2.t_ut1_ns;
 }
 
 /**
@@ -178,10 +198,10 @@ struct BareEOP {
 
     /// Produce an EOP from this BareEOP, computing the redundant fields in the full EOP.
     inline EOP to_EOP() const {
-        int64_t ut1 = get_UT1_from_time(nanosec_i64_to_timespec(t_inst_ns), delta_UT1_inst);
+        int64_t ut1 = get_UT1_from_time_ns(t_inst_ns, delta_UT1_inst);
         double era = get_ERA_from_UT1(ut1, nullptr);
-        return {.t_inst = t_inst_ns,
-                .t_ut1 = ut1,
+        return {.t_inst_ns = t_inst_ns,
+                .t_ut1_ns = ut1,
                 .delta_UT1_inst = delta_UT1_inst,
                 .ERA_deg = era,
                 .xp_as = xp_as,

--- a/lib/utils/timeUtil.hpp
+++ b/lib/utils/timeUtil.hpp
@@ -82,8 +82,8 @@ int64_t get_UT1_from_time_ns(int64_t t_ns, double delta_UT1_inst);
 
 /**
  * @brief   Compute instrument time from UT1 time (J2000(UT1) epoch, nanoseconds).
- * @param   t_ut1 The instrument time to convert, const reference timespec
- * @param   delta_UT1_inst Value of UT1-INST at ut1, seconds
+ * @param   t_ut1 The UT1 time to convert, nanoseconds since J2000(UT1)
+ * @param   delta_UT1_inst Value of UT1-INST at t_ut1, seconds
  * @return  Instrument time in nanoseconds
  */
 int64_t get_time_ns_from_UT1(int64_t t_ut1, double delta_UT1_inst);

--- a/lib/utils/timeUtil.hpp
+++ b/lib/utils/timeUtil.hpp
@@ -37,53 +37,6 @@ back to UT1.
 #include <inttypes.h>
 #include <time.h> // for timespec
 
-/**
- * @brief   Simple struct for containing Earth Orientation Parameter (EOP) data
- *
- * @param   t_inst          int64_t Instrument time, nanoseconds, UNIX epoch.
- * @param   t_ut1           int64_t UT1 time, nanoseconds, J2000(UT1) epoch.
- * @param   delta_UT1_inst  double  Difference between UT1 and Instrument time, seconds.
- * @param   ERA_deg         double  Earth Rotation Angle, degrees.
- * @param   xp_as           double  Polar Motion x', arcseconds.
- * @param   yp_as           double  Polar Motion y', arcseconds.
- */
-struct EOP {
-    int64_t t_inst;        // Instrument time, nanoseconds, UNIX epoch.
-    int64_t t_ut1;         // UT1 time, nanoseconds, J2000(UT1) epoch.
-    double delta_UT1_inst; // Diff between UT1 and Instrument time, seconds
-    double ERA_deg;        // Earth Rotation Angle, degrees
-    double xp_as;          // Polar Motion x', in arcseconds.
-    double yp_as;          // Polar Motion y', in arcseconds.
-};
-
-static constexpr EOP eop_null = {
-    .t_inst = 0, .t_ut1 = 0, .delta_UT1_inst = 0.0, .ERA_deg = 0.0, .xp_as = 0.0, .yp_as = 0.0};
-
-void to_json(nlohmann::json& j, const EOP& m);
-void from_json(const nlohmann::json& j, EOP& m);
-
-/**
- * @brief   Comparison function for searching/sorting the EOP table. Compares
- *          EOP based on t_inst, orders chronologically.
- *
- * @params  eop1    First EOP to compare.
- * @params  eop2    Second EOP to compare.
- **/
-inline bool EOP_comp_time(const EOP& eop1, const EOP& eop2) {
-    return eop1.t_inst < eop2.t_inst;
-}
-
-/**
- * @brief   Comparison function for searching/sorting the EOP table. Compares
- *          EOP based on t_ut1, orders by increasing rotation. Will produce the
- *          same order as t_inst, unless something is apocalyptically wrong.
- *
- * @params  eop1    First EOP to compare.
- * @params  eop2    Second EOP to compare.
- **/
-inline bool EOP_comp_ut1(const EOP& eop1, const EOP& eop2) {
-    return eop1.t_ut1 < eop2.t_ut1;
-}
 
 /**
  * @brief   Directly convert timespec fields into a count of nanoseconds in an int64_t. Overflows
@@ -144,5 +97,100 @@ int64_t get_UT1_from_ERA(int64_t num_rot, double ERA_deg);
  * @return  ERA in degrees, [0.0, 360.0)
  */
 double get_ERA_from_time(const timespec& t_inst, double delta_UT1_inst);
+
+/**
+ * @brief   Simple struct for containing Earth Orientation Parameter (EOP) data
+ *
+ * @param   t_inst          int64_t Instrument time, nanoseconds, UNIX epoch.
+ * @param   t_ut1           int64_t UT1 time, nanoseconds, J2000(UT1) epoch.
+ * @param   delta_UT1_inst  double  Difference between UT1 and Instrument time, seconds.
+ * @param   ERA_deg         double  Earth Rotation Angle, degrees.
+ * @param   xp_as           double  Polar Motion x', arcseconds.
+ * @param   yp_as           double  Polar Motion y', arcseconds.
+ */
+struct EOP {
+    int64_t t_inst;        // Instrument time, nanoseconds, UNIX epoch.
+    int64_t t_ut1;         // UT1 time, nanoseconds, J2000(UT1) epoch.
+    double delta_UT1_inst; // Diff between UT1 and Instrument time, seconds
+    double ERA_deg;        // Earth Rotation Angle, degrees
+    double xp_as;          // Polar Motion x', in arcseconds.
+    double yp_as;          // Polar Motion y', in arcseconds.
+};
+
+static constexpr EOP eop_null = {
+    .t_inst = 0, .t_ut1 = 0, .delta_UT1_inst = 0.0, .ERA_deg = 0.0, .xp_as = 0.0, .yp_as = 0.0};
+
+void to_json(nlohmann::json& j, const EOP& m);
+void from_json(const nlohmann::json& j, EOP& m);
+
+inline bool operator==(const EOP& lhs, const EOP& rhs) {
+    return (lhs.t_inst == rhs.t_inst && lhs.t_ut1 == rhs.t_ut1 && lhs.delta_UT1_inst == rhs.delta_UT1_inst && lhs.ERA_deg == rhs.ERA_deg && lhs.xp_as == rhs.xp_as && lhs.yp_as == rhs.yp_as);
+}
+
+std::ostream& operator<<(std::ostream& os, const EOP& eop);
+/**
+ * @brief   Comparison function for searching/sorting the EOP table. Compares
+ *          EOP based on t_inst, orders chronologically.
+ *
+ * @params  eop1    First EOP to compare.
+ * @params  eop2    Second EOP to compare.
+ **/
+inline bool EOP_comp_time(const EOP& eop1, const EOP& eop2) {
+    return eop1.t_inst < eop2.t_inst;
+}
+
+/**
+ * @brief   Comparison function for searching/sorting the EOP table. Compares
+ *          EOP based on t_ut1, orders by increasing rotation. Will produce the
+ *          same order as t_inst, unless something is apocalyptically wrong.
+ *
+ * @params  eop1    First EOP to compare.
+ * @params  eop2    Second EOP to compare.
+ **/
+inline bool EOP_comp_ut1(const EOP& eop1, const EOP& eop2) {
+    return eop1.t_ut1 < eop2.t_ut1;
+}
+
+/**
+ * @brief A struct used for updating the EOP Table via REST which contains minimal EOP data. A full EOP can be produced from a BareEOP.
+ */
+struct BareEOP {
+    int64_t time_inst_ns;   /// Instrument time INST in nanoseconds for this moment.
+    double delta_UT1_inst;  /// UT1 - INST at this moment.
+    double x_pm;            /// x polar motion parameter at this moment, arcseconds.
+    double y_pm;            /// y polar motion parameter at this moment, arcseconds.
+
+    /*
+    /// Constuct a null BareEOP.
+    inline BareEOP() : time_inst_ns(0), delta_UT1_inst(0.0), x_pm(0.0), y_pm(0.0) {}
+   
+    /// Construct a BareEOP with given parameters.
+    inline BareEOP(int64_t t_inst, double dut1, double xp, double yp) : time_inst_ns(t_inst), delta_UT1_inst(dut1), x_pm(xp), y_pm(yp) {}
+
+    /// Construct a BareEOP from given EOP.
+    inline BareEOP(const EOP& eop) : time_inst_ns(eop.t_inst), delta_UT1_inst(eop.delta_UT1_inst),
+        x_pm(eop.xp_as), y_pm(eop.xp_as) {}
+    */
+
+    /// Produce an EOP from this BareEOP, computing the redundant fields in the full EOP.
+    inline EOP to_EOP() const {
+        int64_t ut1 = get_UT1_from_time(nanosec_i64_to_timespec(time_inst_ns), delta_UT1_inst);
+        double era = get_ERA_from_UT1(ut1, nullptr);
+        return {.t_inst=time_inst_ns, .t_ut1=ut1, .delta_UT1_inst=delta_UT1_inst, .ERA_deg=era, .xp_as=x_pm, .yp_as=y_pm};
+    }
+};
+
+static constexpr BareEOP bare_eop_null = {.time_inst_ns=0, .delta_UT1_inst=0, .x_pm=0, .y_pm=0};
+
+/// Simple equality for BareEOP
+inline bool operator==(const BareEOP& lhs, const BareEOP& rhs) {
+    return (lhs.time_inst_ns == rhs.time_inst_ns && lhs.delta_UT1_inst == rhs.delta_UT1_inst && lhs.x_pm == rhs.x_pm && lhs.y_pm == rhs.y_pm);
+}
+
+std::ostream& operator<<(std::ostream& os, const BareEOP& eop);
+
+void to_json(nlohmann::json& j, const BareEOP& eop);
+void from_json(const nlohmann::json& j, BareEOP& eop);
+
 
 #endif

--- a/lib/utils/timeUtil.hpp
+++ b/lib/utils/timeUtil.hpp
@@ -158,44 +158,44 @@ inline bool EOP_comp_ut1(const EOP& eop1, const EOP& eop2) {
  * EOP can be produced from a BareEOP.
  */
 struct BareEOP {
-    int64_t time_inst_ns;  /// Instrument time INST in nanoseconds for this moment.
+    int64_t t_inst_ns;     /// Instrument time INST in nanoseconds for this moment.
     double delta_UT1_inst; /// UT1 - INST at this moment.
-    double x_pm;           /// x polar motion parameter at this moment, arcseconds.
-    double y_pm;           /// y polar motion parameter at this moment, arcseconds.
+    double xp_as;          /// x polar motion parameter at this moment, arcseconds.
+    double yp_as;          /// y polar motion parameter at this moment, arcseconds.
 
     /*
     /// Constuct a null BareEOP.
-    inline BareEOP() : time_inst_ns(0), delta_UT1_inst(0.0), x_pm(0.0), y_pm(0.0) {}
+    inline BareEOP() : t_inst_ns(0), delta_UT1_inst(0.0), xp_as(0.0), yp_as(0.0) {}
 
     /// Construct a BareEOP with given parameters.
-    inline BareEOP(int64_t t_inst, double dut1, double xp, double yp) : time_inst_ns(t_inst),
-    delta_UT1_inst(dut1), x_pm(xp), y_pm(yp) {}
+    inline BareEOP(int64_t t_inst, double dut1, double xp, double yp) : t_inst_ns(t_inst),
+    delta_UT1_inst(dut1), xp_as(xp), yp_as(yp) {}
 
     /// Construct a BareEOP from given EOP.
-    inline BareEOP(const EOP& eop) : time_inst_ns(eop.t_inst), delta_UT1_inst(eop.delta_UT1_inst),
-        x_pm(eop.xp_as), y_pm(eop.xp_as) {}
+    inline BareEOP(const EOP& eop) : t_inst_ns(eop.t_inst), delta_UT1_inst(eop.delta_UT1_inst),
+        xp_as(eop.xp_as), yp_as(eop.xp_as) {}
     */
 
     /// Produce an EOP from this BareEOP, computing the redundant fields in the full EOP.
     inline EOP to_EOP() const {
-        int64_t ut1 = get_UT1_from_time(nanosec_i64_to_timespec(time_inst_ns), delta_UT1_inst);
+        int64_t ut1 = get_UT1_from_time(nanosec_i64_to_timespec(t_inst_ns), delta_UT1_inst);
         double era = get_ERA_from_UT1(ut1, nullptr);
-        return {.t_inst = time_inst_ns,
+        return {.t_inst = t_inst_ns,
                 .t_ut1 = ut1,
                 .delta_UT1_inst = delta_UT1_inst,
                 .ERA_deg = era,
-                .xp_as = x_pm,
-                .yp_as = y_pm};
+                .xp_as = xp_as,
+                .yp_as = yp_as};
     }
 };
 
 static constexpr BareEOP bare_eop_null = {
-    .time_inst_ns = 0, .delta_UT1_inst = 0, .x_pm = 0, .y_pm = 0};
+    .t_inst_ns = 0, .delta_UT1_inst = 0, .xp_as = 0, .yp_as = 0};
 
 /// Simple equality for BareEOP
 inline bool operator==(const BareEOP& lhs, const BareEOP& rhs) {
-    return (lhs.time_inst_ns == rhs.time_inst_ns && lhs.delta_UT1_inst == rhs.delta_UT1_inst
-            && lhs.x_pm == rhs.x_pm && lhs.y_pm == rhs.y_pm);
+    return (lhs.t_inst_ns == rhs.t_inst_ns && lhs.delta_UT1_inst == rhs.delta_UT1_inst
+            && lhs.xp_as == rhs.xp_as && lhs.yp_as == rhs.yp_as);
 }
 
 std::ostream& operator<<(std::ostream& os, const BareEOP& eop);

--- a/python/kotekan/n2buffer.py
+++ b/python/kotekan/n2buffer.py
@@ -27,8 +27,8 @@ class CTimeSpec(ctypes.Structure):
 class EOP(ctypes.Structure):
 
     _fields_ = [
-        ("t_inst", ctypes.c_int64),
-        ("t_ut1", ctypes.c_int64),
+        ("t_inst_ns", ctypes.c_int64),
+        ("t_ut1_ns", ctypes.c_int64),
         ("delta_UT1_inst", ctypes.c_double),
         ("ERA_deg", ctypes.c_double),
         ("xp_as", ctypes.c_double),

--- a/tests/boost/CMakeLists.txt
+++ b/tests/boost/CMakeLists.txt
@@ -168,8 +168,12 @@ if(HDF5_FOUND AND HighFive_FOUND)
                                PRIVATE TEST_DATA_DIR="${CMAKE_CURRENT_SOURCE_DIR}/testdata")
 endif()
 
+add_executable(test_Telescope test_Telescope.cpp)
+target_link_libraries(test_Telescope PRIVATE -Wl,--whole-archive kotekan_utils kotekan_testing
+                                             -Wl,--no-whole-archive)
+
 add_executable(test_CHORDTelescope test_CHORDTelescope.cpp)
-target_link_libraries(test_CHORDTelescope kotekan_utils)
+target_link_libraries(test_CHORDTelescope PRIVATE kotekan_utils)
 
 # test_N2FrameDesc - unit tests for N2FrameDesc product list features
 add_executable(test_N2FrameDesc test_N2FrameDesc.cpp)

--- a/tests/boost/test_CHORDTelescope.cpp
+++ b/tests/boost/test_CHORDTelescope.cpp
@@ -57,15 +57,15 @@ const std::string default_config_str = R"config_str({
     "kotekan_update_endpoint": "json",
     "earth_orientation_parameter_table": [
         {
-            "time_inst_ns": 1761883200000000000,
+            "t_inst_ns": 1761883200000000000,
             "delta_UT1_inst": 0.0,
-            "x_pm": 0.0,
-            "y_pm": 0.0
+            "xp_as": 0.0,
+            "yp_as": 0.0
         }, {
-            "time_inst_ns": 1761969600000000000,
+            "t_inst_ns": 1761969600000000000,
             "delta_UT1_inst": 0.0,
-            "x_pm": 0.0,
-            "y_pm": 0.0
+            "xp_as": 0.0,
+            "yp_as": 0.0
         }]
     }
 })config_str";

--- a/tests/boost/test_CHORDTelescope.cpp
+++ b/tests/boost/test_CHORDTelescope.cpp
@@ -855,8 +855,12 @@ BOOST_AUTO_TEST_CASE(_vec_cirs_to_itrs) {
     const CHORDTelescope& tel = get_telescope(json_config);
 
     // test EOP
-    EOP eop = {
-        .t_inst = 0, .t_ut1 = 0, .delta_UT1_inst = 0, .ERA_deg = 0.0, .xp_as = 0.0, .yp_as = 0.0};
+    EOP eop = {.t_inst_ns = 0,
+               .t_ut1_ns = 0,
+               .delta_UT1_inst = 0,
+               .ERA_deg = 0.0,
+               .xp_as = 0.0,
+               .yp_as = 0.0};
 
     check_close_vec3d(tel.vec_cirs_to_itrs(n1, eop),
                       cirs_to_itrs(tel, n1, eop.ERA_deg, eop.xp_as, eop.yp_as), 1.0e-14, 1.0e-14,
@@ -940,8 +944,12 @@ BOOST_AUTO_TEST_CASE(_vec_itrs_to_cirs) {
     const CHORDTelescope& tel = get_telescope(json_config);
 
     // test EOP
-    EOP eop = {
-        .t_inst = 0, .t_ut1 = 0, .delta_UT1_inst = 0, .ERA_deg = 0.0, .xp_as = 0.0, .yp_as = 0.0};
+    EOP eop = {.t_inst_ns = 0,
+               .t_ut1_ns = 0,
+               .delta_UT1_inst = 0,
+               .ERA_deg = 0.0,
+               .xp_as = 0.0,
+               .yp_as = 0.0};
 
     check_close_vec3d(tel.vec_itrs_to_cirs(n1, eop),
                       itrs_to_cirs(tel, n1, eop.ERA_deg, eop.xp_as, eop.yp_as), 1.0e-14, 1.0e-14,
@@ -1059,8 +1067,8 @@ BOOST_AUTO_TEST_CASE(_fringestop_phases_1d) {
     dishInfo d3 = dishInfo(3, 2, 2, {-lambda, -lambda, 0.0}, 0.0, DishType::ArrayDish, "D11");
 
     double t = 1.0; // A short time to get only 1st order effects
-    EOP eop0 = {.t_inst = 0, .t_ut1 = 0, .delta_UT1_inst = 0, .ERA_deg = 0, .xp_as = 0, .yp_as = 0};
-    EOP eop = {.t_inst = 0, .t_ut1 = 0, .delta_UT1_inst = 0, .ERA_deg = 0, .xp_as = 0, .yp_as = 0};
+    EOP eop0 = eop_null;
+    EOP eop = eop_null;
     eop.ERA_deg = t * w_e * 180.0 / M_PI;
 
     json json_config = json::parse(default_config_str);

--- a/tests/boost/test_Telescope.cpp
+++ b/tests/boost/test_Telescope.cpp
@@ -1,0 +1,79 @@
+#define BOOST_TEST_MODULE "test_Telescope"
+
+#include "CHORDTelescope.hpp"
+#include "Config.hpp"
+#include "Telescope.hpp"
+#include "configUpdater.hpp"
+#include "errors.h" // _global_log_level
+#include "restServer.hpp"
+#include "timeUtil.hpp"
+
+#include "fmt.hpp"
+#include "json.hpp"
+
+#include <boost/test/included/unit_test.hpp>
+#include <complex>
+#include <filesystem>
+#include <inttypes.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <vector>
+
+using kotekan::Config;
+using json = nlohmann::json;
+using kotekan::configUpdater;
+using kotekan::restServer;
+using namespace std::complex_literals;
+
+const std::string default_tel_config_str = R"tel_config_str({
+"type": "config",
+"log_level": "debug",
+"telescope": {
+    "name": "fake",
+    "require_eop": false,
+    "eop_updatable_config":   "/earth_rotation_data"
+    }
+})tel_config_str";
+
+const std::string default_eop_config_str = R"eop_config_str({
+"earth_rotation_data": {
+    "kotekan_update_endpoint": "json",
+    "earth_orientation_parameter_table": [
+        {
+            "time_inst_ns": 1761883200000000000,
+            "delta_UT1_inst": 0.0,
+            "x_pm": 0.0,
+            "y_pm": 0.0
+        }, {
+            "time_inst_ns": 1761969600000000000,
+            "delta_UT1_inst": 0.0,
+            "x_pm": 0.0,
+            "y_pm": 0.0
+        }]
+    }
+})eop_config_str";
+
+const Telescope& get_telescope(json& json_config) {
+    Config conf;
+    conf.update_config(json_config);
+    configUpdater& config_updater = configUpdater::instance();
+    config_updater.apply_config(conf);
+    Telescope::instance(conf);
+    return Telescope::instance();
+}
+
+
+/******************
+ *
+ * TESTS
+ *
+ ******************/
+
+
+BOOST_AUTO_TEST_CASE(_name_tel) {
+    json json_config = json::parse(default_tel_config_str);
+
+    const Telescope& tel = get_telescope(json_config);
+
+    BOOST_CHECK_EQUAL(tel.get_name(), "fake");
+}

--- a/tests/boost/test_Telescope.cpp
+++ b/tests/boost/test_Telescope.cpp
@@ -70,35 +70,41 @@ const Telescope& get_telescope(json& json_config) {
  ******************/
 
 
-std::vector<EOP> make_full_eop_table(const std::vector<int64_t> &t, const std::vector<double> &dut1,
-                                     const std::vector<double> &xpm, const std::vector<double> &ypm) {
+std::vector<EOP> make_full_eop_table(const std::vector<int64_t>& t, const std::vector<double>& dut1,
+                                     const std::vector<double>& xpm,
+                                     const std::vector<double>& ypm) {
 
     int N = t.size();
-    
+
     std::vector<EOP> eop(N);
 
-    for(int i = 0; i < N; i++) {
+    for (int i = 0; i < N; i++) {
         int64_t ut1 = get_UT1_from_time(nanosec_i64_to_timespec(t[i]), dut1[i]);
-        eop[i] = {.t_inst=t[i], .t_ut1 = ut1,
-                  .delta_UT1_inst=dut1[i], .ERA_deg=get_ERA_from_UT1(ut1, nullptr),
-                  .xp_as=xpm[i], .yp_as=ypm[i]};
+        eop[i] = {.t_inst = t[i],
+                  .t_ut1 = ut1,
+                  .delta_UT1_inst = dut1[i],
+                  .ERA_deg = get_ERA_from_UT1(ut1, nullptr),
+                  .xp_as = xpm[i],
+                  .yp_as = ypm[i]};
     }
 
     return eop;
 }
 
-json make_conf_eop_table(const std::vector<int64_t> &t, const std::vector<double> &dut1,
-                                       const std::vector<double> &xpm, const std::vector<double> &ypm) {
+json make_conf_eop_table(const std::vector<int64_t>& t, const std::vector<double>& dut1,
+                         const std::vector<double>& xpm, const std::vector<double>& ypm) {
 
     int N = t.size();
-    
+
     BOOST_TEST_MESSAGE("make table");
     json eop_update_table = json::array();
 
-    for(int i = 0; i < N; i++) {
+    for (int i = 0; i < N; i++) {
         BOOST_TEST_MESSAGE("add elem");
-        eop_update_table.push_back({{"time_inst_ns", t[i]}, {"delta_UT1_inst", dut1[i]},
-                                    {"x_pm", xpm[i]}, {"y_pm", ypm[i]}});
+        eop_update_table.push_back({{"time_inst_ns", t[i]},
+                                    {"delta_UT1_inst", dut1[i]},
+                                    {"x_pm", xpm[i]},
+                                    {"y_pm", ypm[i]}});
     }
 
     BOOST_TEST_MESSAGE("make final");
@@ -129,9 +135,11 @@ BOOST_AUTO_TEST_CASE(_name_tel) {
 }
 
 BOOST_AUTO_TEST_CASE(_BareEOP_to_json) {
-   
-    BareEOP eop{.time_inst_ns=12345678901234, .delta_UT1_inst=-1.7, .x_pm=1.23, .y_pm=-3.6e-8};
-    json jeop = json::parse(R"({"time_inst_ns": 12345678901234, "delta_UT1_inst": -1.7, "x_pm": 1.23, "y_pm": -3.6e-8})");
+
+    BareEOP eop{
+        .time_inst_ns = 12345678901234, .delta_UT1_inst = -1.7, .x_pm = 1.23, .y_pm = -3.6e-8};
+    json jeop = json::parse(
+        R"({"time_inst_ns": 12345678901234, "delta_UT1_inst": -1.7, "x_pm": 1.23, "y_pm": -3.6e-8})");
 
     json jeop_conv = eop;
 
@@ -139,10 +147,12 @@ BOOST_AUTO_TEST_CASE(_BareEOP_to_json) {
 }
 
 BOOST_AUTO_TEST_CASE(_json_to_BareEOP) {
-   
-    //BareEOP eop(12345678901234, -1.7, 1.23, -3.6e-8);
-    BareEOP eop{.time_inst_ns=12345678901234, .delta_UT1_inst=-1.7, .x_pm=1.23, .y_pm=-3.6e-8};
-    json jeop = json::parse(R"({"time_inst_ns": 12345678901234, "delta_UT1_inst": -1.7, "x_pm": 1.23, "y_pm": -3.6e-8})");
+
+    // BareEOP eop(12345678901234, -1.7, 1.23, -3.6e-8);
+    BareEOP eop{
+        .time_inst_ns = 12345678901234, .delta_UT1_inst = -1.7, .x_pm = 1.23, .y_pm = -3.6e-8};
+    json jeop = json::parse(
+        R"({"time_inst_ns": 12345678901234, "delta_UT1_inst": -1.7, "x_pm": 1.23, "y_pm": -3.6e-8})");
 
     BareEOP eop_conv = jeop;
 
@@ -150,12 +160,19 @@ BOOST_AUTO_TEST_CASE(_json_to_BareEOP) {
 }
 
 BOOST_AUTO_TEST_CASE(_BareEOP_to_EOP) {
-    BareEOP beop{.time_inst_ns=12345678901234567, .delta_UT1_inst=-3.2, .x_pm=-1.6e-8, .y_pm=3.21986e3};
+    BareEOP beop{.time_inst_ns = 12345678901234567,
+                 .delta_UT1_inst = -3.2,
+                 .x_pm = -1.6e-8,
+                 .y_pm = 3.21986e3};
 
-    int64_t ut1 = get_UT1_from_time(nanosec_i64_to_timespec(beop.time_inst_ns),
-                                    beop.delta_UT1_inst);
-    EOP eop = {.t_inst=beop.time_inst_ns, .t_ut1=ut1, .delta_UT1_inst=beop.delta_UT1_inst,
-                .ERA_deg=get_ERA_from_UT1(ut1, nullptr), .xp_as=beop.x_pm, .yp_as=beop.y_pm};
+    int64_t ut1 =
+        get_UT1_from_time(nanosec_i64_to_timespec(beop.time_inst_ns), beop.delta_UT1_inst);
+    EOP eop = {.t_inst = beop.time_inst_ns,
+               .t_ut1 = ut1,
+               .delta_UT1_inst = beop.delta_UT1_inst,
+               .ERA_deg = get_ERA_from_UT1(ut1, nullptr),
+               .xp_as = beop.x_pm,
+               .yp_as = beop.y_pm};
 
     BOOST_CHECK_EQUAL(beop.to_EOP(), eop);
 }

--- a/tests/boost/test_Telescope.cpp
+++ b/tests/boost/test_Telescope.cpp
@@ -7,6 +7,7 @@
 #include "errors.h" // _global_log_level
 #include "restServer.hpp"
 #include "timeUtil.hpp"
+#include "test_logging.hpp"
 
 #include "fmt.hpp"
 #include "json.hpp"
@@ -31,93 +32,114 @@ const std::string default_tel_config_str = R"tel_config_str({
 "type": "config",
 "log_level": "debug",
 "telescope": {
-    "name": "fake",
-    "require_eop": false
+    "name": "TestTelescope",
+    "require_eop": false,
+    "eop_updatable_config": ""
     }
 })tel_config_str";
 
-const std::string default_eop_config_str = R"eop_config_str({
-"earth_rotation_data": {
-    "kotekan_update_endpoint": "json",
-    "earth_orientation_parameter_table": [
-        {
-            "t_inst_ns": 1761883200000000000,
-            "delta_UT1_inst": 0.0,
-            "xp_as": 0.0,
-            "yp_as": 0.0
-        }, {
-            "t_inst_ns": 1761969600000000000,
-            "delta_UT1_inst": 0.0,
-            "xp_as": 0.0,
-            "yp_as": 0.0
-        }]
-    }
-})eop_config_str";
+// Just a hollow Telescope for testing
+class TestTelescope : public Telescope {
+public:
+    TestTelescope(const Config& config, const std::string& path) :
+        Telescope(path, config.get<std::string>(path, "log_level"),
+                config.get<bool>(path, "require_eop"),
+                config.get<std::string>(path, "eop_updatable_config")) {}
 
-const Telescope& get_telescope(json& json_config) {
-    Config conf;
-    conf.update_config(json_config);
-    configUpdater& config_updater = configUpdater::instance();
-    config_updater.apply_config(conf);
-    Telescope::instance(conf);
-    return Telescope::instance();
-}
+    // These functions don't have to do anything, they're not being tested.
+    freq_id_t to_freq_id([[maybe_unused]] stream_t stream, [[maybe_unused]] uint32_t ind) const override {return 0;}
+    double to_freq_MHz([[maybe_unused]] freq_id_t freq_id) const override {return 0.0;}
+    size_t num_freq_per_stream() const override {return 0;}
+    size_t num_freq() const override {return 0;}
+    double freq_width_MHz([[maybe_unused]] freq_id_t freq_id) const override {return 0.0;};
+    uint8_t nyquist_zone() const override {return 0;}
+    bool gps_time_enabled() const override {return false;}
+    timespec to_time([[maybe_unused]] uint64_t seq) const override {return {.tv_sec=0, .tv_nsec=0};};
+    int64_t to_time_ns([[maybe_unused]] uint64_t seq) const override {return 0;}
+    uint64_t to_seq([[maybe_unused]] timespec time) const override {return 0;}
+    uint64_t seq_length_nsec() const override {return 0;}
+};
+
+REGISTER_TELESCOPE(TestTelescope, "TestTelescope");
 
 /******************
  *
- * HELPERS
+ * Fixtures: Logging, RestServer, and Telescope(s)
  *
  ******************/
 
 
-std::vector<EOP> make_full_eop_table(const std::vector<int64_t>& t, const std::vector<double>& dut1,
-                                     const std::vector<double>& xpm,
-                                     const std::vector<double>& ypm) {
+struct LoggingFixture {
+    LoggingFixture() {
+        kotekan_test_logging::configure();
+    }
+};
 
-    int N = t.size();
+struct RestServerFixture {
+    RestServerFixture() {
+        try {
+            kotekan::restServer::instance().start("127.0.0.1", 0);
+        } catch (...) {
+        }
+    }
+};
 
-    std::vector<EOP> eop(N);
+struct TelescopeFixture {
+    TelescopeFixture() {
+        json json_config = json::parse(default_tel_config_str);
+        Config conf;
+        conf.update_config(json_config);
+        configUpdater::instance().apply_config(conf);
+        Telescope::instance(conf);
+    }
+};
 
-    for (int i = 0; i < N; i++) {
-        int64_t ut1 = get_UT1_from_time(nanosec_i64_to_timespec(t[i]), dut1[i]);
-        eop[i] = {.t_inst_ns = t[i],
-                  .t_ut1_ns = ut1,
-                  .delta_UT1_inst = dut1[i],
-                  .ERA_deg = get_ERA_from_UT1(ut1, nullptr),
-                  .xp_as = xpm[i],
-                  .yp_as = ypm[i]};
+struct TelescopeEOPFixture {
+    TelescopeEOPFixture() {
+        json json_config = json::parse(default_tel_config_str);
+
+        N = 5;
+
+        int64_t giga = 1'000'000'000;
+        t = {1, 0, giga, giga*giga, giga*giga + 100'000*giga};
+        dut1 = {0.0, -1.5, 9.8765e-3, 18, 0.123456};
+        x = {0.0, 0.1, -1.0, -987, 1.234e-5};
+        y = {0.0, 0.2, -0.5, 2.345e-5, 123};
+
+        BOOST_REQUIRE(t.size() == N);
+        BOOST_REQUIRE(dut1.size() == N);
+        BOOST_REQUIRE(x.size() == N);
+        BOOST_REQUIRE(y.size() == N);
+
+        for(size_t i = 0; i < N; i++) {
+            BareEOP beop = {.t_inst_ns=t[i], .delta_UT1_inst=dut1[i], .xp_as=x[i], .yp_as=y[i]};
+            fix_bare_eop_table.push_back(beop);
+            fix_eop_table.push_back(beop.to_EOP());
+        }
+
+        json_config["telescope"]["require_eop"] = true;
+        json_config["telescope"]["eop_updatable_config"] = "/eop_update";
+        json_config["eop_update"] = {{"kotekan_update_endpoint", "json"},
+                                     {"earth_orientation_parameter_table", fix_bare_eop_table}};
+
+        Config conf;
+        conf.update_config(json_config);
+        configUpdater::instance().apply_config(conf);
+        Telescope::instance(conf);
     }
 
-    return eop;
-}
+    size_t N;
+    std::vector<int64_t> t;
+    std::vector<double> dut1;
+    std::vector<double> x;
+    std::vector<double> y;
 
-json make_conf_eop_table(const std::vector<int64_t>& t, const std::vector<double>& dut1,
-                         const std::vector<double>& xpm, const std::vector<double>& ypm) {
+    std::vector<EOP> fix_eop_table;
+    std::vector<BareEOP> fix_bare_eop_table;
+};
 
-    int N = t.size();
-
-    BOOST_TEST_MESSAGE("make table");
-    json eop_update_table = json::array();
-
-    for (int i = 0; i < N; i++) {
-        BOOST_TEST_MESSAGE("add elem");
-        eop_update_table.push_back({{"t_inst_ns", t[i]},
-                                    {"delta_UT1_inst", dut1[i]},
-                                    {"xp_as", xpm[i]},
-                                    {"yp_as", ypm[i]}});
-    }
-
-    BOOST_TEST_MESSAGE("make final");
-    json eop_conf_json = {};
-    BOOST_TEST_MESSAGE("add endpoint");
-    eop_conf_json["kotekan_update_endpoint"] = "json";
-    BOOST_TEST_MESSAGE("add table");
-    eop_conf_json["earth_orientation_parameter_table"] = eop_update_table;
-    BOOST_TEST_MESSAGE("return");
-
-    return eop_conf_json;
-}
-
+BOOST_TEST_GLOBAL_FIXTURE(LoggingFixture);
+BOOST_TEST_GLOBAL_FIXTURE(RestServerFixture);
 
 /******************
  *
@@ -126,67 +148,40 @@ json make_conf_eop_table(const std::vector<int64_t>& t, const std::vector<double
  ******************/
 
 
-BOOST_AUTO_TEST_CASE(_name_tel) {
-    json json_config = json::parse(default_tel_config_str);
+BOOST_FIXTURE_TEST_CASE(_name_tel, TelescopeFixture) {
+    const Telescope& tel = Telescope::instance();
 
-    const Telescope& tel = get_telescope(json_config);
-
-    BOOST_CHECK_EQUAL(tel.get_name(), "fake");
+    BOOST_CHECK_EQUAL(tel.get_name(), "TestTelescope");
 }
 
-/*
-BOOST_AUTO_TEST_CASE(_eop_table) {
-    _global_log_level = 5;
-    BOOST_TEST_MESSAGE("parse");
-    json json_config = json::parse(default_tel_config_str);
+BOOST_FIXTURE_TEST_CASE(_get_eop_table, TelescopeEOPFixture) {
+    const Telescope& tel = Telescope::instance();
 
-    BOOST_TEST_MESSAGE("add field");
-    json_config["telescope"]["eop_updatable_config"] = "eop_update";
-    json_config["telescope"]["require_eop"] = true;
+    std::vector<EOP> eop_table = tel.get_current_EOP_table();
 
-    int64_t giga = 1'000'000'000L;
+    // Check table is right size
+    BOOST_CHECK_EQUAL(eop_table.size(), N);
 
-    BOOST_TEST_MESSAGE("init vecs");
-    std::vector<int64_t> t{100 * giga, giga * giga, 2 * giga * giga + 2};
-    std::vector<double> dut1{0.0, 0.5, -1.7};
-    std::vector<double> xpm{0.0, -1.0, 2.34};
-    std::vector<double> ypm{0.0, 0.00001, -8.99999};
+    // Check table is ordered in instrument time
+    for(size_t i = 0; i < N-1; i++)
+        BOOST_CHECK_LT(eop_table[i].t_inst_ns, eop_table[i+1].t_inst_ns);
 
-    std::vector<EOP> eop_true = make_full_eop_table(t, dut1, xpm, ypm);
+    // Check table is also ordered in UT1
+    for(size_t i = 0; i < N-1; i++)
+        BOOST_CHECK_LT(eop_table[i].t_ut1_ns, eop_table[i+1].t_ut1_ns);
 
-    BOOST_TEST_MESSAGE("make conf");
-    json eop_update = make_conf_eop_table(t, dut1, xpm, ypm);
+    // Check table entries are identical to what we sent, they might not be in same order though!
+    std::set<size_t> found_indices;
+    for(size_t i = 0; i < N; i++) {
+        const auto it = std::find(fix_eop_table.begin(), fix_eop_table.end(), eop_table[i]);
+        BOOST_CHECK_MESSAGE(it != fix_eop_table.end(),
+                fmt::format("EOP entry {:d} {} not found", i, eop_table[i]));
 
-    BOOST_TEST_MESSAGE("assign eop");
-    json_config["eop_update"] = eop_update;
+        size_t index = std::distance(fix_eop_table.begin(), it);
 
-    BOOST_TEST_MESSAGE(json_config);
-    std::vector<EOP> eop;
-    BOOST_TEST_MESSAGE("Make tel");
-    boost::test_tools::output_test_stream my_cout;
-    boost::test_tools::output_test_stream my_cerr;
-    {
-        cout_redirect guard_out(my_cout.rdbuf());
-        cerr_redirect guard_err(my_cerr.rdbuf());
-        try {
-            const Telescope& tel = get_telescope(json_config);
-            eop = tel.get_current_EOP_table();
-        } catch (const std::runtime_error &e ) {
-            BOOST_TEST_MESSAGE(fmt::format("ERROR: {}", e.what()));
-
-            BOOST_TEST_MESSAGE("STDOUT");
-            BOOST_TEST_MESSAGE(my_cout.str());
-            BOOST_TEST_MESSAGE("STDERR");
-            BOOST_TEST_MESSAGE(my_cerr.str());
-        }
+        BOOST_CHECK_MESSAGE(found_indices.count(index) == 0, fmt::format("EOP entry {:d} {} occured again!", i, eop_table[i]));
+        found_indices.insert(index);
     }
 
-    BOOST_TEST_MESSAGE("STDOUT");
-    BOOST_TEST_MESSAGE(my_cout.str());
-    BOOST_TEST_MESSAGE("STDERR");
-    BOOST_TEST_MESSAGE(my_cerr.str());
-
-
-    BOOST_CHECK_EQUAL(eop.size(), eop_true.size());
 }
-*/
+

--- a/tests/boost/test_Telescope.cpp
+++ b/tests/boost/test_Telescope.cpp
@@ -134,48 +134,6 @@ BOOST_AUTO_TEST_CASE(_name_tel) {
     BOOST_CHECK_EQUAL(tel.get_name(), "fake");
 }
 
-BOOST_AUTO_TEST_CASE(_BareEOP_to_json) {
-
-    BareEOP eop{
-        .t_inst_ns = 12345678901234, .delta_UT1_inst = -1.7, .xp_as = 1.23, .yp_as = -3.6e-8};
-    json jeop = json::parse(
-        R"({"t_inst_ns": 12345678901234, "delta_UT1_inst": -1.7, "xp_as": 1.23, "yp_as": -3.6e-8})");
-
-    json jeop_conv = eop;
-
-    BOOST_CHECK_MESSAGE(jeop_conv == jeop, "to_json(BareEOP)");
-}
-
-BOOST_AUTO_TEST_CASE(_json_to_BareEOP) {
-
-    // BareEOP eop(12345678901234, -1.7, 1.23, -3.6e-8);
-    BareEOP eop{
-        .t_inst_ns = 12345678901234, .delta_UT1_inst = -1.7, .xp_as = 1.23, .yp_as = -3.6e-8};
-    json jeop = json::parse(
-        R"({"t_inst_ns": 12345678901234, "delta_UT1_inst": -1.7, "xp_as": 1.23, "yp_as": -3.6e-8})");
-
-    BareEOP eop_conv = jeop;
-
-    BOOST_CHECK_MESSAGE(eop_conv == eop, "from_json(BareEOP)");
-}
-
-BOOST_AUTO_TEST_CASE(_BareEOP_to_EOP) {
-    BareEOP beop{.t_inst_ns = 12345678901234567,
-                 .delta_UT1_inst = -3.2,
-                 .xp_as = -1.6e-8,
-                 .yp_as = 3.21986e3};
-
-    int64_t ut1 = get_UT1_from_time_ns(beop.t_inst_ns, beop.delta_UT1_inst);
-    EOP eop = {.t_inst_ns = beop.t_inst_ns,
-               .t_ut1_ns = ut1,
-               .delta_UT1_inst = beop.delta_UT1_inst,
-               .ERA_deg = get_ERA_from_UT1(ut1, nullptr),
-               .xp_as = beop.xp_as,
-               .yp_as = beop.yp_as};
-
-    BOOST_CHECK_EQUAL(beop.to_EOP(), eop);
-}
-
 /*
 BOOST_AUTO_TEST_CASE(_eop_table) {
     _global_log_level = 5;

--- a/tests/boost/test_Telescope.cpp
+++ b/tests/boost/test_Telescope.cpp
@@ -165,8 +165,7 @@ BOOST_AUTO_TEST_CASE(_BareEOP_to_EOP) {
                  .xp_as = -1.6e-8,
                  .yp_as = 3.21986e3};
 
-    int64_t ut1 =
-        get_UT1_from_time(nanosec_i64_to_timespec(beop.t_inst_ns), beop.delta_UT1_inst);
+    int64_t ut1 = get_UT1_from_time(nanosec_i64_to_timespec(beop.t_inst_ns), beop.delta_UT1_inst);
     EOP eop = {.t_inst = beop.t_inst_ns,
                .t_ut1 = ut1,
                .delta_UT1_inst = beop.delta_UT1_inst,

--- a/tests/boost/test_Telescope.cpp
+++ b/tests/boost/test_Telescope.cpp
@@ -130,7 +130,7 @@ BOOST_AUTO_TEST_CASE(_name_tel) {
 
 BOOST_AUTO_TEST_CASE(_BareEOP_to_json) {
    
-    BareEOP eop(12345678901234, -1.7, 1.23, -3.6e-8);
+    BareEOP eop{.time_inst_ns=12345678901234, .delta_UT1_inst=-1.7, .x_pm=1.23, .y_pm=-3.6e-8};
     json jeop = json::parse(R"({"time_inst_ns": 12345678901234, "delta_UT1_inst": -1.7, "x_pm": 1.23, "y_pm": -3.6e-8})");
 
     json jeop_conv = eop;
@@ -140,12 +140,24 @@ BOOST_AUTO_TEST_CASE(_BareEOP_to_json) {
 
 BOOST_AUTO_TEST_CASE(_json_to_BareEOP) {
    
-    BareEOP eop(12345678901234, -1.7, 1.23, -3.6e-8);
+    //BareEOP eop(12345678901234, -1.7, 1.23, -3.6e-8);
+    BareEOP eop{.time_inst_ns=12345678901234, .delta_UT1_inst=-1.7, .x_pm=1.23, .y_pm=-3.6e-8};
     json jeop = json::parse(R"({"time_inst_ns": 12345678901234, "delta_UT1_inst": -1.7, "x_pm": 1.23, "y_pm": -3.6e-8})");
 
     BareEOP eop_conv = jeop;
 
     BOOST_CHECK_MESSAGE(eop_conv == eop, "from_json(BareEOP)");
+}
+
+BOOST_AUTO_TEST_CASE(_BareEOP_to_EOP) {
+    BareEOP beop{.time_inst_ns=12345678901234567, .delta_UT1_inst=-3.2, .x_pm=-1.6e-8, .y_pm=3.21986e3};
+
+    int64_t ut1 = get_UT1_from_time(nanosec_i64_to_timespec(beop.time_inst_ns),
+                                    beop.delta_UT1_inst);
+    EOP eop = {.t_inst=beop.time_inst_ns, .t_ut1=ut1, .delta_UT1_inst=beop.delta_UT1_inst,
+                .ERA_deg=get_ERA_from_UT1(ut1, nullptr), .xp_as=beop.x_pm, .yp_as=beop.y_pm};
+
+    BOOST_CHECK_EQUAL(beop.to_EOP(), eop);
 }
 
 /*

--- a/tests/boost/test_Telescope.cpp
+++ b/tests/boost/test_Telescope.cpp
@@ -80,8 +80,8 @@ std::vector<EOP> make_full_eop_table(const std::vector<int64_t>& t, const std::v
 
     for (int i = 0; i < N; i++) {
         int64_t ut1 = get_UT1_from_time(nanosec_i64_to_timespec(t[i]), dut1[i]);
-        eop[i] = {.t_inst = t[i],
-                  .t_ut1 = ut1,
+        eop[i] = {.t_inst_ns = t[i],
+                  .t_ut1_ns = ut1,
                   .delta_UT1_inst = dut1[i],
                   .ERA_deg = get_ERA_from_UT1(ut1, nullptr),
                   .xp_as = xpm[i],
@@ -165,9 +165,9 @@ BOOST_AUTO_TEST_CASE(_BareEOP_to_EOP) {
                  .xp_as = -1.6e-8,
                  .yp_as = 3.21986e3};
 
-    int64_t ut1 = get_UT1_from_time(nanosec_i64_to_timespec(beop.t_inst_ns), beop.delta_UT1_inst);
-    EOP eop = {.t_inst = beop.t_inst_ns,
-               .t_ut1 = ut1,
+    int64_t ut1 = get_UT1_from_time_ns(beop.t_inst_ns, beop.delta_UT1_inst);
+    EOP eop = {.t_inst_ns = beop.t_inst_ns,
+               .t_ut1_ns = ut1,
                .delta_UT1_inst = beop.delta_UT1_inst,
                .ERA_deg = get_ERA_from_UT1(ut1, nullptr),
                .xp_as = beop.xp_as,

--- a/tests/boost/test_Telescope.cpp
+++ b/tests/boost/test_Telescope.cpp
@@ -22,6 +22,11 @@
 #include <time.h>
 #include <vector>
 
+#define ERA_TOL 2e-12 // <~ 0.5 nanoseconds of rotation in degrees
+#define NS_TOL 0
+#define DUT1_TOL 1.0e-10 // 0.5 ns
+#define XP_TOL 7.5e-9    // 0.5 nanoseconds of rotation in arcseconds
+
 using kotekan::Config;
 using json = nlohmann::json;
 using kotekan::configUpdater;
@@ -87,6 +92,36 @@ REGISTER_TELESCOPE(TestTelescope, "TestTelescope");
 
 /******************
  *
+ * Comparison functions
+ *
+ ******************/
+
+
+void check_ns_close(int64_t t1, int64_t t2, const std::string& name) {
+    BOOST_CHECK_MESSAGE(abs(t1 - t2) <= NS_TOL,
+                        fmt::format("|{0:s}1 - {0:s}2| = |{1:d} - {2:d}| = {3:d} < {4:d} failed",
+                                    name, t1, t2, abs(t1 - t2), NS_TOL));
+}
+
+void check_double_close(double x, double y, double tol, const std::string& name) {
+    BOOST_CHECK_MESSAGE(
+        fabs(x - y) < tol,
+        fmt::format("|{0:s}1 - {0:s}2| = |{1:.14f} - {2:.14f}| = {3:.3e} < {4:.3e} failed", name, x,
+                    y, fabs(x - y), tol));
+}
+
+void check_eop_close(const EOP& eop1, const EOP& eop2) {
+    check_ns_close(eop1.t_inst_ns, eop2.t_inst_ns, "inst");
+    check_ns_close(eop1.t_ut1_ns, eop2.t_ut1_ns, "ut1");
+    check_double_close(eop1.delta_UT1_inst, eop2.delta_UT1_inst, DUT1_TOL, "dut1");
+    check_double_close(eop1.ERA_deg, eop2.ERA_deg, ERA_TOL, "era");
+    check_double_close(eop1.xp_as, eop2.xp_as, XP_TOL, "xp");
+    check_double_close(eop1.yp_as, eop2.yp_as, XP_TOL, "yp");
+}
+
+
+/******************
+ *
  * Fixtures: Logging, RestServer, and Telescope(s)
  *
  ******************/
@@ -124,7 +159,12 @@ struct TelescopeEOPFixture {
         N = 5;
 
         int64_t giga = 1'000'000'000;
-        t = {1, 0, giga, giga * giga, giga * giga + 100'000 * giga};
+        // When we test interpolation later, we test it at 1/4
+        // the distance between table entries. So the smallest
+        // separation in our test table is 4 nanoseconds.
+        //
+        // Deliberately out of order to test Telescope's reordering.
+        t = {4, 0, giga, giga * giga, giga * giga + 100'000 * giga};
         dut1 = {0.0, -1.5, 9.8765e-3, 18, 0.123456};
         x = {0.0, 0.1, -1.0, -987, 1.234e-5};
         y = {0.0, 0.2, -0.5, 2.345e-5, 123};
@@ -162,7 +202,8 @@ struct TelescopeEOPFixture {
     std::vector<BareEOP> fix_bare_eop_table;
 };
 
-BOOST_TEST_GLOBAL_FIXTURE(LoggingFixture);
+// Uncomment to show kotekan logs to stdout during test run.
+// BOOST_TEST_GLOBAL_FIXTURE(LoggingFixture);
 BOOST_TEST_GLOBAL_FIXTURE(RestServerFixture);
 
 /******************
@@ -206,5 +247,135 @@ BOOST_FIXTURE_TEST_CASE(_get_eop_table, TelescopeEOPFixture) {
         BOOST_CHECK_MESSAGE(found_indices.count(index) == 0,
                             fmt::format("EOP entry {:d} {} occured again!", i, eop_table[i]));
         found_indices.insert(index);
+    }
+}
+
+BOOST_FIXTURE_TEST_CASE(_get_eop_at_t, TelescopeEOPFixture) {
+    const Telescope& tel = Telescope::instance();
+
+    int64_t giga = 1'000'000'000;
+
+    std::vector<EOP> eop_table = tel.get_current_EOP_table();
+
+    // Loop over intervals between times in tables (include times before/after
+    for (size_t i = 0; i <= N; i++) {
+
+        // For each interval, grab the left and right values (just copy for before/after)
+        int64_t ta, tb;
+        double dut1a, dut1b, xa, xb, ya, yb;
+        if (i > 0) {
+            ta = eop_table[i - 1].t_inst_ns;
+            dut1a = eop_table[i - 1].delta_UT1_inst;
+            xa = eop_table[i - 1].xp_as;
+            ya = eop_table[i - 1].yp_as;
+        } else {
+            ta = eop_table[0].t_inst_ns - giga;
+            dut1a = eop_table[0].delta_UT1_inst;
+            xa = eop_table[0].xp_as;
+            ya = eop_table[0].yp_as;
+        }
+
+        if (i < N) {
+            tb = eop_table[i].t_inst_ns;
+            dut1b = eop_table[i].delta_UT1_inst;
+            xb = eop_table[i].xp_as;
+            yb = eop_table[i].yp_as;
+        } else {
+            tb = eop_table[N - 1].t_inst_ns + giga;
+            dut1b = eop_table[N - 1].delta_UT1_inst;
+            xb = eop_table[N - 1].xp_as;
+            yb = eop_table[N - 1].yp_as;
+        }
+
+        BOOST_TEST_MESSAGE(fmt::format("eop_a - t: {} dut1: {} x: {} y: {}", ta, dut1a, xa, ya));
+        BOOST_TEST_MESSAGE(fmt::format("eop_b - t: {} dut1: {} x: {} y: {}", tb, dut1b, xb, yb));
+
+        // Test a few points on this interval.
+        for (double w : {0.0, 0.25, 0.5, 0.75, 1.0}) {
+
+            BOOST_TEST_MESSAGE(fmt::format("w: {}", w));
+
+            // Make  the target EOP
+            BareEOP test_beop = {.t_inst_ns = ta + static_cast<int64_t>(w * (tb - ta)),
+                                 .delta_UT1_inst = (1 - w) * dut1a + w * dut1b,
+                                 .xp_as = (1 - w) * xa + w * xb,
+                                 .yp_as = (1 - w) * ya + w * yb};
+            EOP test_eop = test_beop.to_EOP();
+
+            // Check the _at_time_ns function.
+            EOP tel_eop = tel.get_EOP_at_time_ns(test_eop.t_inst_ns);
+
+            check_eop_close(tel_eop, test_eop);
+
+            // Check the _at_function while we're here.
+            EOP tel_eop2 = tel.get_EOP_at_time(nanosec_i64_to_timespec(test_eop.t_inst_ns));
+
+            check_eop_close(tel_eop2, test_eop);
+        }
+    }
+}
+
+BOOST_FIXTURE_TEST_CASE(_get_eop_at_ut1, TelescopeEOPFixture) {
+    const Telescope& tel = Telescope::instance();
+
+    int64_t giga = 1'000'000'000;
+
+    std::vector<EOP> eop_table = tel.get_current_EOP_table();
+
+    // Loop over intervals between times in tables (include times before/after
+    for (size_t i = 0; i <= N; i++) {
+
+        // For each interval, grab the left and right values (just copy for before/after)
+        int64_t ut1a, ut1b;
+        double dut1a, dut1b, xa, xb, ya, yb;
+        if (i > 0) {
+            ut1a = eop_table[i - 1].t_ut1_ns;
+            dut1a = eop_table[i - 1].delta_UT1_inst;
+            xa = eop_table[i - 1].xp_as;
+            ya = eop_table[i - 1].yp_as;
+        } else {
+            ut1a = eop_table[0].t_ut1_ns - giga;
+            dut1a = eop_table[0].delta_UT1_inst;
+            xa = eop_table[0].xp_as;
+            ya = eop_table[0].yp_as;
+        }
+
+        if (i < N) {
+            ut1b = eop_table[i].t_ut1_ns;
+            dut1b = eop_table[i].delta_UT1_inst;
+            xb = eop_table[i].xp_as;
+            yb = eop_table[i].yp_as;
+        } else {
+            ut1b = eop_table[N - 1].t_ut1_ns + giga;
+            dut1b = eop_table[N - 1].delta_UT1_inst;
+            xb = eop_table[N - 1].xp_as;
+            yb = eop_table[N - 1].yp_as;
+        }
+
+        BOOST_TEST_MESSAGE(
+            fmt::format("eop_a - ut1: {} dut1: {} x: {} y: {}", ut1a, dut1a, xa, ya));
+        BOOST_TEST_MESSAGE(
+            fmt::format("eop_b - ut1: {} dut1: {} x: {} y: {}", ut1b, dut1b, xb, yb));
+
+        // Test a few points on this interval.
+        for (double w : {0.0, 0.25, 0.5, 0.75, 1.0}) {
+
+            BOOST_TEST_MESSAGE(fmt::format("w: {}", w));
+
+            // Make  the target EOP
+            EOP test_eop = {.t_inst_ns = 0,
+                            .t_ut1_ns = ut1a + static_cast<int64_t>(w * (ut1b - ut1a)),
+                            .delta_UT1_inst = (1 - w) * dut1a + w * dut1b,
+                            .ERA_deg = 0.0,
+                            .xp_as = (1 - w) * xa + w * xb,
+                            .yp_as = (1 - w) * ya + w * yb};
+            test_eop.t_inst_ns = get_time_ns_from_UT1(test_eop.t_ut1_ns, test_eop.delta_UT1_inst);
+            test_eop.ERA_deg = get_ERA_from_UT1(test_eop.t_ut1_ns, nullptr);
+
+            // Check the _at_UT1 function.
+            EOP tel_eop = tel.get_EOP_at_UT1(test_eop.t_ut1_ns);
+
+            check_eop_close(tel_eop, test_eop);
+        }
     }
 }

--- a/tests/boost/test_Telescope.cpp
+++ b/tests/boost/test_Telescope.cpp
@@ -6,8 +6,8 @@
 #include "configUpdater.hpp"
 #include "errors.h" // _global_log_level
 #include "restServer.hpp"
-#include "timeUtil.hpp"
 #include "test_logging.hpp"
+#include "timeUtil.hpp"
 
 #include "fmt.hpp"
 #include "json.hpp"
@@ -43,21 +43,44 @@ class TestTelescope : public Telescope {
 public:
     TestTelescope(const Config& config, const std::string& path) :
         Telescope(path, config.get<std::string>(path, "log_level"),
-                config.get<bool>(path, "require_eop"),
-                config.get<std::string>(path, "eop_updatable_config")) {}
+                  config.get<bool>(path, "require_eop"),
+                  config.get<std::string>(path, "eop_updatable_config")) {}
 
     // These functions don't have to do anything, they're not being tested.
-    freq_id_t to_freq_id([[maybe_unused]] stream_t stream, [[maybe_unused]] uint32_t ind) const override {return 0;}
-    double to_freq_MHz([[maybe_unused]] freq_id_t freq_id) const override {return 0.0;}
-    size_t num_freq_per_stream() const override {return 0;}
-    size_t num_freq() const override {return 0;}
-    double freq_width_MHz([[maybe_unused]] freq_id_t freq_id) const override {return 0.0;};
-    uint8_t nyquist_zone() const override {return 0;}
-    bool gps_time_enabled() const override {return false;}
-    timespec to_time([[maybe_unused]] uint64_t seq) const override {return {.tv_sec=0, .tv_nsec=0};};
-    int64_t to_time_ns([[maybe_unused]] uint64_t seq) const override {return 0;}
-    uint64_t to_seq([[maybe_unused]] timespec time) const override {return 0;}
-    uint64_t seq_length_nsec() const override {return 0;}
+    freq_id_t to_freq_id([[maybe_unused]] stream_t stream,
+                         [[maybe_unused]] uint32_t ind) const override {
+        return 0;
+    }
+    double to_freq_MHz([[maybe_unused]] freq_id_t freq_id) const override {
+        return 0.0;
+    }
+    size_t num_freq_per_stream() const override {
+        return 0;
+    }
+    size_t num_freq() const override {
+        return 0;
+    }
+    double freq_width_MHz([[maybe_unused]] freq_id_t freq_id) const override {
+        return 0.0;
+    };
+    uint8_t nyquist_zone() const override {
+        return 0;
+    }
+    bool gps_time_enabled() const override {
+        return false;
+    }
+    timespec to_time([[maybe_unused]] uint64_t seq) const override {
+        return {.tv_sec = 0, .tv_nsec = 0};
+    };
+    int64_t to_time_ns([[maybe_unused]] uint64_t seq) const override {
+        return 0;
+    }
+    uint64_t to_seq([[maybe_unused]] timespec time) const override {
+        return 0;
+    }
+    uint64_t seq_length_nsec() const override {
+        return 0;
+    }
 };
 
 REGISTER_TELESCOPE(TestTelescope, "TestTelescope");
@@ -101,7 +124,7 @@ struct TelescopeEOPFixture {
         N = 5;
 
         int64_t giga = 1'000'000'000;
-        t = {1, 0, giga, giga*giga, giga*giga + 100'000*giga};
+        t = {1, 0, giga, giga * giga, giga * giga + 100'000 * giga};
         dut1 = {0.0, -1.5, 9.8765e-3, 18, 0.123456};
         x = {0.0, 0.1, -1.0, -987, 1.234e-5};
         y = {0.0, 0.2, -0.5, 2.345e-5, 123};
@@ -111,8 +134,9 @@ struct TelescopeEOPFixture {
         BOOST_REQUIRE(x.size() == N);
         BOOST_REQUIRE(y.size() == N);
 
-        for(size_t i = 0; i < N; i++) {
-            BareEOP beop = {.t_inst_ns=t[i], .delta_UT1_inst=dut1[i], .xp_as=x[i], .yp_as=y[i]};
+        for (size_t i = 0; i < N; i++) {
+            BareEOP beop = {
+                .t_inst_ns = t[i], .delta_UT1_inst = dut1[i], .xp_as = x[i], .yp_as = y[i]};
             fix_bare_eop_table.push_back(beop);
             fix_eop_table.push_back(beop.to_EOP());
         }
@@ -163,25 +187,24 @@ BOOST_FIXTURE_TEST_CASE(_get_eop_table, TelescopeEOPFixture) {
     BOOST_CHECK_EQUAL(eop_table.size(), N);
 
     // Check table is ordered in instrument time
-    for(size_t i = 0; i < N-1; i++)
-        BOOST_CHECK_LT(eop_table[i].t_inst_ns, eop_table[i+1].t_inst_ns);
+    for (size_t i = 0; i < N - 1; i++)
+        BOOST_CHECK_LT(eop_table[i].t_inst_ns, eop_table[i + 1].t_inst_ns);
 
     // Check table is also ordered in UT1
-    for(size_t i = 0; i < N-1; i++)
-        BOOST_CHECK_LT(eop_table[i].t_ut1_ns, eop_table[i+1].t_ut1_ns);
+    for (size_t i = 0; i < N - 1; i++)
+        BOOST_CHECK_LT(eop_table[i].t_ut1_ns, eop_table[i + 1].t_ut1_ns);
 
     // Check table entries are identical to what we sent, they might not be in same order though!
     std::set<size_t> found_indices;
-    for(size_t i = 0; i < N; i++) {
+    for (size_t i = 0; i < N; i++) {
         const auto it = std::find(fix_eop_table.begin(), fix_eop_table.end(), eop_table[i]);
         BOOST_CHECK_MESSAGE(it != fix_eop_table.end(),
-                fmt::format("EOP entry {:d} {} not found", i, eop_table[i]));
+                            fmt::format("EOP entry {:d} {} not found", i, eop_table[i]));
 
         size_t index = std::distance(fix_eop_table.begin(), it);
 
-        BOOST_CHECK_MESSAGE(found_indices.count(index) == 0, fmt::format("EOP entry {:d} {} occured again!", i, eop_table[i]));
+        BOOST_CHECK_MESSAGE(found_indices.count(index) == 0,
+                            fmt::format("EOP entry {:d} {} occured again!", i, eop_table[i]));
         found_indices.insert(index);
     }
-
 }
-

--- a/tests/boost/test_Telescope.cpp
+++ b/tests/boost/test_Telescope.cpp
@@ -41,15 +41,15 @@ const std::string default_eop_config_str = R"eop_config_str({
     "kotekan_update_endpoint": "json",
     "earth_orientation_parameter_table": [
         {
-            "time_inst_ns": 1761883200000000000,
+            "t_inst_ns": 1761883200000000000,
             "delta_UT1_inst": 0.0,
-            "x_pm": 0.0,
-            "y_pm": 0.0
+            "xp_as": 0.0,
+            "yp_as": 0.0
         }, {
-            "time_inst_ns": 1761969600000000000,
+            "t_inst_ns": 1761969600000000000,
             "delta_UT1_inst": 0.0,
-            "x_pm": 0.0,
-            "y_pm": 0.0
+            "xp_as": 0.0,
+            "yp_as": 0.0
         }]
     }
 })eop_config_str";
@@ -101,10 +101,10 @@ json make_conf_eop_table(const std::vector<int64_t>& t, const std::vector<double
 
     for (int i = 0; i < N; i++) {
         BOOST_TEST_MESSAGE("add elem");
-        eop_update_table.push_back({{"time_inst_ns", t[i]},
+        eop_update_table.push_back({{"t_inst_ns", t[i]},
                                     {"delta_UT1_inst", dut1[i]},
-                                    {"x_pm", xpm[i]},
-                                    {"y_pm", ypm[i]}});
+                                    {"xp_as", xpm[i]},
+                                    {"yp_as", ypm[i]}});
     }
 
     BOOST_TEST_MESSAGE("make final");
@@ -137,9 +137,9 @@ BOOST_AUTO_TEST_CASE(_name_tel) {
 BOOST_AUTO_TEST_CASE(_BareEOP_to_json) {
 
     BareEOP eop{
-        .time_inst_ns = 12345678901234, .delta_UT1_inst = -1.7, .x_pm = 1.23, .y_pm = -3.6e-8};
+        .t_inst_ns = 12345678901234, .delta_UT1_inst = -1.7, .xp_as = 1.23, .yp_as = -3.6e-8};
     json jeop = json::parse(
-        R"({"time_inst_ns": 12345678901234, "delta_UT1_inst": -1.7, "x_pm": 1.23, "y_pm": -3.6e-8})");
+        R"({"t_inst_ns": 12345678901234, "delta_UT1_inst": -1.7, "xp_as": 1.23, "yp_as": -3.6e-8})");
 
     json jeop_conv = eop;
 
@@ -150,9 +150,9 @@ BOOST_AUTO_TEST_CASE(_json_to_BareEOP) {
 
     // BareEOP eop(12345678901234, -1.7, 1.23, -3.6e-8);
     BareEOP eop{
-        .time_inst_ns = 12345678901234, .delta_UT1_inst = -1.7, .x_pm = 1.23, .y_pm = -3.6e-8};
+        .t_inst_ns = 12345678901234, .delta_UT1_inst = -1.7, .xp_as = 1.23, .yp_as = -3.6e-8};
     json jeop = json::parse(
-        R"({"time_inst_ns": 12345678901234, "delta_UT1_inst": -1.7, "x_pm": 1.23, "y_pm": -3.6e-8})");
+        R"({"t_inst_ns": 12345678901234, "delta_UT1_inst": -1.7, "xp_as": 1.23, "yp_as": -3.6e-8})");
 
     BareEOP eop_conv = jeop;
 
@@ -160,19 +160,19 @@ BOOST_AUTO_TEST_CASE(_json_to_BareEOP) {
 }
 
 BOOST_AUTO_TEST_CASE(_BareEOP_to_EOP) {
-    BareEOP beop{.time_inst_ns = 12345678901234567,
+    BareEOP beop{.t_inst_ns = 12345678901234567,
                  .delta_UT1_inst = -3.2,
-                 .x_pm = -1.6e-8,
-                 .y_pm = 3.21986e3};
+                 .xp_as = -1.6e-8,
+                 .yp_as = 3.21986e3};
 
     int64_t ut1 =
-        get_UT1_from_time(nanosec_i64_to_timespec(beop.time_inst_ns), beop.delta_UT1_inst);
-    EOP eop = {.t_inst = beop.time_inst_ns,
+        get_UT1_from_time(nanosec_i64_to_timespec(beop.t_inst_ns), beop.delta_UT1_inst);
+    EOP eop = {.t_inst = beop.t_inst_ns,
                .t_ut1 = ut1,
                .delta_UT1_inst = beop.delta_UT1_inst,
                .ERA_deg = get_ERA_from_UT1(ut1, nullptr),
-               .xp_as = beop.x_pm,
-               .yp_as = beop.y_pm};
+               .xp_as = beop.xp_as,
+               .yp_as = beop.yp_as};
 
     BOOST_CHECK_EQUAL(beop.to_EOP(), eop);
 }

--- a/tests/boost/test_Telescope.cpp
+++ b/tests/boost/test_Telescope.cpp
@@ -12,9 +12,11 @@
 #include "json.hpp"
 
 #include <boost/test/included/unit_test.hpp>
+#include <boost/test/tools/output_test_stream.hpp>
 #include <complex>
 #include <filesystem>
 #include <inttypes.h>
+#include <iostream>
 #include <sys/wait.h>
 #include <time.h>
 #include <vector>
@@ -30,8 +32,7 @@ const std::string default_tel_config_str = R"tel_config_str({
 "log_level": "debug",
 "telescope": {
     "name": "fake",
-    "require_eop": false,
-    "eop_updatable_config":   "/earth_rotation_data"
+    "require_eop": false
     }
 })tel_config_str";
 
@@ -62,6 +63,55 @@ const Telescope& get_telescope(json& json_config) {
     return Telescope::instance();
 }
 
+/******************
+ *
+ * HELPERS
+ *
+ ******************/
+
+
+std::vector<EOP> make_full_eop_table(const std::vector<int64_t> &t, const std::vector<double> &dut1,
+                                     const std::vector<double> &xpm, const std::vector<double> &ypm) {
+
+    int N = t.size();
+    
+    std::vector<EOP> eop(N);
+
+    for(int i = 0; i < N; i++) {
+        int64_t ut1 = get_UT1_from_time(nanosec_i64_to_timespec(t[i]), dut1[i]);
+        eop[i] = {.t_inst=t[i], .t_ut1 = ut1,
+                  .delta_UT1_inst=dut1[i], .ERA_deg=get_ERA_from_UT1(ut1, nullptr),
+                  .xp_as=xpm[i], .yp_as=ypm[i]};
+    }
+
+    return eop;
+}
+
+json make_conf_eop_table(const std::vector<int64_t> &t, const std::vector<double> &dut1,
+                                       const std::vector<double> &xpm, const std::vector<double> &ypm) {
+
+    int N = t.size();
+    
+    BOOST_TEST_MESSAGE("make table");
+    json eop_update_table = json::array();
+
+    for(int i = 0; i < N; i++) {
+        BOOST_TEST_MESSAGE("add elem");
+        eop_update_table.push_back({{"time_inst_ns", t[i]}, {"delta_UT1_inst", dut1[i]},
+                                    {"x_pm", xpm[i]}, {"y_pm", ypm[i]}});
+    }
+
+    BOOST_TEST_MESSAGE("make final");
+    json eop_conf_json = {};
+    BOOST_TEST_MESSAGE("add endpoint");
+    eop_conf_json["kotekan_update_endpoint"] = "json";
+    BOOST_TEST_MESSAGE("add table");
+    eop_conf_json["earth_orientation_parameter_table"] = eop_update_table;
+    BOOST_TEST_MESSAGE("return");
+
+    return eop_conf_json;
+}
+
 
 /******************
  *
@@ -77,3 +127,80 @@ BOOST_AUTO_TEST_CASE(_name_tel) {
 
     BOOST_CHECK_EQUAL(tel.get_name(), "fake");
 }
+
+BOOST_AUTO_TEST_CASE(_BareEOP_to_json) {
+   
+    BareEOP eop(12345678901234, -1.7, 1.23, -3.6e-8);
+    json jeop = json::parse(R"({"time_inst_ns": 12345678901234, "delta_UT1_inst": -1.7, "x_pm": 1.23, "y_pm": -3.6e-8})");
+
+    json jeop_conv = eop;
+
+    BOOST_CHECK_MESSAGE(jeop_conv == jeop, "to_json(BareEOP)");
+}
+
+BOOST_AUTO_TEST_CASE(_json_to_BareEOP) {
+   
+    BareEOP eop(12345678901234, -1.7, 1.23, -3.6e-8);
+    json jeop = json::parse(R"({"time_inst_ns": 12345678901234, "delta_UT1_inst": -1.7, "x_pm": 1.23, "y_pm": -3.6e-8})");
+
+    BareEOP eop_conv = jeop;
+
+    BOOST_CHECK_MESSAGE(eop_conv == eop, "from_json(BareEOP)");
+}
+
+/*
+BOOST_AUTO_TEST_CASE(_eop_table) {
+    _global_log_level = 5;
+    BOOST_TEST_MESSAGE("parse");
+    json json_config = json::parse(default_tel_config_str);
+
+    BOOST_TEST_MESSAGE("add field");
+    json_config["telescope"]["eop_updatable_config"] = "eop_update";
+    json_config["telescope"]["require_eop"] = true;
+
+    int64_t giga = 1'000'000'000L;
+
+    BOOST_TEST_MESSAGE("init vecs");
+    std::vector<int64_t> t{100 * giga, giga * giga, 2 * giga * giga + 2};
+    std::vector<double> dut1{0.0, 0.5, -1.7};
+    std::vector<double> xpm{0.0, -1.0, 2.34};
+    std::vector<double> ypm{0.0, 0.00001, -8.99999};
+
+    std::vector<EOP> eop_true = make_full_eop_table(t, dut1, xpm, ypm);
+
+    BOOST_TEST_MESSAGE("make conf");
+    json eop_update = make_conf_eop_table(t, dut1, xpm, ypm);
+
+    BOOST_TEST_MESSAGE("assign eop");
+    json_config["eop_update"] = eop_update;
+
+    BOOST_TEST_MESSAGE(json_config);
+    std::vector<EOP> eop;
+    BOOST_TEST_MESSAGE("Make tel");
+    boost::test_tools::output_test_stream my_cout;
+    boost::test_tools::output_test_stream my_cerr;
+    {
+        cout_redirect guard_out(my_cout.rdbuf());
+        cerr_redirect guard_err(my_cerr.rdbuf());
+        try {
+            const Telescope& tel = get_telescope(json_config);
+            eop = tel.get_current_EOP_table();
+        } catch (const std::runtime_error &e ) {
+            BOOST_TEST_MESSAGE(fmt::format("ERROR: {}", e.what()));
+
+            BOOST_TEST_MESSAGE("STDOUT");
+            BOOST_TEST_MESSAGE(my_cout.str());
+            BOOST_TEST_MESSAGE("STDERR");
+            BOOST_TEST_MESSAGE(my_cerr.str());
+        }
+    }
+
+    BOOST_TEST_MESSAGE("STDOUT");
+    BOOST_TEST_MESSAGE(my_cout.str());
+    BOOST_TEST_MESSAGE("STDERR");
+    BOOST_TEST_MESSAGE(my_cerr.str());
+
+
+    BOOST_CHECK_EQUAL(eop.size(), eop_true.size());
+}
+*/

--- a/tests/boost/test_hdf5N2Write.cpp
+++ b/tests/boost/test_hdf5N2Write.cpp
@@ -293,8 +293,8 @@ BOOST_AUTO_TEST_CASE(test_visfiledata_add_frame_single_slot) {
     meta->n_valid_fpga_ticks = 80;
     meta->n_rfi_fpga_ticks = 5;
     meta->abs_time_idx = 5;
-    meta->time_center_eop.t_ut1 = 333;
-    meta->bin_eop.t_ut1 = 444;
+    meta->time_center_eop.t_ut1_ns = 333;
+    meta->bin_eop.t_ut1_ns = 444;
     meta->time_center_eop.ERA_deg = 12.34;
     meta->bin_eop.ERA_deg = 56.78;
 
@@ -375,16 +375,16 @@ BOOST_AUTO_TEST_CASE(test_visfiledata_era_and_fraction_guards) {
     meta1->n_valid_fpga_ticks = 80;
     meta1->n_rfi_fpga_ticks = 30; // sum > frame_len -> should clamp to 20
     meta1->abs_time_idx = 10;
-    meta1->time_center_eop.t_ut1 = 10'000;
-    meta1->bin_eop.t_ut1 = 10'000;
+    meta1->time_center_eop.t_ut1_ns = 10'000;
+    meta1->bin_eop.t_ut1_ns = 10'000;
     meta1->time_center_eop.ERA_deg = 0.0; // legitimate 0.0 value
 
     // meta2 (same slot), differing ERA and pathological counts
     *meta2 = *meta1;
     meta2->n_valid_fpga_ticks = 150; // > frame len -> clamp to 100
     meta2->n_rfi_fpga_ticks = 50;    // will be ignored because slot already set; kept for symmetry
-    meta2->time_center_eop.t_ut1 = 11'000; // should not overwrite the first set value
-    meta2->bin_eop.t_ut1 = 11'000;
+    meta2->time_center_eop.t_ut1_ns = 11'000; // should not overwrite the first set value
+    meta2->bin_eop.t_ut1_ns = 11'000;
     meta2->time_center_eop.ERA_deg = 12.34;
 
     N2FrameView fv1(&buf, 0);

--- a/tests/boost/test_timeUtil.cpp
+++ b/tests/boost/test_timeUtil.cpp
@@ -3,6 +3,7 @@
 #include "timeUtil.hpp"
 
 #include "fmt.hpp"
+#include "json.hpp"
 
 #include <boost/test/included/unit_test.hpp>
 #include <filesystem>
@@ -14,6 +15,8 @@
 
 #define ERA_TOL 2e-12 // <~ 0.5 nanoseconds of rotation
 #define NS_TOL 0
+
+using json = nlohmann::json;
 
 void check_timespec_equal(const timespec& t1, const timespec& t2) {
     BOOST_CHECK_EQUAL(t1.tv_sec, t2.tv_sec);
@@ -229,4 +232,60 @@ BOOST_AUTO_TEST_CASE(_era_to_ut1_to_era) {
         check_era_close(era, TimeData::era[i]);
         BOOST_CHECK_EQUAL(nrot, TimeData::nrot[i]);
     }
+}
+
+/*
+ * EOP TESTS
+ */
+
+BOOST_AUTO_TEST_CASE(_eop_to_json) {
+    EOP eop = {.t_inst_ns = 12345678901234,
+               .t_ut1_ns = -54321,
+               .delta_UT1_inst = 0.1,
+               .ERA_deg = 35.1,
+               .xp_as = -3.14e-5,
+               .yp_as = 2.71828};
+
+    json jeop = json::parse(R"({"t_inst_ns": 12345678901234, "t_ut1_ns": -54321, "delta_UT1_inst": 0.1, "ERA_deg": 35.1, "xp_as": -3.14e-5, "yp_as": 2.71828})");
+
+    json jeop_conv = eop;
+
+    BOOST_CHECK_EQUAL(jeop_conv, jeop);
+}
+
+BOOST_AUTO_TEST_CASE(_eop_from_json) {
+    EOP eop = {.t_inst_ns = 12345678901234,
+               .t_ut1_ns = -54321,
+               .delta_UT1_inst = 0.1,
+               .ERA_deg = 35.1,
+               .xp_as = -3.14e-5,
+               .yp_as = 2.71828};
+
+    json jeop = json::parse(R"({"t_inst_ns": 12345678901234, "t_ut1_ns": -54321, "delta_UT1_inst": 0.1, "ERA_deg": 35.1, "xp_as": -3.14e-5, "yp_as": 2.71828})");
+
+    EOP eop_conv = jeop;
+
+    BOOST_CHECK_EQUAL(eop_conv, eop);
+}
+
+BOOST_AUTO_TEST_CASE(_bare_eop_to_json) {
+    BareEOP eop = {
+        .t_inst_ns = 12345678901234, .delta_UT1_inst = 0.1, .xp_as = -3.14e-5, .yp_as = 2.71828};
+
+    json jeop = json::parse(R"({"t_inst_ns": 12345678901234, "delta_UT1_inst": 0.1,  "xp_as": -3.14e-5, "yp_as": 2.71828})");
+
+    json jeop_conv = eop;
+
+    BOOST_CHECK_EQUAL(jeop_conv, jeop);
+}
+
+BOOST_AUTO_TEST_CASE(_bare_eop_from_json) {
+    BareEOP eop = {
+        .t_inst_ns = 12345678901234, .delta_UT1_inst = 0.1, .xp_as = -3.14e-5, .yp_as = 2.71828};
+
+    json jeop = json::parse(R"({"t_inst_ns": 12345678901234, "delta_UT1_inst": 0.1,  "xp_as": -3.14e-5, "yp_as": 2.71828})");
+
+    BareEOP eop_conv = jeop;
+
+    BOOST_CHECK_EQUAL(eop_conv, eop);
 }

--- a/tests/boost/test_timeUtil.cpp
+++ b/tests/boost/test_timeUtil.cpp
@@ -319,6 +319,28 @@ BOOST_AUTO_TEST_CASE(_bare_eop_to_eop) {
     }
 }
 
+BOOST_AUTO_TEST_CASE(_eop_to_bare_eop) {
+
+    std::vector<double> x{0.0, 0.1, -0.3, 5e-8, 15};
+    std::vector<double> y{0.0, -8, 0.7, 32, 8.1e-3};
+
+    for (size_t i = 0; i < TimeData::size; i++) {
+        BareEOP beop = {.t_inst_ns = TimeData::t_unix_ns[i],
+                        .delta_UT1_inst = TimeData::dUT1[i],
+                        .xp_as = x[i % x.size()],
+                        .yp_as = y[i % y.size()]};
+        int64_t ut1 = get_UT1_from_time_ns(beop.t_inst_ns, beop.delta_UT1_inst);
+        EOP eop = {.t_inst_ns = TimeData::t_unix_ns[i],
+                   .t_ut1_ns = ut1,
+                   .delta_UT1_inst = TimeData::dUT1[i],
+                   .ERA_deg = get_ERA_from_UT1(ut1, nullptr),
+                   .xp_as = x[i % x.size()],
+                   .yp_as = y[i % y.size()]};
+
+        BOOST_CHECK_EQUAL(BareEOP::from_EOP(eop), beop);
+    }
+}
+
 BOOST_AUTO_TEST_CASE(_bare_eop_equal) {
 
     std::vector<double> x{0.0, 0.1, -0.3, 5e-8, 15};

--- a/tests/boost/test_timeUtil.cpp
+++ b/tests/boost/test_timeUtil.cpp
@@ -299,22 +299,21 @@ BOOST_AUTO_TEST_CASE(_bare_eop_from_json) {
 
 BOOST_AUTO_TEST_CASE(_bare_eop_to_eop) {
 
-    int N = 5;
-    double x[N] = {0.0, 0.1, -0.3, 5e-8, 15};
-    double y[N] = {0.0, -8, 0.7, 32, 8.1e-3};
+    std::vector<double> x{0.0, 0.1, -0.3, 5e-8, 15};
+    std::vector<double> y{0.0, -8, 0.7, 32, 8.1e-3};
 
     for (size_t i = 0; i < TimeData::size; i++) {
         BareEOP beop = {.t_inst_ns = TimeData::t_unix_ns[i],
                         .delta_UT1_inst = TimeData::dUT1[i],
-                        .xp_as = x[i % N],
-                        .yp_as = y[i % N]};
+                        .xp_as = x[i % x.size()],
+                        .yp_as = y[i % y.size()]};
         int64_t ut1 = get_UT1_from_time_ns(beop.t_inst_ns, beop.delta_UT1_inst);
         EOP eop = {.t_inst_ns = TimeData::t_unix_ns[i],
                    .t_ut1_ns = ut1,
                    .delta_UT1_inst = TimeData::dUT1[i],
                    .ERA_deg = get_ERA_from_UT1(ut1, nullptr),
-                   .xp_as = x[i % N],
-                   .yp_as = y[i % N]};
+                   .xp_as = x[i % x.size()],
+                   .yp_as = y[i % y.size()]};
 
         BOOST_CHECK_EQUAL(beop.to_EOP(), eop);
     }
@@ -322,21 +321,20 @@ BOOST_AUTO_TEST_CASE(_bare_eop_to_eop) {
 
 BOOST_AUTO_TEST_CASE(_bare_eop_equal) {
 
-    int N = 5;
-    double x[N] = {0.0, 0.1, -0.3, 5e-8, 15};
-    double y[N] = {0.0, -8, 0.7, 32, 8.1e-3};
+    std::vector<double> x{0.0, 0.1, -0.3, 5e-8, 15};
+    std::vector<double> y{0.0, -8, 0.7, 32, 8.1e-3};
 
-    for (int i = 0; i < N; i++) {
-        for (int j = 0; j < N; j++) {
+    for (size_t i = 0; i < TimeData::size; i++) {
+        for (size_t j = 0; j < TimeData::size; j++) {
 
             BareEOP beop1 = {.t_inst_ns = TimeData::t_unix_ns[i],
                              .delta_UT1_inst = TimeData::dUT1[i],
-                             .xp_as = x[i % N],
-                             .yp_as = y[i % N]};
+                             .xp_as = x[i % x.size()],
+                             .yp_as = y[i % y.size()]};
             BareEOP beop2 = {.t_inst_ns = TimeData::t_unix_ns[j],
                              .delta_UT1_inst = TimeData::dUT1[j],
-                             .xp_as = x[j % N],
-                             .yp_as = y[j % N]};
+                             .xp_as = x[j % x.size()],
+                             .yp_as = y[j % y.size()]};
 
             if (i == j)
                 BOOST_CHECK_EQUAL(beop1, beop2);
@@ -348,25 +346,24 @@ BOOST_AUTO_TEST_CASE(_bare_eop_equal) {
 
 BOOST_AUTO_TEST_CASE(_eop_comp_time) {
 
-    int N = 5;
-    double x[N] = {0.0, 0.1, -0.3, 5e-8, 15};
-    double y[N] = {0.0, -8, 0.7, 32, 8.1e-3};
+    std::vector<double> x{0.0, 0.1, -0.3, 5e-8, 15};
+    std::vector<double> y{0.0, -8, 0.7, 32, 8.1e-3};
 
-    for (int i = 0; i < N; i++) {
-        for (int j = 0; j < N; j++) {
+    for (size_t i = 0; i < TimeData::size; i++) {
+        for (size_t j = 0; j < TimeData::size; j++) {
 
             EOP eop1 = {.t_inst_ns = TimeData::t_unix_ns[i],
                         .t_ut1_ns = TimeData::t_ut1[i],
                         .delta_UT1_inst = TimeData::dUT1[i],
                         .ERA_deg = TimeData::era[i],
-                        .xp_as = x[i % N],
-                        .yp_as = y[i % N]};
+                        .xp_as = x[i % x.size()],
+                        .yp_as = y[i % y.size()]};
             EOP eop2 = {.t_inst_ns = TimeData::t_unix_ns[j],
                         .t_ut1_ns = TimeData::t_ut1[j],
                         .delta_UT1_inst = TimeData::dUT1[j],
                         .ERA_deg = TimeData::era[j],
-                        .xp_as = x[j % N],
-                        .yp_as = y[j % N]};
+                        .xp_as = x[j % x.size()],
+                        .yp_as = y[j % y.size()]};
 
             if (eop1.t_inst_ns < eop2.t_inst_ns)
                 BOOST_CHECK(EOP_comp_time(eop1, eop2));
@@ -378,25 +375,24 @@ BOOST_AUTO_TEST_CASE(_eop_comp_time) {
 
 BOOST_AUTO_TEST_CASE(_eop_comp_ut1) {
 
-    int N = 5;
-    double x[N] = {0.0, 0.1, -0.3, 5e-8, 15};
-    double y[N] = {0.0, -8, 0.7, 32, 8.1e-3};
+    std::vector<double> x{0.0, 0.1, -0.3, 5e-8, 15};
+    std::vector<double> y{0.0, -8, 0.7, 32, 8.1e-3};
 
-    for (int i = 0; i < N; i++) {
-        for (int j = 0; j < N; j++) {
+    for (size_t i = 0; i < TimeData::size; i++) {
+        for (size_t j = 0; j < TimeData::size; j++) {
 
             EOP eop1 = {.t_inst_ns = TimeData::t_unix_ns[i],
                         .t_ut1_ns = TimeData::t_ut1[i],
                         .delta_UT1_inst = TimeData::dUT1[i],
                         .ERA_deg = TimeData::era[i],
-                        .xp_as = x[i % N],
-                        .yp_as = y[i % N]};
+                        .xp_as = x[i % x.size()],
+                        .yp_as = y[i % y.size()]};
             EOP eop2 = {.t_inst_ns = TimeData::t_unix_ns[j],
                         .t_ut1_ns = TimeData::t_ut1[j],
                         .delta_UT1_inst = TimeData::dUT1[j],
                         .ERA_deg = TimeData::era[j],
-                        .xp_as = x[j % N],
-                        .yp_as = y[j % N]};
+                        .xp_as = x[j % x.size()],
+                        .yp_as = y[j % y.size()]};
 
             if (eop1.t_ut1_ns < eop2.t_ut1_ns)
                 BOOST_CHECK(EOP_comp_ut1(eop1, eop2));

--- a/tests/boost/test_timeUtil.cpp
+++ b/tests/boost/test_timeUtil.cpp
@@ -64,6 +64,7 @@ public:
     };
 
     static std::vector<timespec> t_unix;
+    static std::vector<int64_t> t_unix_ns;
     static std::vector<int64_t> t_ut1;
     static std::vector<double> dUT1;
     static std::vector<double> era;
@@ -72,6 +73,7 @@ public:
 };
 
 std::vector<timespec> TimeData::t_unix{};
+std::vector<int64_t> TimeData::t_unix_ns{};
 std::vector<int64_t> TimeData::t_ut1{};
 std::vector<double> TimeData::dUT1{};
 std::vector<double> TimeData::era{};
@@ -112,6 +114,7 @@ void TimeData::setup() {
         if (words[0] == "UNIX") {
             timespec t = {.tv_sec = std::stol(words[1]), .tv_nsec = std::stol(words[3])};
             t_unix.push_back(t);
+            t_unix_ns.push_back(timespec_to_nanosec_i64(t));
         } else if (words[0] == "UT1") {
             t_ut1.push_back(std::stol(words[1]));
         } else if (words[0] == "dUT1") {
@@ -246,7 +249,8 @@ BOOST_AUTO_TEST_CASE(_eop_to_json) {
                .xp_as = -3.14e-5,
                .yp_as = 2.71828};
 
-    json jeop = json::parse(R"({"t_inst_ns": 12345678901234, "t_ut1_ns": -54321, "delta_UT1_inst": 0.1, "ERA_deg": 35.1, "xp_as": -3.14e-5, "yp_as": 2.71828})");
+    json jeop = json::parse(
+        R"({"t_inst_ns": 12345678901234, "t_ut1_ns": -54321, "delta_UT1_inst": 0.1, "ERA_deg": 35.1, "xp_as": -3.14e-5, "yp_as": 2.71828})");
 
     json jeop_conv = eop;
 
@@ -261,7 +265,8 @@ BOOST_AUTO_TEST_CASE(_eop_from_json) {
                .xp_as = -3.14e-5,
                .yp_as = 2.71828};
 
-    json jeop = json::parse(R"({"t_inst_ns": 12345678901234, "t_ut1_ns": -54321, "delta_UT1_inst": 0.1, "ERA_deg": 35.1, "xp_as": -3.14e-5, "yp_as": 2.71828})");
+    json jeop = json::parse(
+        R"({"t_inst_ns": 12345678901234, "t_ut1_ns": -54321, "delta_UT1_inst": 0.1, "ERA_deg": 35.1, "xp_as": -3.14e-5, "yp_as": 2.71828})");
 
     EOP eop_conv = jeop;
 
@@ -272,7 +277,8 @@ BOOST_AUTO_TEST_CASE(_bare_eop_to_json) {
     BareEOP eop = {
         .t_inst_ns = 12345678901234, .delta_UT1_inst = 0.1, .xp_as = -3.14e-5, .yp_as = 2.71828};
 
-    json jeop = json::parse(R"({"t_inst_ns": 12345678901234, "delta_UT1_inst": 0.1,  "xp_as": -3.14e-5, "yp_as": 2.71828})");
+    json jeop = json::parse(
+        R"({"t_inst_ns": 12345678901234, "delta_UT1_inst": 0.1,  "xp_as": -3.14e-5, "yp_as": 2.71828})");
 
     json jeop_conv = eop;
 
@@ -283,9 +289,119 @@ BOOST_AUTO_TEST_CASE(_bare_eop_from_json) {
     BareEOP eop = {
         .t_inst_ns = 12345678901234, .delta_UT1_inst = 0.1, .xp_as = -3.14e-5, .yp_as = 2.71828};
 
-    json jeop = json::parse(R"({"t_inst_ns": 12345678901234, "delta_UT1_inst": 0.1,  "xp_as": -3.14e-5, "yp_as": 2.71828})");
+    json jeop = json::parse(
+        R"({"t_inst_ns": 12345678901234, "delta_UT1_inst": 0.1,  "xp_as": -3.14e-5, "yp_as": 2.71828})");
 
     BareEOP eop_conv = jeop;
 
     BOOST_CHECK_EQUAL(eop_conv, eop);
+}
+
+BOOST_AUTO_TEST_CASE(_bare_eop_to_eop) {
+
+    int N = 5;
+    double x[N] = {0.0, 0.1, -0.3, 5e-8, 15};
+    double y[N] = {0.0, -8, 0.7, 32, 8.1e-3};
+
+    for (size_t i = 0; i < TimeData::size; i++) {
+        BareEOP beop = {.t_inst_ns = TimeData::t_unix_ns[i],
+                        .delta_UT1_inst = TimeData::dUT1[i],
+                        .xp_as = x[i % N],
+                        .yp_as = y[i % N]};
+        int64_t ut1 = get_UT1_from_time_ns(beop.t_inst_ns, beop.delta_UT1_inst);
+        EOP eop = {.t_inst_ns = TimeData::t_unix_ns[i],
+                   .t_ut1_ns = ut1,
+                   .delta_UT1_inst = TimeData::dUT1[i],
+                   .ERA_deg = get_ERA_from_UT1(ut1, nullptr),
+                   .xp_as = x[i % N],
+                   .yp_as = y[i % N]};
+
+        BOOST_CHECK_EQUAL(beop.to_EOP(), eop);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(_bare_eop_equal) {
+
+    int N = 5;
+    double x[N] = {0.0, 0.1, -0.3, 5e-8, 15};
+    double y[N] = {0.0, -8, 0.7, 32, 8.1e-3};
+
+    for (int i = 0; i < N; i++) {
+        for (int j = 0; j < N; j++) {
+
+            BareEOP beop1 = {.t_inst_ns = TimeData::t_unix_ns[i],
+                             .delta_UT1_inst = TimeData::dUT1[i],
+                             .xp_as = x[i % N],
+                             .yp_as = y[i % N]};
+            BareEOP beop2 = {.t_inst_ns = TimeData::t_unix_ns[j],
+                             .delta_UT1_inst = TimeData::dUT1[j],
+                             .xp_as = x[j % N],
+                             .yp_as = y[j % N]};
+
+            if (i == j)
+                BOOST_CHECK_EQUAL(beop1, beop2);
+            else
+                BOOST_CHECK_NE(beop1, beop2);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(_eop_comp_time) {
+
+    int N = 5;
+    double x[N] = {0.0, 0.1, -0.3, 5e-8, 15};
+    double y[N] = {0.0, -8, 0.7, 32, 8.1e-3};
+
+    for (int i = 0; i < N; i++) {
+        for (int j = 0; j < N; j++) {
+
+            EOP eop1 = {.t_inst_ns = TimeData::t_unix_ns[i],
+                        .t_ut1_ns = TimeData::t_ut1[i],
+                        .delta_UT1_inst = TimeData::dUT1[i],
+                        .ERA_deg = TimeData::era[i],
+                        .xp_as = x[i % N],
+                        .yp_as = y[i % N]};
+            EOP eop2 = {.t_inst_ns = TimeData::t_unix_ns[j],
+                        .t_ut1_ns = TimeData::t_ut1[j],
+                        .delta_UT1_inst = TimeData::dUT1[j],
+                        .ERA_deg = TimeData::era[j],
+                        .xp_as = x[j % N],
+                        .yp_as = y[j % N]};
+
+            if (eop1.t_inst_ns < eop2.t_inst_ns)
+                BOOST_CHECK(EOP_comp_time(eop1, eop2));
+            else
+                BOOST_CHECK(!EOP_comp_time(eop1, eop2));
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(_eop_comp_ut1) {
+
+    int N = 5;
+    double x[N] = {0.0, 0.1, -0.3, 5e-8, 15};
+    double y[N] = {0.0, -8, 0.7, 32, 8.1e-3};
+
+    for (int i = 0; i < N; i++) {
+        for (int j = 0; j < N; j++) {
+
+            EOP eop1 = {.t_inst_ns = TimeData::t_unix_ns[i],
+                        .t_ut1_ns = TimeData::t_ut1[i],
+                        .delta_UT1_inst = TimeData::dUT1[i],
+                        .ERA_deg = TimeData::era[i],
+                        .xp_as = x[i % N],
+                        .yp_as = y[i % N]};
+            EOP eop2 = {.t_inst_ns = TimeData::t_unix_ns[j],
+                        .t_ut1_ns = TimeData::t_ut1[j],
+                        .delta_UT1_inst = TimeData::dUT1[j],
+                        .ERA_deg = TimeData::era[j],
+                        .xp_as = x[j % N],
+                        .yp_as = y[j % N]};
+
+            if (eop1.t_ut1_ns < eop2.t_ut1_ns)
+                BOOST_CHECK(EOP_comp_ut1(eop1, eop2));
+            else
+                BOOST_CHECK(!EOP_comp_ut1(eop1, eop2));
+        }
+    }
 }

--- a/tests/boost/test_utils.hpp
+++ b/tests/boost/test_utils.hpp
@@ -352,8 +352,8 @@ make_writer_config(const std::string& unique_name, const std::string& in_buf,
     auto meta = get_N2_metadata(buf, frame_id);
     BOOST_REQUIRE(meta);
     meta->abs_time_idx = abs_time_idx;
-    meta->time_center_eop.t_ut1 = static_cast<int64_t>(frame_start_time_ns);
-    meta->bin_eop.t_ut1 = static_cast<int64_t>(frame_start_time_ns);
+    meta->time_center_eop.t_ut1_ns = get_UT1_from_time_ns(frame_start_time_ns, 0.0);
+    meta->bin_eop.t_ut1_ns = get_UT1_from_time_ns(frame_start_time_ns, 0.0);
 }
 
 #endif // TEST_UTILS_HPP

--- a/tests/boost/test_utils.hpp
+++ b/tests/boost/test_utils.hpp
@@ -233,6 +233,7 @@ struct CompareCTypes {
                                                        {"type", "ArrayDish"},
                                                        {"label", "D01"}}});
     telescope["eop_updatable_config"] = "/earth_rotation_data";
+    telescope["require_eop"] = false;
     telescope["grid_x_axis"] = {1.0, 0.0, 0.0};
     telescope["grid_y_axis"] = {0.0, 1.0, 0.0};
     telescope["dish_elev_axis"] = {1.0, 0.0, 0.0};
@@ -242,9 +243,7 @@ struct CompareCTypes {
 
     nlohmann::json eop_update;
     eop_update["kotekan_update_endpoint"] = "json";
-    eop_update["earth_orientation_parameter_table"] = nlohmann::json::array(
-        {{{"time_inst_ns", 0}, {"delta_UT1_inst", 0.0}, {"x_pm", 0.0}, {"y_pm", 0.0}},
-         {{"time_inst_ns", 1'000'000}, {"delta_UT1_inst", 0.0}, {"x_pm", 0.0}, {"y_pm", 0.0}}});
+    eop_update["earth_orientation_parameter_table"] = nlohmann::json::array();
 
     auto set_path = [&](const std::string& key, const nlohmann::json& val) {
         cfg[key] = val;

--- a/tests/test_countcheck.py
+++ b/tests/test_countcheck.py
@@ -57,16 +57,16 @@ EARTH_ROTATION_DATA = {
     "kotekan_update_endpoint": "json",
     "earth_orientation_parameter_table": [
         {
-            "time_inst_ns": (T_START_S - 1000) * GIGA,
+            "t_inst_ns": (T_START_S - 1000) * GIGA,
             "delta_UT1_inst": 0.0,
-            "x_pm": 0.0,
-            "y_pm": 0.0,
+            "xp_as": 0.0,
+            "yp_as": 0.0,
         },
         {
-            "time_inst_ns": (T_START_S + 100000) * GIGA,
+            "t_inst_ns": (T_START_S + 100000) * GIGA,
             "delta_UT1_inst": 0.0,
-            "x_pm": 1.0,
-            "y_pm": 1.0,
+            "xp_as": 1.0,
+            "yp_as": 1.0,
         },
     ],
 }

--- a/tests/test_n2_accumulate.py
+++ b/tests/test_n2_accumulate.py
@@ -116,16 +116,16 @@ global_params = {
         "kotekan_update_endpoint": "json",
         "earth_orientation_parameter_table": [
             {
-                "time_inst_ns": (t_start_s - 1000) * GIGA,
+                "t_inst_ns": (t_start_s - 1000) * GIGA,
                 "delta_UT1_inst": 0.0,
-                "x_pm": 0.0,
-                "y_pm": 0.0,
+                "xp_as": 0.0,
+                "yp_as": 0.0,
             },
             {
-                "time_inst_ns": (t_start_s + 100000) * GIGA,
+                "t_inst_ns": (t_start_s + 100000) * GIGA,
                 "delta_UT1_inst": 0.0,
-                "x_pm": 1.0,
-                "y_pm": 1.0,
+                "xp_as": 1.0,
+                "yp_as": 1.0,
             },
         ],
     },
@@ -340,9 +340,7 @@ def test_EOP(accumulate_data):
 
         t_inst_ns = seq * dt_ns + t0_ns
 
-        wA = (eopB["time_inst_ns"] - t_inst_ns) / (
-            eopB["time_inst_ns"] - eopA["time_inst_ns"]
-        )
+        wA = (eopB["t_inst_ns"] - t_inst_ns) / (eopB["t_inst_ns"] - eopA["t_inst_ns"])
         wB = 1.0 - wA
 
         assert frame.metadata.bin_eop.t_inst == t_inst_ns
@@ -354,13 +352,13 @@ def test_EOP(accumulate_data):
         )
         assert np.isclose(
             frame.metadata.bin_eop.xp_as,
-            wA * eopA["x_pm"] + wB * eopB["x_pm"],
+            wA * eopA["xp_as"] + wB * eopB["xp_as"],
             atol=0.0,
             rtol=1.0e-12,
         )
         assert np.isclose(
             frame.metadata.bin_eop.yp_as,
-            wA * eopA["y_pm"] + wB * eopB["y_pm"],
+            wA * eopA["yp_as"] + wB * eopB["yp_as"],
             atol=0.0,
             rtol=1.0e-12,
         )

--- a/tests/test_n2_accumulate.py
+++ b/tests/test_n2_accumulate.py
@@ -343,7 +343,7 @@ def test_EOP(accumulate_data):
         wA = (eopB["t_inst_ns"] - t_inst_ns) / (eopB["t_inst_ns"] - eopA["t_inst_ns"])
         wB = 1.0 - wA
 
-        assert frame.metadata.bin_eop.t_inst == t_inst_ns
+        assert frame.metadata.bin_eop.t_inst_ns == t_inst_ns
         assert np.isclose(
             frame.metadata.bin_eop.delta_UT1_inst,
             wA * eopA["delta_UT1_inst"] + wB * eopB["delta_UT1_inst"],

--- a/tests/test_n2_time_downsample.py
+++ b/tests/test_n2_time_downsample.py
@@ -428,8 +428,8 @@ def test_time(n2_data):
 
 def test_eop(n2_data):
 
-    eop_t_inst = np.array([v.metadata.bin_eop.t_inst for v in n2_data])
-    eop_t_ut1 = np.array([v.metadata.bin_eop.t_ut1 for v in n2_data])
+    eop_t_inst_ns = np.array([v.metadata.bin_eop.t_inst_ns for v in n2_data])
+    eop_t_ut1_ns = np.array([v.metadata.bin_eop.t_ut1_ns for v in n2_data])
     eop_dut1 = np.array([v.metadata.bin_eop.delta_UT1_inst for v in n2_data])
     eop_xp_as = np.array([v.metadata.bin_eop.xp_as for v in n2_data])
     eop_yp_as = np.array([v.metadata.bin_eop.yp_as for v in n2_data])
@@ -454,8 +454,8 @@ def test_eop(n2_data):
             f.write("     XPM_TEST:    {:.17f}\n".format(xp_as))
             f.write("     YPM_FRAME:   {:.17f}\n".format(eop_yp_as[i]))
             f.write("     YPM_TEST:    {:.17f}\n".format(yp_as))
-            f.write("     T_DIFF_NS:   {:d}\n".format(eop_t_inst[i] - t_inst_bin[i]))
-            f.write("     UT1_DIFF_NS: {:d}\n".format(eop_t_ut1[i] - ut1_bin[i]))
+            f.write("     T_DIFF_NS:   {:d}\n".format(eop_t_inst_ns[i] - t_inst_bin[i]))
+            f.write("     UT1_DIFF_NS: {:d}\n".format(eop_t_ut1_ns[i] - ut1_bin[i]))
     """
 
     # check EOP
@@ -464,15 +464,15 @@ def test_eop(n2_data):
     assert np.all(np.isclose(eop_yp_as, y_pm, 1.0e-15, 0.0))
 
     # check times
-    assert np.all(np.fabs(eop_t_inst - t_inst_bin) <= eop_t_ns_tol)
-    assert np.all(np.fabs(eop_t_ut1 - ut1_bin) <= eop_ut1_ns_tol)
+    assert np.all(np.fabs(eop_t_inst_ns - t_inst_bin) <= eop_t_ns_tol)
+    assert np.all(np.fabs(eop_t_ut1_ns - ut1_bin) <= eop_ut1_ns_tol)
 
     # check ERA
     assert np.all(np.fabs(eop_era - era_bin) <= era_deg_tol)
 
     # check nanoseconds
-    # assert np.all(np.fabs(eop_t_inst[:, 1] - t_inst_bin[:, 1]) <= eop_t_ns_tol)
-    # assert np.all(np.fabs(eop_t_ut1[:, 1] - ut1_bin[:, 1]) <= eop_ut1_ns_tol)
+    # assert np.all(np.fabs(eop_t_inst_ns[:, 1] - t_inst_bin[:, 1]) <= eop_t_ns_tol)
+    # assert np.all(np.fabs(eop_t_ut1_ns[:, 1] - ut1_bin[:, 1]) <= eop_ut1_ns_tol)
 
 
 def test_contents(n2_data):

--- a/tests/test_n2_time_downsample.py
+++ b/tests/test_n2_time_downsample.py
@@ -59,16 +59,16 @@ global_params = {
         "kotekan_update_endpoint": "json",
         "earth_orientation_parameter_table": [
             {
-                "time_inst_ns": t_start_inst_ns - 2000 * GIGA,
+                "t_inst_ns": t_start_inst_ns - 2000 * GIGA,
                 "delta_UT1_inst": dut1,
-                "x_pm": x_pm,
-                "y_pm": y_pm,
+                "xp_as": x_pm,
+                "yp_as": y_pm,
             },
             {
-                "time_inst_ns": t_end_inst_ns + 2000 * GIGA,
+                "t_inst_ns": t_end_inst_ns + 2000 * GIGA,
                 "delta_UT1_inst": dut1,
-                "x_pm": x_pm,
-                "y_pm": y_pm,
+                "xp_as": x_pm,
+                "yp_as": y_pm,
             },
         ],
     },
@@ -431,8 +431,8 @@ def test_eop(n2_data):
     eop_t_inst = np.array([v.metadata.bin_eop.t_inst for v in n2_data])
     eop_t_ut1 = np.array([v.metadata.bin_eop.t_ut1 for v in n2_data])
     eop_dut1 = np.array([v.metadata.bin_eop.delta_UT1_inst for v in n2_data])
-    eop_x_pm = np.array([v.metadata.bin_eop.xp_as for v in n2_data])
-    eop_y_pm = np.array([v.metadata.bin_eop.yp_as for v in n2_data])
+    eop_xp_as = np.array([v.metadata.bin_eop.xp_as for v in n2_data])
+    eop_yp_as = np.array([v.metadata.bin_eop.yp_as for v in n2_data])
     eop_era = np.array([v.metadata.bin_eop.ERA_deg for v in n2_data])
 
     out_frame_metas = calc_downsamp_frame_meta()
@@ -450,18 +450,18 @@ def test_eop(n2_data):
             f.write("     ERA_TEST:    {:.17f}\n".format(era_bin[i]))
             f.write("     DUT1_FRAME:  {:.17f}\n".format(eop_dut1[i]))
             f.write("     DUT1_TEST:   {:.17f}\n".format(dut1))
-            f.write("     XPM_FRAME:   {:.17f}\n".format(eop_x_pm[i]))
-            f.write("     XPM_TEST:    {:.17f}\n".format(x_pm))
-            f.write("     YPM_FRAME:   {:.17f}\n".format(eop_y_pm[i]))
-            f.write("     YPM_TEST:    {:.17f}\n".format(y_pm))
+            f.write("     XPM_FRAME:   {:.17f}\n".format(eop_xp_as[i]))
+            f.write("     XPM_TEST:    {:.17f}\n".format(xp_as))
+            f.write("     YPM_FRAME:   {:.17f}\n".format(eop_yp_as[i]))
+            f.write("     YPM_TEST:    {:.17f}\n".format(yp_as))
             f.write("     T_DIFF_NS:   {:d}\n".format(eop_t_inst[i] - t_inst_bin[i]))
             f.write("     UT1_DIFF_NS: {:d}\n".format(eop_t_ut1[i] - ut1_bin[i]))
     """
 
     # check EOP
     assert np.all(np.isclose(eop_dut1, dut1, 1.0e-15, 0.0))
-    assert np.all(np.isclose(eop_x_pm, x_pm, 1.0e-15, 0.0))
-    assert np.all(np.isclose(eop_y_pm, y_pm, 1.0e-15, 0.0))
+    assert np.all(np.isclose(eop_xp_as, x_pm, 1.0e-15, 0.0))
+    assert np.all(np.isclose(eop_yp_as, y_pm, 1.0e-15, 0.0))
 
     # check times
     assert np.all(np.fabs(eop_t_inst - t_inst_bin) <= eop_t_ns_tol)

--- a/tools/earth_orientation/broadcastEOPTable.py
+++ b/tools/earth_orientation/broadcastEOPTable.py
@@ -1,4 +1,14 @@
 #!/usr/bin/env python3
+"""
+/*********************************************************************************
+* Earth Orientation Parameter Tools 
+* File: broadcastEOPTable.py
+* Purpose: Send the given EOP table to running kotekan instance(s).
+* Python Version: 3.12
+* Dependencies: argparse, eop_utils
+* Authors: Geoffrey Ryan
+*********************************************************************************/
+"""
 import argparse
 import json
 from pathlib import Path

--- a/tools/earth_orientation/broadcastEOPTable.py
+++ b/tools/earth_orientation/broadcastEOPTable.py
@@ -10,7 +10,7 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(
         prog="EOP Table Broadcaster",
-        description="Send an Earth Orientation Parameter (EOP) update table to Kotekan",
+        description="Send an Earth Orientation Parameter (EOP) update table (BareEOP) to Kotekan",
     )
 
     parser.add_argument(
@@ -49,7 +49,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "input_json_file",
         nargs=1,
-        help='Input file name, a JSON file containing the EOP update table to send: An object with the member "earth_orientation_paramer_table" whose value is a list of EOP update objects.',
+        help='Input file name, a JSON file containing the EOP update table to send: An object with the member "earth_orientation_paramer_table" whose value is a list of BareEOP objects.',
     )
 
     args = parser.parse_args()

--- a/tools/earth_orientation/eop_utils.py
+++ b/tools/earth_orientation/eop_utils.py
@@ -335,10 +335,10 @@ def broadcast_kotekan_eop_table(
         The port at which to find the kotekan instance. For instance 12048.
     eop_endpoint : The endpoint for the EOP table config updater in Kotekan,
         no leading "/".
-    eop_table : dict containing a List of dicts, each an EOP update table entry
+    eop_table : dict containing a List of dicts, each a BareEOP table entry
         The EOP table. A dict with a single key "earth_orientation_parameter_table",
-        whose value is a list of EOP table update entries, each a dict with
-        entries "time_inst_ns", "delta_UT1_inst", "x_pm", and "y_pm".
+        whose value is a list of BareEOP table update entries, each a dict with
+        entries "t_inst_ns", "delta_UT1_inst", "xp_as", and "yp_as".
     timeout : float
         Timeout in seconds for the request.
     protocol : String, optional
@@ -580,11 +580,11 @@ def build_EOP_table(times, time0_ns, iers):
 
     Each EOP table entry is a dict with 4 entries:
 
-        - "time_inst_ns" : int, the instrument timestamp in nanoseconds
+        - "t_inst_ns" : int, the instrument timestamp in nanoseconds
         - "delta_UT1_inst" : float, the difference between UT1 and instrument
         time, in seconds.
-        - "x_pm" : float, Polar Motion x' coordinate, in arcseconds.
-        - "y_pm" : float, Polar Motion y' coordinate, in arcseconds.
+        - "xp_as" : float, Polar Motion x' coordinate, in arcseconds.
+        - "yp_as" : float, Polar Motion y' coordinate, in arcseconds.
 
     Parameters
     ----------
@@ -642,10 +642,10 @@ def build_EOP_table(times, time0_ns, iers):
 
         # Build the EOP entry! Remove numpy-ness.
         eop = dict(
-            time_inst_ns=t_inst,
+            t_inst_ns=t_inst,
             delta_UT1_inst=delta_ut1_inst.item(),
-            x_pm=x.to_value("arcsecond").item(),
-            y_pm=y.to_value("arcsecond").item(),
+            xp_as=x.to_value("arcsecond").item(),
+            yp_as=y.to_value("arcsecond").item(),
         )
 
         # Append to the table.
@@ -766,9 +766,9 @@ def build_time_array(
     return times
 
 
-def make_update_EOP_from_full_EOP(eop):
+def make_bare_EOP_from_full_EOP(eop):
     r"""
-    Produce an EOP update dict (suitable for sending to Kotekan or putting in a config
+    Produce a BareEOP dict (suitable for sending to Kotekan or putting in a config
     file) from a full EOP dict (one received from Kotekan)
     
     Parameters
@@ -780,16 +780,16 @@ def make_update_EOP_from_full_EOP(eop):
     Returns
     -------
 
-    eop_update : EOP update dict
-        An EOP update table entry, contain the fields: time_inst_ns, delta_UT1_inst,
-        x_pm, y_pm.
+    eop_bare : BareEOP dict
+        An BareEOP table entry, contain the fields: t_inst_ns, delta_UT1_inst,
+        xp_as, yp_as.
     """
 
     return dict(
-        time_inst_ns=eop["t_inst"],
+        t_inst_ns=eop["t_inst"],
         delta_UT1_inst=eop["delta_UT1_inst"],
-        x_pm=eop["xp_as"],
-        y_pm=eop["yp_as"],
+        xp_as=eop["xp_as"],
+        yp_as=eop["yp_as"],
     )
 
 
@@ -811,9 +811,9 @@ def merge_eop_tables(
     current_eop_table : list of eop entry dicts
         the current table in kotekan (fields: t_inst, t_ut1, delta_ut1_inst, era_deg,
         xp_as, yp_as)
-    new_eop_table : list of eop update entry dicts
+    new_eop_table : list of BareEOP update entry dicts
         the proposed new eop table, may conflict with current table. (fields: 
-        time_inst_ns, delta_ut1_inst, x_pm, y_pm)
+        t_inst_ns, delta_ut1_inst, xp_as, yp_as)
     t_ref : Astropy Time object
         The reference (likely current) time used to determine the current interval.
     time0_ns : int
@@ -825,7 +825,7 @@ def merge_eop_tables(
     
     Returns
     -------
-    final_eop_table : List of EOP entry dicts
+    final_eop_table : List of BareEOP entry dicts
         The final blended table.
     """
 
@@ -855,7 +855,7 @@ def merge_eop_tables(
                 "current_eop_table is not sorted. Can only merge sorted tables"
             )
     for i in range(len(new_eop_table) - 1):
-        if new_eop_table[i]["time_inst_ns"] >= new_eop_table[i + 1]["time_inst_ns"]:
+        if new_eop_table[i]["t_inst_ns"] >= new_eop_table[i + 1]["t_inst_ns"]:
             raise RuntimeError(
                 "new_eop_table is not sorted. Can only merge sorted tables"
             )
@@ -863,7 +863,7 @@ def merge_eop_tables(
     # Extract array of times for easier searching.  If we're here, both arrays have
     # strictly increasing instrument times
     current_times = np.array([eop["t_inst"] for eop in current_eop_table])
-    new_times = np.array([eop["time_inst_ns"] for eop in new_eop_table])
+    new_times = np.array([eop["t_inst_ns"] for eop in new_eop_table])
 
     # For current_times, the pivot_idx will be the index of the first element strictly
     # greater than the pivot time.  For new_times, the pivot_idx is the index of the
@@ -928,13 +928,11 @@ def merge_eop_tables(
         current_eop_to_keep = [current_eop_table[-1], eop_pivot]
 
     # Initialize the final EOP update table.
-    final_eop_table = [
-        make_update_EOP_from_full_EOP(eop) for eop in current_eop_to_keep
-    ]
+    final_eop_table = [make_bare_EOP_from_full_EOP(eop) for eop in current_eop_to_keep]
 
     # Easy now.  Find the first entry in the new table that's ahead of the end of
     # the preliminary final table.
-    new_pivot_idx = np.searchsorted(new_times, final_eop_table[-1]["time_inst_ns"])
+    new_pivot_idx = np.searchsorted(new_times, final_eop_table[-1]["t_inst_ns"])
 
     # If there are any entries (in normal operations there should be!) add them to
     # the end of the table

--- a/tools/earth_orientation/eop_utils.py
+++ b/tools/earth_orientation/eop_utils.py
@@ -965,7 +965,7 @@ def print_eop_table(eop_table):
 
     print("\n#### BEGIN EOP TABLE ####\n")
     # JSON for prettier printing and consistent formatting
-    eop_json = json.dumps({"earth_orientation_paramter_table": eop_table}, indent=4)
+    eop_json = json.dumps({"earth_orientation_parameter_table": eop_table}, indent=4)
     print(eop_json)
     print("####  END  EOP TABLE ####\n")
 

--- a/tools/earth_orientation/eop_utils.py
+++ b/tools/earth_orientation/eop_utils.py
@@ -619,7 +619,7 @@ def build_EOP_table(times, time0_ns, iers):
 
         # Instrument time is the UNIX timestamp PLUS the TAI time elapsed
         # since start up.
-        t_inst = time0_ns + dt_ns
+        t_inst_ns = time0_ns + dt_ns
 
         # Get the UTC -> UT1 conversion offset at t. This value is
         # discontinuous over a leap second.
@@ -630,7 +630,7 @@ def build_EOP_table(times, time0_ns, iers):
 
         # The Instrument -> UT1 conversion is UT1-UTC PLUS any elapsed leap
         # seconds since t0 (startup). This ensures
-        # UT1 = t_inst + delta_UT1_inst is a continuous function over a leap
+        # UT1 = t_inst_ns + delta_UT1_inst is a continuous function over a leap
         # second.
         delta_ut1_inst = delta_ut1_utc.to_value("second") - (dtai - dtai0)
 
@@ -642,7 +642,7 @@ def build_EOP_table(times, time0_ns, iers):
 
         # Build the EOP entry! Remove numpy-ness.
         eop = dict(
-            t_inst_ns=t_inst,
+            t_inst_ns=t_inst_ns,
             delta_UT1_inst=delta_ut1_inst.item(),
             xp_as=x.to_value("arcsecond").item(),
             yp_as=y.to_value("arcsecond").item(),
@@ -774,7 +774,7 @@ def make_bare_EOP_from_full_EOP(eop):
     Parameters
     ----------
     eop : EOP full entry dict
-        A full Kotekan EOP table entry, containing the fields: t_inst, t_ut1,
+        A full Kotekan EOP table entry, containing the fields: t_inst_ns, t_ut1_ns,
         delta_UT1_inst, ERA_deg, xp_as, yp_as.
 
     Returns
@@ -786,7 +786,7 @@ def make_bare_EOP_from_full_EOP(eop):
     """
 
     return dict(
-        t_inst_ns=eop["t_inst"],
+        t_inst_ns=eop["t_inst_ns"],
         delta_UT1_inst=eop["delta_UT1_inst"],
         xp_as=eop["xp_as"],
         yp_as=eop["yp_as"],
@@ -809,7 +809,7 @@ def merge_eop_tables(
     Parameters
     ----------
     current_eop_table : list of eop entry dicts
-        the current table in kotekan (fields: t_inst, t_ut1, delta_ut1_inst, era_deg,
+        the current table in kotekan (fields: t_inst_ns, t_ut1_ns, delta_ut1_inst, era_deg,
         xp_as, yp_as)
     new_eop_table : list of BareEOP update entry dicts
         the proposed new eop table, may conflict with current table. (fields: 
@@ -850,7 +850,7 @@ def merge_eop_tables(
 
     # Check input tables are sorted.
     for i in range(len(current_eop_table) - 1):
-        if current_eop_table[i]["t_inst"] >= current_eop_table[i + 1]["t_inst"]:
+        if current_eop_table[i]["t_inst_ns"] >= current_eop_table[i + 1]["t_inst_ns"]:
             raise RuntimeError(
                 "current_eop_table is not sorted. Can only merge sorted tables"
             )
@@ -862,7 +862,7 @@ def merge_eop_tables(
 
     # Extract array of times for easier searching.  If we're here, both arrays have
     # strictly increasing instrument times
-    current_times = np.array([eop["t_inst"] for eop in current_eop_table])
+    current_times = np.array([eop["t_inst_ns"] for eop in current_eop_table])
     new_times = np.array([eop["t_inst_ns"] for eop in new_eop_table])
 
     # For current_times, the pivot_idx will be the index of the first element strictly
@@ -920,7 +920,7 @@ def merge_eop_tables(
         # new (correct, hopefully) table.
 
         eop_pivot = current_eop_table[-1].copy()
-        eop_pivot["t_inst"] = t_pivot_inst_ns
+        eop_pivot["t_inst_ns"] = t_pivot_inst_ns
 
         print(
             "The pivot time is after the current table expires. Keeping only the last entry and cloning it to the pivot time"

--- a/tools/earth_orientation/eop_utils.py
+++ b/tools/earth_orientation/eop_utils.py
@@ -1,5 +1,14 @@
 #!/usr/bin/env python3
-import argparse
+"""
+/*********************************************************************************
+* Earth Orientation Parameter Tools 
+* File: eop_utils.py
+* Purpose: Provide helper functions for converting between Astropy, Instrument, and UT1 times, for parsing EOP objects, and making REST calls to Kotekan and fpga_master
+* Python Version: 3.12
+* Dependencies: requests, astropy, numpy
+* Authors: Geoffrey Ryan
+*********************************************************************************/
+"""
 import json
 from pathlib import Path
 import sys

--- a/tools/earth_orientation/generateEOPTable.py
+++ b/tools/earth_orientation/generateEOPTable.py
@@ -216,6 +216,7 @@ if __name__ == "__main__":
 
     # Build the table, use astropy's automatic IERS table
     iers = astropy.utils.iers.IERS_Auto.open()
+    # This is a list of BareEOP objects
     new_eop_table = eop_utils.build_EOP_table(ts, t0_ns, iers)
     iers.close()
 
@@ -239,6 +240,8 @@ if __name__ == "__main__":
                 )
             )
             sys.exit()
+
+        # This is a table of EOP objects
         current_eop_table = eop_utils.read_kotekan_eop_table(
             kotekan_host, kotekan_port, timeout, kotekan_protocol
         )
@@ -259,10 +262,10 @@ if __name__ == "__main__":
         "The final EOP table contains {:d} entries from {} to {}".format(
             len(eop_table),
             eop_utils.calc_astropy_time_from_inst_ns(
-                eop_table[0]["time_inst_ns"], t0_ns
+                eop_table[0]["t_inst_ns"], t0_ns
             ).utc.isot,
             eop_utils.calc_astropy_time_from_inst_ns(
-                eop_table[-1]["time_inst_ns"], t0_ns
+                eop_table[-1]["t_inst_ns"], t0_ns
             ).utc.isot,
         )
     )

--- a/tools/earth_orientation/generateEOPTable.py
+++ b/tools/earth_orientation/generateEOPTable.py
@@ -1,4 +1,14 @@
 #!/usr/bin/env python3
+"""
+/*********************************************************************************
+* Earth Orientation Parameter Tools 
+* File: generateEOPTable.py
+* Purpose: Generate an Earth Orientation Parameter (EOP) Table suitable for broadcasting to Kotekan, compatible with the current frame0 time and any currently loaded EOP table.
+* Python Version: 3.12
+* Dependencies: argparse, eop_utils, astropy
+* Authors: Geoffrey Ryan
+*********************************************************************************/
+"""
 import argparse
 import json
 from pathlib import Path

--- a/tools/earth_orientation/readFrame0.py
+++ b/tools/earth_orientation/readFrame0.py
@@ -1,0 +1,82 @@
+import argparse
+import eop_utils
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(
+        prog="Read Frame0 Time",
+        description="Read Frame0 Time from kotekan and fpga_master",
+    )
+
+    parser.add_argument(
+        "--kotekan-host-port-list",
+        nargs="*",
+        default=[],
+        help="List of hosts and ports running kotekan. Adjacent hosts and ports are paired, hosts (ports) without a port (host) pair use default_port (default_port)",
+    )
+    parser.add_argument(
+        "-kh",
+        "--kotekan_host",
+        default="localhost",
+        help="The default host to use. default: localhost",
+    )
+    parser.add_argument(
+        "-kp",
+        "--kotekan_port",
+        default=12048,
+        type=int,
+        help="The default port to use. default: 12048",
+    )
+    parser.add_argument(
+        "-fh",
+        "--fpga_host",
+        default=None,
+        help="The default host to use. default: localhost",
+    )
+    parser.add_argument(
+        "-fp",
+        "--fpga_port",
+        default=54321,
+        type=int,
+        help="The default port to use. default: 12048",
+    )
+    parser.add_argument(
+        "--protocol",
+        default="http://",
+        help="Protocol to use for REST requests, default: 'http://'",
+    )
+    parser.add_argument(
+        "--timeout",
+        default=30.0,
+        type=float,
+        help="REST timeout in seconds, default: 30.0",
+    )
+
+    args = parser.parse_args()
+
+    print("Frame0 times")
+
+    if args.fpga_host is not None:
+        t0_ns = eop_utils.read_fpga_master_frame0_ns(
+            args.fpga_host, args.fpga_port, args.timeout
+        )
+        print(
+            "fpga_master {:d}".format(t0_ns),
+            eop_utils.calc_astropy_time_from_unix_ns(t0_ns).isot,
+            "{:s}:{:d}".format(args.fpga_host, args.fpga_port),
+        )
+
+    hostports = eop_utils.parse_hostport_list(
+        args.kotekan_host_port_list, args.kotekan_host, args.kotekan_port
+    )
+
+    for host, port in hostports:
+        if not eop_utils.is_kotekan_alive(host, port, args.timeout):
+            print("kotekan {:s}:{:d} down".format(host, port))
+            continue
+        t0_ns = eop_utils.read_kotekan_frame0_ns(host, port, args.timeout)
+        print(
+            "kotekan     {:d}".format(t0_ns),
+            eop_utils.calc_astropy_time_from_unix_ns(t0_ns).isot,
+            "{:s}:{:d}".format(host, port),
+        )

--- a/tools/earth_orientation/readFrame0.py
+++ b/tools/earth_orientation/readFrame0.py
@@ -1,5 +1,17 @@
+#!/usr/bin/env python3
+"""
+/*********************************************************************************
+* Earth Orientation Parameter Tools 
+* File: readFrame0.py
+* Purpose: Contact running fpga_master and/or kotekan instances via REST and output their values for `frame0_nano`.
+* Python Version: 3.12
+* Dependencies: argparse, eop_utils
+* Authors: Geoffrey Ryan
+*********************************************************************************/
+"""
 import argparse
 import eop_utils
+
 
 if __name__ == "__main__":
 

--- a/tools/earth_orientation/test_updateEOPTable.py
+++ b/tools/earth_orientation/test_updateEOPTable.py
@@ -62,10 +62,10 @@ if __name__ == "__main__":
 
     eop_table = eop_utils.build_EOP_table(ts, t0_ns, iers)
 
-    t_ns = np.array([eop["time_inst_ns"] for eop in eop_table])
+    t_ns = np.array([eop["t_inst_ns"] for eop in eop_table])
     dut1 = np.array([eop["delta_UT1_inst"] for eop in eop_table])
-    x = np.array([eop["x_pm"] for eop in eop_table])
-    y = np.array([eop["y_pm"] for eop in eop_table])
+    x = np.array([eop["xp_as"] for eop in eop_table])
+    y = np.array([eop["yp_as"] for eop in eop_table])
 
     fig, ax = plt.subplots(3, 1, figsize=(12, 9))
 


### PR DESCRIPTION
- adds `require_eop` config parameter to generic Telescope. If false, Earth Orientation Parameters do not need to be in the config and a dummy table (with 0.0 EOP values covering all times) is used.
- adds system_time fallback to `CHORDTelescope::gps_time`, using the system clock to set `frame0_nano` if gps_required is false.
- adds EOP / Telescope boost tests.
- Refactors EOP fields `t_inst` and `t_ut1` to `t_inst_ns` and `t_ut1_ns`
- Introduces BareEOP struct with only `t_inst_ns`, `delta_UT1_inst`, `xp_as`, `yp_as` fields (no UT1 or ERA) for EOP table updates.