### PR TITLE
Lost Samples consistency test

### DIFF
--- a/config/ci-tests/cpu_batch/verify_lost_samples_n2k_counts.yaml
+++ b/config/ci-tests/cpu_batch/verify_lost_samples_n2k_counts.yaml
@@ -2,6 +2,9 @@
 # Tests that the lostSamples --> N2 Counts pipeline for CHIME/HIRAX produces matching output
 # as n2k pipeline for CHORD.
 #
+# This currently uses the CPU version of the pipeline, as something about the GPU setup in this file is wrong.
+# TODO: Fix, make the comparison against the GPU.
+
 type: config
 log_level: INFO
 
@@ -66,11 +69,11 @@ dummy_pl_mask_buffer:
     frame_size: ((samples_per_data_set / pl_mask_downsampling_factor) * (num_local_freq / 4) * (num_elements / 8)) / 8
     metadata_pool: main_pool
 
-host_n2k_counts_buffer:
-    kotekan_buffer: standard
-    num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * counts_num_blocks * counts_blocksize * counts_blocksize * sizeof_int
-    metadata_pool: main_pool
+# host_n2k_counts_buffer:
+#     kotekan_buffer: standard
+#     num_frames: buffer_depth
+#     frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * counts_num_blocks * counts_blocksize * counts_blocksize * sizeof_int
+#     metadata_pool: main_pool
 
 host_ls_counts_buffer:
     kotekan_buffer: standard
@@ -94,20 +97,20 @@ simulated_n2k_counts_buffer:
 # Ringbuffer signalling buffers
 ###############################
 
-host_rfi_RFImask_ringbuffer:
-    kotekan_buffer: ring
-    ring_buffer_size: buffer_depth * samples_per_data_set * num_local_freq / 8
-    metadata_pool: main_pool
-
-host_pl_mask_ringbuffer:
-    kotekan_buffer: ring
-    ring_buffer_size: buffer_depth * ((samples_per_data_set / 2) * (num_local_freq / 4) * (num_elements / 8)) / 8
-    metadata_pool: main_pool
-
-host_pl_mask_exp_ringbuffer:
-    kotekan_buffer: ring
-    ring_buffer_size: buffer_depth * (samples_per_data_set * num_local_freq * (num_elements / 8)) / 8
-    metadata_pool: main_pool
+# host_rfi_RFImask_ringbuffer:
+#     kotekan_buffer: ring
+#     ring_buffer_size: buffer_depth * samples_per_data_set * num_local_freq / 8
+#     metadata_pool: main_pool
+# 
+# host_pl_mask_ringbuffer:
+#     kotekan_buffer: ring
+#     ring_buffer_size: buffer_depth * ((samples_per_data_set / 2) * (num_local_freq / 4) * (num_elements / 8)) / 8
+#     metadata_pool: main_pool
+# 
+# host_pl_mask_exp_ringbuffer:
+#     kotekan_buffer: ring
+#     ring_buffer_size: buffer_depth * (samples_per_data_set * num_local_freq * (num_elements / 8)) / 8
+#     metadata_pool: main_pool
 
 ################
 # Kotekan stages
@@ -153,71 +156,71 @@ lostSamplesToPLMask:
       - lost_samples_buffer_1
       - lost_samples_buffer_2
 
