### PR TITLE
Update list of extra N2 freqs to write

### DIFF
--- a/config/chime_science_run_recv.yaml
+++ b/config/chime_science_run_recv.yaml
@@ -124,7 +124,8 @@ vis_buffer:
 # Subset of good frequencies to output whole for monitoring
 mfreq: &mfreq [107, 344, 619, 938]
 # Subset of frequencies to save to a separate acquisition for comparing to upgrade test node
-extra_mfreq: &extra_mfreq [269, 277, 285, 293, 301, 477, 485, 493, 541, 717, 749, 901, 957, 981, 989, 1005]
+# extra_mfreq: &extra_mfreq [269, 277, 285, 293, 301, 477, 485, 493, 541, 717, 749, 901, 957, 981, 989, 1005]
+extra_mfreq: &extra_mfreq [58, 66, 234, 666, 698, 730, 738, 746, 802, 818, 826, 898, 906, 954, 962, 978]
 # Larger subset to be sent to map maker, spanning entire band
 mapfreq: &mapfreq [
         1, 12, 23, 36, 47, 58, 70, 82, 92, 103, 184, 194, 205, 216,


### PR DESCRIPTION
The upgrade node has a different set of frequencies now due to a frequency remap. So, we should write out these new frequencies on the production system as well