### PR TITLE
Added buffer size checks when allocating NDArray frame descriptions.

### DIFF
--- a/lib/core/buffer.hpp
+++ b/lib/core/buffer.hpp
@@ -566,6 +566,12 @@ public:
                 ERROR("Dimnames do not match: [{:s}] != [{:s}]", fmt::join(dimnames, ", "),
                       fmt::join(nd_desc->get_dimnames(), ", "));
         }
+
+        if (frames_desc->get_byte_size() != frame_size) {
+            FATAL_ERROR("Buffer {:s} ndarray_frame_desc has size {:d}, does not match buffer "
+                        "frame_size {:d}",
+                        buffer_name, frames_desc->get_byte_size(), frame_size);
+        }
     }
 
     /**
@@ -605,6 +611,12 @@ public:
                 ERROR("Dimnames do not match: [{:s}] != [{:s}]",
                       fmt::format("{:s}", fmt::join(dimnames, ", ")),
                       fmt::format("{:s}", fmt::join(nd_desc->get_dimnames(), ", ")));
+        }
+
+        if (frames_desc->get_byte_size() != frame_size) {
+            FATAL_ERROR("Buffer {:s} ndarray_frame_desc has size {:d}, does not match buffer "
+                        "frame_size {:d}",
+                        buffer_name, frames_desc->get_byte_size(), frame_size);
         }
     }
 


### PR DESCRIPTION
Adds a safety check when setting ndarray frame descriptions on buffers.   FATAL_ERROR if the size does not match the buffer size.