-run_send_rfi_RFImask:
-    gpu_0:
-        kotekan_stage: cudaProcess
-        gpu_id: 0
-        in_buffers:
-            host_rfi_RFImask_buffer_in: host_rfi_RFImask_buffer
-        out_buffers:
-            host_rfi_RFImask_ringbuffer_out: host_rfi_RFImask_ringbuffer
-        commands:
-        - name: cudaCopyToRingbuffer
-          input_size: samples_per_data_set * num_local_freq  / 8
-          ring_buffer_size: buffer_depth * samples_per_data_set * num_local_freq / 8
-          in_buf: host_rfi_RFImask_buffer_in
-          signal_buf: host_rfi_RFImask_ringbuffer_out
-          gpu_mem_output: rfi_RFImask_buffer
-
-run_send_pl_mask:
-    gpu_0:
-        kotekan_stage: cudaProcess
-        gpu_id: 0
-        in_buffers:
-            host_pl_mask_buffer_in: host_pl_mask_buffer
-        out_buffers:
-            host_pl_mask_ringbuffer_out: host_pl_mask_ringbuffer
-        commands:
-        - name: cudaCopyToRingbuffer
-          input_size: (samples_per_data_set/2) * (num_local_freq/4) * (num_elements/8) / 8
-          ring_buffer_size: buffer_depth * input_size
-          in_buf: host_pl_mask_buffer_in
-          signal_buf: host_pl_mask_ringbuffer_out
-          gpu_mem_output: pl_mask_buffer
-
-run_pl_expand:
-    gpu_0:
-        kotekan_stage: cudaProcess
-        gpu_id: 0
-        in_buffers:
-            host_pl_mask_ringbuffer: host_pl_mask_ringbuffer
-        out_buffers:
-            host_pl_mask_exp_ringbuffer: host_pl_mask_exp_ringbuffer
-        commands:
-        - name: cudaPLMaskExpander
-          num_frequencies: num_local_freq
-          pl_mask_name: pl_mask
-          pl_expanded_mask_name: pl_mask_exp
-
-run_pl_corr:
-    gpu_0:
-        kotekan_stage: cudaProcess
-        gpu_id: 0
-        in_buffers:
-            host_pl_mask_exp_ringbuffer: host_pl_mask_exp_ringbuffer
-            host_rfi_RFImask_ringbuffer: host_rfi_RFImask_ringbuffer
-        out_buffers:
-            host_n2k_counts_buffer: host_n2k_counts_buffer
-        commands:
-        - name: cudaPL1bitCorrelator
-          num_frequencies: num_local_freq
-          pl_expanded_mask_name: pl_mask_exp
-          rfi_RFImask_name: rfi_RFImask
-          n2k_counts_name: n2k_counts
-        - name: cudaSyncOutput
-        - name: cudaOutputData
-          gpu_mem: n2k_counts_buffer
-          out_buf: host_n2k_counts_buffer
+# run_send_rfi_RFImask:
+#     gpu_0:
+#         kotekan_stage: cudaProcess
+#         gpu_id: 0
+#         in_buffers:
+#             host_rfi_RFImask_buffer_in: host_rfi_RFImask_buffer
+#         out_buffers:
+#             host_rfi_RFImask_ringbuffer_out: host_rfi_RFImask_ringbuffer
+#         commands:
+#         - name: cudaCopyToRingbuffer
+#           input_size: samples_per_data_set * num_local_freq  / 8
+#           ring_buffer_size: buffer_depth * samples_per_data_set * num_local_freq / 8
+#           in_buf: host_rfi_RFImask_buffer_in
+#           signal_buf: host_rfi_RFImask_ringbuffer_out
+#           gpu_mem_output: rfi_RFImask_buffer
+# 
+# run_send_pl_mask:
+#     gpu_0:
+#         kotekan_stage: cudaProcess
+#         gpu_id: 0
+#         in_buffers:
+#             host_pl_mask_buffer_in: host_pl_mask_buffer
+#         out_buffers:
+#             host_pl_mask_ringbuffer_out: host_pl_mask_ringbuffer
+#         commands:
+#         - name: cudaCopyToRingbuffer
+#           input_size: (samples_per_data_set/2) * (num_local_freq/4) * (num_elements/8) / 8
+#           ring_buffer_size: buffer_depth * input_size
+#           in_buf: host_pl_mask_buffer_in
+#           signal_buf: host_pl_mask_ringbuffer_out
+#           gpu_mem_output: pl_mask_buffer
+# 
+# run_pl_expand:
+#     gpu_0:
+#         kotekan_stage: cudaProcess
+#         gpu_id: 0
+#         in_buffers:
+#             host_pl_mask_ringbuffer: host_pl_mask_ringbuffer
+#         out_buffers:
+#             host_pl_mask_exp_ringbuffer: host_pl_mask_exp_ringbuffer
+#         commands:
+#         - name: cudaPLMaskExpander
+#           num_frequencies: num_local_freq
+#           pl_mask_name: pl_mask
+#           pl_expanded_mask_name: pl_mask_exp
+# 
+# run_pl_corr:
+#     gpu_0:
+#         kotekan_stage: cudaProcess
+#         gpu_id: 0
+#         in_buffers:
+#             host_pl_mask_exp_ringbuffer: host_pl_mask_exp_ringbuffer
+#             host_rfi_RFImask_ringbuffer: host_rfi_RFImask_ringbuffer
+#         out_buffers:
+#             host_n2k_counts_buffer: host_n2k_counts_buffer
+#         commands:
+#         - name: cudaPL1bitCorrelator
+#           num_frequencies: num_local_freq
+#           pl_expanded_mask_name: pl_mask_exp
+#           rfi_RFImask_name: rfi_RFImask
+#           n2k_counts_name: n2k_counts
+#         - name: cudaSyncOutput
+#         - name: cudaOutputData
+#           gpu_mem: n2k_counts_buffer
+#           out_buf: host_n2k_counts_buffer
 
 cpu_pl_exp:
     kotekan_stage: gpuSimulateN2kPLExpand
@@ -269,10 +272,14 @@ writers:
         kotekan_stage: hdf5FileWrite
         file_name: dummy_pl_mask
         in_buf: dummy_pl_mask_buffer
