### PR TITLE
cudaCopyFromRingbuffer: only unregister memory if actually registered

### DIFF
--- a/lib/cuda/cudaCopyFromRingbuffer.cpp
+++ b/lib/cuda/cudaCopyFromRingbuffer.cpp
@@ -79,7 +79,8 @@ cudaCopyFromRingbuffer::cudaCopyFromRingbuffer(Config& config, const std::string
 cudaCopyFromRingbuffer::~cudaCopyFromRingbuffer() {
     if (out_buffer && out_buffer->frame_size) {
         uint flags;
-        if (cudaErrorInvalidValue == cudaHostGetFlags(&flags, out_buffer->frames[instance_num])) {
+        // only unregister if it's already been registered
+        if (cudaSuccess == cudaHostGetFlags(&flags, out_buffer->frames[instance_num])) {
             CHECK_CUDA_ERROR(cudaHostUnregister(out_buffer->frames[instance_num]));
         }
     }

--- a/lib/cuda/cudaOutputData.cpp
+++ b/lib/cuda/cudaOutputData.cpp
@@ -69,9 +69,8 @@ cudaOutputData::cudaOutputData(Config& config, const std::string& unique_name,
 cudaOutputData::~cudaOutputData() {
     if (output_buffer->frame_size) {
         uint flags;
-        // only register the memory if it isn't already...
-        if (cudaErrorInvalidValue
-            == cudaHostGetFlags(&flags, output_buffer->frames[instance_num])) {
+        // only unregister if it's already been registered
+        if (cudaSuccess == cudaHostGetFlags(&flags, output_buffer->frames[instance_num])) {
             CHECK_CUDA_ERROR(cudaHostUnregister(output_buffer->frames[instance_num]));
         }
     }


### PR DESCRIPTION
matches CopyToRingBuffer, fails otherwise and leaves behind corrupted files