### PR TITLE
Implement CHIME's 8-bit quantizer

### DIFF
--- a/config/ci-tests/gpu_batch/test_quantize8chime.yaml
+++ b/config/ci-tests/gpu_batch/test_quantize8chime.yaml
@@ -1,0 +1,10 @@
+---
+# Run just the test
+
+type: config
+log_level: INFO
+
+cpu_affinity: [0]
+
+test_quantize_kernel_8_chime:
+    kotekan_stage: testQuantizeKernel8Chime

--- a/lib/cuda/CMakeLists.txt
+++ b/lib/cuda/CMakeLists.txt
@@ -35,10 +35,13 @@ add_library(
     cudaPL1bitCorrelator.cpp
     cudaQuantize4.cpp
     cudaQuantize8.cpp
+    cudaQuantize8Chime.cpp
     cudaQuantizeKernel4.cu
     cudaQuantizeKernel8.cu
+    cudaQuantizeKernel8Chime.cu
     testQuantizeKernel4.cpp
     testQuantizeKernel8.cpp
+    testQuantizeKernel8Chime.cpp
     cudaRechunk.cpp
     cudaRFIS012.cpp
     cudaRFIS012bar.cpp

--- a/lib/cuda/cudaQuantize4.cpp
+++ b/lib/cuda/cudaQuantize4.cpp
@@ -69,8 +69,8 @@ cudaQuantize4::cudaQuantize4(Config& config, const std::string& unique_name,
     _num_beams(config.get<std::int64_t>(unique_name, "num_beams")),
     _num_frequencies(config.get<std::int64_t>(unique_name, "num_frequencies")),
     _num_times(config.get<std::int64_t>(unique_name, "num_times")),
-    _num_chunks(
-        kotekan::div_noremainder(1LL * _num_beams * _num_frequencies * _num_times, CHUNK_SIZE)),
+    _num_chunks(1LL * _num_beams * _num_frequencies
+                * kotekan::div_noremainder(_num_times, CHUNK_SIZE)),
     //
     _stddev_cutoff(config.get<float>(unique_name, "stddev_cutoff")),
     //

--- a/lib/cuda/cudaQuantize4.cpp
+++ b/lib/cuda/cudaQuantize4.cpp
@@ -1,3 +1,5 @@
+// 4-bit FRB beam quantizer for CHORD
+
 #include <cuda_fp16.h>              // for __half
 #include <cuda_runtime_api.h>       // for cudaGetLastError
 #include <algorithm>                // for max
@@ -23,6 +25,7 @@
 #include "bufferContainer.hpp"      // for bufferContainer
 #include "driver_types.h"           // for cudaEvent_t, CUevent_st, CUstream_st, cudaStream_t
 #include "fmt.hpp"                  // for format
+#include "metadata.hpp"             // for metadataObject
 
 using kotekan::bufferContainer;
 using kotekan::Config;

--- a/lib/cuda/cudaQuantize8.cpp
+++ b/lib/cuda/cudaQuantize8.cpp
@@ -1,3 +1,6 @@
+// 8-bit FRB beam quantizer for CHIME, using the float16 FRB beamformer and CHIME's
+// sending-to-Bonsai network format
+
 #include <cuda_fp16.h>              // for __half
 #include <cuda_runtime_api.h>       // for cudaGetLastError
 #include <algorithm>                // for max
@@ -23,6 +26,7 @@
 #include "bufferContainer.hpp"      // for bufferContainer
 #include "driver_types.h"           // for cudaEvent_t, CUevent_st, CUstream_st, cudaStream_t
 #include "fmt.hpp"                  // for format
+#include "metadata.hpp"             // for metadataObject
 
 using kotekan::bufferContainer;
 using kotekan::Config;
@@ -95,9 +99,14 @@ cudaQuantize8::cudaQuantize8(Config& config, const std::string& unique_name,
                                            *this);
     }()),
     beam_buffer([&]() {
-        const std::array<std::ptrdiff_t, 8> beam_lengths{1, out_nbeams_outer,
-                                                         out_nfreqs_outer, out_ntimes_outer, out_nbeams_packet,
-                                                         out_nfreqs_packet, out_nfreqs_chunk, out_ntimes_chunk};
+        const std::array<std::ptrdiff_t, 8> beam_lengths{1,
+                                                         out_nbeams_outer,
+                                                         out_nfreqs_outer,
+                                                         out_ntimes_outer,
+                                                         out_nbeams_packet,
+                                                         out_nfreqs_packet,
+                                                         out_nfreqs_chunk,
+                                                         out_ntimes_chunk};
         const std::array<std::string, 8> beam_dimnames{"Ttilde256",     "R8",        "Fbar64",
                                                        "Ttilde16_lo16", "Rlo8",      "Fbar16_lo4",
                                                        "Fbarlo16",      "Ttildelo16"};
@@ -105,9 +114,13 @@ cudaQuantize8::cudaQuantize8(Config& config, const std::string& unique_name,
                                               *this);
     }()),
     offsetscale_buffer([&]() {
-        const std::array<std::ptrdiff_t, 7> offsetscale_lengths{1, out_nbeams_outer,
-                                                         out_nfreqs_outer, out_ntimes_outer, out_nbeams_packet,
-                                                         out_nfreqs_packet, 2};
+        const std::array<std::ptrdiff_t, 7> offsetscale_lengths{1,
+                                                                out_nbeams_outer,
+                                                                out_nfreqs_outer,
+                                                                out_ntimes_outer,
+                                                                out_nbeams_packet,
+                                                                out_nfreqs_packet,
+                                                                2};
         const std::array<std::string, 7> offsetscale_dimnames{
             "Ttilde256", "R8", "Fbar64", "Ttilde16_lo16", "Rlo8", "Fbar16_lo4", "offset/scale"};
         return NDArrayBuffer<float16_t, 7>(_gpu_mem_beams_offsetscale, "I3_offsetscale",
@@ -124,7 +137,8 @@ cudaQuantize8::cudaQuantize8(Config& config, const std::string& unique_name,
 
     // these sizes are hard-coded in the CUDA kernel
     if (_num_beams != in_nbeams || _num_frequencies != in_nfreqs || _num_times != in_ntimes) {
-        FATAL_ERROR("This stage's CUDA kernel hard-codes [num_beams, num_frequencies, num_times] to [{:d}, {:d}, {:d}] and does not support [{:d}, {:d}, {:d}]",
+        FATAL_ERROR("This stage's CUDA kernel hard-codes [num_beams, num_frequencies, num_times] "
+                    "to [{:d}, {:d}, {:d}] and does not support [{:d}, {:d}, {:d}]",
                     in_nbeams, in_nfreqs, in_ntimes, _num_beams, _num_frequencies, _num_times);
     }
 }
@@ -146,41 +160,16 @@ cudaEvent_t cudaQuantize8::execute(cudaPipelineState&, const std::vector<cudaEve
 
     const auto& input_ndarray = input_buffer.get_ndarray();
     const float16_t* const input = input_ndarray.data();
-    const int input_size1 = input_ndarray.extent(3); // time
-    const int input_size2 = input_ndarray.extent(2); // freq
-    const int input_size3 = input_ndarray.extent(1); // beam
     assert(input_ndarray.extent(0) == 1);
-    assert(input_ndarray.stride(3) == 1);              // time
-    const int input_stride2 = input_ndarray.stride(2); // freq
-    const int input_stride3 = input_ndarray.stride(1); // beam
 
     auto& offsetscale_ndarray = offsetscale_buffer.get_ndarray();
     float16_t* const outputf = offsetscale_ndarray.data();
-    const int outputf_size1 = offsetscale_ndarray.extent(3); // time
-    const int outputf_size2 = offsetscale_ndarray.extent(2); // freq
-    const int outputf_size3 = offsetscale_ndarray.extent(1); // beam
-    assert(offsetscale_ndarray.extent(0) == 1);
-    assert(offsetscale_ndarray.stride(3) == 1);                // time
-    const int outputf_stride2 = offsetscale_ndarray.stride(2); // freq
-    const int outputf_stride3 = offsetscale_ndarray.stride(1); // beam
 
     auto& beam_ndarray = beam_buffer.get_ndarray();
     std::uint8_t* const outputi = beam_ndarray.data();
-    const int outputi_size1 = beam_ndarray.extent(3); // time
-    const int outputi_size2 = beam_ndarray.extent(2); // freq
-    const int outputi_size3 = beam_ndarray.extent(1); // beam
-    assert(beam_ndarray.extent(0) == 1);
-    assert(beam_ndarray.stride(3) == 1);                // time
-    const int outputi_stride2 = beam_ndarray.stride(2); // freq
-    const int outputi_stride3 = beam_ndarray.stride(1); // beam
 
     cudaStream_t stream = device.getStream(cuda_stream_id);
-
-    gpu_quantize8(input, outputf, outputi,                                                       //
-                  input_size1, input_size2, input_size3, input_stride2, input_stride3,           //
-                  outputf_size1, outputf_size2, outputf_size3, outputf_stride2, outputf_stride3, //
-                  outputi_size1, outputi_size2, outputi_size3, outputi_stride2, outputi_stride3, //
-                  stream);
+    gpu_quantize8(input, outputf, outputi, stream);
     CHECK_CUDA_ERROR(cudaGetLastError());
 
     return record_end_event();

--- a/lib/cuda/cudaQuantize8Chime.cpp
+++ b/lib/cuda/cudaQuantize8Chime.cpp
@@ -1,3 +1,6 @@
+// 8-bit FRB beam quantizer for CHIME, using the chromatic CHIME float32 FRB beamformer and CHIME's
+// sending-to-Bonsai network format
+
 #include "DataType.hpp"            // for float16_t
 #include "NDArray.hpp"             // for NDArray
 #include "NDArrayBuffer.hpp"       // for NDArrayBuffer
@@ -71,7 +74,7 @@ private:
 
     const NDArrayBuffer<float, 4> input_buffer;
     NDArrayBuffer<std::uint8_t, 8> beam_buffer;
-    NDArrayBuffer<float16_t, 7> offsetscale_buffer;
+    NDArrayBuffer<float, 7> offsetscale_buffer;
 };
 
 REGISTER_CUDA_COMMAND(cudaQuantize8Chime);
@@ -96,9 +99,14 @@ cudaQuantize8Chime::cudaQuantize8Chime(Config& config, const std::string& unique
         return NDArrayBuffer<float, 4>(_gpu_mem_input, "I2", input_lengths, input_dimnames, *this);
     }()),
     beam_buffer([&]() {
-        const std::array<std::ptrdiff_t, 8> beam_lengths{1, out_nbeams_outer,
-                                                         out_nfreqs_outer, out_ntimes_outer, out_nbeams_packet,
-                                                         out_nfreqs_packet, out_nfreqs_chunk, out_ntimes_chunk};
+        const std::array<std::ptrdiff_t, 8> beam_lengths{1,
+                                                         out_nbeams_outer,
+                                                         out_nfreqs_outer,
+                                                         out_ntimes_outer,
+                                                         out_nbeams_packet,
+                                                         out_nfreqs_packet,
+                                                         out_nfreqs_chunk,
+                                                         out_ntimes_chunk};
         const std::array<std::string, 8> beam_dimnames{"Ttilde256",     "R8",        "Fbar64",
                                                        "Ttilde16_lo16", "Rlo8",      "Fbar16_lo4",
                                                        "Fbarlo16",      "Ttildelo16"};
@@ -106,13 +114,17 @@ cudaQuantize8Chime::cudaQuantize8Chime(Config& config, const std::string& unique
                                               *this);
     }()),
     offsetscale_buffer([&]() {
-        const std::array<std::ptrdiff_t, 7> offsetscale_lengths{1, out_nbeams_outer,
-                                                         out_nfreqs_outer, out_ntimes_outer, out_nbeams_packet,
-                                                         out_nfreqs_packet, 2};
+        const std::array<std::ptrdiff_t, 7> offsetscale_lengths{1,
+                                                                out_nbeams_outer,
+                                                                out_nfreqs_outer,
+                                                                out_ntimes_outer,
+                                                                out_nbeams_packet,
+                                                                out_nfreqs_packet,
+                                                                2};
         const std::array<std::string, 7> offsetscale_dimnames{
             "Ttilde256", "R8", "Fbar64", "Ttilde16_lo16", "Rlo8", "Fbar16_lo4", "offset/scale"};
-        return NDArrayBuffer<float16_t, 7>(_gpu_mem_beams_offsetscale, "I3_offsetscale",
-                                           offsetscale_lengths, offsetscale_dimnames, *this);
+        return NDArrayBuffer<float, 7>(_gpu_mem_beams_offsetscale, "I3_offsetscale",
+                                       offsetscale_lengths, offsetscale_dimnames, *this);
     }())
 //
 {
@@ -125,7 +137,8 @@ cudaQuantize8Chime::cudaQuantize8Chime(Config& config, const std::string& unique
 
     // these sizes are hard-coded in the CUDA kernel
     if (_num_beams != in_nbeams || _num_frequencies != in_nfreqs || _num_times != in_ntimes) {
-        FATAL_ERROR("This stage's CUDA kernel hard-codes [num_beams, num_frequencies, num_times] to [{:d}, {:d}, {:d}] and does not support [{:d}, {:d}, {:d}]",
+        FATAL_ERROR("This stage's CUDA kernel hard-codes [num_beams, num_frequencies, num_times] "
+                    "to [{:d}, {:d}, {:d}] and does not support [{:d}, {:d}, {:d}]",
                     in_nbeams, in_nfreqs, in_ntimes, _num_beams, _num_frequencies, _num_times);
     }
 }
@@ -150,7 +163,7 @@ cudaEvent_t cudaQuantize8Chime::execute(cudaPipelineState&, const std::vector<cu
     assert(input_ndarray.extent(0) == 1);
 
     auto& offsetscale_ndarray = offsetscale_buffer.get_ndarray();
-    float16_t* const outputf = offsetscale_ndarray.data();
+    float* const outputf = offsetscale_ndarray.data();
 
     auto& beam_ndarray = beam_buffer.get_ndarray();
     std::uint8_t* const outputi = beam_ndarray.data();

--- a/lib/cuda/cudaQuantize8Chime.cpp
+++ b/lib/cuda/cudaQuantize8Chime.cpp
@@ -1,37 +1,38 @@
-#include <cuda_fp16.h>              // for __half
-#include <cuda_runtime_api.h>       // for cudaGetLastError
-#include <algorithm>                // for max
-#include <array>                    // for array
-#include <cassert>                  // for assert
-#include <cstddef>                  // for ptrdiff_t
-#include <cstdint>                  // for int64_t, uint8_t
-#include <stdexcept>                // for runtime_error
-#include <string>                   // for allocator, basic_string, string
-#include <tuple>                    // for tuple, make_tuple
-#include <vector>                   // for vector
+#include "DataType.hpp"            // for float16_t
+#include "NDArray.hpp"             // for NDArray
+#include "NDArrayBuffer.hpp"       // for NDArrayBuffer
+#include "chordMetadata.hpp"       // for chordMetadata, get_chord_metadata, metadata_is_chord
+#include "cudaCommand.hpp"         // for cudaCommand, REGISTER_CUDA_COMMAND, _factory_aliascud...
+#include "cudaDeviceInterface.hpp" // for cudaDeviceInterface
+#include "cudaQuantizeKernel8Chime.hpp" // for gpu_quantize8
+#include "cudaUtils.hpp"                // for CHECK_CUDA_ERROR
+#include "div.hpp"                      // for div_noremainder
+#include "gpuCommand.hpp"               // for gpuCommandType
+#include "metadata.hpp"                 // for metadataObject
 
-#include "DataType.hpp"             // for float16_t
-#include "NDArray.hpp"              // for NDArray
-#include "NDArrayBuffer.hpp"        // for NDArrayBuffer
-#include "cudaCommand.hpp"          // for cudaCommand, cudaPipelineState, REGISTER_CUDA_COMMAND
-#include "cudaDeviceInterface.hpp"  // for cudaDeviceInterface
-#include "cudaQuantizeKernel8.hpp"  // for gpu_quantize8
-#include "cudaUtils.hpp"            // for CHECK_CUDA_ERROR
-#include "div.hpp"                  // for div_noremainder
-#include "gpuCommand.hpp"           // for gpuCommandType
-#include "Config.hpp"               // for Config
-#include "bufferContainer.hpp"      // for bufferContainer
-#include "driver_types.h"           // for cudaEvent_t, CUevent_st, CUstream_st, cudaStream_t
-#include "fmt.hpp"                  // for format
+#include <algorithm>          // for max
+#include <array>              // for array
+#include <cassert>            // for assert
+#include <cmath>              //
+#include <cstddef>            // for size_t, ptrdiff_t
+#include <cstdint>            // for int64_t
+#include <cuda_fp16.h>        // for __half2, __half
+#include <cuda_runtime_api.h> // for cudaGetLastError, cudaMemcpy
+#include <memory>             // for shared_ptr, __shared_ptr_access
+#include <stdexcept>          // for runtime_error
+#include <string>             // for allocator, basic_string, string, operator+
+#include <tuple>              // for tuple, make_tuple
+#include <vector>             // for vector
 
 using kotekan::bufferContainer;
 using kotekan::Config;
 
-class cudaQuantize8 : public cudaCommand {
+class cudaQuantize8Chime : public cudaCommand {
 public:
-    cudaQuantize8(kotekan::Config& config, const std::string& unique_name,
-                  kotekan::bufferContainer& host_buffers, cudaDeviceInterface& device, int inst);
-    ~cudaQuantize8();
+    cudaQuantize8Chime(kotekan::Config& config, const std::string& unique_name,
+                       kotekan::bufferContainer& host_buffers, cudaDeviceInterface& device,
+                       int inst);
+    ~cudaQuantize8Chime();
     cudaEvent_t execute(cudaPipelineState& pipestate,
                         const std::vector<cudaEvent_t>& pre_events) override;
 
@@ -68,15 +69,16 @@ private:
     static_assert(out_nfreqs_chunk * out_nfreqs_packet * out_nfreqs_outer == in_nfreqs);
     static_assert(out_nbeams_packet * out_nbeams_outer == in_nbeams);
 
-    const NDArrayBuffer<float16_t, 4> input_buffer;
+    const NDArrayBuffer<float, 4> input_buffer;
     NDArrayBuffer<std::uint8_t, 8> beam_buffer;
     NDArrayBuffer<float16_t, 7> offsetscale_buffer;
 };
 
-REGISTER_CUDA_COMMAND(cudaQuantize8);
+REGISTER_CUDA_COMMAND(cudaQuantize8Chime);
 
-cudaQuantize8::cudaQuantize8(Config& config, const std::string& unique_name,
-                             bufferContainer& host_buffers, cudaDeviceInterface& device, int inst) :
+cudaQuantize8Chime::cudaQuantize8Chime(Config& config, const std::string& unique_name,
+                                       bufferContainer& host_buffers, cudaDeviceInterface& device,
+                                       int inst) :
     cudaCommand(config, unique_name, host_buffers, device, inst),
     //
     _num_beams(config.get<std::int64_t>(unique_name, "num_beams")),
@@ -91,8 +93,7 @@ cudaQuantize8::cudaQuantize8(Config& config, const std::string& unique_name,
         const std::array<std::ptrdiff_t, 4> input_lengths{1, _num_beams, _num_frequencies,
                                                           _num_times};
         const std::array<std::string, 4> input_dimnames{"Ttildehi256", "R", "Fbar", "Ttildelo256"};
-        return NDArrayBuffer<float16_t, 4>(_gpu_mem_input, "I2", input_lengths, input_dimnames,
-                                           *this);
+        return NDArrayBuffer<float, 4>(_gpu_mem_input, "I2", input_lengths, input_dimnames, *this);
     }()),
     beam_buffer([&]() {
         const std::array<std::ptrdiff_t, 8> beam_lengths{1, out_nbeams_outer,
@@ -116,7 +117,7 @@ cudaQuantize8::cudaQuantize8(Config& config, const std::string& unique_name,
 //
 {
     set_command_type(gpuCommandType::KERNEL);
-    set_name("cudaQuantize8");
+    set_name("cudaQuantize8Chime");
 
     gpu_buffers_used.push_back(std::make_tuple(_gpu_mem_input, true, true, false));
     gpu_buffers_used.push_back(std::make_tuple(_gpu_mem_beams, true, false, true));
@@ -129,9 +130,9 @@ cudaQuantize8::cudaQuantize8(Config& config, const std::string& unique_name,
     }
 }
 
-cudaQuantize8::~cudaQuantize8() {}
+cudaQuantize8Chime::~cudaQuantize8Chime() {}
 
-cudaEvent_t cudaQuantize8::execute(cudaPipelineState&, const std::vector<cudaEvent_t>&) {
+cudaEvent_t cudaQuantize8Chime::execute(cudaPipelineState&, const std::vector<cudaEvent_t>&) {
     pre_execute();
 
     record_start_event();
@@ -145,42 +146,17 @@ cudaEvent_t cudaQuantize8::execute(cudaPipelineState&, const std::vector<cudaEve
     offsetscale_buffer.set_metadata(input_meta);
 
     const auto& input_ndarray = input_buffer.get_ndarray();
-    const float16_t* const input = input_ndarray.data();
-    const int input_size1 = input_ndarray.extent(3); // time
-    const int input_size2 = input_ndarray.extent(2); // freq
-    const int input_size3 = input_ndarray.extent(1); // beam
+    const float* const input = input_ndarray.data();
     assert(input_ndarray.extent(0) == 1);
-    assert(input_ndarray.stride(3) == 1);              // time
-    const int input_stride2 = input_ndarray.stride(2); // freq
-    const int input_stride3 = input_ndarray.stride(1); // beam
 
     auto& offsetscale_ndarray = offsetscale_buffer.get_ndarray();
     float16_t* const outputf = offsetscale_ndarray.data();
-    const int outputf_size1 = offsetscale_ndarray.extent(3); // time
-    const int outputf_size2 = offsetscale_ndarray.extent(2); // freq
-    const int outputf_size3 = offsetscale_ndarray.extent(1); // beam
-    assert(offsetscale_ndarray.extent(0) == 1);
-    assert(offsetscale_ndarray.stride(3) == 1);                // time
-    const int outputf_stride2 = offsetscale_ndarray.stride(2); // freq
-    const int outputf_stride3 = offsetscale_ndarray.stride(1); // beam
 
     auto& beam_ndarray = beam_buffer.get_ndarray();
     std::uint8_t* const outputi = beam_ndarray.data();
-    const int outputi_size1 = beam_ndarray.extent(3); // time
-    const int outputi_size2 = beam_ndarray.extent(2); // freq
-    const int outputi_size3 = beam_ndarray.extent(1); // beam
-    assert(beam_ndarray.extent(0) == 1);
-    assert(beam_ndarray.stride(3) == 1);                // time
-    const int outputi_stride2 = beam_ndarray.stride(2); // freq
-    const int outputi_stride3 = beam_ndarray.stride(1); // beam
 
     cudaStream_t stream = device.getStream(cuda_stream_id);
-
-    gpu_quantize8(input, outputf, outputi,                                                       //
-                  input_size1, input_size2, input_size3, input_stride2, input_stride3,           //
-                  outputf_size1, outputf_size2, outputf_size3, outputf_stride2, outputf_stride3, //
-                  outputi_size1, outputi_size2, outputi_size3, outputi_stride2, outputi_stride3, //
-                  stream);
+    gpu_quantize8chime(input, outputf, outputi, stream);
     CHECK_CUDA_ERROR(cudaGetLastError());
 
     return record_end_event();

--- a/lib/cuda/cudaQuantizeKernel4.cu
+++ b/lib/cuda/cudaQuantizeKernel4.cu
@@ -1,3 +1,5 @@
+// 4-bit FRB beam quantizer for CHORD
+
 #include "DataType.hpp"
 #include "cudaQuantizeKernel4.hpp"
 

--- a/lib/cuda/cudaQuantizeKernel4.cu
+++ b/lib/cuda/cudaQuantizeKernel4.cu
@@ -42,12 +42,14 @@ __device__ static inline half2x4 load_half2x4(const __half2* __restrict__ const 
 // Round to nearest integer, avoiding all the implementation-defined cases
 static int sane_lrint(const float x) {
     using std::isnan, std::lrint;
-    if (x < INT_MIN)
-        return INT_MIN;
-    if (x > INT_MAX)
-        return INT_MAX;
+    // INT_MIN = -2^31 is exact in float; INT_MAX = 2^31 - 1 rounds up to 2^31
+    // when promoted, so the upper check uses `>=`.
     if (isnan(x))
         return 0; // we could mask to -8 instead
+    if (x < INT_MIN)
+        return INT_MIN;
+    if (x >= INT_MAX)
+        return INT_MAX;
     return int(lrint(x));
 }
 
@@ -76,10 +78,9 @@ void cpu_quantize4_chunk(const __half* __restrict__ const input, __half* __restr
         sum2 += x * x;
     }
     // Calculate the mean and corrected standard deviation
-    using std::fmax, std::sqrt;
     const float mean = sum / chunk_size;
     const float stddev = sqrt(fmax(0.0f, sum2 / chunk_size - mean * mean));
-    // Calculate offset and scale. Ensure the scale is nonzero.
+    // Calculate offset and scale.
     // There are 15 possible int4 values since we don't use 0.
     // Values are reconstructed as `offset + scale * n`, with `int4 n`.
     constexpr int outi_min = -7;
@@ -107,8 +108,12 @@ void cpu_quantize4_chunk(const __half* __restrict__ const input, __half* __restr
     }
 
     // Store offset and scale in the output array
-    outputf[0] = __float2half(offset);
-    outputf[1] = __float2half(scale);
+    outputf[0] = offseth;
+    outputf[1] = scaleh;
+
+    // Recalculate offset and scale from the stored half precision values
+    offset = __half2float(offseth);
+    scale = __half2float(scaleh);
 
     // We encode values as signed 4-bit integers. We combine two 4-bit integers into one byte. The
     // lower 4 bits hold the first value, the upper 4 bits hold the second value.
@@ -117,14 +122,14 @@ void cpu_quantize4_chunk(const __half* __restrict__ const input, __half* __restr
         const float x0 = __half2float(input[i + 0]);
         const float x1 = __half2float(input[i + 1]);
         // Scale
-        const float y0 = (x0 - offset) / scale;
-        const float y1 = (x1 - offset) / scale;
+        const float y0 = scale == 0 ? float(outi_min + outi_max) / 2.0f : (x0 - offset) / scale;
+        const float y1 = scale == 0 ? float(outi_min + outi_max) / 2.0f : (x1 - offset) / scale;
         // Round
         const int j0 = sane_lrint(y0);
         const int j1 = sane_lrint(y1);
         // Clamp; use -8 for nan
-        const int k0 = isnan(y0) ? -8 : max(outi_min, min(outi_max, j0));
-        const int k1 = isnan(y1) ? -8 : max(outi_min, min(outi_max, j1));
+        const int k0 = isnan(x0) ? -8 : max(outi_min, min(outi_max, j0));
+        const int k1 = isnan(x1) ? -8 : max(outi_min, min(outi_max, j1));
         // Combine
         const kotekan::int4x2_t k01(k0, k1);
         // Store
@@ -221,7 +226,7 @@ gpu_quantize4_chunks(const __half* __restrict__ const input0, __half* __restrict
         constexpr float outf_range = outf_max - outf_min;
         const float in_range = 2 * stddev * stddev_cutoff;
         const float offset = mean;
-        const float scale = fmax(0.0f, in_range / outf_range);
+        const float scale = in_range / outf_range;
 
         // Idea: Add 8 before converting to int, then the result will be positive and we don't need
         // to mask when combining. Mapping nans will also work naturally. Use a single xor to
@@ -245,7 +250,7 @@ gpu_quantize4_chunks(const __half* __restrict__ const input0, __half* __restrict
             // Offset and scale are fine, but the inverse scale is non-finite. This means the scale
             // is too close to zero.
             scaleh = __float2half_rn(0.0f);
-            inv_offseth = -offseth;
+            inv_offseth = __float2half_rn(0.0f);
             inv_scaleh = __float2half_rn(0.0f);
         }
 

--- a/lib/cuda/cudaQuantizeKernel4.cu
+++ b/lib/cuda/cudaQuantizeKernel4.cu
@@ -237,8 +237,8 @@ gpu_quantize4_chunks(const __half* __restrict__ const input0, __half* __restrict
             // Offset or scale are non-finite
             offseth = __float2half_rn(0.0f);
             scaleh = __float2half_rn(0.0f);
-            inv_offseth = __float2half_rn(inv_offset);
-            inv_scaleh = __float2half_rn(inv_scale);
+            inv_offseth = __float2half_rn(0.0f);
+            inv_scaleh = __float2half_rn(0.0f);
         } else if (!isfinite(__half2float(inv_offseth)) || !isfinite(__half2float(inv_scaleh))) {
             // Offset and scale are fine, but the inverse scale is non-finite. This means the scale
             // is too close to zero.

--- a/lib/cuda/cudaQuantizeKernel4.hpp
+++ b/lib/cuda/cudaQuantizeKernel4.hpp
@@ -1,3 +1,5 @@
+// 4-bit FRB beam quantizer for CHORD
+
 #ifndef CUDA_QUANTIZE_KERNEL_4_HPP
 #define CUDA_QUANTIZE_KERNEL_4_HPP
 

--- a/lib/cuda/cudaQuantizeKernel8.cu
+++ b/lib/cuda/cudaQuantizeKernel8.cu
@@ -74,14 +74,16 @@ __device__ __host__ static inline float sane_fmin(const float x, const float y) 
 }
 
 // Round to nearest integer, avoiding all the implementation-defined cases
-__device__ __host__ static inline int sane_lrint(const float x) {
+static int sane_lrint(const float x) {
     using std::isnan, std::lrint;
+    // INT_MIN = -2^31 is exact in float; INT_MAX = 2^31 - 1 rounds up to 2^31
+    // when promoted, so the upper check uses `>=`.
+    if (isnan(x))
+        return 0; // we could mask to -8 instead
     if (x < INT_MIN)
         return INT_MIN;
-    if (x > INT_MAX)
+    if (x >= INT_MAX)
         return INT_MAX;
-    if (isnan(x))
-        return 0; // we could mask to 0 instead
     return int(lrint(x));
 }
 
@@ -107,7 +109,7 @@ void cpu_quantize8_chunk(const __half* __restrict__ const input, __half* __restr
             maxval = sane_fmax(maxval, x);
         }
     }
-    // Calculate offset and scale. Ensure the scale is nonzero.
+    // Calculate offset and scale.
     // There are 254 possible uint8 values since we don't use 0 or 255 for regular values.
     // Values are reconstructed as `offset + scale * n`, with `uint8 n`.
     // NaN in the input is represented as `n = 0`.
@@ -119,16 +121,7 @@ void cpu_quantize8_chunk(const __half* __restrict__ const input, __half* __restr
     //     minval => outf_min
     //     maxval => outf_max
     const float outf_range = outf_max - outf_min;
-    float in_range = maxval - minval;
-    // Ensure that the input range is not too small, which woud lead to an overflow when dividing by
-    // the scale
-    constexpr float min_in_range = 1.0e-3f; // approximately eps(__half)
-    if (in_range < min_in_range) {
-        const float avgval = (minval + maxval) / 2;
-        minval = avgval - min_in_range / 2;
-        maxval = avgval + min_in_range / 2;
-        in_range = maxval - minval;
-    }
+    const float in_range = maxval - minval;
 
     float scale = in_range / outf_range;
     float offset = minval - outf_min * scale;
@@ -144,8 +137,12 @@ void cpu_quantize8_chunk(const __half* __restrict__ const input, __half* __restr
     }
 
     // Store offset and scale in the output array
-    outputf[0] = __float2half(offset);
-    outputf[1] = __float2half(scale);
+    outputf[0] = offseth;
+    outputf[1] = scaleh;
+
+    // Recalculate offset and scale from the stored half precision values
+    offset = __half2float(offseth);
+    scale = __half2float(scaleh);
 
     // We encode values as unsigned 8-bit integers.
     for (int freq = 0; freq < out_nfreqs_chunk; ++freq) {
@@ -155,11 +152,11 @@ void cpu_quantize8_chunk(const __half* __restrict__ const input, __half* __restr
             // Get value
             const float x = __half2float(input[in_ind]);
             // Scale
-            const float y = (x - offset) / scale;
+            const float y = scale == 0 ? float(outi_min + outi_max) / 2.0f : (x - offset) / scale;
             // Round
             const int j = sane_lrint(y);
             // Clamp; use 0 for nan
-            const int k = isnan(y) ? 0 : max(outi_min, min(outi_max, j));
+            const int k = isnan(x) ? 0 : max(outi_min, min(outi_max, j));
             // Store
             outputi[out_ind] = k;
         }
@@ -224,6 +221,11 @@ __global__ void gpu_quantize8_chunks(const __half* __restrict__ const input,
                                                             + out_nfreqs_outer * beam_outer)))));
     };
 
+    // Per-thread tile within each chunk: 8 contiguous times × 1 freq. 32 threads
+    // cover the 16 × 16 chunk as 2 time-groups × 16 freqs = 32 tiles.
+    const int in_time_chunk = 8 * (threadIdx.x % 2); // 0 or 8
+    const int in_freq_chunk = threadIdx.x / 2;       // 0..15
+
     // We store offset and scale only after finishing the loop over all chunks. Each thread stores
     // one offset/scale pair.
     __half2 outf;
@@ -235,8 +237,6 @@ __global__ void gpu_quantize8_chunks(const __half* __restrict__ const input,
         // There are 256 values and 32 threads, so each thread loads 8 values.
         // We load these 8 values as a batch of 8 times.
         // (This is not cache-efficient because the frequencies are not adjacent.)
-        const int in_time_chunk = 2 * threadIdx.x % 2; // 0...15 in steps of 8
-        const int in_freq_chunk = threadIdx.x / 2;     // 0...15
         const int input_offset_01234567 = input_offset(time(in_time_chunk, time_outer),
                                                        freq(in_freq_chunk, freq_packet, freq_outer),
                                                        beam(beam_packet, beam_outer));
@@ -298,7 +298,7 @@ __global__ void gpu_quantize8_chunks(const __half* __restrict__ const input,
             // Offset and scale are fine, but the inverse scale is non-finite. This means the scale
             // is too close to zero.
             scaleh = __float2half_rn(0.0f);
-            inv_offseth = -offseth;
+            inv_offseth = __float2half_rn(0.0f);
             inv_scaleh = __float2half_rn(0.0f);
         }
 
@@ -349,10 +349,9 @@ __global__ void gpu_quantize8_chunks(const __half* __restrict__ const input,
                                    | (std::uint64_t(i4) << 0x20) | (std::uint64_t(i5) << 0x28)
                                    | (std::uint64_t(i6) << 0x30) | (std::uint64_t(i7) << 0x38);
 
-        const int out_time_chunk = 8 * (chunk % 2); // 0...15 in steps of 8
-        const int out_freq_chunk = chunk / 2;       // 0...7
+        // Each thread writes its own tile, the same (in_time_chunk, in_freq_chunk) it loaded from.
         *(std::uint64_t*)(outputi
-                          + outputi_offset(out_time_chunk, out_freq_chunk, freq_packet, beam_packet,
+                          + outputi_offset(in_time_chunk, in_freq_chunk, freq_packet, beam_packet,
                                            time_outer, freq_outer, beam_outer)) = outi;
     }
     const int out_beam_outer = beam_outer0 + thread;

--- a/lib/cuda/cudaQuantizeKernel8.cu
+++ b/lib/cuda/cudaQuantizeKernel8.cu
@@ -1,3 +1,6 @@
+// 8-bit FRB beam quantizer for CHIME, using the float16 FRB beamformer and CHIME's
+// sending-to-Bonsai network format
+
 #include "DataType.hpp"
 #include "cudaQuantizeKernel8.hpp"
 
@@ -12,14 +15,31 @@
 
 // Global constants
 
+// Input array layout
+static constexpr int in_ntimes = 256;
+static constexpr int in_nfreqs = 256; // 16 coarse channels, upchannelized by 16
+static constexpr int in_nbeams = 1024;
+
+// Output array layout
 // The output is quantized in "chunks". Each chunk has a different offset and scale.
-static constexpr int chunk_size = 256;
+static constexpr int out_ntimes_chunk = 16;
+static constexpr int out_nfreqs_chunk = 16;
+// Chunks are combined into packets.
+static constexpr int out_nfreqs_packet = 4;
+static constexpr int out_nbeams_packet = 8;
+// There are several packets.
+static constexpr int out_ntimes_outer = 16;
+static constexpr int out_nfreqs_outer = 4;
+static constexpr int out_nbeams_outer = 128;
+
+static_assert(out_ntimes_chunk * out_ntimes_outer == in_ntimes);
+static_assert(out_nfreqs_chunk * out_nfreqs_packet * out_nfreqs_outer == in_nfreqs);
+static_assert(out_nbeams_packet * out_nbeams_outer == in_nbeams);
 
 // For efficiency we proceess several chunks at once on the GPU.
 static constexpr int nchunks = 32;
 
-// Number of threads per block
-static constexpr int nthreads = nchunks;
+static_assert(out_nbeams_outer % nchunks == 0);
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -32,7 +52,7 @@ struct half2x4 {
 
 // Load 4 `half2` values from memory simultaneously. This is more efficient than loading each
 // `half2` separately.
-__device__ static inline half2x4 load_half2x4(const __half2* __restrict__ const ptr) {
+__device__ static inline half2x4 load_half2x4(const __half* __restrict__ const ptr) {
     const int4 data = *reinterpret_cast<const int4*>(ptr);
     return reinterpret_cast<const half2x4&>(data);
 }
@@ -74,21 +94,23 @@ __device__ __host__ static inline int sane_lrint(const float x) {
 // produces a different result, then the GPU version is wrong.
 void cpu_quantize8_chunk(const __half* __restrict__ const input, __half* __restrict__ const outputf,
                          std::uint8_t* __restrict__ const outputi) {
-    static_assert(chunk_size >= 0);
-
-    using std::isfinite, std::max, std::min;
+    using std::isfinite, std::isnan, std::max, std::min;
 
     // Find the minimum and maximum of all input values. Calculate
     // everything as `float` for convenience.
     float minval = +1.0f / 0.0f, maxval = -1.0f / 0.0f;
-    for (int i = 0; i < chunk_size; ++i) {
-        const float x = __half2float(input[i]);
-        minval = sane_fmin(minval, x);
-        maxval = sane_fmax(maxval, x);
+    for (int freq = 0; freq < out_nfreqs_chunk; ++freq) {
+        for (int time = 0; time < out_ntimes_chunk; ++time) {
+            const int in_ind = time + in_ntimes * freq;
+            const float x = __half2float(input[in_ind]);
+            minval = sane_fmin(minval, x);
+            maxval = sane_fmax(maxval, x);
+        }
     }
     // Calculate offset and scale. Ensure the scale is nonzero.
-    // There are 254 possible uint8 values since we don't use 0 or 255.
+    // There are 254 possible uint8 values since we don't use 0 or 255 for regular values.
     // Values are reconstructed as `offset + scale * n`, with `uint8 n`.
+    // NaN in the input is represented as `n = 0`.
     constexpr int outi_min = 1;
     constexpr int outi_max = 254;
     constexpr float outf_min = outi_min - 0.5f;
@@ -97,7 +119,16 @@ void cpu_quantize8_chunk(const __half* __restrict__ const input, __half* __restr
     //     minval => outf_min
     //     maxval => outf_max
     const float outf_range = outf_max - outf_min;
-    const float in_range = maxval - minval;
+    float in_range = maxval - minval;
+    // Ensure that the input range is not too small, which woud lead to an overflow when dividing by
+    // the scale
+    constexpr float min_in_range = 1.0e-3f; // approximately eps(__half)
+    if (in_range < min_in_range) {
+        const float avgval = (minval + maxval) / 2;
+        minval = avgval - min_in_range / 2;
+        maxval = avgval + min_in_range / 2;
+        in_range = maxval - minval;
+    }
 
     float scale = in_range / outf_range;
     float offset = minval - outf_min * scale;
@@ -117,72 +148,103 @@ void cpu_quantize8_chunk(const __half* __restrict__ const input, __half* __restr
     outputf[1] = __float2half(scale);
 
     // We encode values as unsigned 8-bit integers.
-    for (int i = 0; i < chunk_size; ++i) {
-        // Get value
-        const float x = __half2float(input[i]);
-        // Scale
-        const float y = (x - offset) / scale;
-        // Round
-        const int j = sane_lrint(y);
-        // Clamp; use 0 for nan
-        const int k = isnan(y) ? 0 : max(outi_min, min(outi_max, j));
-        // Store
-        outputi[i] = k;
+    for (int freq = 0; freq < out_nfreqs_chunk; ++freq) {
+        for (int time = 0; time < out_ntimes_chunk; ++time) {
+            const int in_ind = time + in_ntimes * freq;
+            const int out_ind = time + out_ntimes_chunk * freq;
+            // Get value
+            const float x = __half2float(input[in_ind]);
+            // Scale
+            const float y = (x - offset) / scale;
+            // Round
+            const int j = sane_lrint(y);
+            // Clamp; use 0 for nan
+            const int k = isnan(y) ? 0 : max(outi_min, min(outi_max, j));
+            // Store
+            outputi[out_ind] = k;
+        }
     }
 }
 
 // Quantize a set of "chunk"s. This is an efficient GPU implementation.
-__global__ void
-gpu_quantize8_chunks(const __half* __restrict__ const input0, __half* __restrict__ const outputf0,
-                     std::uint8_t* __restrict__ const outputi0, const int input_size1,
-                     const int input_size2, const int input_size3, const int input_stride2,
-                     const int input_stride3, const int outputf_size1, const int outputf_size2,
-                     const int outputf_size3, const int outputf_stride2, const int outputf_stride3,
-                     const int outputi_size1, const int outputi_size2, const int outputi_size3,
-                     const int outputi_stride2, const int outputi_stride3) {
-    static_assert(chunk_size >= 0);
-    static_assert(chunk_size % (8 * nthreads) == 0);
+__global__ void gpu_quantize8_chunks(const __half* __restrict__ const input,
+                                     __half* __restrict__ const outputf,
+                                     std::uint8_t* __restrict__ const outputi) {
+    using std::isfinite;
 
-    // Calculate array indices and convert to SIMD reference
-    const auto input = [&](const int dim1, const int dim2, const int dim3) -> const __half2& {
-        assert(dim1 >= 0 && dim1 < input_size1);
-        assert(dim2 >= 0 && dim2 < input_size2);
-        assert(dim3 >= 0 && dim3 < input_size3);
-        return *(const __half2*)&(input0[dim1 + input_stride2 * dim2 + input_stride3 * dim3]);
-    };
-    const auto outputi = [&](const int dim1, const int dim2, const int dim3) -> std::uint64_t& {
-        assert(dim1 >= 0 && dim1 < outputi_size1);
-        assert(dim2 >= 0 && dim2 < outputi_size2);
-        assert(dim3 >= 0 && dim3 < outputi_size3);
-        return *(std::uint64_t*)&(outputi0[dim1 + outputi_stride2 * dim2 + outputi_stride3 * dim3]);
-    };
-    const auto outputf = [&](const int dim1, const int dim2, const int dim3) -> __half2& {
-        assert(dim1 >= 0 && dim1 < outputf_size1);
-        assert(dim2 >= 0 && dim2 < outputf_size2);
-        assert(dim3 >= 0 && dim3 < outputf_size3);
-        return *(__half2*)&(outputf0[dim1 + outputf_stride2 * dim2 + outputf_stride3 * dim3]);
-    };
-
-    // // Find our position in the arrays
+    // Find our position in the arrays
     const int thread = threadIdx.x;
-    const int dim1 = blockIdx.x * chunk_size;
-    const int dim2 = blockIdx.y;
-    const int dim3 = blockIdx.z * nchunks;
+    const int time_outer = blockIdx.x;
+    const int freq_packet = blockIdx.y % out_nfreqs_packet;
+    const int freq_outer = blockIdx.y / out_nfreqs_packet;
+    const int beam_packet = blockIdx.z % out_nbeams_packet;
+    const int beam_outer0 = nchunks * (blockIdx.z / out_nbeams_packet); // not adding threadIdx.x
 
-    static_assert(nchunks == nthreads);
+    // Calculate input indices
+    const auto time = [&](int time_chunk, int time_outer) {
+        return time_chunk + out_ntimes_chunk * time_outer;
+    };
+    const auto freq = [&](int freq_chunk, int freq_packet, int freq_outer) {
+        return freq_chunk + out_nfreqs_chunk * (freq_packet + out_nfreqs_packet * freq_outer);
+    };
+    const auto beam = [&](int beam_packet, int beam_outer) {
+        return beam_packet + out_nbeams_packet * beam_outer;
+    };
+
+    const auto input_offset = [&](int time, int freq, int beam) {
+        return time + in_ntimes * (freq + in_nfreqs * beam);
+    };
+
+    // Calculate output indices
+    const auto outputf_offset = [&](int freq_packet, int beam_packet, int time_outer,
+                                    int freq_outer, int beam_outer) {
+        return 2
+               * (freq_packet
+                  + out_nfreqs_packet
+                        * (beam_packet
+                           + out_nbeams_packet
+                                 * (time_outer
+                                    + out_ntimes_outer
+                                          * (freq_outer + out_nfreqs_outer * beam_outer))));
+    };
+    const auto outputi_offset = [&](int time_chunk, int freq_chunk, int freq_packet,
+                                    int beam_packet, int time_outer, int freq_outer,
+                                    int beam_outer) {
+        return time_chunk
+               + out_ntimes_chunk
+                     * (freq_chunk
+                        + out_nfreqs_chunk
+                              * (freq_packet
+                                 + out_nfreqs_packet
+                                       * (beam_packet
+                                          + out_nbeams_packet
+                                                * (time_outer
+                                                   + out_ntimes_outer
+                                                         * (freq_outer
+                                                            + out_nfreqs_outer * beam_outer)))));
+    };
+
     // We store offset and scale only after finishing the loop over all chunks. Each thread stores
     // one offset/scale pair.
     __half2 outf;
-    // Loop over all chunks in the frame
+    // Loop over all beams we're handling
     for (int chunk = 0; chunk < nchunks; ++chunk) {
-        static_assert(chunk_size == 8 * nthreads);
+        const int beam_outer = beam_outer0 + chunk;
 
         // Load all values in this chunk. We load all values at once in the beginning.
-        const half2x4 xs = load_half2x4(&input(dim1 + 8 * thread, dim2, dim3 + chunk));
-        const __half2 x01 = xs.x;
-        const __half2 x23 = xs.y;
-        const __half2 x45 = xs.z;
-        const __half2 x67 = xs.w;
+        // There are 256 values and 32 threads, so each thread loads 8 values.
+        // We load these 8 values as a batch of 8 times.
+        // (This is not cache-efficient because the frequencies are not adjacent.)
+        const int in_time_chunk = 2 * threadIdx.x % 2; // 0...15 in steps of 8
+        const int in_freq_chunk = threadIdx.x / 2;     // 0...15
+        const int input_offset_01234567 = input_offset(time(in_time_chunk, time_outer),
+                                                       freq(in_freq_chunk, freq_packet, freq_outer),
+                                                       beam(beam_packet, beam_outer));
+        const half2x4 xs01234567 = load_half2x4(input + input_offset_01234567);
+        const __half2 x01 = xs01234567.x;
+        const __half2 x23 = xs01234567.y;
+        const __half2 x45 = xs01234567.w;
+        const __half2 x67 = xs01234567.z;
 
         const float x0 = __half2float(__low2half(x01));
         const float x1 = __half2float(__high2half(x01));
@@ -287,9 +349,16 @@ gpu_quantize8_chunks(const __half* __restrict__ const input0, __half* __restrict
                                    | (std::uint64_t(i4) << 0x20) | (std::uint64_t(i5) << 0x28)
                                    | (std::uint64_t(i6) << 0x30) | (std::uint64_t(i7) << 0x38);
 
-        outputi((dim1 + 8 * thread), dim2, dim3 + chunk) = outi;
+        const int out_time_chunk = 8 * (chunk % 2); // 0...15 in steps of 8
+        const int out_freq_chunk = chunk / 2;       // 0...7
+        *(std::uint64_t*)(outputi
+                          + outputi_offset(out_time_chunk, out_freq_chunk, freq_packet, beam_packet,
+                                           time_outer, freq_outer, beam_outer)) = outi;
     }
-    outputf(2 * dim1 / chunk_size, dim2, dim3 + thread) = outf;
+    const int out_beam_outer = beam_outer0 + thread;
+    *(__half2*)(outputf
+                + outputf_offset(freq_packet, beam_packet, time_outer, freq_outer,
+                                 out_beam_outer)) = outf;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -297,107 +366,72 @@ gpu_quantize8_chunks(const __half* __restrict__ const input0, __half* __restrict
 // Drivers (externally visible)
 
 void cpu_quantize8(const __half* __restrict__ const input, __half* __restrict__ const outputf,
-                   std::uint8_t* __restrict__ const outputi, const int input_size1,
-                   const int input_size2, const int input_size3, const int input_stride2,
-                   const int input_stride3, const int outputf_size1, const int outputf_size2,
-                   const int outputf_size3, const int outputf_stride2, const int outputf_stride3,
-                   const int outputi_size1, const int outputi_size2, const int outputi_size3,
-                   const int outputi_stride2, const int outputi_stride3) {
+                   std::uint8_t* __restrict__ const outputi) {
     assert(input);
     assert(outputf);
     assert(outputi);
 
-    assert(input_size1 >= 0);
-    assert(input_size2 >= 0);
-    assert(input_size3 >= 0);
-    assert(input_stride2 >= 0);
-    assert(input_stride3 >= 0);
-    assert(outputf_size1 >= 0);
-    assert(outputf_size2 >= 0);
-    assert(outputf_size3 >= 0);
-    assert(outputf_stride2 >= 0);
-    assert(outputf_stride3 >= 0);
-    assert(outputi_size1 >= 0);
-    assert(outputi_size2 >= 0);
-    assert(outputi_size3 >= 0);
-    assert(outputi_stride2 >= 0);
-    assert(outputi_stride3 >= 0);
-    static_assert(chunk_size > 0);
+    // Loop over all packets
+    for (int beam_outer = 0; beam_outer < out_nbeams_outer; ++beam_outer) {
+        for (int freq_outer = 0; freq_outer < out_nfreqs_outer; ++freq_outer) {
+            for (int time_outer = 0; time_outer < out_ntimes_outer; ++time_outer) {
 
-    assert(input_size1 % chunk_size == 0);
+                // Loop over the chunks in each packets
+                for (int beam_packet = 0; beam_packet < out_nbeams_packet; ++beam_packet) {
+                    for (int freq_packet = 0; freq_packet < out_nfreqs_packet; ++freq_packet) {
 
-    assert(outputf_size1 == 2 * input_size1 / chunk_size);
-    assert(outputf_size2 == input_size2);
-    assert(outputf_size3 == input_size3);
-    assert(outputi_size1 == input_size1);
-    assert(outputi_size2 == input_size2);
-    assert(outputi_size3 == input_size3);
+                        // Process one chunk
+                        const int time = out_ntimes_chunk * time_outer;
+                        const int freq =
+                            out_nfreqs_chunk * (freq_packet + out_nfreqs_packet * freq_outer);
+                        const int beam = beam_packet + out_nbeams_packet * beam_outer;
+                        const int input_offset = time + in_ntimes * (freq + in_nfreqs * beam);
 
-    for (int dim3 = 0; dim3 < input_size3; ++dim3) {
-        for (int dim2 = 0; dim2 < input_size2; ++dim2) {
-            for (int dim1 = 0; dim1 < input_size1; dim1 += chunk_size) {
-                const int input_dim1 = dim1;
-                const int outputf_dim1 = 2 * dim1 / chunk_size;
-                const int outputi_dim1 = dim1;
-                const int input_offset = input_dim1 + input_stride2 * dim2 + input_stride3 * dim3;
-                const int outputf_offset =
-                    outputf_dim1 + outputf_stride2 * dim2 + outputf_stride3 * dim3;
-                const int outputi_offset =
-                    outputi_dim1 + outputi_stride2 * dim2 + outputi_stride3 * dim3;
-                cpu_quantize8_chunk(input + input_offset, outputf + outputf_offset,
-                                    outputi + outputi_offset);
+                        const int outputf_offset =
+                            2
+                            * (freq_packet
+                               + out_nfreqs_packet
+                                     * (beam_packet
+                                        + out_nbeams_packet
+                                              * (time_outer
+                                                 + out_ntimes_outer
+                                                       * (freq_outer
+                                                          + out_nfreqs_outer * beam_outer))));
+                        const int outputi_offset =
+                            out_ntimes_chunk * out_nfreqs_chunk
+                            * (freq_packet
+                               + out_nfreqs_packet
+                                     * (beam_packet
+                                        + out_nbeams_packet
+                                              * (time_outer
+                                                 + out_ntimes_outer
+                                                       * (freq_outer
+                                                          + out_nfreqs_outer * beam_outer))));
+
+                        cpu_quantize8_chunk(input + input_offset, outputf + outputf_offset,
+                                            outputi + outputi_offset);
+                    }
+                }
             }
         }
     }
 }
 
 void gpu_quantize8(const __half* __restrict__ const input, __half* __restrict__ const outputf,
-                   std::uint8_t* __restrict__ const outputi, const int input_size1,
-                   const int input_size2, const int input_size3, const int input_stride2,
-                   const int input_stride3, const int outputf_size1, const int outputf_size2,
-                   const int outputf_size3, const int outputf_stride2, const int outputf_stride3,
-                   const int outputi_size1, const int outputi_size2, const int outputi_size3,
-                   const int outputi_stride2, const int outputi_stride3, cudaStream_t stream) {
+                   std::uint8_t* __restrict__ const outputi, cudaStream_t stream) {
     assert(input);
     assert(outputf);
     assert(outputi);
 
-    assert(input_size1 >= 0);
-    assert(input_size2 >= 0);
-    assert(input_size3 >= 0);
-    assert(input_stride2 >= 0);
-    assert(input_stride3 >= 0);
-    assert(outputf_size1 >= 0);
-    assert(outputf_size2 >= 0);
-    assert(outputf_size3 >= 0);
-    assert(outputf_stride2 >= 0);
-    assert(outputf_stride3 >= 0);
-    assert(outputi_size1 >= 0);
-    assert(outputi_size2 >= 0);
-    assert(outputi_size3 >= 0);
-    assert(outputi_stride2 >= 0);
-    assert(outputi_stride3 >= 0);
-    static_assert(chunk_size > 0);
-    static_assert(nchunks > 0);
-
-    assert(input_size1 % chunk_size == 0);
-    assert(input_size3 % nchunks == 0);
-
-    assert(outputf_size1 == 2 * input_size1 / chunk_size);
-    assert(outputf_size2 == input_size2);
-    assert(outputf_size3 == input_size3);
-    assert(outputi_size1 == input_size1);
-    assert(outputi_size2 == input_size2);
-    assert(outputi_size3 == input_size3);
-
+    dim3 nthreads;
+    nthreads.x = nchunks;
+    nthreads.y = 1;
+    nthreads.z = 1;
     dim3 nblocks;
-    nblocks.x = input_size1 / chunk_size;
-    nblocks.y = input_size2;
-    nblocks.z = input_size3 / nchunks;
+    nblocks.x = out_ntimes_outer;
+    nblocks.y = out_nfreqs_packet * out_nfreqs_outer;
+    nblocks.z = out_nbeams_packet * out_nbeams_outer / nchunks;
     const int shmem_nbytes = 0;
-    gpu_quantize8_chunks<<<nblocks, nthreads, shmem_nbytes, stream>>>(
-        input, outputf, outputi, input_size1, input_size2, input_size3, input_stride2,
-        input_stride3, outputf_size1, outputf_size2, outputf_size3, outputf_stride2,
-        outputf_stride3, outputi_size1, outputi_size2, outputi_size3, outputi_stride2,
-        outputi_stride3);
+
+    gpu_quantize8_chunks<<<nblocks, nthreads, shmem_nbytes, stream>>>(input, outputf, outputi);
 }

--- a/lib/cuda/cudaQuantizeKernel8.cu
+++ b/lib/cuda/cudaQuantizeKernel8.cu
@@ -226,13 +226,12 @@ gpu_quantize8_chunks(const __half* __restrict__ const input0, __half* __restrict
         __half inv_scaleh = __float2half_rn(inv_scale);
 
         // Avoid non-finite numbers
-        using std::isfinite;
         if (!isfinite(__half2float(offseth)) || !isfinite(__half2float(scaleh))) {
             // Offset or scale are non-finite
             offseth = __float2half_rn(0.0f);
             scaleh = __float2half_rn(0.0f);
-            inv_offseth = __float2half_rn(inv_offset);
-            inv_scaleh = __float2half_rn(inv_scale);
+            inv_offseth = __float2half_rn(0.0f);
+            inv_scaleh = __float2half_rn(0.0f);
         } else if (!isfinite(__half2float(inv_offseth)) || !isfinite(__half2float(inv_scaleh))) {
             // Offset and scale are fine, but the inverse scale is non-finite. This means the scale
             // is too close to zero.

--- a/lib/cuda/cudaQuantizeKernel8.hpp
+++ b/lib/cuda/cudaQuantizeKernel8.hpp
@@ -1,3 +1,6 @@
+// 8-bit FRB beam quantizer for CHIME, using the float16 FRB beamformer and CHIME's
+// sending-to-Bonsai network format
+
 #ifndef CUDA_QUANTIZE_KERNEL_8_HPP
 #define CUDA_QUANTIZE_KERNEL_8_HPP
 
@@ -6,17 +9,9 @@
 #include <cstdint>
 #include <cuda_runtime.h>
 
-void cpu_quantize8(const float16_t* input, float16_t* outputf, std::uint8_t* outputi,
-                   int input_size1, int input_size2, int input_size3, int input_stride2,
-                   int input_stride3, int outputf_size1, int outputf_size2, int outputf_size3,
-                   int outputf_stride2, int outputf_stride3, int outputi_size1, int outputi_size2,
-                   int outputi_size3, int outputi_stride2, int outputi_stride3);
+void cpu_quantize8(const float16_t* input, float16_t* outputf, std::uint8_t* outputi);
 
 void gpu_quantize8(const float16_t* input, float16_t* outputf, std::uint8_t* outputi,
-                   int input_size1, int input_size2, int input_size3, int input_stride2,
-                   int input_stride3, int outputf_size1, int outputf_size2, int outputf_size3,
-                   int outputf_stride2, int outputf_stride3, int outputi_size1, int outputi_size2,
-                   int outputi_size3, int outputi_stride2, int outputi_stride3,
                    cudaStream_t stream);
 
 #endif // #ifndef CUDA_QUANTIZE_KERNEL_8_HPP

--- a/lib/cuda/cudaQuantizeKernel8.hpp
+++ b/lib/cuda/cudaQuantizeKernel8.hpp
@@ -6,11 +6,11 @@
 #include <cstdint>
 #include <cuda_runtime.h>
 
-void cpu_quantize8(const __half* input, __half* outputf, std::uint8_t* outputi, int input_size1,
-                   int input_size2, int input_size3, int input_stride2, int input_stride3,
-                   int outputf_size1, int outputf_size2, int outputf_size3, int outputf_stride2,
-                   int outputf_stride3, int outputi_size1, int outputi_size2, int outputi_size3,
-                   int outputi_stride2, int outputi_stride3);
+void cpu_quantize8(const float16_t* input, float16_t* outputf, std::uint8_t* outputi,
+                   int input_size1, int input_size2, int input_size3, int input_stride2,
+                   int input_stride3, int outputf_size1, int outputf_size2, int outputf_size3,
+                   int outputf_stride2, int outputf_stride3, int outputi_size1, int outputi_size2,
+                   int outputi_size3, int outputi_stride2, int outputi_stride3);
 
 void gpu_quantize8(const float16_t* input, float16_t* outputf, std::uint8_t* outputi,
                    int input_size1, int input_size2, int input_size3, int input_stride2,

--- a/lib/cuda/cudaQuantizeKernel8Chime.cu
+++ b/lib/cuda/cudaQuantizeKernel8Chime.cu
@@ -1,0 +1,405 @@
+#include "DataType.hpp"
+#include "cudaQuantizeKernel8Chime.hpp"
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Global constants
+
+// Input array layout
+static constexpr int in_ntimes = 256;
+static constexpr int in_nfreqs = 256; // 16 coarse channels, upchannelized by 16
+static constexpr int in_nbeams = 1024;
+
+// Output array layout
+// The output is quantized in "chunks". Each chunk has a different offset and scale.
+static constexpr int out_ntimes_chunk = 16;
+static constexpr int out_nfreqs_chunk = 16;
+// Chunks are combined into packets.
+static constexpr int out_nfreqs_packet = 4;
+static constexpr int out_nbeams_packet = 8;
+// There are several packets.
+static constexpr int out_ntimes_outer = 16;
+static constexpr int out_nfreqs_outer = 4;
+static constexpr int out_nbeams_outer = 128;
+
+static_assert(out_ntimes_chunk * out_ntimes_outer == in_ntimes);
+static_assert(out_nfreqs_chunk * out_nfreqs_packet * out_nfreqs_outer == in_nfreqs);
+static_assert(out_nbeams_packet * out_nbeams_outer == in_nbeams);
+
+// For efficiency we proceess several chunks at once on the GPU.
+static constexpr int nchunks = 32;
+
+static_assert(out_nbeams_outer % nchunks == 0);
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Helper types and functions
+
+// Load 4 `float` values from memory simultaneously. This is more efficient than loading each
+// `float` separately.
+__device__ static inline float4 load_float4(const float* __restrict__ const ptr) {
+    return *reinterpret_cast<const float4*>(ptr);
+}
+
+// Calculate the maximum but do not ignore not-a-numbers
+__device__ __host__ static inline float sane_fmax(const float x, const float y) {
+    using std::fmax, std::isnan;
+    if (isnan(x) || isnan(y))
+        return 0.0f / 0.0f;
+    return fmax(x, y);
+}
+
+// Calculate the minimum but do not ignore not-a-numbers
+__device__ __host__ static inline float sane_fmin(const float x, const float y) {
+    using std::fmin, std::isnan;
+    if (isnan(x) || isnan(y))
+        return 0.0f / 0.0f;
+    return fmin(x, y);
+}
+
+// Round to nearest integer, avoiding all the implementation-defined cases
+__device__ __host__ static inline int sane_lrint(const float x) {
+    using std::isnan, std::lrint;
+    if (x < INT_MIN)
+        return INT_MIN;
+    if (x > INT_MAX)
+        return INT_MAX;
+    if (isnan(x))
+        return 0; // we could mask to 0 instead
+    return int(lrint(x));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Kernels (called by the drivers below)
+
+// Quantize a "chunk". This is a CPU implementation that is
+// straightforward and thus "obviously correct". If the GPU version
+// produces a different result, then the GPU version is wrong.
+void cpu_quantize8chime_chunk(const float* __restrict__ const input,
+                              __half* __restrict__ const outputf,
+                              std::uint8_t* __restrict__ const outputi) {
+    using std::isfinite, std::max, std::min;
+
+    // Find the minimum and maximum of all input values.
+    float minval = +1.0f / 0.0f, maxval = -1.0f / 0.0f;
+    for (int freq = 0; freq < out_nfreqs_chunk; ++freq) {
+        for (int time = 0; time < out_ntimes_chunk; ++time) {
+            const int in_ind = time + in_ntimes * freq;
+            const float x = input[in_ind];
+            minval = sane_fmin(minval, x);
+            maxval = sane_fmax(maxval, x);
+        }
+    }
+    // Calculate offset and scale. Ensure the scale is nonzero.
+    // There are 254 possible uint8 values since we don't use 0 or 255.
+    // Values are reconstructed as `offset + scale * n`, with `uint8 n`.
+    constexpr int outi_min = 1;
+    constexpr int outi_max = 254;
+    constexpr float outf_min = outi_min - 0.5f;
+    constexpr float outf_max = outi_max + 0.5f;
+    // We want this mapping:
+    //     minval => outf_min
+    //     maxval => outf_max
+    const float outf_range = outf_max - outf_min;
+    const float in_range = maxval - minval;
+
+    float scale = in_range / outf_range;
+    float offset = minval - outf_min * scale;
+    __half offseth = __float2half(offset);
+    __half scaleh = __float2half(scale);
+
+    // Avoid non-finite numbers
+    if (!isfinite(__half2float(offseth)) || !isfinite(__half2float(scaleh))) {
+        offset = 0.0f;
+        scale = 0.0f;
+        offseth = __float2half(offset);
+        scaleh = __float2half(scale);
+    }
+
+    // Store offset and scale in the output array
+    outputf[0] = __float2half(offset);
+    outputf[1] = __float2half(scale);
+
+    // We encode values as unsigned 8-bit integers.
+    for (int freq = 0; freq < out_nfreqs_chunk; ++freq) {
+        for (int time = 0; time < out_ntimes_chunk; ++time) {
+            const int in_ind = time + in_ntimes * freq;
+            const int out_ind = time + out_ntimes_chunk * freq;
+            // Get value
+            const float x = input[in_ind];
+            // Scale
+            const float y = (x - offset) / scale;
+            // Round
+            const int j = sane_lrint(y);
+            // Clamp; use 0 for nan
+            const int k = isnan(y) ? 0 : max(outi_min, min(outi_max, j));
+            // Store
+            outputi[out_ind] = k;
+        }
+    }
+}
+
+// Quantize a set of "chunk"s. This is an efficient GPU implementation.
+__global__ void gpu_quantize8chime_chunks(const float* __restrict__ const input,
+                                          __half* __restrict__ const outputf,
+                                          std::uint8_t* __restrict__ const outputi) {
+    using std::isfinite, std::max, std::min;
+
+    // Find our position in the arrays
+    const int thread = threadIdx.x;
+    const int time_outer = blockIdx.x;
+    const int freq_packet = blockIdx.y % out_nfreqs_packet;
+    const int freq_outer = blockIdx.y / out_nfreqs_packet;
+    const int beam_packet = blockIdx.z % out_nbeams_packet;
+    const int beam_outer0 = nchunks * (blockIdx.z / out_nbeams_packet); // not adding threadIdx.x
+
+    // Calculate input indices
+    const auto time = [&](int time_chunk, int time_outer) {
+        return time_chunk + out_ntimes_chunk * time_outer;
+    };
+    const auto freq = [&](int freq_chunk, int freq_packet, int freq_outer) {
+        return freq_chunk + out_nfreqs_chunk * (freq_packet + out_nfreqs_packet * freq_outer);
+    };
+    const auto beam = [&](int beam_packet, int beam_outer) {
+        return beam_packet + out_nbeams_packet * beam_outer;
+    };
+
+    const auto input_offset = [&](int time, int freq, int beam) {
+        return time + in_ntimes * (freq + in_nfreqs * beam);
+    };
+
+    // Calculate output indices
+    const auto outputf_offset = [&](int freq_packet, int beam_packet, int time_outer,
+                                    int freq_outer, int beam_outer) {
+        return freq_packet
+               + out_nfreqs_packet
+                     * (beam_packet
+                        + out_nbeams_packet
+                              * (time_outer
+                                 + out_ntimes_outer
+                                       * (freq_outer + out_nfreqs_outer * beam_outer)));
+    };
+    const auto outputi_offset = [&](int time_chunk, int freq_chunk, int freq_packet,
+                                    int beam_packet, int time_outer, int freq_outer,
+                                    int beam_outer) {
+        return time_chunk
+               + out_ntimes_chunk
+                     * (freq_chunk
+                        + out_nfreqs_chunk
+                              * outputf_offset(freq_packet, beam_packet, time_outer, freq_outer,
+                                               beam_outer));
+    };
+
+    // We store offset and scale only after finishing the loop over all chunks. Each thread stores
+    // one offset/scale pair.
+    __half2 outf;
+    // Loop over all beams we're handling
+    for (int chunk = 0; chunk < nchunks; ++chunk) {
+        const int beam_outer = beam_outer0 + chunk;
+
+        // Load all values in this chunk. We load all values at once in the beginning.
+        // There are 256 values and 32 threads, so each thread loads 8 values.
+        // We load these 8 values in 2 batches of 4 times each.
+        // We space these batches 4 * 32 = 128 elements apart to be cache-efficient.
+        const int in_time_chunk = 4 * threadIdx.x % 4; // 0...15 in steps of 4
+        const int in_freq_chunk = threadIdx.x / 4;     // 0...7
+        const int input_offset_0123 = input_offset(time(in_time_chunk, time_outer),
+                                                   freq(in_freq_chunk + 0, freq_packet, freq_outer),
+                                                   beam(beam_packet, beam_outer));
+        const int input_offset_4567 = input_offset(time(in_time_chunk, time_outer),
+                                                   freq(in_freq_chunk + 8, freq_packet, freq_outer),
+                                                   beam(beam_packet, beam_outer));
+
+        const float4 xs0123 = load_float4(input + input_offset_0123);
+        const float4 xs4567 = load_float4(input + input_offset_4567);
+        const float x0 = xs0123.x;
+        const float x1 = xs0123.y;
+        const float x2 = xs0123.z;
+        const float x3 = xs0123.w;
+        const float x4 = xs4567.x;
+        const float x5 = xs4567.y;
+        const float x6 = xs4567.z;
+        const float x7 = xs4567.w;
+
+        float minval = sane_fmin(sane_fmin(sane_fmin(x0, x1), sane_fmin(x2, x3)),
+                                 sane_fmin(sane_fmin(x4, x5), sane_fmin(x6, x7)));
+        float maxval = sane_fmax(sane_fmax(sane_fmax(x0, x1), sane_fmax(x2, x3)),
+                                 sane_fmax(sane_fmax(x4, x5), sane_fmax(x6, x7)));
+
+        minval = sane_fmin(minval, __shfl_sync(0xffffffff, minval, thread ^ 0x01));
+        maxval = sane_fmax(maxval, __shfl_sync(0xffffffff, maxval, thread ^ 0x01));
+        minval = sane_fmin(minval, __shfl_sync(0xffffffff, minval, thread ^ 0x02));
+        maxval = sane_fmax(maxval, __shfl_sync(0xffffffff, maxval, thread ^ 0x02));
+        minval = sane_fmin(minval, __shfl_sync(0xffffffff, minval, thread ^ 0x04));
+        maxval = sane_fmax(maxval, __shfl_sync(0xffffffff, maxval, thread ^ 0x04));
+        minval = sane_fmin(minval, __shfl_sync(0xffffffff, minval, thread ^ 0x08));
+        maxval = sane_fmax(maxval, __shfl_sync(0xffffffff, maxval, thread ^ 0x08));
+        minval = sane_fmin(minval, __shfl_sync(0xffffffff, minval, thread ^ 0x10));
+        maxval = sane_fmax(maxval, __shfl_sync(0xffffffff, maxval, thread ^ 0x10));
+
+        constexpr int outi_min = 1;
+        constexpr int outi_max = 254;
+        constexpr float outf_min = outi_min - 0.5f;
+        constexpr float outf_max = outi_max + 0.5f;
+        const float outf_range = outf_max - outf_min;
+        const float in_range = maxval - minval;
+        const float scale = in_range / outf_range;
+        const float offset = minval - outf_min * scale;
+
+        const float inv_offset = -offset / scale;
+        const float inv_scale = 1.0f / scale;
+        __half offseth = __float2half_rn(offset);
+        __half scaleh = __float2half_rn(scale);
+        __half inv_offseth = __float2half_rn(inv_offset);
+        __half inv_scaleh = __float2half_rn(inv_scale);
+
+        // Avoid non-finite numbers
+        if (!isfinite(__half2float(offseth)) || !isfinite(__half2float(scaleh))) {
+            // Offset or scale are non-finite
+            offseth = __float2half_rn(0.0f);
+            scaleh = __float2half_rn(0.0f);
+            inv_offseth = __float2half_rn(0.0f);
+            inv_scaleh = __float2half_rn(0.0f);
+        } else if (!isfinite(__half2float(inv_offseth)) || !isfinite(__half2float(inv_scaleh))) {
+            // Offset and scale are fine, but the inverse scale is non-finite. This means the scale
+            // is too close to zero.
+            scaleh = __float2half_rn(0.0f);
+            inv_offseth = -offseth;
+            inv_scaleh = __float2half_rn(0.0f);
+        }
+
+        if (chunk == thread)
+            outf = {offset, scale};
+
+        const __half2 minh = __half2half2(__int2half_rn(outi_min));
+        const __half2 maxh = __half2half2(__int2half_rn(outi_max));
+        const __half2 inv_offseth2 = __half2half2(inv_offseth);
+        const __half2 inv_scaleh2 = __half2half2(inv_scaleh);
+
+        // Note:
+        //     float2int_rn(+/-0) returns 0.
+        //     float2int_rn(+Inf) returns INT_MAX = 0x7FFFFFFF.
+        //     float2int_rn(-Inf) returns INT_MIN = 0x80000000.
+        //     float2int_rn(NaN)  returns 0.
+        // This is consistent with what we need. There is also no performance penalty.
+
+        const auto half2int = [](const __half x) {
+            // This special case is not necessary since float2int_rn maps nan to 0 anyway
+            // if (__hisnan(x))
+            //     return 0;
+            return __half2int_rn(x);
+        };
+
+        const __half2 x01 = __floats2half2_rn(x0, x1);
+        const __half2 y01 =
+            __hmax2_nan(minh, __hmin2_nan(maxh, __hfma2(x01, inv_scaleh2, inv_offseth2)));
+        const int i0 = half2int(__low2half(y01));
+        const int i1 = half2int(__high2half(y01));
+
+        const __half2 x23 = __floats2half2_rn(x2, x3);
+        const __half2 y23 =
+            __hmax2_nan(minh, __hmin2_nan(maxh, __hfma2(x23, inv_scaleh2, inv_offseth2)));
+        const int i2 = half2int(__low2half(y23));
+        const int i3 = half2int(__high2half(y23));
+
+        const __half2 x45 = __floats2half2_rn(x4, x5);
+        const __half2 y45 =
+            __hmax2_nan(minh, __hmin2_nan(maxh, __hfma2(x45, inv_scaleh2, inv_offseth2)));
+        const int i4 = half2int(__low2half(y45));
+        const int i5 = half2int(__high2half(y45));
+
+        const __half2 x67 = __floats2half2_rn(x6, x7);
+        const __half2 y67 =
+            __hmax2_nan(minh, __hmin2_nan(maxh, __hfma2(x67, inv_scaleh2, inv_offseth2)));
+        const int i6 = half2int(__low2half(y67));
+        const int i7 = half2int(__high2half(y67));
+
+        const std::uint64_t outi = (std::uint64_t(i0) << 0x00) | (std::uint64_t(i1) << 0x08)
+                                   | (std::uint64_t(i2) << 0x10) | (std::uint64_t(i3) << 0x18)
+                                   | (std::uint64_t(i4) << 0x20) | (std::uint64_t(i5) << 0x28)
+                                   | (std::uint64_t(i6) << 0x30) | (std::uint64_t(i7) << 0x38);
+
+        const int out_time_chunk = 8 * (chunk % 2); // 0...15 in steps of 8
+        const int out_freq_chunk = chunk / 2;       // 0...7
+        *(std::uint64_t*)(outputi
+                          + outputi_offset(out_time_chunk, out_freq_chunk, freq_packet, beam_packet,
+                                           time_outer, freq_outer, beam_outer)) = outi;
+    }
+    const int out_beam_outer = beam_outer0 + thread;
+    *((__half2*)outputf
+      + outputf_offset(freq_packet, beam_packet, time_outer, freq_outer, out_beam_outer)) = outf;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Drivers (externally visible)
+
+void cpu_quantize8chime(const float* __restrict__ const input, __half* __restrict__ const outputf,
+                        std::uint8_t* __restrict__ const outputi) {
+    assert(input);
+    assert(outputf);
+    assert(outputi);
+
+    // Loop over all packets
+    for (int beam_outer = 0; beam_outer < out_nbeams_outer; ++beam_outer) {
+        for (int freq_outer = 0; freq_outer < out_nfreqs_outer; ++freq_outer) {
+            for (int time_outer = 0; time_outer < out_ntimes_outer; ++time_outer) {
+
+                // Loop over the chunks in each packets
+                for (int beam_packet = 0; beam_packet < out_nbeams_packet; ++beam_packet) {
+                    for (int freq_packet = 0; freq_packet < out_nfreqs_packet; ++freq_packet) {
+
+                        // Process one chunk
+                        const int time = out_ntimes_chunk * time_outer;
+                        const int freq =
+                            out_nfreqs_chunk * (freq_packet + out_nfreqs_packet * freq_outer);
+                        const int beam = beam_packet + out_nbeams_packet * beam_outer;
+                        const int input_offset = time + in_ntimes * (freq + in_nfreqs * beam);
+
+                        const int outputf_offset =
+                            freq_packet
+                            + out_nfreqs_packet
+                                  * (beam_packet
+                                     + out_nbeams_packet
+                                           * (time_outer
+                                              + out_ntimes_outer
+                                                    * (freq_outer
+                                                       + out_nfreqs_outer * beam_outer)));
+                        const int outputi_offset =
+                            out_ntimes_chunk * out_nfreqs_chunk * outputf_offset;
+
+                        cpu_quantize8chime_chunk(input + input_offset, outputf + outputf_offset,
+                                                 outputi + outputi_offset);
+                    }
+                }
+            }
+        }
+    }
+}
+
+void gpu_quantize8chime(const float* __restrict__ const input, __half* __restrict__ const outputf,
+                        std::uint8_t* __restrict__ const outputi, cudaStream_t stream) {
+    assert(input);
+    assert(outputf);
+    assert(outputi);
+
+    dim3 nthreads;
+    nthreads.x = nchunks;
+    nthreads.y = 1;
+    nthreads.z = 1;
+    dim3 nblocks;
+    nblocks.x = out_ntimes_outer;
+    nblocks.y = out_nfreqs_packet * out_nfreqs_outer;
+    nblocks.z = out_nbeams_packet * out_nbeams_outer / nchunks;
+    const int shmem_nbytes = 0;
+
+    gpu_quantize8chime_chunks<<<nblocks, nthreads, shmem_nbytes, stream>>>(input, outputf, outputi);
+}

--- a/lib/cuda/cudaQuantizeKernel8Chime.cu
+++ b/lib/cuda/cudaQuantizeKernel8Chime.cu
@@ -67,14 +67,16 @@ __device__ __host__ static inline float sane_fmin(const float x, const float y) 
 }
 
 // Round to nearest integer, avoiding all the implementation-defined cases
-__device__ __host__ static inline int sane_lrint(const float x) {
+static int sane_lrint(const float x) {
     using std::isnan, std::lrint;
+    // INT_MIN = -2^31 is exact in float; INT_MAX = 2^31 - 1 rounds up to 2^31
+    // when promoted, so the upper check uses `>=`.
+    if (isnan(x))
+        return 0; // we could mask to -8 instead
     if (x < INT_MIN)
         return INT_MIN;
-    if (x > INT_MAX)
+    if (x >= INT_MAX)
         return INT_MAX;
-    if (isnan(x))
-        return 0; // we could mask to 0 instead
     return int(lrint(x));
 }
 
@@ -100,7 +102,7 @@ void cpu_quantize8chime_chunk(const float* __restrict__ const input,
             maxval = sane_fmax(maxval, x);
         }
     }
-    // Calculate offset and scale. Ensure the scale is nonzero.
+    // Calculate offset and scale.
     // There are 254 possible uint8 values since we don't use 0 or 255.
     // Values are reconstructed as `offset + scale * n`, with `uint8 n`.
     // NaN in the input is represented as `n = 0`.
@@ -112,16 +114,7 @@ void cpu_quantize8chime_chunk(const float* __restrict__ const input,
     //     minval => outf_min
     //     maxval => outf_max
     const float outf_range = outf_max - outf_min;
-    float in_range = maxval - minval;
-    // Ensure that the input range is not too small, which woud lead to an overflow when dividing by
-    // the scale
-    constexpr float min_in_range = 1.0e-6f; // approximately eps(float)
-    if (in_range < min_in_range) {
-        const float avgval = (minval + maxval) / 2;
-        minval = avgval - min_in_range / 2;
-        maxval = avgval + min_in_range / 2;
-        in_range = maxval - minval;
-    }
+    const float in_range = maxval - minval;
 
     float scale = in_range / outf_range;
     float offset = minval - outf_min * scale;
@@ -144,11 +137,11 @@ void cpu_quantize8chime_chunk(const float* __restrict__ const input,
             // Get value
             const float x = input[in_ind];
             // Scale
-            const float y = (x - offset) / scale;
+            const float y = scale == 0 ? float(outi_min + outi_max) / 2.0f : (x - offset) / scale;
             // Round
             const int j = sane_lrint(y);
             // Clamp; use 0 for nan
-            const int k = isnan(y) ? 0 : max(outi_min, min(outi_max, j));
+            const int k = isnan(x) ? 0 : max(outi_min, min(outi_max, j));
             // Store
             outputi[out_ind] = k;
         }
@@ -225,8 +218,8 @@ __global__ void gpu_quantize8chime_chunks(const float* __restrict__ const input,
         // We load these 8 values in 2 batches of 4 times each.
         // We space these batches 4 * 32 = 128 elements apart.
         // (This is not cache-efficient because the frequencies are not adjacent.)
-        const int in_time_chunk = 4 * threadIdx.x % 4; // 0...15 in steps of 4
-        const int in_freq_chunk = threadIdx.x / 4;     // 0...7
+        const int in_time_chunk = 4 * (threadIdx.x % 4); // 0...15 in steps of 4
+        const int in_freq_chunk = threadIdx.x / 4;       // 0...7
         const int input_offset_0123 = input_offset(time(in_time_chunk, time_outer),
                                                    freq(in_freq_chunk + 0, freq_packet, freq_outer),
                                                    beam(beam_packet, beam_outer));
@@ -284,7 +277,7 @@ __global__ void gpu_quantize8chime_chunks(const float* __restrict__ const input,
             // Offset and scale are fine, but the inverse scale is non-finite. This means the scale
             // is too close to zero.
             scale = 0.0f;
-            inv_offset = -offset;
+            inv_offset = 0.0f;
             inv_scale = 0.0f;
         }
 
@@ -301,25 +294,30 @@ __global__ void gpu_quantize8chime_chunks(const float* __restrict__ const input,
             return __float2int_rn(fmaxf(xlo, fminf(xhi, x)));
         };
 
-        const float i0 = clamp_and_convert(fmaf(x0, inv_scale, inv_offset), minf, maxf);
-        const float i1 = clamp_and_convert(fmaf(x1, inv_scale, inv_offset), minf, maxf);
-        const float i2 = clamp_and_convert(fmaf(x2, inv_scale, inv_offset), minf, maxf);
-        const float i3 = clamp_and_convert(fmaf(x3, inv_scale, inv_offset), minf, maxf);
-        const float i4 = clamp_and_convert(fmaf(x4, inv_scale, inv_offset), minf, maxf);
-        const float i5 = clamp_and_convert(fmaf(x5, inv_scale, inv_offset), minf, maxf);
-        const float i6 = clamp_and_convert(fmaf(x6, inv_scale, inv_offset), minf, maxf);
-        const float i7 = clamp_and_convert(fmaf(x7, inv_scale, inv_offset), minf, maxf);
+        const int i0 = clamp_and_convert(fmaf(x0, inv_scale, inv_offset), minf, maxf);
+        const int i1 = clamp_and_convert(fmaf(x1, inv_scale, inv_offset), minf, maxf);
+        const int i2 = clamp_and_convert(fmaf(x2, inv_scale, inv_offset), minf, maxf);
+        const int i3 = clamp_and_convert(fmaf(x3, inv_scale, inv_offset), minf, maxf);
+        const int i4 = clamp_and_convert(fmaf(x4, inv_scale, inv_offset), minf, maxf);
+        const int i5 = clamp_and_convert(fmaf(x5, inv_scale, inv_offset), minf, maxf);
+        const int i6 = clamp_and_convert(fmaf(x6, inv_scale, inv_offset), minf, maxf);
+        const int i7 = clamp_and_convert(fmaf(x7, inv_scale, inv_offset), minf, maxf);
 
-        const std::uint64_t outi = (std::uint64_t(i0) << 0x00) | (std::uint64_t(i1) << 0x08)
-                                   | (std::uint64_t(i2) << 0x10) | (std::uint64_t(i3) << 0x18)
-                                   | (std::uint64_t(i4) << 0x20) | (std::uint64_t(i5) << 0x28)
-                                   | (std::uint64_t(i6) << 0x30) | (std::uint64_t(i7) << 0x38);
-
-        const int out_time_chunk = 8 * (chunk % 2); // 0...15 in steps of 8
-        const int out_freq_chunk = chunk / 2;       // 0...7
-        *(std::uint64_t*)(outputi
-                          + outputi_offset(out_time_chunk, out_freq_chunk, freq_packet, beam_packet,
-                                           time_outer, freq_outer, beam_outer)) = outi;
+        // The thread loaded 4 contiguous times at freq+0 (x0..x3) and 4 contiguous times at
+        // freq+8 (x4..x7), so the encoded bytes span two freqs and need two separate 4-byte
+        // writes — one per freq, at the same (in_time_chunk, in_freq_chunk) tile it loaded.
+        const std::uint32_t outi_lo = std::uint32_t(i0) << 0x00 | std::uint32_t(i1) << 0x08
+                                      | std::uint32_t(i2) << 0x10 | std::uint32_t(i3) << 0x18;
+        const std::uint32_t outi_hi = std::uint32_t(i4) << 0x00 | std::uint32_t(i5) << 0x08
+                                      | std::uint32_t(i6) << 0x10 | std::uint32_t(i7) << 0x18;
+        *(std::uint32_t*)(outputi
+                          + outputi_offset(in_time_chunk, in_freq_chunk + 0, freq_packet,
+                                           beam_packet, time_outer, freq_outer, beam_outer)) =
+            outi_lo;
+        *(std::uint32_t*)(outputi
+                          + outputi_offset(in_time_chunk, in_freq_chunk + 8, freq_packet,
+                                           beam_packet, time_outer, freq_outer, beam_outer)) =
+            outi_hi;
     }
     const int out_beam_outer = beam_outer0 + thread;
     *(float2*)(outputf

--- a/lib/cuda/cudaQuantizeKernel8Chime.cu
+++ b/lib/cuda/cudaQuantizeKernel8Chime.cu
@@ -1,4 +1,6 @@
-#include "DataType.hpp"
+// 8-bit FRB beam quantizer for CHIME, using the chromatic CHIME float32 FRB beamformer and CHIME's
+// sending-to-Bonsai network format
+
 #include "cudaQuantizeKernel8Chime.hpp"
 
 #include <algorithm>
@@ -84,9 +86,9 @@ __device__ __host__ static inline int sane_lrint(const float x) {
 // straightforward and thus "obviously correct". If the GPU version
 // produces a different result, then the GPU version is wrong.
 void cpu_quantize8chime_chunk(const float* __restrict__ const input,
-                              __half* __restrict__ const outputf,
+                              float* __restrict__ const outputf,
                               std::uint8_t* __restrict__ const outputi) {
-    using std::isfinite, std::max, std::min;
+    using std::isfinite, std::isnan, std::max, std::min;
 
     // Find the minimum and maximum of all input values.
     float minval = +1.0f / 0.0f, maxval = -1.0f / 0.0f;
@@ -101,6 +103,7 @@ void cpu_quantize8chime_chunk(const float* __restrict__ const input,
     // Calculate offset and scale. Ensure the scale is nonzero.
     // There are 254 possible uint8 values since we don't use 0 or 255.
     // Values are reconstructed as `offset + scale * n`, with `uint8 n`.
+    // NaN in the input is represented as `n = 0`.
     constexpr int outi_min = 1;
     constexpr int outi_max = 254;
     constexpr float outf_min = outi_min - 0.5f;
@@ -109,24 +112,29 @@ void cpu_quantize8chime_chunk(const float* __restrict__ const input,
     //     minval => outf_min
     //     maxval => outf_max
     const float outf_range = outf_max - outf_min;
-    const float in_range = maxval - minval;
+    float in_range = maxval - minval;
+    // Ensure that the input range is not too small, which woud lead to an overflow when dividing by
+    // the scale
+    constexpr float min_in_range = 1.0e-6f; // approximately eps(float)
+    if (in_range < min_in_range) {
+        const float avgval = (minval + maxval) / 2;
+        minval = avgval - min_in_range / 2;
+        maxval = avgval + min_in_range / 2;
+        in_range = maxval - minval;
+    }
 
     float scale = in_range / outf_range;
     float offset = minval - outf_min * scale;
-    __half offseth = __float2half(offset);
-    __half scaleh = __float2half(scale);
 
     // Avoid non-finite numbers
-    if (!isfinite(__half2float(offseth)) || !isfinite(__half2float(scaleh))) {
+    if (!isfinite(offset) || !isfinite(scale)) {
         offset = 0.0f;
         scale = 0.0f;
-        offseth = __float2half(offset);
-        scaleh = __float2half(scale);
     }
 
     // Store offset and scale in the output array
-    outputf[0] = __float2half(offset);
-    outputf[1] = __float2half(scale);
+    outputf[0] = offset;
+    outputf[1] = scale;
 
     // We encode values as unsigned 8-bit integers.
     for (int freq = 0; freq < out_nfreqs_chunk; ++freq) {
@@ -149,9 +157,9 @@ void cpu_quantize8chime_chunk(const float* __restrict__ const input,
 
 // Quantize a set of "chunk"s. This is an efficient GPU implementation.
 __global__ void gpu_quantize8chime_chunks(const float* __restrict__ const input,
-                                          __half* __restrict__ const outputf,
+                                          float* __restrict__ const outputf,
                                           std::uint8_t* __restrict__ const outputi) {
-    using std::isfinite, std::max, std::min;
+    using std::isfinite;
 
     // Find our position in the arrays
     const int thread = threadIdx.x;
@@ -179,13 +187,14 @@ __global__ void gpu_quantize8chime_chunks(const float* __restrict__ const input,
     // Calculate output indices
     const auto outputf_offset = [&](int freq_packet, int beam_packet, int time_outer,
                                     int freq_outer, int beam_outer) {
-        return freq_packet
-               + out_nfreqs_packet
-                     * (beam_packet
-                        + out_nbeams_packet
-                              * (time_outer
-                                 + out_ntimes_outer
-                                       * (freq_outer + out_nfreqs_outer * beam_outer)));
+        return 2
+               * (freq_packet
+                  + out_nfreqs_packet
+                        * (beam_packet
+                           + out_nbeams_packet
+                                 * (time_outer
+                                    + out_ntimes_outer
+                                          * (freq_outer + out_nfreqs_outer * beam_outer))));
     };
     const auto outputi_offset = [&](int time_chunk, int freq_chunk, int freq_packet,
                                     int beam_packet, int time_outer, int freq_outer,
@@ -194,13 +203,19 @@ __global__ void gpu_quantize8chime_chunks(const float* __restrict__ const input,
                + out_ntimes_chunk
                      * (freq_chunk
                         + out_nfreqs_chunk
-                              * outputf_offset(freq_packet, beam_packet, time_outer, freq_outer,
-                                               beam_outer));
+                              * (freq_packet
+                                 + out_nfreqs_packet
+                                       * (beam_packet
+                                          + out_nbeams_packet
+                                                * (time_outer
+                                                   + out_ntimes_outer
+                                                         * (freq_outer
+                                                            + out_nfreqs_outer * beam_outer)))));
     };
 
     // We store offset and scale only after finishing the loop over all chunks. Each thread stores
     // one offset/scale pair.
-    __half2 outf;
+    float2 outf;
     // Loop over all beams we're handling
     for (int chunk = 0; chunk < nchunks; ++chunk) {
         const int beam_outer = beam_outer0 + chunk;
@@ -208,7 +223,8 @@ __global__ void gpu_quantize8chime_chunks(const float* __restrict__ const input,
         // Load all values in this chunk. We load all values at once in the beginning.
         // There are 256 values and 32 threads, so each thread loads 8 values.
         // We load these 8 values in 2 batches of 4 times each.
-        // We space these batches 4 * 32 = 128 elements apart to be cache-efficient.
+        // We space these batches 4 * 32 = 128 elements apart.
+        // (This is not cache-efficient because the frequencies are not adjacent.)
         const int in_time_chunk = 4 * threadIdx.x % 4; // 0...15 in steps of 4
         const int in_freq_chunk = threadIdx.x / 4;     // 0...7
         const int input_offset_0123 = input_offset(time(in_time_chunk, time_outer),
@@ -251,76 +267,48 @@ __global__ void gpu_quantize8chime_chunks(const float* __restrict__ const input,
         constexpr float outf_max = outi_max + 0.5f;
         const float outf_range = outf_max - outf_min;
         const float in_range = maxval - minval;
-        const float scale = in_range / outf_range;
-        const float offset = minval - outf_min * scale;
+        float scale = in_range / outf_range;
+        float offset = minval - outf_min * scale;
 
-        const float inv_offset = -offset / scale;
-        const float inv_scale = 1.0f / scale;
-        __half offseth = __float2half_rn(offset);
-        __half scaleh = __float2half_rn(scale);
-        __half inv_offseth = __float2half_rn(inv_offset);
-        __half inv_scaleh = __float2half_rn(inv_scale);
+        float inv_offset = -offset / scale;
+        float inv_scale = 1.0f / scale;
 
         // Avoid non-finite numbers
-        if (!isfinite(__half2float(offseth)) || !isfinite(__half2float(scaleh))) {
+        if (!isfinite(offset) || !isfinite(scale)) {
             // Offset or scale are non-finite
-            offseth = __float2half_rn(0.0f);
-            scaleh = __float2half_rn(0.0f);
-            inv_offseth = __float2half_rn(0.0f);
-            inv_scaleh = __float2half_rn(0.0f);
-        } else if (!isfinite(__half2float(inv_offseth)) || !isfinite(__half2float(inv_scaleh))) {
+            offset = 0.0f;
+            scale = 0.0f;
+            inv_offset = 0.0f;
+            inv_scale = 0.0f;
+        } else if (!isfinite(inv_offset) || !isfinite(inv_scale)) {
             // Offset and scale are fine, but the inverse scale is non-finite. This means the scale
             // is too close to zero.
-            scaleh = __float2half_rn(0.0f);
-            inv_offseth = -offseth;
-            inv_scaleh = __float2half_rn(0.0f);
+            scale = 0.0f;
+            inv_offset = -offset;
+            inv_scale = 0.0f;
         }
 
         if (chunk == thread)
             outf = {offset, scale};
 
-        const __half2 minh = __half2half2(__int2half_rn(outi_min));
-        const __half2 maxh = __half2half2(__int2half_rn(outi_max));
-        const __half2 inv_offseth2 = __half2half2(inv_offseth);
-        const __half2 inv_scaleh2 = __half2half2(inv_scaleh);
+        const float minf = outi_min;
+        const float maxf = outi_max;
 
-        // Note:
-        //     float2int_rn(+/-0) returns 0.
-        //     float2int_rn(+Inf) returns INT_MAX = 0x7FFFFFFF.
-        //     float2int_rn(-Inf) returns INT_MIN = 0x80000000.
-        //     float2int_rn(NaN)  returns 0.
-        // This is consistent with what we need. There is also no performance penalty.
-
-        const auto half2int = [](const __half x) {
-            // This special case is not necessary since float2int_rn maps nan to 0 anyway
-            // if (__hisnan(x))
-            //     return 0;
-            return __half2int_rn(x);
+        // Clamp, then convert to int. Map nan to 0.
+        const auto clamp_and_convert = [](const float x, const float xlo, const float xhi) {
+            if (isnan(x) || isnan(xlo) || isnan(xhi))
+                return 0;
+            return __float2int_rn(fmaxf(xlo, fminf(xhi, x)));
         };
 
-        const __half2 x01 = __floats2half2_rn(x0, x1);
-        const __half2 y01 =
-            __hmax2_nan(minh, __hmin2_nan(maxh, __hfma2(x01, inv_scaleh2, inv_offseth2)));
-        const int i0 = half2int(__low2half(y01));
-        const int i1 = half2int(__high2half(y01));
-
-        const __half2 x23 = __floats2half2_rn(x2, x3);
-        const __half2 y23 =
-            __hmax2_nan(minh, __hmin2_nan(maxh, __hfma2(x23, inv_scaleh2, inv_offseth2)));
-        const int i2 = half2int(__low2half(y23));
-        const int i3 = half2int(__high2half(y23));
-
-        const __half2 x45 = __floats2half2_rn(x4, x5);
-        const __half2 y45 =
-            __hmax2_nan(minh, __hmin2_nan(maxh, __hfma2(x45, inv_scaleh2, inv_offseth2)));
-        const int i4 = half2int(__low2half(y45));
-        const int i5 = half2int(__high2half(y45));
-
-        const __half2 x67 = __floats2half2_rn(x6, x7);
-        const __half2 y67 =
-            __hmax2_nan(minh, __hmin2_nan(maxh, __hfma2(x67, inv_scaleh2, inv_offseth2)));
-        const int i6 = half2int(__low2half(y67));
-        const int i7 = half2int(__high2half(y67));
+        const float i0 = clamp_and_convert(fmaf(x0, inv_scale, inv_offset), minf, maxf);
+        const float i1 = clamp_and_convert(fmaf(x1, inv_scale, inv_offset), minf, maxf);
+        const float i2 = clamp_and_convert(fmaf(x2, inv_scale, inv_offset), minf, maxf);
+        const float i3 = clamp_and_convert(fmaf(x3, inv_scale, inv_offset), minf, maxf);
+        const float i4 = clamp_and_convert(fmaf(x4, inv_scale, inv_offset), minf, maxf);
+        const float i5 = clamp_and_convert(fmaf(x5, inv_scale, inv_offset), minf, maxf);
+        const float i6 = clamp_and_convert(fmaf(x6, inv_scale, inv_offset), minf, maxf);
+        const float i7 = clamp_and_convert(fmaf(x7, inv_scale, inv_offset), minf, maxf);
 
         const std::uint64_t outi = (std::uint64_t(i0) << 0x00) | (std::uint64_t(i1) << 0x08)
                                    | (std::uint64_t(i2) << 0x10) | (std::uint64_t(i3) << 0x18)
@@ -334,15 +322,16 @@ __global__ void gpu_quantize8chime_chunks(const float* __restrict__ const input,
                                            time_outer, freq_outer, beam_outer)) = outi;
     }
     const int out_beam_outer = beam_outer0 + thread;
-    *((__half2*)outputf
-      + outputf_offset(freq_packet, beam_packet, time_outer, freq_outer, out_beam_outer)) = outf;
+    *(float2*)(outputf
+               + outputf_offset(freq_packet, beam_packet, time_outer, freq_outer, out_beam_outer)) =
+        outf;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 // Drivers (externally visible)
 
-void cpu_quantize8chime(const float* __restrict__ const input, __half* __restrict__ const outputf,
+void cpu_quantize8chime(const float* __restrict__ const input, float* __restrict__ const outputf,
                         std::uint8_t* __restrict__ const outputi) {
     assert(input);
     assert(outputf);
@@ -365,16 +354,25 @@ void cpu_quantize8chime(const float* __restrict__ const input, __half* __restric
                         const int input_offset = time + in_ntimes * (freq + in_nfreqs * beam);
 
                         const int outputf_offset =
-                            freq_packet
-                            + out_nfreqs_packet
-                                  * (beam_packet
-                                     + out_nbeams_packet
-                                           * (time_outer
-                                              + out_ntimes_outer
-                                                    * (freq_outer
-                                                       + out_nfreqs_outer * beam_outer)));
+                            2
+                            * (freq_packet
+                               + out_nfreqs_packet
+                                     * (beam_packet
+                                        + out_nbeams_packet
+                                              * (time_outer
+                                                 + out_ntimes_outer
+                                                       * (freq_outer
+                                                          + out_nfreqs_outer * beam_outer))));
                         const int outputi_offset =
-                            out_ntimes_chunk * out_nfreqs_chunk * outputf_offset;
+                            out_ntimes_chunk * out_nfreqs_chunk
+                            * (freq_packet
+                               + out_nfreqs_packet
+                                     * (beam_packet
+                                        + out_nbeams_packet
+                                              * (time_outer
+                                                 + out_ntimes_outer
+                                                       * (freq_outer
+                                                          + out_nfreqs_outer * beam_outer))));
 
                         cpu_quantize8chime_chunk(input + input_offset, outputf + outputf_offset,
                                                  outputi + outputi_offset);
@@ -385,7 +383,7 @@ void cpu_quantize8chime(const float* __restrict__ const input, __half* __restric
     }
 }
 
-void gpu_quantize8chime(const float* __restrict__ const input, __half* __restrict__ const outputf,
+void gpu_quantize8chime(const float* __restrict__ const input, float* __restrict__ const outputf,
                         std::uint8_t* __restrict__ const outputi, cudaStream_t stream) {
     assert(input);
     assert(outputf);

--- a/lib/cuda/cudaQuantizeKernel8Chime.hpp
+++ b/lib/cuda/cudaQuantizeKernel8Chime.hpp
@@ -1,14 +1,15 @@
+// 8-bit FRB beam quantizer for CHIME, using the chromatic CHIME float32 FRB beamformer and CHIME's
+// sending-to-Bonsai network format
+
 #ifndef CUDA_QUANTIZE_KERNEL_8_CHIME_HPP
 #define CUDA_QUANTIZE_KERNEL_8_CHIME_HPP
-
-#include "DataType.hpp"
 
 #include <cstdint>
 #include <cuda_runtime.h>
 
-void cpu_quantize8chime(const float* input, float16_t* outputf, std::uint8_t* outputi);
+void cpu_quantize8chime(const float* input, float* outputf, std::uint8_t* outputi);
 
-void gpu_quantize8chime(const float* input, float16_t* outputf, std::uint8_t* outputi,
+void gpu_quantize8chime(const float* input, float* outputf, std::uint8_t* outputi,
                         cudaStream_t stream);
 
 #endif // #ifndef CUDA_QUANTIZE_KERNEL_8_CHIME_HPP

--- a/lib/cuda/cudaQuantizeKernel8Chime.hpp
+++ b/lib/cuda/cudaQuantizeKernel8Chime.hpp
@@ -1,0 +1,14 @@
+#ifndef CUDA_QUANTIZE_KERNEL_8_CHIME_HPP
+#define CUDA_QUANTIZE_KERNEL_8_CHIME_HPP
+
+#include "DataType.hpp"
+
+#include <cstdint>
+#include <cuda_runtime.h>
+
+void cpu_quantize8chime(const float* input, float16_t* outputf, std::uint8_t* outputi);
+
+void gpu_quantize8chime(const float* input, float16_t* outputf, std::uint8_t* outputi,
+                        cudaStream_t stream);
+
+#endif // #ifndef CUDA_QUANTIZE_KERNEL_8_CHIME_HPP

--- a/lib/cuda/testQuantizeKernel4.cpp
+++ b/lib/cuda/testQuantizeKernel4.cpp
@@ -1,3 +1,5 @@
+// Test 4-bit FRB beam quantizer for CHORD
+
 #include <algorithm>                // for fill, fill_n
 #include <cassert>                  // for assert
 #include <cfloat>                   // for FLT_MAX

--- a/lib/cuda/testQuantizeKernel4.cpp
+++ b/lib/cuda/testQuantizeKernel4.cpp
@@ -75,13 +75,13 @@ public:
                 case 5:
                     return 0.5f * x + 0.5f * x * x * x + 10 * (time % 23 == 0);
                 case 6:
-                    return 10000.0f * time; // large but not infinity
+                    return 1000.0f * time; // large but not infinity
                 case 7:
-                    return 100000.0f * time; // some values are infinity
+                    return 10000.0f * time; // some values are infinity
                 case 8:
-                    return time / 10000.0f; // small, but 1/x is less than infinity
+                    return time / 1000.0f; // small, but 1/x is less than infinity
                 case 9:
-                    return time / 100000.0f; // small, and some 1/x are infinity
+                    return time / 10000.0f; // small, and some 1/x are infinity
                 case 10:
                     return 0.5f * x + 0.5f * x * x * x + (time % 23 == 0 ? 0.0f / 0.0f : 0.0f);
             }
@@ -208,7 +208,8 @@ public:
                                 // Handle non-finite inputs
                                 if (may_overflow && offset == 0.0f && scale == 0.0f)
                                     isgood = true;
-                                if (scale_may_collapse && scale == 0.0f)
+                                if (scale_may_collapse && scale == 0.0f && i != -8
+                                    && !isnan(expected_x))
                                     isgood = true;
                                 if (!isgood)
                                     FATAL_ERROR("Found inaccurate value: "

--- a/lib/cuda/testQuantizeKernel8.cpp
+++ b/lib/cuda/testQuantizeKernel8.cpp
@@ -1,3 +1,6 @@
+// Test 8-bit FRB beam quantizer for CHIME, using the float16 FRB beamformer and CHIME's
+// sending-to-Bonsai network format
+
 #include <algorithm>                // for fill, fill_n
 #include <cassert>                  // for assert
 #include <cfloat>                   // for FLT_MAX
@@ -39,29 +42,136 @@ public:
 
         const float epsilon = 1.0e-3; // We're using float16
 
-        const int chunk_size = 256;
+        // Input array layout
+        const int in_ntimes = 256;
+        const int in_nfreqs = 256; // 16 coarse channels, upchannelized by 16
+        const int in_nbeams = 1024;
 
-        const int ntimes = 512;
-        const int nfreqs = 32;
-        const int nbeams = 64;
+        // Output array layout
+        // The output is quantized in "chunks". Each chunk has a different offset and scale.
+        const int out_ntimes_chunk = 16;
+        const int out_nfreqs_chunk = 16;
+        // Chunks are combined into packets.
+        const int out_nfreqs_packet = 4;
+        const int out_nbeams_packet = 8;
+        // There are several packets.
+        const int out_ntimes_outer = 16;
+        const int out_nfreqs_outer = 4;
+        const int out_nbeams_outer = 128;
+
+        static_assert(out_ntimes_chunk * out_ntimes_outer == in_ntimes);
+        static_assert(out_nfreqs_chunk * out_nfreqs_packet * out_nfreqs_outer == in_nfreqs);
+        static_assert(out_nbeams_packet * out_nbeams_outer == in_nbeams);
 
         ////////////////////////////////////////////////////////////////////////////////
 
         // layout: input[beam, freq, time]
-        std::vector<float16_t> input(ntimes * nfreqs * nbeams);
-        assert(ntimes % chunk_size == 0);
-        const int nchunks = ntimes / chunk_size;
-        std::vector<float16_t> offsetscale(2 * nchunks * nfreqs * nbeams);
-        std::vector<std::uint8_t> beams(ntimes * nfreqs * nbeams);
+        std::vector<float16_t> input(in_nbeams * in_nfreqs * in_ntimes);
+        const auto inputat = [&](int beam, int freq, int time) -> float16_t& {
+            assert(0 <= beam && beam < in_nbeams);
+            assert(0 <= freq && freq < in_nfreqs);
+            assert(0 <= time && time < in_ntimes);
+            return input.at(time + in_ntimes * (freq + in_nfreqs * beam));
+        };
+        std::fill(input.begin(), input.end(), 1);
+        for (int beam = 0; beam < in_nbeams; ++beam)
+            for (int freq = 0; freq < in_nfreqs; ++freq)
+                for (int time = 0; time < in_ntimes; ++time)
+                    inputat(beam, freq, time) = 0;
+        if (std::find(input.begin(), input.end(), float16_t(1)) != input.end())
+            FATAL_ERROR("input array indexing error");
+
+        // layout: offsetscale[out_nbeams_outer, out_nfreqs_outer, out_ntimes_outer,
+        //                     out_nbeams_packet, out_nfreqs_packet]
+        std::vector<float16_t> offsetscale(2 * out_nbeams_outer * out_nfreqs_outer
+                                           * out_ntimes_outer * out_nbeams_packet
+                                           * out_nfreqs_packet);
+        const auto offsetscaleat = [&](int beam_outer, int freq_outer, int time_outer,
+                                       int beam_packet, int freq_packet, int offsca) -> float16_t& {
+            assert(0 <= beam_outer && beam_outer < out_nbeams_outer);
+            assert(0 <= freq_outer && freq_outer < out_nfreqs_outer);
+            assert(0 <= time_outer && time_outer < out_ntimes_outer);
+            assert(0 <= beam_packet && beam_packet < out_nbeams_packet);
+            assert(0 <= freq_packet && freq_packet < out_nfreqs_packet);
+            assert(0 <= offsca && offsca < 2);
+            return offsetscale.at(
+                offsca
+                + 2
+                      * (freq_packet
+                         + out_nfreqs_packet
+                               * (beam_packet
+                                  + out_nbeams_packet
+                                        * (time_outer
+                                           + out_ntimes_outer
+                                                 * (freq_outer + out_nfreqs_outer * beam_outer)))));
+        };
+        std::fill(offsetscale.begin(), offsetscale.end(), 1);
+        for (int beam_outer = 0; beam_outer < out_nbeams_outer; ++beam_outer)
+            for (int freq_outer = 0; freq_outer < out_nfreqs_outer; ++freq_outer)
+                for (int time_outer = 0; time_outer < out_ntimes_outer; ++time_outer)
+                    for (int beam_packet = 0; beam_packet < out_nbeams_packet; ++beam_packet)
+                        for (int freq_packet = 0; freq_packet < out_nfreqs_packet; ++freq_packet) {
+                            offsetscaleat(beam_outer, freq_outer, time_outer, beam_packet,
+                                          freq_packet, 0) = 0;
+                            offsetscaleat(beam_outer, freq_outer, time_outer, beam_packet,
+                                          freq_packet, 1) = 0;
+                        }
+        if (std::find(offsetscale.begin(), offsetscale.end(), float16_t(1)) != offsetscale.end())
+            FATAL_ERROR("offsetscale array indexing error");
+
+        // layout: beams[out_nbeams_outer, out_nfreqs_outer, out_ntimes_outer,
+        //               out_nbeams_packet, out_nfreqs_packet,
+        //               out_nfreqs_chunk, out_ntimes_chunk]
+        std::vector<std::uint8_t> beams(out_nbeams_outer * out_nfreqs_outer * out_ntimes_outer
+                                        * out_nbeams_packet * out_nfreqs_packet * out_nfreqs_chunk
+                                        * out_ntimes_chunk);
+        const auto beamsat = [&](int beam_outer, int freq_outer, int time_outer, int beam_packet,
+                                 int freq_packet, int freq_chunk, int time_chunk) -> std::uint8_t& {
+            assert(0 <= beam_outer && beam_outer < out_nbeams_outer);
+            assert(0 <= freq_outer && freq_outer < out_nfreqs_outer);
+            assert(0 <= time_outer && time_outer < out_ntimes_outer);
+            assert(0 <= beam_packet && beam_packet < out_nbeams_packet);
+            assert(0 <= freq_packet && freq_packet < out_nfreqs_packet);
+            assert(0 <= freq_chunk && freq_chunk < out_nfreqs_chunk);
+            assert(0 <= time_chunk && time_chunk < out_ntimes_chunk);
+            return beams.at(
+                time_chunk
+                + out_ntimes_chunk
+                      * (freq_chunk
+                         + out_nfreqs_chunk
+                               * (freq_packet
+                                  + out_nfreqs_packet
+                                        * (beam_packet
+                                           + out_nbeams_packet
+                                                 * (time_outer
+                                                    + out_ntimes_outer
+                                                          * (freq_outer
+                                                             + out_nfreqs_outer * beam_outer))))));
+        };
+        std::fill(beams.begin(), beams.end(), 1);
+        for (int beam_outer = 0; beam_outer < out_nbeams_outer; ++beam_outer)
+            for (int freq_outer = 0; freq_outer < out_nfreqs_outer; ++freq_outer)
+                for (int time_outer = 0; time_outer < out_ntimes_outer; ++time_outer)
+                    for (int beam_packet = 0; beam_packet < out_nbeams_packet; ++beam_packet)
+                        for (int freq_packet = 0; freq_packet < out_nfreqs_packet; ++freq_packet)
+                            for (int freq_chunk = 0; freq_chunk < out_nfreqs_chunk; ++freq_chunk)
+                                for (int time_chunk = 0; time_chunk < out_ntimes_chunk;
+                                     ++time_chunk)
+                                    beamsat(beam_outer, freq_outer, time_outer, beam_packet,
+                                            freq_packet, freq_chunk, time_chunk) = 0;
+        if (std::find(beams.begin(), beams.end(), 1) != beams.end())
+            FATAL_ERROR("beams array indexing error");
+
+        ////////////////////////////////////////////////////////////////////////////////
 
         // Invent some data
         const auto f = [&](const int beam, const int freq, const int time) -> float {
-            const float x = (time + 0.5) / ntimes;
+            const float x = (time + 0.5) / in_ntimes;
             switch ((beam + freq) % 11) {
                 case 0:
                     return 0.0f;
                 case 1:
-                    return 0.1f * beam;
+                    return 0.1f * (beam % 64);
                 case 2:
                     return time % 2;
                 case 3:
@@ -71,29 +181,27 @@ public:
                 case 5:
                     return 0.5f * x + 0.5f * x * x * x + 10 * (time % 23 == 0);
                 case 6:
-                    return 10000.0f * time; // large but not infinity
+                    return 10000.0f * (time % 512); // large but not infinity
                 case 7:
-                    return 100000.0f * time; // some values are infinity
+                    return 100000.0f * (time % 512); // some values are infinity
                 case 8:
-                    return time / 10000.0f; // small, but 1/x is less than infinity
+                    return (time % 512) / 10000.0f; // small, but 1/x is less than infinity
                 case 9:
-                    return time / 100000.0f; // small, and some 1/x are infinity
+                    return (time % 512) / 100000.0f; // small, and some 1/x are infinity
                 case 10:
                     return 0.5f * x + 0.5f * x * x * x + (time % 23 == 0 ? 0.0f / 0.0f : 0.0f);
             }
             std::abort();
         };
 
-
         ////////////////////////////////////////////////////////////////////////////////
 
         // Set input
-        for (int beam = 0; beam < nbeams; ++beam) {
-            for (int freq = 0; freq < nfreqs; ++freq) {
-                for (int time = 0; time < ntimes; ++time) {
-                    const float x = f(beam, freq, time % chunk_size);
-                    const int idx = time + ntimes * (freq + nfreqs * beam);
-                    input.at(idx) = float16_t(x);
+        for (int beam = 0; beam < in_nbeams; ++beam) {
+            for (int freq = 0; freq < in_nfreqs; ++freq) {
+                for (int time = 0; time < in_ntimes; ++time) {
+                    const float x = f(beam, freq, time);
+                    inputat(beam, freq, time) = float16_t(x);
                 }
             }
         }
@@ -102,112 +210,148 @@ public:
         const auto check_result = [&]() {
             using std::fabs, std::fmin, std::fmax, std::isfinite, std::isnan;
 
-            for (int beam = 0; beam < nbeams; ++beam) {
-                for (int freq = 0; freq < nfreqs; ++freq) {
+            // We love ourselves a good indentation
+            for (int beam_outer = 0; beam_outer < out_nbeams_outer; ++beam_outer) {
+                for (int freq_outer = 0; freq_outer < out_nfreqs_outer; ++freq_outer) {
+                    for (int time_outer = 0; time_outer < out_ntimes_outer; ++time_outer) {
+                        for (int beam_packet = 0; beam_packet < out_nbeams_packet; ++beam_packet) {
+                            for (int freq_packet = 0; freq_packet < out_nfreqs_packet;
+                                 ++freq_packet) {
+                                const int beam = beam_packet + out_nbeams_packet * beam_outer;
 
-                    // Calculate expected result
-                    //
-                    // When comparing to the expected result, two things can go wrong:
-                    // 1. The scale can be zero, or can be close to zero (`scale_may_collapse`)
-                    // 2. The input can contain large numbers, or infinities, or not-a-numbers
-                    //    (`may_overflow`)
-                    //
-                    // We need to handle both cases, and we need to be lenient when comparing when
-                    // this happens. For example, there might be an overflow on the GPU, but not in
-                    // the CPU implementation. This should not be flagged as error.
-                    float minval = +FLT_MAX, maxval = -FLT_MAX;
-                    bool may_overflow = false;
-                    for (int time = 0; time < chunk_size; ++time) {
-                        const float x = f(beam, freq, time);
-                        minval = isnan(minval) || isnan(x) ? 0.0f / 0.0f : fmin(minval, x);
-                        maxval = isnan(maxval) || isnan(x) ? 0.0f / 0.0f : fmax(maxval, x);
-                        // Allow the respective float16 calculations to overflow
-                        may_overflow |= !isfinite(x) || fabs(x) >= 2048.0f;
-                    }
-                    may_overflow |= !isfinite(minval) || fabs(minval) >= 2048.0f
-                                    || !isfinite(maxval) || fabs(maxval) >= 2048.0f;
-                    // Allow the scale to be inaccurate when all inputs are close together
-                    const bool scale_may_collapse = fabs(maxval - minval) < 10 * epsilon;
-                    const int uint8_range = 254; // avoid 0 and 255
-                    float expected_scale = (maxval - minval) / uint8_range;
-                    float expected_offset = minval - 0.5f * expected_scale;
-                    if (!isfinite(expected_offset) || !isfinite(expected_scale)) {
-                        may_overflow = true;
-                        expected_offset = 0.0f;
-                        expected_scale = 0.0f;
-                    }
+                                // Calculate expected result
+                                //
+                                // When comparing to the expected result, two things can go wrong:
+                                // 1. The scale can be zero, or can be close to zero
+                                //    (`scale_may_collapse`)
+                                // 2. The input can contain large numbers, or infinities, or
+                                //    not-a-numbers (`may_overflow`)
+                                //
+                                // We need to handle both cases, and we need to be lenient when
+                                // comparing when this happens. For example, there might be an
+                                // overflow on the GPU, but not in the CPU implementation. This
+                                // should not be flagged as error.
+                                float minval = +FLT_MAX, maxval = -FLT_MAX;
+                                bool may_overflow = false;
+                                for (int freq_chunk = 0; freq_chunk < out_nfreqs_chunk;
+                                     ++freq_chunk) {
+                                    for (int time_chunk = 0; time_chunk < out_ntimes_chunk;
+                                         ++time_chunk) {
+                                        const int freq =
+                                            freq_chunk
+                                            + out_nfreqs_chunk
+                                                  * (freq_packet + out_nfreqs_packet * freq_outer);
+                                        const int time = time_chunk + out_ntimes_chunk * time_outer;
+                                        const float x = f(beam, freq, time);
+                                        minval = isnan(minval) || isnan(x) ? 0.0f / 0.0f
+                                                                           : fmin(minval, x);
+                                        maxval = isnan(maxval) || isnan(x) ? 0.0f / 0.0f
+                                                                           : fmax(maxval, x);
+                                        // Allow the respective float16 calculations to overflow
+                                        may_overflow |= !isfinite(x) || fabs(x) >= 2048.0f;
+                                    }
+                                }
+                                may_overflow |= !isfinite(minval) || fabs(minval) >= 2048.0f
+                                                || !isfinite(maxval) || fabs(maxval) >= 2048.0f;
+                                // Allow the scale to be inaccurate when all inputs are close
+                                // together
+                                const bool scale_may_collapse =
+                                    fabs(maxval - minval) < 10 * epsilon;
+                                const int uint8_range = 254; // avoid 0 and 255
+                                float expected_scale = (maxval - minval) / uint8_range;
+                                float expected_offset = minval - 0.5f * expected_scale;
+                                if (!isfinite(expected_offset) || !isfinite(expected_scale)) {
+                                    may_overflow = true;
+                                    expected_offset = 0.0f;
+                                    expected_scale = 0.0f;
+                                }
 
-                    for (int chunk = 0; chunk < nchunks; ++chunk) {
-                        const float offset =
-                            offsetscale.at(2 * chunk + 2 * nchunks * (freq + nfreqs * beam) + 0);
-                        const float scale =
-                            offsetscale.at(2 * chunk + 2 * nchunks * (freq + nfreqs * beam) + 1);
-                        if (!isfinite(offset))
-                            FATAL_ERROR("Found non-finite offset {}", offset);
-                        if (!isfinite(scale))
-                            FATAL_ERROR("Found non-finite scale {}", scale);
+                                const float offset =
+                                    offsetscaleat(beam_outer, freq_outer, time_outer, beam_packet,
+                                                  freq_packet, 0);
+                                const float scale =
+                                    offsetscaleat(beam_outer, freq_outer, time_outer, beam_packet,
+                                                  freq_packet, 1);
+                                if (!isfinite(offset))
+                                    FATAL_ERROR("Found non-finite offset {}", offset);
 
-                        // Check relative error of offset
-                        bool offset_is_good =
-                            fabs(offset - expected_offset)
-                            <= epsilon * fmax(1.0f, fmax(fabs(offset), fabs(expected_offset)));
-                        // If we think an overflow is allowed, and if the other implementation might
-                        // have detected one (offset=0), then all is fine as well
-                        if (may_overflow && scale == 0.0f && offset == 0.0f)
-                            offset_is_good = true;
-                        if (!offset_is_good)
-                            FATAL_ERROR("Found inaccurate offset: beam {}, want {}, have {}, "
-                                        "scale_may_collapse={}",
-                                        beam, expected_offset, offset, scale_may_collapse);
+                                // Check relative error of offset
+                                bool offset_is_good =
+                                    fabs(offset - expected_offset)
+                                    <= epsilon
+                                           * fmax(1.0f, fmax(fabs(offset), fabs(expected_offset)));
+                                // If we think an overflow is allowed, and if the other
+                                // implementation might have detected one (offset=0), then
+                                // all is fine as well
+                                if (may_overflow && scale == 0.0f && offset == 0.0f)
+                                    offset_is_good = true;
+                                if (!offset_is_good)
+                                    FATAL_ERROR("Found inaccurate offset: beam {}, want {}, have "
+                                                "{}, scale_may_collapse={}",
+                                                beam, expected_offset, offset, scale_may_collapse);
 
-                        // Check absolute error of scale
-                        bool scale_is_good = fabs(scale - expected_scale) <= epsilon;
-                        // If the scale is close to zero then don't worry about the scale at all
-                        if (scale_may_collapse)
-                            scale_is_good = true;
-                        // If we think an overflow is allowed, and if the other implementation might
-                        // have detected one (scale=0, offset=0), then all is fine as well
-                        if (may_overflow && scale == 0.0f && offset == 0.0f)
-                            scale_is_good = true;
-                        if (!scale_is_good)
-                            FATAL_ERROR("Found inaccurate scale: beam{}, want {}, have {}, "
-                                        "scale_may_collapse={}",
-                                        beam, expected_scale, scale, scale_may_collapse);
+                                // Check absolute error of scale
+                                bool scale_is_good = fabs(scale - expected_scale) <= epsilon;
+                                // If the scale is close to zero then don't worry about the
+                                // scale at all
+                                if (scale_may_collapse)
+                                    scale_is_good = true;
+                                // If we think an overflow is allowed, and if the other
+                                // implementation might have detected one (scale=0,
+                                // offset=0), then all is fine as well
+                                if (may_overflow && scale == 0.0f && offset == 0.0f)
+                                    scale_is_good = true;
+                                if (!scale_is_good)
+                                    FATAL_ERROR("Found inaccurate scale: beam{}, want {}, have {}, "
+                                                "scale_may_collapse={}",
+                                                beam, expected_scale, scale, scale_may_collapse);
 
-                        for (int time = chunk * chunk_size; time < (chunk + 1) * chunk_size;
-                             ++time) {
-                            const int idx = time + ntimes * (freq + nfreqs * beam);
-                            const float expected_x = input.at(idx);
+                                for (int freq_chunk = 0; freq_chunk < out_nfreqs_chunk;
+                                     ++freq_chunk) {
+                                    for (int time_chunk = 0; time_chunk < out_ntimes_chunk;
+                                         ++time_chunk) {
+                                        const int freq =
+                                            freq_chunk
+                                            + out_nfreqs_chunk
+                                                  * (freq_packet + out_nfreqs_packet * freq_outer);
+                                        const int time = time_chunk + out_ntimes_chunk * time_outer;
+                                        const float expected_x = inputat(beam, freq, time);
 
-                            const std::uint8_t i = beams.at(time + ntimes * (freq + nfreqs * beam));
-                            if (i == 255)
-                                FATAL_ERROR("Unexpected value {}", i);
-                            const float x = i == 0 ? 0.0f / 0.0f : offset + scale * i;
+                                        const std::uint8_t i =
+                                            beamsat(beam_outer, freq_outer, time_outer, beam_packet,
+                                                    freq_packet, freq_chunk, time_chunk);
+                                        if (i == 255)
+                                            FATAL_ERROR("Unexpected value {}", i);
+                                        const float x = i == 0 ? 0.0f / 0.0f : offset + scale * i;
 
-                            bool isgood = false;
+                                        bool isgood = false;
 
-                            // Allow the value to be clamped
-                            if (i == 0 && isnan(x))
-                                isgood = true;
-                            if (i == 1 && x > expected_x)
-                                isgood = true;
-                            if (i == 254 && x < expected_x)
-                                isgood = true;
-                            // The value should differ by no more than scale/2
-                            isgood |=
-                                fabs(x - expected_x) <= fmax(scale, expected_scale) / 2 + epsilon;
-                            // Handle non-finite inputs
-                            if (may_overflow && offset == 0.0f && scale == 0.0f)
-                                isgood = true;
-                            if (scale_may_collapse && scale == 0.0f)
-                                isgood = true;
-                            if (!isgood)
-                                FATAL_ERROR("Found inaccurate value: beam {}, time {}, want {}, "
-                                            "have {}, offset {}, "
-                                            "scale {}, may_overflow={}, scale_may_collapse={}, "
-                                            "expected_offset={}, expected_scale={}",
-                                            beam, time, expected_x, x, offset, scale, may_overflow,
-                                            scale_may_collapse, expected_offset, expected_scale);
+                                        // Allow the value to be clamped
+                                        if (i == 0 && isnan(x))
+                                            isgood = true;
+                                        if (i == 1 && x > expected_x)
+                                            isgood = true;
+                                        if (i == 254 && x < expected_x)
+                                            isgood = true;
+                                        // The value should differ by no more than scale/2
+                                        isgood |= fabs(x - expected_x)
+                                                  <= fmax(scale, expected_scale) / 2 + epsilon;
+                                        // Handle non-finite inputs
+                                        if (may_overflow && offset == 0.0f && scale == 0.0f)
+                                            isgood = true;
+                                        if (scale_may_collapse && scale == 0.0f)
+                                            isgood = true;
+                                        if (!isgood)
+                                            FATAL_ERROR("Found inaccurate value: beam {}, time {}, "
+                                                        "want {}, have {}, offset {}, scale {}, "
+                                                        "may_overflow={}, scale_may_collapse={}, "
+                                                        "expected_offset={}, expected_scale={}",
+                                                        beam, time, expected_x, x, offset, scale,
+                                                        may_overflow, scale_may_collapse,
+                                                        expected_offset, expected_scale);
+                                    }
+                                }
+                            }
                         }
                     }
                 }
@@ -222,11 +366,7 @@ public:
 
         // Quantize on the CPU
         INFO("Testing on CPU...");
-        cpu_quantize8(input.data(), offsetscale.data(), beams.data(),                 //
-                      ntimes, nfreqs, nbeams, ntimes, ntimes * nfreqs,                //
-                      2 * nchunks, nfreqs, nbeams, 2 * nchunks, 2 * nchunks * nfreqs, //
-                      ntimes, nfreqs, nbeams, ntimes, ntimes * nfreqs                 //
-        );
+        cpu_quantize8(input.data(), offsetscale.data(), beams.data());
 
         // Check CPU result
         check_result();
@@ -257,12 +397,7 @@ public:
 
         // Quantize on the GPU
         INFO("Testing on GPU...");
-        gpu_quantize8(gpu_input, gpu_offsetscale, gpu_beams,                          //
-                      ntimes, nfreqs, nbeams, ntimes, ntimes * nfreqs,                //
-                      2 * nchunks, nfreqs, nbeams, 2 * nchunks, 2 * nchunks * nfreqs, //
-                      ntimes, nfreqs, nbeams, ntimes, ntimes * nfreqs,                //
-                      nullptr                                                         //
-        );
+        gpu_quantize8(gpu_input, gpu_offsetscale, gpu_beams, nullptr);
 
         // Copy output from GPU
         CHECK_CUDA_ERROR(cudaMemcpy(offsetscale.data(), gpu_offsetscale,

--- a/lib/cuda/testQuantizeKernel8.cpp
+++ b/lib/cuda/testQuantizeKernel8.cpp
@@ -38,7 +38,7 @@ public:
 
     void main_thread() override {
         const float16_t fpoison(0.0f / 0.0f);
-        const std::uint8_t ipoison(0);
+        const std::uint8_t ipoison(255);
 
         const float epsilon = 1.0e-3; // We're using float16
 
@@ -181,13 +181,13 @@ public:
                 case 5:
                     return 0.5f * x + 0.5f * x * x * x + 10 * (time % 23 == 0);
                 case 6:
-                    return 10000.0f * (time % 512); // large but not infinity
+                    return 1000.0f * (time % 512); // large but not infinity
                 case 7:
-                    return 100000.0f * (time % 512); // some values are infinity
+                    return 10000.0f * (time % 512); // some values are infinity
                 case 8:
-                    return (time % 512) / 10000.0f; // small, but 1/x is less than infinity
+                    return (time % 512) / 1000.0f; // small, but 1/x is less than infinity
                 case 9:
-                    return (time % 512) / 100000.0f; // small, and some 1/x are infinity
+                    return (time % 512) / 10000.0f; // small, and some 1/x are infinity
                 case 10:
                     return 0.5f * x + 0.5f * x * x * x + (time % 23 == 0 ? 0.0f / 0.0f : 0.0f);
             }
@@ -327,7 +327,7 @@ public:
                                         bool isgood = false;
 
                                         // Allow the value to be clamped
-                                        if (i == 0 && isnan(x))
+                                        if (i == 0 && isnan(expected_x))
                                             isgood = true;
                                         if (i == 1 && x > expected_x)
                                             isgood = true;
@@ -339,7 +339,8 @@ public:
                                         // Handle non-finite inputs
                                         if (may_overflow && offset == 0.0f && scale == 0.0f)
                                             isgood = true;
-                                        if (scale_may_collapse && scale == 0.0f)
+                                        if (scale_may_collapse && scale == 0.0f && i != 0
+                                            && !isnan(expected_x))
                                             isgood = true;
                                         if (!isgood)
                                             FATAL_ERROR("Found inaccurate value: beam {}, time {}, "

--- a/lib/cuda/testQuantizeKernel8Chime.cpp
+++ b/lib/cuda/testQuantizeKernel8Chime.cpp
@@ -1,5 +1,7 @@
+// Test 8-bit FRB beam quantizer for CHIME,
+// using the chromatic CHIME float32 FRB beamformer and CHIME's sending-to-Bonsai network format
+
 #include "Config.hpp"
-#include "DataType.hpp"
 #include "Stage.hpp"
 #include "StageFactory.hpp"
 #include "bufferContainer.hpp"
@@ -31,29 +33,135 @@ public:
 
         const float epsilon = 1.0e-6; // We're using float
 
-        const int chunk_size = 256;
+        // Input array layout
+        const int in_ntimes = 256;
+        const int in_nfreqs = 256; // 16 coarse channels, upchannelized by 16
+        const int in_nbeams = 1024;
 
-        const int ntimes = 512;
-        const int nfreqs = 256;
-        const int nbeams = 1024;
+        // Output array layout
+        // The output is quantized in "chunks". Each chunk has a different offset and scale.
+        const int out_ntimes_chunk = 16;
+        const int out_nfreqs_chunk = 16;
+        // Chunks are combined into packets.
+        const int out_nfreqs_packet = 4;
+        const int out_nbeams_packet = 8;
+        // There are several packets.
+        const int out_ntimes_outer = 16;
+        const int out_nfreqs_outer = 4;
+        const int out_nbeams_outer = 128;
+
+        static_assert(out_ntimes_chunk * out_ntimes_outer == in_ntimes);
+        static_assert(out_nfreqs_chunk * out_nfreqs_packet * out_nfreqs_outer == in_nfreqs);
+        static_assert(out_nbeams_packet * out_nbeams_outer == in_nbeams);
 
         ////////////////////////////////////////////////////////////////////////////////
 
         // layout: input[beam, freq, time]
-        std::vector<float> input(ntimes * nfreqs * nbeams);
-        assert(ntimes % chunk_size == 0);
-        const int nchunks = ntimes / chunk_size;
-        std::vector<float16_t> offsetscale(2 * nchunks * nfreqs * nbeams);
-        std::vector<std::uint8_t> beams(ntimes * nfreqs * nbeams);
+        std::vector<float> input(in_nbeams * in_nfreqs * in_ntimes);
+        const auto inputat = [&](int beam, int freq, int time) -> float& {
+            assert(0 <= beam && beam < in_nbeams);
+            assert(0 <= freq && freq < in_nfreqs);
+            assert(0 <= time && time < in_ntimes);
+            return input.at(time + in_ntimes * (freq + in_nfreqs * beam));
+        };
+        std::fill(input.begin(), input.end(), 1.0f);
+        for (int beam = 0; beam < in_nbeams; ++beam)
+            for (int freq = 0; freq < in_nfreqs; ++freq)
+                for (int time = 0; time < in_ntimes; ++time)
+                    inputat(beam, freq, time) = 0;
+        if (std::find(input.begin(), input.end(), 1.0f) != input.end())
+            FATAL_ERROR("input array indexing error");
+
+        // layout: offsetscale[out_nbeams_outer, out_nfreqs_outer, out_ntimes_outer,
+        //                     out_nbeams_packet, out_nfreqs_packet]
+        std::vector<float> offsetscale(2 * out_nbeams_outer * out_nfreqs_outer * out_ntimes_outer
+                                       * out_nbeams_packet * out_nfreqs_packet);
+        const auto offsetscaleat = [&](int beam_outer, int freq_outer, int time_outer,
+                                       int beam_packet, int freq_packet, int offsca) -> float& {
+            assert(0 <= beam_outer && beam_outer < out_nbeams_outer);
+            assert(0 <= freq_outer && freq_outer < out_nfreqs_outer);
+            assert(0 <= time_outer && time_outer < out_ntimes_outer);
+            assert(0 <= beam_packet && beam_packet < out_nbeams_packet);
+            assert(0 <= freq_packet && freq_packet < out_nfreqs_packet);
+            assert(0 <= offsca && offsca < 2);
+            return offsetscale.at(
+                offsca
+                + 2
+                      * (freq_packet
+                         + out_nfreqs_packet
+                               * (beam_packet
+                                  + out_nbeams_packet
+                                        * (time_outer
+                                           + out_ntimes_outer
+                                                 * (freq_outer + out_nfreqs_outer * beam_outer)))));
+        };
+        std::fill(offsetscale.begin(), offsetscale.end(), 1.0f);
+        for (int beam_outer = 0; beam_outer < out_nbeams_outer; ++beam_outer)
+            for (int freq_outer = 0; freq_outer < out_nfreqs_outer; ++freq_outer)
+                for (int time_outer = 0; time_outer < out_ntimes_outer; ++time_outer)
+                    for (int beam_packet = 0; beam_packet < out_nbeams_packet; ++beam_packet)
+                        for (int freq_packet = 0; freq_packet < out_nfreqs_packet; ++freq_packet) {
+                            offsetscaleat(beam_outer, freq_outer, time_outer, beam_packet,
+                                          freq_packet, 0) = 0;
+                            offsetscaleat(beam_outer, freq_outer, time_outer, beam_packet,
+                                          freq_packet, 1) = 0;
+                        }
+        if (std::find(offsetscale.begin(), offsetscale.end(), 1.0f) != offsetscale.end())
+            FATAL_ERROR("offsetscale array indexing error");
+
+        // layout: beams[out_nbeams_outer, out_nfreqs_outer, out_ntimes_outer,
+        //               out_nbeams_packet, out_nfreqs_packet,
+        //               out_nfreqs_chunk, out_ntimes_chunk]
+        std::vector<std::uint8_t> beams(out_nbeams_outer * out_nfreqs_outer * out_ntimes_outer
+                                        * out_nbeams_packet * out_nfreqs_packet * out_nfreqs_chunk
+                                        * out_ntimes_chunk);
+        const auto beamsat = [&](int beam_outer, int freq_outer, int time_outer, int beam_packet,
+                                 int freq_packet, int freq_chunk, int time_chunk) -> std::uint8_t& {
+            assert(0 <= beam_outer && beam_outer < out_nbeams_outer);
+            assert(0 <= freq_outer && freq_outer < out_nfreqs_outer);
+            assert(0 <= time_outer && time_outer < out_ntimes_outer);
+            assert(0 <= beam_packet && beam_packet < out_nbeams_packet);
+            assert(0 <= freq_packet && freq_packet < out_nfreqs_packet);
+            assert(0 <= freq_chunk && freq_chunk < out_nfreqs_chunk);
+            assert(0 <= time_chunk && time_chunk < out_ntimes_chunk);
+            return beams.at(
+                time_chunk
+                + out_ntimes_chunk
+                      * (freq_chunk
+                         + out_nfreqs_chunk
+                               * (freq_packet
+                                  + out_nfreqs_packet
+                                        * (beam_packet
+                                           + out_nbeams_packet
+                                                 * (time_outer
+                                                    + out_ntimes_outer
+                                                          * (freq_outer
+                                                             + out_nfreqs_outer * beam_outer))))));
+        };
+        std::fill(beams.begin(), beams.end(), 1);
+        for (int beam_outer = 0; beam_outer < out_nbeams_outer; ++beam_outer)
+            for (int freq_outer = 0; freq_outer < out_nfreqs_outer; ++freq_outer)
+                for (int time_outer = 0; time_outer < out_ntimes_outer; ++time_outer)
+                    for (int beam_packet = 0; beam_packet < out_nbeams_packet; ++beam_packet)
+                        for (int freq_packet = 0; freq_packet < out_nfreqs_packet; ++freq_packet)
+                            for (int freq_chunk = 0; freq_chunk < out_nfreqs_chunk; ++freq_chunk)
+                                for (int time_chunk = 0; time_chunk < out_ntimes_chunk;
+                                     ++time_chunk)
+                                    beamsat(beam_outer, freq_outer, time_outer, beam_packet,
+                                            freq_packet, freq_chunk, time_chunk) = 0;
+        if (std::find(beams.begin(), beams.end(), 1) != beams.end())
+            FATAL_ERROR("beams array indexing error");
+
+        ////////////////////////////////////////////////////////////////////////////////
 
         // Invent some data
         const auto f = [&](const int beam, const int freq, const int time) -> float {
-            const float x = (time + 0.5) / ntimes;
+            const float x = (time + 0.5) / in_ntimes;
             switch ((beam + freq) % 11) {
                 case 0:
                     return 0.0f;
                 case 1:
-                    return 0.1f * beam;
+                    return 0.1f * (beam % 64);
                 case 2:
                     return time % 2;
                 case 3:
@@ -63,29 +171,27 @@ public:
                 case 5:
                     return 0.5f * x + 0.5f * x * x * x + 10 * (time % 23 == 0);
                 case 6:
-                    return 10000.0f * time; // large but not infinity
+                    return 10000.0f * (time % 512); // large but not infinity
                 case 7:
-                    return 100000.0f * time; // some values are infinity
+                    return 100000.0f * (time % 512); // some values are infinity
                 case 8:
-                    return time / 10000.0f; // small, but 1/x is less than infinity
+                    return (time % 512) / 10000.0f; // small, but 1/x is less than infinity
                 case 9:
-                    return time / 100000.0f; // small, and some 1/x are infinity
+                    return (time % 512) / 100000.0f; // small, and some 1/x are infinity
                 case 10:
                     return 0.5f * x + 0.5f * x * x * x + (time % 23 == 0 ? 0.0f / 0.0f : 0.0f);
             }
             std::abort();
         };
 
-
         ////////////////////////////////////////////////////////////////////////////////
 
         // Set input
-        for (int beam = 0; beam < nbeams; ++beam) {
-            for (int freq = 0; freq < nfreqs; ++freq) {
-                for (int time = 0; time < ntimes; ++time) {
-                    const float x = f(beam, freq, time % chunk_size);
-                    const int idx = time + ntimes * (freq + nfreqs * beam);
-                    input.at(idx) = float(x);
+        for (int beam = 0; beam < in_nbeams; ++beam) {
+            for (int freq = 0; freq < in_nfreqs; ++freq) {
+                for (int time = 0; time < in_ntimes; ++time) {
+                    const float x = f(beam, freq, time);
+                    inputat(beam, freq, time) = x;
                 }
             }
         }
@@ -94,112 +200,161 @@ public:
         const auto check_result = [&]() {
             using std::fabs, std::fmin, std::fmax, std::isfinite, std::isnan, std::sqrt;
 
-            for (int beam = 0; beam < nbeams; ++beam) {
-                for (int freq = 0; freq < nfreqs; ++freq) {
+            // We love ourselves a good indentation
+            for (int beam_outer = 0; beam_outer < out_nbeams_outer; ++beam_outer) {
+                for (int freq_outer = 0; freq_outer < out_nfreqs_outer; ++freq_outer) {
+                    for (int time_outer = 0; time_outer < out_ntimes_outer; ++time_outer) {
+                        for (int beam_packet = 0; beam_packet < out_nbeams_packet; ++beam_packet) {
+                            for (int freq_packet = 0; freq_packet < out_nfreqs_packet;
+                                 ++freq_packet) {
+                                const int beam = beam_packet + out_nbeams_packet * beam_outer;
 
-                    // Calculate expected result
-                    //
-                    // When comparing to the expected result, two things can go wrong:
-                    // 1. The scale can be zero, or can be close to zero (`scale_may_collapse`)
-                    // 2. The input can contain large numbers, or infinities, or not-a-numbers
-                    //    (`may_overflow`)
-                    //
-                    // We need to handle both cases, and we need to be lenient when comparing when
-                    // this happens. For example, there might be an overflow on the GPU, but not in
-                    // the CPU implementation. This should not be flagged as error.
-                    float minval = +FLT_MAX, maxval = -FLT_MAX;
-                    bool may_overflow = false;
-                    for (int time = 0; time < chunk_size; ++time) {
-                        const float x = f(beam, freq, time);
-                        minval = isnan(minval) || isnan(x) ? 0.0f / 0.0f : fmin(minval, x);
-                        maxval = isnan(maxval) || isnan(x) ? 0.0f / 0.0f : fmax(maxval, x);
-                        // Allow the respective float16 calculations to overflow
-                        may_overflow |= !isfinite(x) || fabs(x) >= 2048.0f;
-                    }
-                    may_overflow |= !isfinite(minval) || fabs(minval) >= 2048.0f
-                                    || !isfinite(maxval) || fabs(maxval) >= 2048.0f;
-                    // Allow the scale to be inaccurate when all inputs are close together
-                    const bool scale_may_collapse = fabs(maxval - minval) < 10 * epsilon;
-                    const int uint8_range = 254; // avoid 0 and 255
-                    float expected_scale = (maxval - minval) / uint8_range;
-                    float expected_offset = minval - 0.5f * expected_scale;
-                    if (!isfinite(expected_offset) || !isfinite(expected_scale)) {
-                        may_overflow = true;
-                        expected_offset = 0.0f;
-                        expected_scale = 0.0f;
-                    }
+                                // Calculate expected result
+                                //
+                                // When comparing to the expected result, two things can go wrong:
+                                // 1. The scale can be zero, or can be close to zero
+                                //    (`scale_may_collapse`)
+                                // 2. The input can contain large numbers, or infinities, or
+                                //    not-a-numbers (`may_overflow`)
+                                //
+                                // We need to handle both cases, and we need to be lenient when
+                                // comparing when this happens. For example, there might be an
+                                // overflow on the GPU, but not in the CPU implementation. This
+                                // should not be flagged as error.
+                                float minval = +FLT_MAX, maxval = -FLT_MAX;
+                                bool may_overflow = false;
+                                for (int freq_chunk = 0; freq_chunk < out_nfreqs_chunk;
+                                     ++freq_chunk) {
+                                    for (int time_chunk = 0; time_chunk < out_ntimes_chunk;
+                                         ++time_chunk) {
+                                        const int freq =
+                                            freq_chunk
+                                            + out_nfreqs_chunk
+                                                  * (freq_packet + out_nfreqs_packet * freq_outer);
+                                        const int time = time_chunk + out_ntimes_chunk * time_outer;
+                                        const float x = f(beam, freq, time);
+                                        minval = isnan(minval) || isnan(x) ? 0.0f / 0.0f
+                                                                           : fmin(minval, x);
+                                        maxval = isnan(maxval) || isnan(x) ? 0.0f / 0.0f
+                                                                           : fmax(maxval, x);
+                                        // Allow the calculations to overflow
+                                        may_overflow |= !isfinite(x);
+                                    }
+                                }
+                                may_overflow |= !isfinite(minval) || !isfinite(maxval);
+                                // Allow the scale to be inaccurate when all inputs are close
+                                // together
+                                const bool scale_may_collapse =
+                                    fabs(maxval - minval) < 10 * epsilon;
+                                const int uint8_range = 254; // avoid 0 and 255
+                                float expected_scale = (maxval - minval) / uint8_range;
+                                float expected_offset = minval - 0.5f * expected_scale;
+                                if (!isfinite(expected_offset) || !isfinite(expected_scale)) {
+                                    may_overflow = true;
+                                    expected_offset = 0.0f;
+                                    expected_scale = 0.0f;
+                                }
 
-                    for (int chunk = 0; chunk < nchunks; ++chunk) {
-                        const float offset =
-                            offsetscale.at(2 * chunk + 2 * nchunks * (freq + nfreqs * beam) + 0);
-                        const float scale =
-                            offsetscale.at(2 * chunk + 2 * nchunks * (freq + nfreqs * beam) + 1);
-                        if (!isfinite(offset))
-                            FATAL_ERROR("Found non-finite offset {}", offset);
-                        if (!isfinite(scale))
-                            FATAL_ERROR("Found non-finite scale {}", scale);
+                                const float offset =
+                                    offsetscaleat(beam_outer, freq_outer, time_outer, beam_packet,
+                                                  freq_packet, 0);
+                                const float scale =
+                                    offsetscaleat(beam_outer, freq_outer, time_outer, beam_packet,
+                                                  freq_packet, 1);
+                                if (!isfinite(offset))
+                                    FATAL_ERROR("Found non-finite offset {}", offset);
 
-                        // Check relative error of offset
-                        bool offset_is_good =
-                            fabs(offset - expected_offset)
-                            <= epsilon * fmax(1.0f, fmax(fabs(offset), fabs(expected_offset)));
-                        // If we think an overflow is allowed, and if the other implementation might
-                        // have detected one (offset=0), then all is fine as well
-                        if (may_overflow && scale == 0.0f && offset == 0.0f)
-                            offset_is_good = true;
-                        if (!offset_is_good)
-                            FATAL_ERROR("Found inaccurate offset: beam {}, want {}, have {}, "
-                                        "scale_may_collapse={}",
-                                        beam, expected_offset, offset, scale_may_collapse);
+                                // Check relative error of offset
+                                bool offset_is_good =
+                                    fabs(offset - expected_offset)
+                                    <= epsilon
+                                           * fmax(1.0f, fmax(fabs(offset), fabs(expected_offset)));
+                                // If we think an overflow is allowed, and if the other
+                                // implementation might have detected one (offset=0), then
+                                // all is fine as well
+                                if (may_overflow && scale == 0.0f && offset == 0.0f)
+                                    offset_is_good = true;
+                                if (!offset_is_good) {
+                                    const int freq0 =
+                                        out_nfreqs_chunk
+                                        * (freq_packet + out_nfreqs_packet * freq_outer);
+                                    const int time0 = out_ntimes_chunk * time_outer;
+                                    FATAL_ERROR(
+                                        "Found inaccurate offset: beam {}, freq0 {}, time0 {}, "
+                                        "want {}, have {}, scale_may_collapse={}",
+                                        beam, freq0, time0, expected_offset, offset,
+                                        scale_may_collapse);
+                                }
 
-                        // Check absolute error of scale
-                        bool scale_is_good = fabs(scale - expected_scale) <= epsilon;
-                        // If the scale is close to zero then don't worry about the scale at all
-                        if (scale_may_collapse)
-                            scale_is_good = true;
-                        // If we think an overflow is allowed, and if the other implementation might
-                        // have detected one (scale=0, offset=0), then all is fine as well
-                        if (may_overflow && scale == 0.0f && offset == 0.0f)
-                            scale_is_good = true;
-                        if (!scale_is_good)
-                            FATAL_ERROR("Found inaccurate scale: beam{}, want {}, have {}, "
-                                        "scale_may_collapse={}",
-                                        beam, expected_scale, scale, scale_may_collapse);
+                                // Check absolute error of scale
+                                bool scale_is_good = fabs(scale - expected_scale) <= epsilon;
+                                // If the scale is close to zero then don't worry about the
+                                // scale at all
+                                if (scale_may_collapse)
+                                    scale_is_good = true;
+                                // If we think an overflow is allowed, and if the other
+                                // implementation might have detected one (scale=0,
+                                // offset=0), then all is fine as well
+                                if (may_overflow && scale == 0.0f && offset == 0.0f)
+                                    scale_is_good = true;
+                                if (!scale_is_good) {
+                                    const int freq0 =
+                                        out_nfreqs_chunk
+                                        * (freq_packet + out_nfreqs_packet * freq_outer);
+                                    const int time0 = out_ntimes_chunk * time_outer;
+                                    FATAL_ERROR(
+                                        "Found inaccurate scale: beam {}, freq0 {}, time0 {}, "
+                                        "want {}, have {}, scale_may_collapse={}",
+                                        beam, freq0, time0, expected_scale, scale,
+                                        scale_may_collapse);
+                                }
 
-                        for (int time = chunk * chunk_size; time < (chunk + 1) * chunk_size;
-                             ++time) {
-                            const int idx = time + ntimes * (freq + nfreqs * beam);
-                            const float expected_x = input.at(idx);
+                                for (int freq_chunk = 0; freq_chunk < out_nfreqs_chunk;
+                                     ++freq_chunk) {
+                                    for (int time_chunk = 0; time_chunk < out_ntimes_chunk;
+                                         ++time_chunk) {
+                                        const int freq =
+                                            freq_chunk
+                                            + out_nfreqs_chunk
+                                                  * (freq_packet + out_nfreqs_packet * freq_outer);
+                                        const int time = time_chunk + out_ntimes_chunk * time_outer;
+                                        const float expected_x = inputat(beam, freq, time);
 
-                            const std::uint8_t i = beams.at(time + ntimes * (freq + nfreqs * beam));
-                            if (i == 255)
-                                FATAL_ERROR("Unexpected value {}", i);
-                            const float x = i == 0 ? 0.0f / 0.0f : offset + scale * i;
+                                        const std::uint8_t i =
+                                            beamsat(beam_outer, freq_outer, time_outer, beam_packet,
+                                                    freq_packet, freq_chunk, time_chunk);
+                                        if (i == 255)
+                                            FATAL_ERROR("Unexpected value {}", i);
+                                        const float x = i == 0 ? 0.0f / 0.0f : offset + scale * i;
 
-                            bool isgood = false;
+                                        bool isgood = false;
 
-                            // Allow the value to be clamped
-                            if (i == 0 && isnan(x))
-                                isgood = true;
-                            if (i == 1 && x > expected_x)
-                                isgood = true;
-                            if (i == 254 && x < expected_x)
-                                isgood = true;
-                            // The value should differ by no more than scale/2
-                            isgood |=
-                                fabs(x - expected_x) <= fmax(scale, expected_scale) / 2 + epsilon;
-                            // Handle non-finite inputs
-                            if (may_overflow && offset == 0.0f && scale == 0.0f)
-                                isgood = true;
-                            if (scale_may_collapse && scale == 0.0f)
-                                isgood = true;
-                            if (!isgood)
-                                FATAL_ERROR("Found inaccurate value: beam {}, time {}, want {}, "
-                                            "have {}, offset {}, "
-                                            "scale {}, may_overflow={}, scale_may_collapse={}, "
-                                            "expected_offset={}, expected_scale={}",
-                                            beam, time, expected_x, x, offset, scale, may_overflow,
-                                            scale_may_collapse, expected_offset, expected_scale);
+                                        // Allow the value to be clamped
+                                        if (i == 0 && isnan(x))
+                                            isgood = true;
+                                        if (i == 1 && x > expected_x)
+                                            isgood = true;
+                                        if (i == 254 && x < expected_x)
+                                            isgood = true;
+                                        // The value should differ by no more than scale/2
+                                        isgood |= fabs(x - expected_x)
+                                                  <= fmax(scale, expected_scale) / 2 + epsilon;
+                                        // Handle non-finite inputs
+                                        if (may_overflow && offset == 0.0f && scale == 0.0f)
+                                            isgood = true;
+                                        if (scale_may_collapse && scale == 0.0f)
+                                            isgood = true;
+                                        if (!isgood)
+                                            FATAL_ERROR("Found inaccurate value: beam {}, time {}, "
+                                                        "want {}, have {}, offset {}, scale {}, "
+                                                        "may_overflow={}, scale_may_collapse={}, "
+                                                        "expected_offset={}, expected_scale={}",
+                                                        beam, time, expected_x, x, offset, scale,
+                                                        may_overflow, scale_may_collapse,
+                                                        expected_offset, expected_scale);
+                                    }
+                                }
+                            }
                         }
                     }
                 }
@@ -224,7 +379,7 @@ public:
         // Allocate memory on the GPU
         float* gpu_input;
         CHECK_CUDA_ERROR(cudaMalloc(&gpu_input, input.size() * sizeof *input.data()));
-        float16_t* gpu_offsetscale;
+        float* gpu_offsetscale;
         CHECK_CUDA_ERROR(
             cudaMalloc(&gpu_offsetscale, offsetscale.size() * sizeof *offsetscale.data()));
         std::uint8_t* gpu_beams;

--- a/lib/cuda/testQuantizeKernel8Chime.cpp
+++ b/lib/cuda/testQuantizeKernel8Chime.cpp
@@ -29,7 +29,7 @@ public:
 
     void main_thread() override {
         const float fpoison(0.0f / 0.0f);
-        const std::uint8_t ipoison(0);
+        const std::uint8_t ipoison(255);
 
         const float epsilon = 1.0e-6; // We're using float
 
@@ -171,13 +171,13 @@ public:
                 case 5:
                     return 0.5f * x + 0.5f * x * x * x + 10 * (time % 23 == 0);
                 case 6:
-                    return 10000.0f * (time % 512); // large but not infinity
+                    return 1000.0f * (time % 512); // large but not infinity
                 case 7:
-                    return 100000.0f * (time % 512); // some values are infinity
+                    return 10000.0f * (time % 512); // some values are infinity
                 case 8:
-                    return (time % 512) / 10000.0f; // small, but 1/x is less than infinity
+                    return (time % 512) / 1000.0f; // small, but 1/x is less than infinity
                 case 9:
-                    return (time % 512) / 100000.0f; // small, and some 1/x are infinity
+                    return (time % 512) / 10000.0f; // small, and some 1/x are infinity
                 case 10:
                     return 0.5f * x + 0.5f * x * x * x + (time % 23 == 0 ? 0.0f / 0.0f : 0.0f);
             }
@@ -330,7 +330,7 @@ public:
                                         bool isgood = false;
 
                                         // Allow the value to be clamped
-                                        if (i == 0 && isnan(x))
+                                        if (i == 0 && isnan(expected_x))
                                             isgood = true;
                                         if (i == 1 && x > expected_x)
                                             isgood = true;
@@ -342,7 +342,8 @@ public:
                                         // Handle non-finite inputs
                                         if (may_overflow && offset == 0.0f && scale == 0.0f)
                                             isgood = true;
-                                        if (scale_may_collapse && scale == 0.0f)
+                                        if (scale_may_collapse && scale == 0.0f && i != 0
+                                            && !isnan(expected_x))
                                             isgood = true;
                                         if (!isgood)
                                             FATAL_ERROR("Found inaccurate value: beam {}, time {}, "

--- a/lib/cuda/testQuantizeKernel8Chime.cpp
+++ b/lib/cuda/testQuantizeKernel8Chime.cpp
@@ -1,0 +1,265 @@
+#include "Config.hpp"
+#include "DataType.hpp"
+#include "Stage.hpp"
+#include "StageFactory.hpp"
+#include "bufferContainer.hpp"
+#include "cudaQuantizeKernel8Chime.hpp"
+#include "cudaUtils.hpp"
+
+#include <algorithm>
+#include <cassert>
+#include <cfloat>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+class testQuantizeKernel8Chime : public kotekan::Stage {
+public:
+    testQuantizeKernel8Chime(kotekan::Config& config, const std::string& unique_name,
+                             kotekan::bufferContainer& buffer_container) :
+        Stage(config, unique_name, buffer_container, [](const kotekan::Stage& stage) {
+            return const_cast<kotekan::Stage&>(stage).main_thread();
+        }) {}
+
+    virtual ~testQuantizeKernel8Chime() {}
+
+    void main_thread() override {
+        const float fpoison(0.0f / 0.0f);
+        const std::uint8_t ipoison(0);
+
+        const float epsilon = 1.0e-6; // We're using float
+
+        const int chunk_size = 256;
+
+        const int ntimes = 512;
+        const int nfreqs = 256;
+        const int nbeams = 1024;
+
+        ////////////////////////////////////////////////////////////////////////////////
+
+        // layout: input[beam, freq, time]
+        std::vector<float> input(ntimes * nfreqs * nbeams);
+        assert(ntimes % chunk_size == 0);
+        const int nchunks = ntimes / chunk_size;
+        std::vector<float16_t> offsetscale(2 * nchunks * nfreqs * nbeams);
+        std::vector<std::uint8_t> beams(ntimes * nfreqs * nbeams);
+
+        // Invent some data
+        const auto f = [&](const int beam, const int freq, const int time) -> float {
+            const float x = (time + 0.5) / ntimes;
+            switch ((beam + freq) % 11) {
+                case 0:
+                    return 0.0f;
+                case 1:
+                    return 0.1f * beam;
+                case 2:
+                    return time % 2;
+                case 3:
+                    return x;
+                case 4:
+                    return 0.5f * x + 0.5f * x * x * x;
+                case 5:
+                    return 0.5f * x + 0.5f * x * x * x + 10 * (time % 23 == 0);
+                case 6:
+                    return 10000.0f * time; // large but not infinity
+                case 7:
+                    return 100000.0f * time; // some values are infinity
+                case 8:
+                    return time / 10000.0f; // small, but 1/x is less than infinity
+                case 9:
+                    return time / 100000.0f; // small, and some 1/x are infinity
+                case 10:
+                    return 0.5f * x + 0.5f * x * x * x + (time % 23 == 0 ? 0.0f / 0.0f : 0.0f);
+            }
+            std::abort();
+        };
+
+
+        ////////////////////////////////////////////////////////////////////////////////
+
+        // Set input
+        for (int beam = 0; beam < nbeams; ++beam) {
+            for (int freq = 0; freq < nfreqs; ++freq) {
+                for (int time = 0; time < ntimes; ++time) {
+                    const float x = f(beam, freq, time % chunk_size);
+                    const int idx = time + ntimes * (freq + nfreqs * beam);
+                    input.at(idx) = float(x);
+                }
+            }
+        }
+
+        // A function to check the result
+        const auto check_result = [&]() {
+            using std::fabs, std::fmin, std::fmax, std::isfinite, std::isnan, std::sqrt;
+
+            for (int beam = 0; beam < nbeams; ++beam) {
+                for (int freq = 0; freq < nfreqs; ++freq) {
+
+                    // Calculate expected result
+                    //
+                    // When comparing to the expected result, two things can go wrong:
+                    // 1. The scale can be zero, or can be close to zero (`scale_may_collapse`)
+                    // 2. The input can contain large numbers, or infinities, or not-a-numbers
+                    //    (`may_overflow`)
+                    //
+                    // We need to handle both cases, and we need to be lenient when comparing when
+                    // this happens. For example, there might be an overflow on the GPU, but not in
+                    // the CPU implementation. This should not be flagged as error.
+                    float minval = +FLT_MAX, maxval = -FLT_MAX;
+                    bool may_overflow = false;
+                    for (int time = 0; time < chunk_size; ++time) {
+                        const float x = f(beam, freq, time);
+                        minval = isnan(minval) || isnan(x) ? 0.0f / 0.0f : fmin(minval, x);
+                        maxval = isnan(maxval) || isnan(x) ? 0.0f / 0.0f : fmax(maxval, x);
+                        // Allow the respective float16 calculations to overflow
+                        may_overflow |= !isfinite(x) || fabs(x) >= 2048.0f;
+                    }
+                    may_overflow |= !isfinite(minval) || fabs(minval) >= 2048.0f
+                                    || !isfinite(maxval) || fabs(maxval) >= 2048.0f;
+                    // Allow the scale to be inaccurate when all inputs are close together
+                    const bool scale_may_collapse = fabs(maxval - minval) < 10 * epsilon;
+                    const int uint8_range = 254; // avoid 0 and 255
+                    float expected_scale = (maxval - minval) / uint8_range;
+                    float expected_offset = minval - 0.5f * expected_scale;
+                    if (!isfinite(expected_offset) || !isfinite(expected_scale)) {
+                        may_overflow = true;
+                        expected_offset = 0.0f;
+                        expected_scale = 0.0f;
+                    }
+
+                    for (int chunk = 0; chunk < nchunks; ++chunk) {
+                        const float offset =
+                            offsetscale.at(2 * chunk + 2 * nchunks * (freq + nfreqs * beam) + 0);
+                        const float scale =
+                            offsetscale.at(2 * chunk + 2 * nchunks * (freq + nfreqs * beam) + 1);
+                        if (!isfinite(offset))
+                            FATAL_ERROR("Found non-finite offset {}", offset);
+                        if (!isfinite(scale))
+                            FATAL_ERROR("Found non-finite scale {}", scale);
+
+                        // Check relative error of offset
+                        bool offset_is_good =
+                            fabs(offset - expected_offset)
+                            <= epsilon * fmax(1.0f, fmax(fabs(offset), fabs(expected_offset)));
+                        // If we think an overflow is allowed, and if the other implementation might
+                        // have detected one (offset=0), then all is fine as well
+                        if (may_overflow && scale == 0.0f && offset == 0.0f)
+                            offset_is_good = true;
+                        if (!offset_is_good)
+                            FATAL_ERROR("Found inaccurate offset: beam {}, want {}, have {}, "
+                                        "scale_may_collapse={}",
+                                        beam, expected_offset, offset, scale_may_collapse);
+
+                        // Check absolute error of scale
+                        bool scale_is_good = fabs(scale - expected_scale) <= epsilon;
+                        // If the scale is close to zero then don't worry about the scale at all
+                        if (scale_may_collapse)
+                            scale_is_good = true;
+                        // If we think an overflow is allowed, and if the other implementation might
+                        // have detected one (scale=0, offset=0), then all is fine as well
+                        if (may_overflow && scale == 0.0f && offset == 0.0f)
+                            scale_is_good = true;
+                        if (!scale_is_good)
+                            FATAL_ERROR("Found inaccurate scale: beam{}, want {}, have {}, "
+                                        "scale_may_collapse={}",
+                                        beam, expected_scale, scale, scale_may_collapse);
+
+                        for (int time = chunk * chunk_size; time < (chunk + 1) * chunk_size;
+                             ++time) {
+                            const int idx = time + ntimes * (freq + nfreqs * beam);
+                            const float expected_x = input.at(idx);
+
+                            const std::uint8_t i = beams.at(time + ntimes * (freq + nfreqs * beam));
+                            if (i == 255)
+                                FATAL_ERROR("Unexpected value {}", i);
+                            const float x = i == 0 ? 0.0f / 0.0f : offset + scale * i;
+
+                            bool isgood = false;
+
+                            // Allow the value to be clamped
+                            if (i == 0 && isnan(x))
+                                isgood = true;
+                            if (i == 1 && x > expected_x)
+                                isgood = true;
+                            if (i == 254 && x < expected_x)
+                                isgood = true;
+                            // The value should differ by no more than scale/2
+                            isgood |=
+                                fabs(x - expected_x) <= fmax(scale, expected_scale) / 2 + epsilon;
+                            // Handle non-finite inputs
+                            if (may_overflow && offset == 0.0f && scale == 0.0f)
+                                isgood = true;
+                            if (scale_may_collapse && scale == 0.0f)
+                                isgood = true;
+                            if (!isgood)
+                                FATAL_ERROR("Found inaccurate value: beam {}, time {}, want {}, "
+                                            "have {}, offset {}, "
+                                            "scale {}, may_overflow={}, scale_may_collapse={}, "
+                                            "expected_offset={}, expected_scale={}",
+                                            beam, time, expected_x, x, offset, scale, may_overflow,
+                                            scale_may_collapse, expected_offset, expected_scale);
+                        }
+                    }
+                }
+            }
+        };
+
+        ////////////////////////////////////////////////////////////////////////////////
+
+        // Poison output
+        std::fill(offsetscale.begin(), offsetscale.end(), fpoison);
+        std::fill(beams.begin(), beams.end(), ipoison);
+
+        // Quantize on the CPU
+        INFO("Testing on CPU...");
+        cpu_quantize8chime(input.data(), offsetscale.data(), beams.data());
+
+        // Check CPU result
+        check_result();
+
+        ////////////////////////////////////////////////////////////////////////////////
+
+        // Allocate memory on the GPU
+        float* gpu_input;
+        CHECK_CUDA_ERROR(cudaMalloc(&gpu_input, input.size() * sizeof *input.data()));
+        float16_t* gpu_offsetscale;
+        CHECK_CUDA_ERROR(
+            cudaMalloc(&gpu_offsetscale, offsetscale.size() * sizeof *offsetscale.data()));
+        std::uint8_t* gpu_beams;
+        CHECK_CUDA_ERROR(cudaMalloc(&gpu_beams, beams.size() * sizeof *beams.data()));
+
+        // Poison output
+        std::fill(offsetscale.begin(), offsetscale.end(), fpoison);
+        std::fill(beams.begin(), beams.end(), ipoison);
+
+        // Copy input and poisoned outputs to GPU
+        CHECK_CUDA_ERROR(cudaMemcpy(gpu_input, input.data(), input.size() * sizeof *input.data(),
+                                    cudaMemcpyHostToDevice));
+        CHECK_CUDA_ERROR(cudaMemcpy(gpu_offsetscale, offsetscale.data(),
+                                    offsetscale.size() * sizeof *offsetscale.data(),
+                                    cudaMemcpyHostToDevice));
+        CHECK_CUDA_ERROR(cudaMemcpy(gpu_beams, beams.data(), beams.size() * sizeof *beams.data(),
+                                    cudaMemcpyHostToDevice));
+
+        // Quantize on the GPU
+        INFO("Testing on GPU...");
+        gpu_quantize8chime(gpu_input, gpu_offsetscale, gpu_beams, nullptr);
+
+        // Copy output from GPU
+        CHECK_CUDA_ERROR(cudaMemcpy(offsetscale.data(), gpu_offsetscale,
+                                    offsetscale.size() * sizeof *offsetscale.data(),
+                                    cudaMemcpyDeviceToHost));
+        CHECK_CUDA_ERROR(cudaMemcpy(beams.data(), gpu_beams, beams.size() * sizeof *beams.data(),
+                                    cudaMemcpyDeviceToHost));
+
+        // Check GPU result
+        check_result();
+
+        // Done.
+        TEST_PASSED();
+    }
+};
+
+REGISTER_KOTEKAN_STAGE(testQuantizeKernel8Chime);


### PR DESCRIPTION
This implements the actual kernel (probably – @rhaas80 to check details). Compared to the CHORD 8-bit quantizer, the main difference is that the GPU loops over a 2d array (both time and frequency), not just time.

It does not yet implement the Kotekan stage.