-    n2k_counts:
+#     n2k_counts:
+#         kotekan_stage: hdf5FileWrite
+#         file_name: n2k_counts
+#         in_buf: host_n2k_counts_buffer
+    cpu_n2k_counts:
         kotekan_stage: hdf5FileWrite
-        file_name: n2k_counts
-        in_buf: host_n2k_counts_buffer
+        file_name: cpu_n2k_counts
+        in_buf: simulated_n2k_counts_buffer
     ls_counts:
         kotekan_stage: hdf5FileWrite
         file_name: ls_counts

--- a/config/ci-tests/cpu_batch/verify_lost_samples_n2k_counts.yaml
+++ b/config/ci-tests/cpu_batch/verify_lost_samples_n2k_counts.yaml
@@ -128,7 +128,7 @@ gen_lost_samples:
       - lost_samples_buffer_2
 
 gen_rfimask:
-    type: const1x8  # For the real test, this should be `random1x8`
+    type: random1x8  # For the real test, this should be `random1x8`
     value: 255
     kotekan_stage: testDataGen
     out_buf: host_rfi_RFImask_buffer

--- a/config/ci-tests/gpu_batch/verify_lost_samples_n2k_counts.yaml
+++ b/config/ci-tests/gpu_batch/verify_lost_samples_n2k_counts.yaml
@@ -232,6 +232,7 @@ cpu_pl_corr:
 
 check_counts_data:
     kotekan_stage: testDataCheckInt
+    # first_buf: host_n2k_counts_buffer
     first_buf: simulated_n2k_counts_buffer
     second_buf: host_ls_counts_buffer
     num_frames_to_test: 2*buffer_depth

