### PR TITLE
N2Accum optionally prints profiling to INFO

### DIFF
--- a/config/tests/thrash_n2accum_chime.yaml
+++ b/config/tests/thrash_n2accum_chime.yaml
@@ -172,7 +172,6 @@ gen_fake_rfiframemask:
     repeat_count: repeat
 
 N2_accumulate:
-    log_level: DEBUG
     kotekan_stage: N2Accumulate
     cpu_affinity: [8, 9, 10, 11]
     in_buf: fake_correlation_buffer
@@ -183,11 +182,11 @@ N2_accumulate:
     out_buf: n2_buffer
     num_freq_per_n2k_frame: num_local_freq
     packet_loss_is_scalar: True
-      # variance_mode: CHIMEv1
     variance_mode: EvenOddPosDef
     num_workers: 2
     output_batch_size: 8
     do_fringestop: True
+    profile_info: True
     debug_accum_mode: False
 
 eat_n2:

--- a/config/tests/thrash_n2accum_chord.yaml
+++ b/config/tests/thrash_n2accum_chord.yaml
@@ -172,7 +172,6 @@ gen_fake_rfiframemask:
     repeat_count: repeat
 
 N2_accumulate:
-    log_level: DEBUG
     kotekan_stage: N2Accumulate
     cpu_affinity: [8, 9, 10, 11]
     in_buf: fake_correlation_buffer
@@ -185,10 +184,10 @@ N2_accumulate:
     packet_loss_is_scalar: True
     # variance_mode: CHIMEv1
     variance_mode: EvenOddPosDef
-    num_workers: 2
+    num_workers: 4
     output_batch_size: 8
     do_fringestop: True
-    debug_accum_mode: False
+    profile_info: True
 
 eat_n2:
   kotekan_stage: dropAllFrames

--- a/config/tests/thrash_n2accum_pathfinder.yaml
+++ b/config/tests/thrash_n2accum_pathfinder.yaml
@@ -172,7 +172,6 @@ gen_fake_rfiframemask:
     repeat_count: repeat
 
 N2_accumulate:
-    log_level: DEBUG
     kotekan_stage: N2Accumulate
     cpu_affinity: [8, 9, 10, 11]
     in_buf: fake_correlation_buffer
@@ -188,7 +187,7 @@ N2_accumulate:
     num_workers: 1
     output_batch_size: 8
     do_fringestop: True
-    debug_accum_mode: False
+    profile_info: True
 
 eat_n2:
   kotekan_stage: dropAllFrames

--- a/lib/stages/N2Accumulate.cpp
+++ b/lib/stages/N2Accumulate.cpp
@@ -67,6 +67,7 @@ N2Accumulate::N2Accumulate(Config& config, const std::string& unique_name,
     _do_fringestop(config.get_default<bool>(unique_name, "do_fringestop", false)),
     _variance_mode(config.get<N2VarianceMode>(unique_name, "variance_mode")),
     _debug_accum_mode(config.get_default<bool>(unique_name, "debug_accum_mode", false)),
+    _profile_info(config.get_default<bool>(unique_name, "profile_info", false)),
     _tel(Telescope::instance()),
     skipped_frame_counter(Metrics::instance().add_counter(
         "kotekan_N2accumulate_skipped_frame_total", unique_name, {"freq_id", "reason"})) {
@@ -562,9 +563,15 @@ void N2Accumulate::main_thread() {
 
 #ifdef WITH_OMP
             [[maybe_unused]] double prof_curr_time = omp_get_wtime();
-            DEBUG("Adding input frame pair took {:f} ms + {:f} ms idle",
-                  (prof_curr_time - prof_start_time) * 1000,
-                  (prof_start_time - prof_last_time) * 1000);
+            if (_profile_info) {
+                INFO("Adding input frame pair took {:f} ms + {:f} ms idle",
+                     (prof_curr_time - prof_start_time) * 1000,
+                     (prof_start_time - prof_last_time) * 1000);
+            } else {
+                DEBUG("Adding input frame pair took {:f} ms + {:f} ms idle",
+                      (prof_curr_time - prof_start_time) * 1000,
+                      (prof_start_time - prof_last_time) * 1000);
+            }
             prof_last_time = prof_curr_time;
 #endif
 
@@ -1144,12 +1151,21 @@ bool N2Accumulate::output_and_reset(frameID& in_frame_id, frameID& in_rfiframema
 
 #ifdef WITH_OMP
     [[maybe_unused]] double prof_out_end_time = omp_get_wtime();
-
-    DEBUG("Outputting {:d} frames took {:f} ms\n    setup: {:f} ms\n    work:  {:f} ms\n    free:  "
-          "{:f} ms\n    fill:  {:f} ms",
-          _num_freq_per_n2k_frame, 1000 * (prof_out_end_time - prof_out_start_time),
-          1000 * prof_out_setup_time, 1000 * prof_out_work_time, 1000 * prof_out_free_time,
-          1000 * (prof_out_end_time - prof_out_fill_time));
+    if (_profile_info) {
+        INFO("Outputting {:d} frames took {:f} ms\n    setup: {:f} ms\n    work:  {:f} ms\n    "
+             "free:  "
+             "{:f} ms\n    fill:  {:f} ms",
+             _num_freq_per_n2k_frame, 1000 * (prof_out_end_time - prof_out_start_time),
+             1000 * prof_out_setup_time, 1000 * prof_out_work_time, 1000 * prof_out_free_time,
+             1000 * (prof_out_end_time - prof_out_fill_time));
+    } else {
+        DEBUG("Outputting {:d} frames took {:f} ms\n    setup: {:f} ms\n    work:  {:f} ms\n    "
+              "free:  "
+              "{:f} ms\n    fill:  {:f} ms",
+              _num_freq_per_n2k_frame, 1000 * (prof_out_end_time - prof_out_start_time),
+              1000 * prof_out_setup_time, 1000 * prof_out_work_time, 1000 * prof_out_free_time,
+              1000 * (prof_out_end_time - prof_out_fill_time));
+    }
 #endif
 
     return true;

--- a/lib/stages/N2Accumulate.hpp
+++ b/lib/stages/N2Accumulate.hpp
@@ -254,6 +254,7 @@ private:
     const bool _do_fringestop; ///< Whether to fringestop
     const N2VarianceMode _variance_mode;
     const bool _debug_accum_mode;
+    const bool _profile_info;
 
 
     // Some derived parameters


### PR DESCRIPTION
Just an option to emit N2Accumulate's profiling timing as INFO instead of DEBUG. Defaults to false, useful for testing performance on release builds.