### PR TITLE
Bad input buffer reorder

### DIFF
--- a/lib/stages/bufferBadInputs.cpp
+++ b/lib/stages/bufferBadInputs.cpp
@@ -6,6 +6,7 @@
 #include "chordMetadata.hpp"  // for get_chord_metadata, chordMetadata
 #include "configUpdater.hpp"  // for configUpdater
 #include "kotekanLogging.hpp" // for DEBUG, ERROR
+#include "visUtil.hpp"        // for get_cylinder_to_beamformer_reorder_table
 
 #include <exception>  // for exception
 #include <functional> // for bind, function, _1
@@ -39,6 +40,8 @@ bool bufferBadInputs::update_bad_inputs_callback(nlohmann::json& json) {
     uint8_t* host_mask = (uint8_t*)out_buf->wait_for_empty_frame(unique_name, frame_id);
     // Reset the mask (1 == good)
     std::memset(host_mask, 1U, num_elements);
+    // Get the reorder mapping
+    constexpr const auto reorder = get_cylinder_to_beamformer_reorder_table();
 
     bool all_good = true;
 
@@ -52,7 +55,7 @@ bool bufferBadInputs::update_bad_inputs_callback(nlohmann::json& json) {
     // Add current bad input to the mask
     for (int element : bad_inputs) {
         if (element < (int)num_elements && element >= 0) {
-            host_mask[element] = 0;
+            host_mask[reorder[element]] = 0;
         } else {
             ERROR("Got input with invalid index: {:d}", element);
             all_good = false;

--- a/lib/stages/bufferBadInputs.hpp
+++ b/lib/stages/bufferBadInputs.hpp
@@ -20,14 +20,18 @@
 
 /**
  * @class bufferBadInputs
- * @brief Buffers updates to the bad input list.
+ * @brief CHIME-specific stage which buffers updates to the bad input list.
  *
  * Copies a list of bad inputs into a mask buffer, which is 0 if
  * an element is bad and 1 if it is good.
  *
+ * This stage expects the input buffer to be recieved in CHIME cylinder order,
+ * and automatically remaps into beamformer order.
+ *
  * @par Buffers
  * @buffer out_buf Kotekan buffer of bad inputs.
- *     @buffer_format Array of @c uint8_t
+ *     @buffer_shape [num_element]
+ *     @buffer_format uint8_t
  *
  * @conf   updatable_config/bad_inputs  String.  String pointing to the location of the
  *                                      config block containing the following properties:

--- a/lib/utils/visUtil.cpp
+++ b/lib/utils/visUtil.cpp
@@ -212,7 +212,6 @@ parse_reorder_default(kotekan::Config& config, const std::string base_path) {
     }
 }
 
-
 size_t _member_alignment(size_t offset, size_t size) {
     return (((size - (offset % size)) % size) + offset);
 }

--- a/lib/utils/visUtil.hpp
+++ b/lib/utils/visUtil.hpp
@@ -464,6 +464,20 @@ std::tuple<std::vector<uint32_t>, std::vector<input_ctype>>
 parse_reorder_default(kotekan::Config& config, const std::string base_path);
 
 /**
+ * @brief Fixed mapping from CHIME cylinder ordering to beamformer ordering.
+ * @return Array of indices mapping cylinder order to beamformer oreder.
+ */
+constexpr std::array<size_t, 2048> get_cylinder_to_beamformer_reorder_table() {
+    std::array<size_t, 2048> mapping{};
+
+    for (size_t i = 0; i < 2048; ++i) {
+        mapping[i] = 256 * (i / 1024) + 2 * (256 * (i / 256) % 1024) + (i % 256);
+    }
+
+    return mapping;
+}
+
+/**
  * @brief Return the next aligned location for a given type size
  * @param  offset Start offset.
  * @param  size   Item size.


### PR DESCRIPTION
Adds a helper function in `visUtil` with the mapping from cylinder to beamformer order. `visUtil` seems like a reasonable place for this, but I'm fine with suggestions to put it elsewhere.