--- a/config/ci-tests/gpu_batch/verify_lost_samples_n2k_counts.yaml
+++ b/config/ci-tests/gpu_batch/verify_lost_samples_n2k_counts.yaml
@@ -1,0 +1,279 @@
+#
+# Tests that the lostSamples --> N2 Counts pipeline for CHIME/HIRAX produces matching output
+# as n2k pipeline for CHORD.
+#
+type: config
+log_level: INFO
+
+cpu_affinity: [0, 1]
+num_gpus: 1
+
+frame_arrival_period: 5.12e-6 * samples_per_data_set
+sizeof_int: 4
+
+num_dishes: 64   # Needs to be CHORD/Pathfinder compatible.
+num_polarizations: 2
+num_elements: num_polarizations * num_dishes
+num_freq_bins: 3 # actual CHIME has 4, but then its 4 bins of 4 freqs each, which is a worse test case
+num_local_freq: 4 *  num_freq_bins
+
+pl_mask_downsampling_factor: 2
+pl_mask_dishes_per_bin: 8
+
+#counts matrix size
+counts_blocksize: 8
+counts_num_blocks_lin: (num_elements / 8) / counts_blocksize
+counts_num_blocks: (counts_num_blocks_lin * (counts_num_blocks_lin + 1)) / 2
+
+buffer_depth: 5
+samples_per_data_set: 2048
+sub_integration_ntime: 1024
+num_times: samples_per_data_set
+  # num_frame_samples: pl_mask_hilo_split * pl_mask_downsampling_factor * 2  # 2 pl_mask tiles worth of samples
+
+# Pools
+main_pool:
+    kotekan_metadata_pool: chordMetadata
+    num_metadata_objects: 20*buffer_depth
+
+# Buffers
+lost_samples_buffers:
+    num_frames: buffer_depth
+    frame_size: samples_per_data_set
+    metadata_pool: main_pool
+    lost_samples_buffer_0:
+        kotekan_buffer: standard
+    lost_samples_buffer_1:
+        kotekan_buffer: standard
+    lost_samples_buffer_2:
+        kotekan_buffer: standard
+
+host_rfi_RFImask_buffer:
+    kotekan_buffer: standard
+    num_frames: buffer_depth
+    frame_size: samples_per_data_set * num_local_freq / 8
+    metadata_pool: main_pool
+
+host_pl_mask_buffer:
+    kotekan_buffer: standard
+    num_frames: buffer_depth
+    frame_size: ((samples_per_data_set / pl_mask_downsampling_factor) * (num_local_freq / 4) * (num_elements / pl_mask_dishes_per_bin)) / 8
+    metadata_pool: main_pool
+
+dummy_pl_mask_buffer:
+    kotekan_buffer: standard
+    num_frames: buffer_depth
+    frame_size: ((samples_per_data_set / pl_mask_downsampling_factor) * (num_local_freq / 4) * (num_elements / 8)) / 8
+    metadata_pool: main_pool
+
+host_n2k_counts_buffer:
+    kotekan_buffer: standard
+    num_frames: buffer_depth
+    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * counts_num_blocks * counts_blocksize * counts_blocksize * sizeof_int
+    metadata_pool: main_pool
+
+host_ls_counts_buffer:
+    kotekan_buffer: standard
+    num_frames: buffer_depth
+    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * counts_num_blocks * counts_blocksize * counts_blocksize * sizeof_int
+    metadata_pool: main_pool
+
+simulated_pl_mask_exp_buffer:
+    kotekan_buffer: standard
+    num_frames: buffer_depth
+    frame_size: (samples_per_data_set * (num_local_freq) * (num_elements / 8)) / 8
+    metadata_pool: main_pool
+
+simulated_n2k_counts_buffer:
+    kotekan_buffer: standard
+    num_frames: buffer_depth
+    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * counts_num_blocks * counts_blocksize * counts_blocksize * sizeof_int
+    metadata_pool: main_pool
+
+###############################
+# Ringbuffer signalling buffers
+###############################
+
+host_rfi_RFImask_ringbuffer:
+    kotekan_buffer: ring
+    ring_buffer_size: buffer_depth * samples_per_data_set * num_local_freq / 8
+    metadata_pool: main_pool
+
+host_pl_mask_ringbuffer:
+    kotekan_buffer: ring
+    ring_buffer_size: buffer_depth * ((samples_per_data_set / 2) * (num_local_freq / 4) * (num_elements / 8)) / 8
+    metadata_pool: main_pool
+
+host_pl_mask_exp_ringbuffer:
+    kotekan_buffer: ring
+    ring_buffer_size: buffer_depth * (samples_per_data_set * num_local_freq * (num_elements / 8)) / 8
+    metadata_pool: main_pool
+
+################
+# Kotekan stages
+################
+
+gen_lost_samples:
+    log_level: WARN
+    kotekan_stage: testLostSamplesToPLMask
+    # num_dishes: num_dishes # set via global
+    # num_polarizations: num_polarizations # set via global
+    pl_mask_buf: dummy_pl_mask_buffer
+    lost_samples_buffers:
+      - lost_samples_buffer_0
+      - lost_samples_buffer_1
+      - lost_samples_buffer_2
+
+gen_rfimask:
+    type: const1x8  # For the real test, this should be `random1x8`
+    value: 255
+    kotekan_stage: testDataGen
+    out_buf: host_rfi_RFImask_buffer
+    name: "RFImask"
+    array_shape: [ 2, 12, 128 ]  # [samples_per_data_set/1024, num_local_freq, 128]
+    dim_name: ["T8hi128", "F", "T8lo128"]
+    num_frames: 2*buffer_depth
+    meta_time_downsample_factor: 1024  # The number of time samples represented by each coarse time index.
+
+lostSamplesToN2Counts:
+    kotekan_stage: lostSamplesToN2Counts
+    rfi_mask_buf: host_rfi_RFImask_buffer
+    lost_samples_buffers:
+      - lost_samples_buffer_0
+      - lost_samples_buffer_1
+      - lost_samples_buffer_2
+    n2k_counts_buf: host_ls_counts_buffer
+    num_n2k_freq: num_local_freq
+
+lostSamplesToPLMask:
+    kotekan_stage: lostSamplesToPLMask
+    pl_mask_buf: host_pl_mask_buffer
+    lost_samples_buffers:
+      - lost_samples_buffer_0
+      - lost_samples_buffer_1
+      - lost_samples_buffer_2
+
+run_send_rfi_RFImask:
+    gpu_0:
+        kotekan_stage: cudaProcess
+        gpu_id: 0
+        in_buffers:
+            host_rfi_RFImask_buffer_in: host_rfi_RFImask_buffer
+        out_buffers:
+            host_rfi_RFImask_ringbuffer_out: host_rfi_RFImask_ringbuffer
+        commands:
+        - name: cudaCopyToRingbuffer
+          input_size: samples_per_data_set * num_local_freq  / 8
+          ring_buffer_size: buffer_depth * samples_per_data_set * num_local_freq / 8
+          in_buf: host_rfi_RFImask_buffer_in
+          signal_buf: host_rfi_RFImask_ringbuffer_out
+          gpu_mem_output: rfi_RFImask_buffer
+
+run_send_pl_mask:
+    gpu_0:
+        kotekan_stage: cudaProcess
+        gpu_id: 0
+        in_buffers:
+            host_pl_mask_buffer_in: host_pl_mask_buffer
+        out_buffers:
+            host_pl_mask_ringbuffer_out: host_pl_mask_ringbuffer
+        commands:
+        - name: cudaCopyToRingbuffer
+          input_size: (samples_per_data_set/2) * (num_local_freq/4) * (num_elements/8) / 8
+          ring_buffer_size: buffer_depth * input_size
+          in_buf: host_pl_mask_buffer_in
+          signal_buf: host_pl_mask_ringbuffer_out
+          gpu_mem_output: pl_mask_buffer
+
+run_pl_expand:
+    gpu_0:
+        kotekan_stage: cudaProcess
+        gpu_id: 0
+        in_buffers:
+            host_pl_mask_ringbuffer: host_pl_mask_ringbuffer
+        out_buffers:
+            host_pl_mask_exp_ringbuffer: host_pl_mask_exp_ringbuffer
+        commands:
+        - name: cudaPLMaskExpander
+          num_frequencies: num_local_freq
+          pl_mask_name: pl_mask
+          pl_expanded_mask_name: pl_mask_exp
+
+run_pl_corr:
+    gpu_0:
+        kotekan_stage: cudaProcess
+        gpu_id: 0
+        in_buffers:
+            host_pl_mask_exp_ringbuffer: host_pl_mask_exp_ringbuffer
+            host_rfi_RFImask_ringbuffer: host_rfi_RFImask_ringbuffer
+        out_buffers:
+            host_n2k_counts_buffer: host_n2k_counts_buffer
+        commands:
+        - name: cudaPL1bitCorrelator
+          num_frequencies: num_local_freq
+          pl_expanded_mask_name: pl_mask_exp
+          rfi_RFImask_name: rfi_RFImask
+          n2k_counts_name: n2k_counts
+        - name: cudaSyncOutput
+        - name: cudaOutputData
+          gpu_mem: n2k_counts_buffer
+          out_buf: host_n2k_counts_buffer
+
+cpu_pl_exp:
+    kotekan_stage: gpuSimulateN2kPLExpand
+    in_buf: host_pl_mask_buffer
+    out_buf: simulated_pl_mask_exp_buffer
+
+cpu_pl_corr:
+    kotekan_stage: gpuSimulateN2kPL1bitCorr
+    in_plmask_buf: simulated_pl_mask_exp_buffer
+    in_rfimask_buf: host_rfi_RFImask_buffer
+    out_buf: simulated_n2k_counts_buffer
+
+check_counts_data:
+    kotekan_stage: testDataCheckInt
+    first_buf: simulated_n2k_counts_buffer
+    second_buf: host_ls_counts_buffer
+    num_frames_to_test: 2*buffer_depth
+    trigger_exit_on_pass: False
+    check_metadata: True
+
+# dump to disk to inspect manually
+writers:
+    base_dir: test_lostSamplesToPLMask
+    prefix_hostname: false
+    max_frames: buffer_depth
+    skip_writing: true # change to false to see the files
+    lost_samples_0:
+        kotekan_stage: hdf5FileWrite
+        file_name: lost_samples_buffer_0
+        in_buf: lost_samples_buffer_0
+    lost_samples_1:
+        kotekan_stage: hdf5FileWrite
+        file_name: lost_samples_buffer_1
+        in_buf: lost_samples_buffer_1
+    lost_samples_2:
+        kotekan_stage: hdf5FileWrite
+        file_name: lost_samples_buffer_2
+        in_buf: lost_samples_buffer_2
+    rfi_RFImask:
+        kotekan_stage: hdf5FileWrite
+        file_name: rfi_RFImask
+        in_buf: host_rfi_RFImask_buffer
+    pl_mask:
+        kotekan_stage: hdf5FileWrite
+        file_name: pl_mask
+        in_buf: host_pl_mask_buffer
+    dummy_pl_mask:
+        kotekan_stage: hdf5FileWrite
+        file_name: dummy_pl_mask
+        in_buf: dummy_pl_mask_buffer
+    n2k_counts:
+        kotekan_stage: hdf5FileWrite
+        file_name: n2k_counts
+        in_buf: host_n2k_counts_buffer
+    ls_counts:
+        kotekan_stage: hdf5FileWrite
+        file_name: ls_counts
+        in_buf: host_ls_counts_buffer
+

