### PR TITLE
Reduce lcore startup delay in the CHORD Pathfinder config.

### DIFF
--- a/config/chord_pathfinder.j2
+++ b/config/chord_pathfinder.j2
@@ -558,6 +558,7 @@ dpdk:
     burst_size: 32
     # The number of stream IDs expected per worker
     num_expected_stream_ids: 4
+    lcore_start_delay: 40
     # List of PCIe addresses to block from DPDK use
     pcie_block_list:
         - "0000:37:00.0"

--- a/config/chord_pathfinder.j2
+++ b/config/chord_pathfinder.j2
@@ -558,7 +558,7 @@ dpdk:
     burst_size: 32
     # The number of stream IDs expected per worker
     num_expected_stream_ids: 4
-    lcore_start_delay: 40
+    lcore_start_delay: 10
     # List of PCIe addresses to block from DPDK use
     pcie_block_list:
         - "0000:37:00.0"

--- a/lib/dpdk/dpdkCore.cpp
+++ b/lib/dpdk/dpdkCore.cpp
@@ -64,6 +64,7 @@ dpdkCore::dpdkCore(Config& config, const string& unique_name, bufferContainer& b
 
     num_mem_channels = config.get_default<uint32_t>(unique_name, "num_mem_channels", 4);
     init_mem_alloc = config.get_default<std::string>(unique_name, "init_mem_alloc", "256");
+    lcore_start_delay = config.get_default<uint32_t>(unique_name, "lcore_start_delay", 40);
 
     // Setup the lcore mappings
     // Basically this is mapping the DPDK EAL framework way of assigning threads
@@ -507,10 +508,11 @@ int dpdkCore::lcore_rx(void* args) {
         }
     }
 
-    // TODO Figure out why this sleep is need.  It seems like the when starting the E810
+    // TODO Figure out why this sleep is needed.  It seems like when starting the E810
     // ports, there is a delay between when they are started in DPDK and when they become
-    // ready.  There might be a function to check their readness state we could query?
-    sleep(40);
+    // ready.  There might be a function to check their readiness state we could query?
+    INFO_NON_OO("DPDK Sleeping for {} seconds before starting network handlers", core->lcore_start_delay);
+    sleep(core->lcore_start_delay);
     const uint32_t num_local_ports = ports.size();
 
     // Enforce that all handlers on this lcore are either all distributors or all

--- a/lib/dpdk/dpdkCore.cpp
+++ b/lib/dpdk/dpdkCore.cpp
@@ -511,7 +511,8 @@ int dpdkCore::lcore_rx(void* args) {
     // TODO Figure out why this sleep is needed.  It seems like when starting the E810
     // ports, there is a delay between when they are started in DPDK and when they become
     // ready.  There might be a function to check their readiness state we could query?
-    INFO_NON_OO("DPDK Sleeping for {} seconds before starting network handlers", core->lcore_start_delay);
+    INFO_NON_OO("DPDK Sleeping for {} seconds before starting network handlers",
+                core->lcore_start_delay);
     sleep(core->lcore_start_delay);
     const uint32_t num_local_ports = ports.size();
 

--- a/lib/dpdk/dpdkCore.hpp
+++ b/lib/dpdk/dpdkCore.hpp
@@ -154,6 +154,9 @@ protected:
  * @conf   num_mem_channels Int. Default 4     The number of system memory channels
  * @conf   init_mem_alloc   Int.  Default 256  The initial memory allocation in MB
  * @conf   pcie_block_list  Array of strings.  List of PCIe devices to block DPDK from using.
+ * @conf   lcore_start_delay Int. Default 40   Seconds to wait after port start before the
+ *                                             lcore RX loop begins. Required on E810 NICs
+ *                                             to allow ports to become ready.
  *
  * @author Andre Renard
  */
@@ -234,6 +237,9 @@ private:
 
     /// Initial memory allocation in MB
     std::string init_mem_alloc;
+
+    /// Seconds to wait after port start before the lcore RX loop begins
+    uint32_t lcore_start_delay;
 
     /// One of these exists per system port
     dpdkRXhandler** handlers;


### PR DESCRIPTION
This fixes an issue that got added in the CHIME support changes.   CHIME has many more NICs so the startup time needed before starting the lcores is much longer.  However in the CHORD case, we only have 2 NICs so the startup is faster.  

Having said that, I think I understand better why some of the synchronization delays are needed - and I have some ideas to reduce them with better startup handling.   I will implement those changes in a separate PR. 