--- a/lib/stages/lostSamplesToN2Counts.cpp
+++ b/lib/stages/lostSamplesToN2Counts.cpp
@@ -238,7 +238,8 @@ void lostSamplesToN2Counts::main_thread() {
                     // set the 0th value of each stride. If we wanted to set the
                     // entire block, just add an extra loop here
                     size_t idx = cidx_f + tau * num_n2k_freq * _counts_stride;
-                    n2k_count_frame[idx] = _sum;
+                    for (size_t ee = 0; ee < _counts_stride; ee++)
+                        n2k_count_frame[idx+ee] = _sum;
                 }
                 // Shift frequency offset
                 ridx_f += _rfi_f_stride;

--- a/lib/stages/lostSamplesToN2Counts.cpp
+++ b/lib/stages/lostSamplesToN2Counts.cpp
@@ -239,7 +239,7 @@ void lostSamplesToN2Counts::main_thread() {
                     // entire block, just add an extra loop here
                     size_t idx = cidx_f + tau * num_n2k_freq * _counts_stride;
                     for (size_t ee = 0; ee < _counts_stride; ee++)
-                        n2k_count_frame[idx+ee] = _sum;
+                        n2k_count_frame[idx + ee] = _sum;
                 }
                 // Shift frequency offset
                 ridx_f += _rfi_f_stride;

--- a/lib/stages/lostSamplesToPLMask.cpp
+++ b/lib/stages/lostSamplesToPLMask.cpp
@@ -63,6 +63,15 @@ lostSamplesToPLMask::lostSamplesToPLMask(Config& config, const std::string& uniq
                / PL_MASK_DISHES_PER_BIN * num_polarizations / BITS_PER_BYTE * num_freq_bins)
         FATAL_ERROR("Unexpected frames sizes for pl_mask {:d} and lost_samples {:d}",
                     pl_mask_buf->frame_size, lost_samples_bufs.at(0)->frame_size);
+
+    pl_mask_buf->allocate_ndarray_frame_desc<kotekan::GetType_t<kotekan::uint1x8>, 5>(
+        "pl_mask",
+        {ptrdiff_t(lost_samples_bufs.at(0)->frame_size / PL_MASK_DOWNSAMPLING_FACTOR
+                   / PL_MASK_HILO_SPLIT),
+         ptrdiff_t(lost_samples_bufs.size()), num_polarizations,
+         num_dishes / PL_MASK_DISHES_PER_BIN,
+         PL_MASK_HILO_SPLIT / BITS_PER_BYTE /* because we count uint1x8, not uint1 */},
+        {"T2hi64", "F4", "P", "D8", "T2lo64"});
 }
 
 lostSamplesToPLMask::~lostSamplesToPLMask() {}
@@ -136,28 +145,7 @@ void lostSamplesToPLMask::main_thread() {
                 pl_mask_meta->deepCopy(lost_samples_meta);
 
                 // update array description
-                std::strncpy(pl_mask_meta->name, "pl_mask", sizeof pl_mask_meta->name);
-                pl_mask_meta->type = kotekan::uint1x8;
-                pl_mask_meta->dims = 5;
-                assert(pl_mask_meta->dims <= CHORD_META_MAX_DIM);
-                std::strncpy(pl_mask_meta->dim_name[0], "T2hi64", sizeof pl_mask_meta->dim_name[0]);
-                std::strncpy(pl_mask_meta->dim_name[1], "F4", sizeof pl_mask_meta->dim_name[1]);
-                std::strncpy(pl_mask_meta->dim_name[2], "P", sizeof pl_mask_meta->dim_name[2]);
-                std::strncpy(pl_mask_meta->dim_name[3], "D8", sizeof pl_mask_meta->dim_name[3]);
-                std::strncpy(pl_mask_meta->dim_name[4], "T2lo64", sizeof pl_mask_meta->dim_name[4]);
-                pl_mask_meta->dim[0] = lost_samples_bufs.at(0)->frame_size
-                                       / PL_MASK_DOWNSAMPLING_FACTOR / PL_MASK_HILO_SPLIT;
-                pl_mask_meta->dim[1] = lost_samples_bufs.size();
-                pl_mask_meta->dim[2] = num_polarizations;
-                pl_mask_meta->dim[3] = num_dishes / PL_MASK_DISHES_PER_BIN;
-                pl_mask_meta->dim[4] =
-                    PL_MASK_HILO_SPLIT / BITS_PER_BYTE; // because we count uint1x8, not uint1
-                for (int d = pl_mask_meta->dims - 1; d >= 0; --d)
-                    if (d == pl_mask_meta->dims - 1)
-                        pl_mask_meta->stride[d] = 1;
-                    else
-                        pl_mask_meta->stride[d] =
-                            pl_mask_meta->stride[d + 1] * pl_mask_meta->dim[d + 1];
+                pl_mask_meta->set_from_frame_desc(pl_mask_buf->get_ndarray_frame_desc());
 
                 // update metadata
                 pl_mask_meta->set_time_downsampling_fpga(pl_mask_meta->get_time_downsampling_fpga()
@@ -196,14 +184,6 @@ void lostSamplesToPLMask::main_thread() {
         lost_samples_buf_frame_id =
             (lost_samples_buf_frame_id + 1) % lost_samples_bufs.at(0)->num_frames;
 
-        pl_mask_buf->allocate_ndarray_frame_desc<kotekan::GetType_t<kotekan::uint1x8>, 5>(
-            "pl_mask",
-            {ptrdiff_t(lost_samples_bufs.at(0)->frame_size / PL_MASK_DOWNSAMPLING_FACTOR
-                       / PL_MASK_HILO_SPLIT),
-             ptrdiff_t(lost_samples_bufs.size()), num_polarizations,
-             num_dishes / PL_MASK_DISHES_PER_BIN,
-             PL_MASK_HILO_SPLIT / BITS_PER_BYTE /* because we count uint1x8, not uint1 */},
-            {"T2hi64", "F4", "P", "D8", "T2lo64"});
         pl_mask_meta->check_frame_desc(pl_mask_buf->get_ndarray_frame_desc());
         pl_mask_buf->mark_frame_full(unique_name, pl_mask_buf_frame_id);
         pl_mask_buf_frame_id = (pl_mask_buf_frame_id + 1) % pl_mask_buf->num_frames;

--- a/lib/testing/testLostSamplesToPLMask.cpp
+++ b/lib/testing/testLostSamplesToPLMask.cpp
@@ -70,8 +70,10 @@ testLostSamplesToPLMask::~testLostSamplesToPLMask() {}
 // produce some data somewhat randomly
 static bool is_lost(int time, int fbin) {
     std::string buffer(2 * sizeof(int), '\0');
+    // ensure result is consistent across PL mask downsampling.
+    int time_ds = (time / PL_MASK_DOWNSAMPLING_FACTOR) * PL_MASK_DOWNSAMPLING_FACTOR;
     // lost_samples do not depend on dish or polarization
-    std::memcpy(buffer.data() + 0 * sizeof(int), &time, sizeof(int));
+    std::memcpy(buffer.data() + 0 * sizeof(int), &time_ds, sizeof(int));
     std::memcpy(buffer.data() + 1 * sizeof(int), &fbin, sizeof(int));
     Hash hashval = hash(buffer);
     return hashval.l & 1;
@@ -214,6 +216,7 @@ void testLostSamplesToPLMask::main_thread() {
             // done
             lost_samples_buf->mark_frame_full(unique_name, frame_id);
         }
+        seq_num += samples_in_dataset;
         frame_id = (frame_id + 1) % pl_mask_buf->num_frames;
     }
 }

--- a/lib/testing/testLostSamplesToPLMask.cpp
+++ b/lib/testing/testLostSamplesToPLMask.cpp
@@ -63,6 +63,21 @@ testLostSamplesToPLMask::testLostSamplesToPLMask(Config& config, const std::stri
                / PL_MASK_DISHES_PER_BIN * num_polarizations / BITS_PER_BYTE * num_freq_bins)
         FATAL_ERROR("Unexpected frames sizes for pl_mask {:d} and lost_samples {:d}",
                     pl_mask_buf->frame_size, lost_samples_bufs.at(0)->frame_size);
+
+    pl_mask_buf->allocate_ndarray_frame_desc<kotekan::GetType_t<kotekan::uint1x8>, 5>(
+        "pl_mask",
+        {ptrdiff_t(lost_samples_bufs.at(0)->frame_size / PL_MASK_DOWNSAMPLING_FACTOR
+                   / PL_MASK_HILO_SPLIT),
+         ptrdiff_t(lost_samples_bufs.size()), num_polarizations,
+         num_dishes / PL_MASK_DISHES_PER_BIN,
+         PL_MASK_HILO_SPLIT / BITS_PER_BYTE /* because we count uint1x8, not uint1 */},
+        {"T2hi64", "F4", "P", "D8", "T2lo64"});
+
+    for (int fbin = 0; fbin < num_freq_bins; ++fbin) {
+        auto lost_samples_buf = lost_samples_bufs.at(fbin);
+        lost_samples_buf->allocate_ndarray_frame_desc<kotekan::GetType_t<kotekan::uint8>, 1>(
+            "lost_samples", {ptrdiff_t(lost_samples_bufs.at(0)->frame_size)}, {"T"});
+    }
 }
 
 testLostSamplesToPLMask::~testLostSamplesToPLMask() {}
@@ -122,6 +137,8 @@ void testLostSamplesToPLMask::main_thread() {
         pl_mask_buf->allocate_new_metadata_object(frame_id);
         auto pl_mask_meta = get_chord_metadata(pl_mask_buf, frame_id);
 
+        pl_mask_meta->set_from_frame_desc(pl_mask_buf->get_ndarray_frame_desc());
+
         // physics metadata
         // TODO: add more that dpdk adds
         pl_mask_meta->set_fpga_seq_num(seq_num);
@@ -138,37 +155,6 @@ void testLostSamplesToPLMask::main_thread() {
         pl_mask_meta->set_freq_upchan_factor(freq_upchan_factor);
         pl_mask_meta->set_freq_upchan_index(freq_upchan_index);
 
-        // array description
-        std::strncpy(pl_mask_meta->name, "pl_mask", sizeof pl_mask_meta->name);
-        pl_mask_meta->type = kotekan::uint1x8;
-        pl_mask_meta->dims = 5;
-        assert(pl_mask_meta->dims <= CHORD_META_MAX_DIM);
-        std::strncpy(pl_mask_meta->dim_name[0], "T2hi64", sizeof pl_mask_meta->dim_name[0]);
-        std::strncpy(pl_mask_meta->dim_name[1], "F4", sizeof pl_mask_meta->dim_name[1]);
-        std::strncpy(pl_mask_meta->dim_name[2], "P", sizeof pl_mask_meta->dim_name[2]);
-        std::strncpy(pl_mask_meta->dim_name[3], "D8", sizeof pl_mask_meta->dim_name[3]);
-        std::strncpy(pl_mask_meta->dim_name[4], "T2lo64", sizeof pl_mask_meta->dim_name[4]);
-        pl_mask_meta->dim[0] =
-            lost_samples_bufs.at(0)->frame_size / PL_MASK_DOWNSAMPLING_FACTOR / PL_MASK_HILO_SPLIT;
-        pl_mask_meta->dim[1] = lost_samples_bufs.size();
-        pl_mask_meta->dim[2] = num_polarizations;
-        pl_mask_meta->dim[3] = num_dishes / PL_MASK_DISHES_PER_BIN;
-        pl_mask_meta->dim[4] =
-            PL_MASK_HILO_SPLIT / BITS_PER_BYTE; // because we count uint1x8, not uint1
-        for (int d = pl_mask_meta->dims - 1; d >= 0; --d)
-            if (d == pl_mask_meta->dims - 1)
-                pl_mask_meta->stride[d] = 1;
-            else
-                pl_mask_meta->stride[d] = pl_mask_meta->stride[d + 1] * pl_mask_meta->dim[d + 1];
-
-        pl_mask_buf->allocate_ndarray_frame_desc<kotekan::GetType_t<kotekan::uint1x8>, 5>(
-            "pl_mask",
-            {ptrdiff_t(lost_samples_bufs.at(0)->frame_size / PL_MASK_DOWNSAMPLING_FACTOR
-                       / PL_MASK_HILO_SPLIT),
-             ptrdiff_t(lost_samples_bufs.size()), num_polarizations,
-             num_dishes / PL_MASK_DISHES_PER_BIN,
-             PL_MASK_HILO_SPLIT / BITS_PER_BYTE /* because we count uint1x8, not uint1 */},
-            {"T2hi64", "F4", "P", "D8", "T2lo64"});
         pl_mask_meta->check_frame_desc(pl_mask_buf->get_ndarray_frame_desc());
 
         // done
@@ -187,6 +173,7 @@ void testLostSamplesToPLMask::main_thread() {
 
             lost_samples_buf->allocate_new_metadata_object(frame_id);
             auto lost_samples_meta = get_chord_metadata(lost_samples_buf, frame_id);
+            lost_samples_meta->set_from_frame_desc(lost_samples_buf->get_ndarray_frame_desc());
 
             // physics metadata
             // TODO: add more that dpdk adds
@@ -199,18 +186,6 @@ void testLostSamplesToPLMask::main_thread() {
                 std::vector<int>(&coarse_freq[fbin * PL_MASK_FREQS_PER_BIN],
                                  &coarse_freq[(fbin + 1) * PL_MASK_FREQS_PER_BIN]));
 
-            // array description
-            std::strncpy(lost_samples_meta->name, "lost_samples", sizeof lost_samples_meta->name);
-            lost_samples_meta->type = kotekan::uint8;
-            lost_samples_meta->dims = 1;
-            assert(lost_samples_meta->dims <= CHORD_META_MAX_DIM);
-            std::strncpy(lost_samples_meta->dim_name[0], "T",
-                         sizeof lost_samples_meta->dim_name[0]);
-            lost_samples_meta->dim[0] = lost_samples_bufs.at(0)->frame_size;
-            lost_samples_meta->stride[0] = 1;
-
-            lost_samples_buf->allocate_ndarray_frame_desc<kotekan::GetType_t<kotekan::uint8>, 1>(
-                "lost_samples", {ptrdiff_t(lost_samples_bufs.at(0)->frame_size)}, {"T"});
             lost_samples_meta->check_frame_desc(lost_samples_buf->get_ndarray_frame_desc());
 
             // done


### PR DESCRIPTION
Adds a CI test comparing the `cudaPL1bitCorrelator` and `lostSamplesToN2Counts` stages and ensuring they produce identical output.

~~Currently the test uses a trivial RFI mask.  This should be changed to a random mask once #1458 is completed.~~
Test uses a random RFI mask.

Note: ~~currently in draft~~ due to GPU issue. Test (with trivial mask) passes using CPU pipeline.