### PR TITLE
Rhaas/updates

### DIFF
--- a/lib/core/Config.hpp
+++ b/lib/core/Config.hpp
@@ -31,10 +31,13 @@ namespace kotekan {
 
 // Define a "large" type for every arithmetic type
 template<typename Type>
-using LargeType = typename std::conditional<
-    std::is_integral<Type>::value,
-    typename std::conditional<std::is_unsigned<Type>::value, unsigned long long, long long>::type,
-    double>::type;
+using LargeType =
+    typename std::conditional<std::is_integral<Type>::value,
+                              // "long double" will have at least 64bits for the significant plus an
+                              // additional sign bit, enough to hold both int64_t and uint64_t
+                              // do not use "unsigned long long" to avoid unsigned(-1) ==
+                              // unsigned_max issues
+                              long double, double>::type;
 
 // Convert types, with checking for overflows
 template<typename Ret, typename Type>

--- a/lib/stages/UpchannelizationSchedule.cpp
+++ b/lib/stages/UpchannelizationSchedule.cpp
@@ -58,7 +58,7 @@ std::map<int, std::set<int>> UpchannelizationSchedule::make_upchan_channels_to_f
 }
 
 void UpchannelizationSchedule::output_statistics() const {
-    const auto& chord_telescope = Telescope::instance().cast<CHORDTelescope>();
+    const auto& telescope = Telescope::instance();
 
     INFO("Upchannelization schedule:");
 
@@ -77,8 +77,8 @@ void UpchannelizationSchedule::output_statistics() const {
     int total_output_channels = 0;
     INFO("There are {} local input frequency channels", frequency_channels.size());
     for (std::size_t index = 0; index < frequency_channels.size(); ++index) {
-        const int channel = frequency_channels.at(index);
-        const double frequency = chord_telescope.to_freq_MHz(channel);
+        const freq_id_t channel = frequency_channels.at(index);
+        const double frequency = telescope.to_freq_MHz(channel);
         const auto factors = get_upchan_factors(channel);
         std::ostringstream upchannelized;
         if (factors.empty()) {

--- a/lib/stages/calcFRB2Weights.cpp
+++ b/lib/stages/calcFRB2Weights.cpp
@@ -97,12 +97,13 @@ public:
             return;
 
         // Telescope
-        const auto& chord_telescope = Telescope::instance().cast<CHORDTelescope>();
+        const auto& telescope = Telescope::instance();
 
         // Upchannelization schedule
         const auto& upchan_schedule = UpchannelizationSchedule::instance(config);
 
-        // Calculate dish positions
+#if 0 // not used
+      // Calculate dish positions
         const float dish_separation_x = chord_telescope.get_dish_separation_x_m();
         const float dish_separation_y = chord_telescope.get_dish_separation_y_m();
         const auto& dish_grid = chord_telescope.get_dish_grid();
@@ -122,6 +123,7 @@ public:
             }
         }
         assert(std::ptrdiff_t(dish_loc_x.size()) == num_dishes);
+#endif
 
         // Calculate frequencies
         const auto& frequency_channels = upchan_schedule.get_frequency_channels();
@@ -130,8 +132,8 @@ public:
         std::vector<int> freq_upchan_index;
         std::vector<float> frequencies;
         for (const int channel : frequency_channels) {
-            const float frequency = chord_telescope.to_freq_MHz(channel) * 1.0e+6f;
-            const float frequency_spacing = chord_telescope.freq_width_MHz(channel) * 1.0e+6f;
+            const float frequency = telescope.to_freq_MHz(freq_id_t(channel)) * 1.0e+6f;
+            const float frequency_spacing = telescope.freq_width_MHz(freq_id_t(channel)) * 1.0e+6f;
             const auto& upchan_factors = upchan_schedule.get_upchan_factors(channel);
             if (upchan_factors.empty()) {
                 // Assume we keep the frequency itself

--- a/lib/stages/parseReorderDefault.cpp
+++ b/lib/stages/parseReorderDefault.cpp
@@ -75,19 +75,22 @@ parseReorderDefault::parseReorderDefault(Config& config, const std::string& uniq
 #endif
 }
 
-int parseReorderDefault::correlator_index_to_station_id(const int idx) const {
+parseReorderDefault::station_id_t
+parseReorderDefault::correlator_index_to_station_id(const int idx) const {
     assert(idx >= 0 && idx < _num_dishes * _num_polarizations);
     const auto id_it = std::find(_input_reorder.cbegin(), _input_reorder.cend(), idx);
     assert(id_it != _input_reorder.end());
-    return static_cast<int>(id_it - _input_reorder.cbegin());
+    return static_cast<station_id_t>(id_it - _input_reorder.cbegin());
 }
 
-int parseReorderDefault::cylinder_index_to_station_id(const int idx) const {
+parseReorderDefault::station_id_t
+parseReorderDefault::cylinder_index_to_station_id(const int idx) const {
     assert(idx >= 0 && idx <= _num_dishes * _num_polarizations);
-    return idx;
+    return static_cast<station_id_t>(idx);
 }
 
-int parseReorderDefault::beamformer_index_to_station_id(const int idx) const {
+parseReorderDefault::station_id_t
+parseReorderDefault::beamformer_index_to_station_id(const int idx) const {
     assert(idx >= 0 && idx < _num_dishes * _num_polarizations);
     constexpr auto cylinder_to_beamforrmer_table = get_cylinder_to_beamformer_reorder_table();
     const auto cylinder_idx_it = std::find(cylinder_to_beamforrmer_table.cbegin(),
@@ -96,17 +99,17 @@ int parseReorderDefault::beamformer_index_to_station_id(const int idx) const {
     return cylinder_index_to_station_id(*cylinder_idx_it);
 }
 
-int parseReorderDefault::station_id_to_correlator_index(const int id) const {
+int parseReorderDefault::station_id_to_correlator_index(const station_id_t id) const {
     assert(id >= 0 && id <= _num_dishes * _num_polarizations);
     return static_cast<int>(_input_reorder.at(id));
 }
 
-int parseReorderDefault::station_id_to_cylinder_index(const int id) const {
+int parseReorderDefault::station_id_to_cylinder_index(const station_id_t id) const {
     assert(id >= 0 && id <= _num_dishes * _num_polarizations);
     return id;
 }
 
-int parseReorderDefault::station_id_to_beamformer_index(const int id) const {
+int parseReorderDefault::station_id_to_beamformer_index(const station_id_t id) const {
     assert(id >= 0 && id < _num_dishes * _num_polarizations);
     constexpr auto cylinder_to_beamforrmer_table = get_cylinder_to_beamformer_reorder_table();
     const int cylinder_idx = station_id_to_cylinder_index(id);
@@ -116,7 +119,7 @@ int parseReorderDefault::station_id_to_beamformer_index(const int id) const {
 void parseReorderDefault::main_thread() {
     int abs_frame_id = 0;
 
-    int (parseReorderDefault::*input_index_to_station_id)(const int) const;
+    station_id_t (parseReorderDefault::*input_index_to_station_id)(const int) const;
     if (_input_order == CHIME_ORDER_CORRELATOR)
         input_index_to_station_id = &parseReorderDefault::correlator_index_to_station_id;
     else if (_input_order == CHIME_ORDER_CYLINDER)
@@ -126,13 +129,13 @@ void parseReorderDefault::main_thread() {
     else
         FATAL_ERROR("Unexpected order {:s}", _input_order);
 
-    int (parseReorderDefault::*station_id_to_output_index)(const int) const;
+    int (parseReorderDefault::*station_id_to_output_index)(const station_id_t) const;
     if (_output_order == CHIME_ORDER_CORRELATOR)
-        station_id_to_output_index = &parseReorderDefault::correlator_index_to_station_id;
+        station_id_to_output_index = &parseReorderDefault::station_id_to_correlator_index;
     else if (_output_order == CHIME_ORDER_CYLINDER)
-        station_id_to_output_index = &parseReorderDefault::cylinder_index_to_station_id;
+        station_id_to_output_index = &parseReorderDefault::station_id_to_cylinder_index;
     else if (_output_order == CHIME_ORDER_BEAMFORMER)
-        station_id_to_output_index = &parseReorderDefault::beamformer_index_to_station_id;
+        station_id_to_output_index = &parseReorderDefault::station_id_to_beamformer_index;
     else
         FATAL_ERROR("Unexpected order {:s}", _output_order);
 

--- a/lib/stages/parseReorderDefault.cpp
+++ b/lib/stages/parseReorderDefault.cpp
@@ -75,30 +75,6 @@ parseReorderDefault::parseReorderDefault(Config& config, const std::string& uniq
 #endif
 }
 
-parseReorderDefault::station_id_t
-parseReorderDefault::correlator_index_to_station_id(const int idx) const {
-    assert(idx >= 0 && idx < _num_dishes * _num_polarizations);
-    const auto id_it = std::find(_input_reorder.cbegin(), _input_reorder.cend(), idx);
-    assert(id_it != _input_reorder.end());
-    return static_cast<station_id_t>(id_it - _input_reorder.cbegin());
-}
-
-parseReorderDefault::station_id_t
-parseReorderDefault::cylinder_index_to_station_id(const int idx) const {
-    assert(idx >= 0 && idx <= _num_dishes * _num_polarizations);
-    return static_cast<station_id_t>(idx);
-}
-
-parseReorderDefault::station_id_t
-parseReorderDefault::beamformer_index_to_station_id(const int idx) const {
-    assert(idx >= 0 && idx < _num_dishes * _num_polarizations);
-    constexpr auto cylinder_to_beamforrmer_table = get_cylinder_to_beamformer_reorder_table();
-    const auto cylinder_idx_it = std::find(cylinder_to_beamforrmer_table.cbegin(),
-                                           cylinder_to_beamforrmer_table.cend(), idx);
-    assert(cylinder_idx_it != cylinder_to_beamforrmer_table.cend());
-    return cylinder_index_to_station_id(*cylinder_idx_it);
-}
-
 int parseReorderDefault::station_id_to_correlator_index(const station_id_t id) const {
     assert(id >= 0 && id <= _num_dishes * _num_polarizations);
     return static_cast<int>(_input_reorder.at(id));
@@ -111,21 +87,26 @@ int parseReorderDefault::station_id_to_cylinder_index(const station_id_t id) con
 
 int parseReorderDefault::station_id_to_beamformer_index(const station_id_t id) const {
     assert(id >= 0 && id < _num_dishes * _num_polarizations);
-    constexpr auto cylinder_to_beamforrmer_table = get_cylinder_to_beamformer_reorder_table();
+    // this table is indexed by the index of a station in beamformer order and
+    // returns that index of the station in cylinder order
+    constexpr auto cylinder_to_beamformer_table = get_cylinder_to_beamformer_reorder_table();
     const int cylinder_idx = station_id_to_cylinder_index(id);
-    return static_cast<int>(cylinder_to_beamforrmer_table.at(cylinder_idx));
+    const auto cylinder_idx_it = std::find(cylinder_to_beamformer_table.cbegin(),
+                                           cylinder_to_beamformer_table.cend(), cylinder_idx);
+    assert(cylinder_idx_it != cylinder_to_beamformer_table.cend());
+    return static_cast<int>(cylinder_idx_it - cylinder_to_beamformer_table.cbegin());
 }
 
 void parseReorderDefault::main_thread() {
     int abs_frame_id = 0;
 
-    station_id_t (parseReorderDefault::*input_index_to_station_id)(const int) const;
+    int (parseReorderDefault::*station_id_to_input_index)(const station_id_t) const;
     if (_input_order == CHIME_ORDER_CORRELATOR)
-        input_index_to_station_id = &parseReorderDefault::correlator_index_to_station_id;
+        station_id_to_input_index = &parseReorderDefault::station_id_to_correlator_index;
     else if (_input_order == CHIME_ORDER_CYLINDER)
-        input_index_to_station_id = &parseReorderDefault::cylinder_index_to_station_id;
+        station_id_to_input_index = &parseReorderDefault::station_id_to_cylinder_index;
     else if (_input_order == CHIME_ORDER_BEAMFORMER)
-        input_index_to_station_id = &parseReorderDefault::beamformer_index_to_station_id;
+        station_id_to_input_index = &parseReorderDefault::station_id_to_beamformer_index;
     else
         FATAL_ERROR("Unexpected order {:s}", _input_order);
 
@@ -155,8 +136,10 @@ void parseReorderDefault::main_thread() {
 
         for (int idx = 0; idx < static_cast<int>(_input_reorder.size()); ++idx) {
             // indexed by input_index, returns output_index
-            frame[idx] = static_cast<int32_t>(
-                (this->*station_id_to_output_index)((this->*input_index_to_station_id)(idx)));
+            const station_id_t station_id = static_cast<station_id_t>(idx);
+            const int input_idx = (this->*station_id_to_input_index)(station_id);
+            const int output_idx = (this->*station_id_to_output_index)(station_id);
+            frame[input_idx] = static_cast<int32_t>(output_idx);
         }
 
         _out_buf->allocate_new_metadata_object(frame_id);

--- a/lib/stages/parseReorderDefault.cpp
+++ b/lib/stages/parseReorderDefault.cpp
@@ -6,6 +6,7 @@
 #include "chordMetadata.hpp"   // for chordMetadata, get_chord_metadata, CHORD_META_MAX_FREQ
 #include "kotekanLogging.hpp"  // for INFO, DEBUG, ERROR
 
+#include <algorithm> // for find
 #include <assert.h>  // for assert
 #include <stdint.h>  // for int8_t, uint32_t, uint8_t, int16_t, int32_t, uint64_t
 #include <string>    // for std::string
@@ -20,13 +21,20 @@ using kotekan::Stage;
 
 REGISTER_KOTEKAN_STAGE(parseReorderDefault);
 
+#define CHIME_ORDER_CORRELATOR "correlator" // not regular
+#define CHIME_ORDER_CYLINDER "cylinder"     // cyl-pol-dish
+#define CHIME_ORDER_BEAMFORMER "beamformer" // pol-dish
+
 parseReorderDefault::parseReorderDefault(Config& config, const std::string& unique_name,
                                          bufferContainer& buffer_container) :
     Stage(config, unique_name, buffer_container,
           std::bind(&parseReorderDefault::main_thread, this)),
     _out_buf(get_buffer("out_buf")), _name(config.get<std::string>(unique_name, "name")),
     _input_reorder(std::get<0>(parse_reorder_default(config, unique_name))),
-    _invert_mapping(config.get_default<bool>(unique_name, "invert_mapping", true)),
+    _input_order(
+        config.get_default<std::string>(unique_name, "input_order", CHIME_ORDER_CORRELATOR)),
+    _output_order(
+        config.get_default<std::string>(unique_name, "output_order", CHIME_ORDER_CYLINDER)),
     _num_polarizations(config.get<int>(unique_name, "num_polarizations")),
     _num_dishes(config.get<int>(unique_name, "num_dishes")) {
     _out_buf->register_producer(unique_name);
@@ -35,15 +43,98 @@ parseReorderDefault::parseReorderDefault(Config& config, const std::string& uniq
         throw std::invalid_argument("parseReorderDefault: incorrect frame size");
     }
 
-    // TODO: this is not quite correct. Really if going to cylinder order
-    // the array is {4,2,256} {"C", "P", "D"}
+    if (_input_order != CHIME_ORDER_CORRELATOR && _input_order != CHIME_ORDER_CYLINDER
+        && _input_order != CHIME_ORDER_BEAMFORMER) {
+        FATAL_ERROR("input_order must be one of {:s}, {:s}, or {:s}", CHIME_ORDER_CORRELATOR,
+                    CHIME_ORDER_CYLINDER, CHIME_ORDER_BEAMFORMER);
+    }
+
+    if (_output_order != CHIME_ORDER_CORRELATOR && _output_order != CHIME_ORDER_CYLINDER
+        && _output_order != CHIME_ORDER_BEAMFORMER) {
+        FATAL_ERROR("output_order must be one of {:s}, {:s}, or {:s}", CHIME_ORDER_CORRELATOR,
+                    CHIME_ORDER_CYLINDER, CHIME_ORDER_BEAMFORMER);
+    }
+
+#if 0 // this is what it should be
+    if(_input_order == CHIME_ORDER_CORRELATOR) {
+          _out_buf->allocate_ndarray_frame_desc(kotekan::int32, _name, {_num_polarizations*_num_dishes},
+                                                {"E"});
+    } else if(_input_order == CHIME_ORDER_CYLINDER) {
+          _out_buf->allocate_ndarray_frame_desc(kotekan::int32, _name, {_num_chime_cylinders, _num_polarizations, _num_dishes/_num_chime_cylinders},
+                                                {"C", "P", "D"});
+    } else if(_input_order == CHIME_ORDER_BEAMFORMER) {
+          _out_buf->allocate_ndarray_frame_desc(kotekan::int32, _name, {_num_polarizations, _num_dishes},
+                                                {"P", "D"});
+    } else {
+        FATAL_ERROR("Unexpected input_order {:s}", _input_order);
+    }
+#else
+    // this is what xpose2048 expects
     _out_buf->allocate_ndarray_frame_desc(kotekan::int32, _name, {_num_polarizations, _num_dishes},
                                           {"P", "D"});
+#endif
 }
 
+int parseReorderDefault::correlator_index_to_station_id(const int idx) const {
+    assert(idx >= 0 && idx < _num_dishes * _num_polarizations);
+    const auto id_it = std::find(_input_reorder.cbegin(), _input_reorder.cend(), idx);
+    assert(id_it != _input_reorder.end());
+    return static_cast<int>(id_it - _input_reorder.cbegin());
+}
+
+int parseReorderDefault::cylinder_index_to_station_id(const int idx) const {
+    assert(idx >= 0 && idx <= _num_dishes * _num_polarizations);
+    return idx;
+}
+
+int parseReorderDefault::beamformer_index_to_station_id(const int idx) const {
+    assert(idx >= 0 && idx < _num_dishes * _num_polarizations);
+    constexpr auto cylinder_to_beamforrmer_table = get_cylinder_to_beamformer_reorder_table();
+    const auto cylinder_idx_it = std::find(cylinder_to_beamforrmer_table.cbegin(),
+                                           cylinder_to_beamforrmer_table.cend(), idx);
+    assert(cylinder_idx_it != cylinder_to_beamforrmer_table.cend());
+    return cylinder_index_to_station_id(*cylinder_idx_it);
+}
+
+int parseReorderDefault::station_id_to_correlator_index(const int id) const {
+    assert(id >= 0 && id <= _num_dishes * _num_polarizations);
+    return static_cast<int>(_input_reorder.at(id));
+}
+
+int parseReorderDefault::station_id_to_cylinder_index(const int id) const {
+    assert(id >= 0 && id <= _num_dishes * _num_polarizations);
+    return id;
+}
+
+int parseReorderDefault::station_id_to_beamformer_index(const int id) const {
+    assert(id >= 0 && id < _num_dishes * _num_polarizations);
+    constexpr auto cylinder_to_beamforrmer_table = get_cylinder_to_beamformer_reorder_table();
+    const int cylinder_idx = station_id_to_cylinder_index(id);
+    return static_cast<int>(cylinder_to_beamforrmer_table.at(cylinder_idx));
+}
 
 void parseReorderDefault::main_thread() {
     int abs_frame_id = 0;
+
+    int (parseReorderDefault::*input_index_to_station_id)(const int) const;
+    if (_input_order == CHIME_ORDER_CORRELATOR)
+        input_index_to_station_id = &parseReorderDefault::correlator_index_to_station_id;
+    else if (_input_order == CHIME_ORDER_CYLINDER)
+        input_index_to_station_id = &parseReorderDefault::cylinder_index_to_station_id;
+    else if (_input_order == CHIME_ORDER_BEAMFORMER)
+        input_index_to_station_id = &parseReorderDefault::beamformer_index_to_station_id;
+    else
+        FATAL_ERROR("Unexpected order {:s}", _input_order);
+
+    int (parseReorderDefault::*station_id_to_output_index)(const int) const;
+    if (_output_order == CHIME_ORDER_CORRELATOR)
+        station_id_to_output_index = &parseReorderDefault::correlator_index_to_station_id;
+    else if (_output_order == CHIME_ORDER_CYLINDER)
+        station_id_to_output_index = &parseReorderDefault::cylinder_index_to_station_id;
+    else if (_output_order == CHIME_ORDER_BEAMFORMER)
+        station_id_to_output_index = &parseReorderDefault::beamformer_index_to_station_id;
+    else
+        FATAL_ERROR("Unexpected order {:s}", _output_order);
 
     bool first_time = true;
     while (!stop_thread) {
@@ -59,18 +150,10 @@ void parseReorderDefault::main_thread() {
         if (frame == nullptr)
             break;
 
-        for (size_t i = 0; i < _input_reorder.size(); ++i) {
-            if (_invert_mapping) {
-                // the (ptrdiff_t) cast is just there to pacify a warning about
-                // comparing unsigned >= 0 being always true. The assert is to
-                // future proof this in case anyone ever changes the type of
-                // _input_reorder to be signed.
-                assert((ptrdiff_t)_input_reorder.at(i) >= 0
-                       && _input_reorder.at(i) < _input_reorder.size());
-                frame[_input_reorder.at(i)] = static_cast<int32_t>(i);
-            } else {
-                frame[i] = _input_reorder.at(i);
-            }
+        for (int idx = 0; idx < static_cast<int>(_input_reorder.size()); ++idx) {
+            // indexed by input_index, returns output_index
+            frame[idx] = static_cast<int32_t>(
+                (this->*station_id_to_output_index)((this->*input_index_to_station_id)(idx)));
         }
 
         _out_buf->allocate_new_metadata_object(frame_id);

--- a/lib/stages/parseReorderDefault.hpp
+++ b/lib/stages/parseReorderDefault.hpp
@@ -12,7 +12,8 @@
 
 /**
  * @class parseReorderDefault
- * @brief Parse the reordering configuration section
+ * @brief Parse the reordering configuration section and create a mapping
+ * yielding elements in output_order when indexed in input_order.
  *
  * @par Buffers
  * @buffer out_buf Buffer to with reorder table column
@@ -20,9 +21,10 @@
  *
  * @conf  name                  String. Name of the quantity being set.
  * @conf  input_reorder         Table. The input reorder table to parse.
- * @conf  invert_mapping        Bool. Default: true. Invert the input reorder
- *                              table, that is store the target indices instead
- *                              of the source indices consecutively.
+ * @conf  input_order           String. Default: correlator. One of correlator,
+ *                              cylinder, or beamformer.
+ * @conf  output_order          String. Default: cylinder. One of correlator,
+ *                              cylinder, or beamformer.
  * @conf  num_polarizations     Int. Number of polarizations. Used only to
  *                              compute number of elements.
  * @conf  num_dishes            Int. Number of dishes in telescope. Used only to
@@ -41,9 +43,20 @@ private:
     Buffer* const _out_buf;
     const std::string _name;
     const std::vector<uint32_t> _input_reorder;
-    const bool _invert_mapping;
+    const std::string _input_order;
+    const std::string _output_order;
     const int _num_polarizations;
     const int _num_dishes;
+    static const int _num_chime_cylinders = 4;
+
+    // the actual mappings (these are terribly inefficient)
+    int correlator_index_to_station_id(const int idx) const;
+    int cylinder_index_to_station_id(const int idx) const;
+    int beamformer_index_to_station_id(const int idx) const;
+
+    int station_id_to_correlator_index(const int id) const;
+    int station_id_to_cylinder_index(const int id) const;
+    int station_id_to_beamformer_index(const int id) const;
 };
 
 #endif

--- a/lib/stages/parseReorderDefault.hpp
+++ b/lib/stages/parseReorderDefault.hpp
@@ -50,13 +50,14 @@ private:
     static const int _num_chime_cylinders = 4;
 
     // the actual mappings (these are terribly inefficient)
-    int correlator_index_to_station_id(const int idx) const;
-    int cylinder_index_to_station_id(const int idx) const;
-    int beamformer_index_to_station_id(const int idx) const;
+    enum station_id_t {};
+    station_id_t correlator_index_to_station_id(const int idx) const;
+    station_id_t cylinder_index_to_station_id(const int idx) const;
+    station_id_t beamformer_index_to_station_id(const int idx) const;
 
-    int station_id_to_correlator_index(const int id) const;
-    int station_id_to_cylinder_index(const int id) const;
-    int station_id_to_beamformer_index(const int id) const;
+    int station_id_to_correlator_index(const station_id_t id) const;
+    int station_id_to_cylinder_index(const station_id_t id) const;
+    int station_id_to_beamformer_index(const station_id_t id) const;
 };
 
 #endif

--- a/lib/stages/parseReorderDefault.hpp
+++ b/lib/stages/parseReorderDefault.hpp
@@ -51,10 +51,6 @@ private:
 
     // the actual mappings (these are terribly inefficient)
     enum station_id_t {};
-    station_id_t correlator_index_to_station_id(const int idx) const;
-    station_id_t cylinder_index_to_station_id(const int idx) const;
-    station_id_t beamformer_index_to_station_id(const int idx) const;
-
     int station_id_to_correlator_index(const station_id_t id) const;
     int station_id_to_cylinder_index(const station_id_t id) const;
     int station_id_to_beamformer_index(const station_id_t id) const;

--- a/lib/utils/L0_L1_packet.hpp
+++ b/lib/utils/L0_L1_packet.hpp
@@ -81,6 +81,7 @@ struct L0_L1_header {
     uint16_t    nupfreq;        // upsampling factor (probably either 1 or 16)
     uint16_t    ntsamp;         // number of time samples in packet
 
+#ifdef L0_L1_HEADER_VARIABLE_SIZE_PART
     // Beam IDs in the data packet, numbered from 0-1023. 
     // It is not assumed that the 8 beams processed on each frbsearch node are consecutive. 
     // The mapping between beam ids and sky locations is currently undefined.
@@ -121,4 +122,5 @@ struct L0_L1_header {
     // 0x00 or 0xff, it should be treated as masked.
 
     uint8_t     data[ abs(data_nbytes) ];
+#endif
 };

--- a/lib/utils/L0_L1_packet.hpp
+++ b/lib/utils/L0_L1_packet.hpp
@@ -1,0 +1,124 @@
+//
+// The following pseudo header file isn't actually valid C++ code, but is
+// intended to document the L0_L1 UDP packet format in a C++-like syntax.
+//
+// Here we are specifying the data packet sent from the L0 beam forming process to
+// the L1 nodes to search for FRBs.  The characteristics of the system are as follows:
+//
+//    - Each correlator node (where the L0 process operates) processes all 1024
+//      fan-beams for 4 x 390kHz-wide "coarse" frequency bands.  
+// 
+//    - The L0 process upchannelizes each 390kHz "coarse" frequency band to form 
+//      128 x 3.05kHz subbands. In the same process it will dedisperse the data to 
+//      a fiducial DM value, then downsample the data to  16 x 24kHz "fine" subbands. 
+//
+//    - The 4 coarse frequency bands on each correlator node are not currently considered 
+//      to be contiguous/consecutive.
+//
+//    - The amplitude time series for each beam is then squared, polarization summed and 
+//      integrated to a 1-ms timescale and stored as uint8. 
+//
+//    - Each of the 256 correlator nodes will send data packets to each of the frbsearch 
+//      nodes (which operate the L1 processes for n beams, currently n=8).
+//
+//    - The number of time samples per packet is chosen to match the max ethernet packet
+//      size (approx 9KB assuming Gbps ethernet with jumbo frames).  For full CHIME,
+//      16 time samples per packet is a good choice.
+//
+//    - Thus each packet contains a 4-dimensional 8-bit array of shape (nbeams, nfreq_coarse, 
+//      nupfreq, ntsamp), where:
+//
+//         nbeams = number of beams processed by each L1 node (currently 8)
+//         nfreq_coarse = number of coarse frequencies processed by each L0 node (currently 4)
+//         nupfreq = upchannelization channel (currently 16)
+//         ntsamp = number of time samples (currently 16)
+//
+//     - The packets are sent via UDP to the frbsearch node and some fraction may drop along the way.
+//
+//     - Optionally, the packet may allow for data compression using bitshuffle
+//        (https://github.com/kiyo-masui/bitshuffle).
+//
+// We don't bother putting integer data in network byte order, or converting floating-point data to
+// an external representation, since we're assuming that all nodes are Intel CPUs with little-endian
+// ints and IEEE 754 floats.
+//
+// The packet header size in bytes is currently
+//    32 + 2*nbeam + 2*nfreq_coarse + 8*nbeam*nfreq
+//
+// For full CHIME, we expect to use (nbeam, nfreq_coarse, nupfreq, ntsamp) = (8, 4, 16, 16)
+// which gives a 304-byte header and an 8192-byte data segment.
+//
+// For the pathfinder, I'm currently using  (nbeam, nfreq_coarse, nupfreq, ntsamp) = (1, 32, 1, 256) 
+// which gives a 346-byte header and an 8192-byte data segment.
+//
+
+struct L0_L1_header {
+    // This file describes protocol version 2.
+    // A 32-bit protocol number is overkill, but means that all fields below are aligned on their
+    // "natural" boundaries (i.e. fields with size Nbytes have byte offsets which are multiples of Nbytes)
+    uint32_t    protocol_version;
+
+    // This is a signed 16 bit integer which  gives the total size of the 'data' array below in bytes. 
+    // Negative sizes indicate that bitshuffle compression has been applied and in this case, the 
+    // absolute value indicates the size of the array.  If data_nbytes is positive, it should always
+    // be equal to (nbeam * nfreq_coarse * nupfreq * ntsamp).
+    int16_t     data_nbytes;
+
+    // This is the duration of a time sample, in FPGA counts.
+    // The duration in seconds is dt = (2.56e-6 * fpga_counts_per_sample)
+    uint16_t    fpga_counts_per_sample;
+
+    // This is the time in nanoseconds since Unix epoch of the first FPGA sample (fpga_count=0)
+    uint64_t    fpga_frame0_ns;
+
+    // This is the time index (in FPGA counts) of the first time sample in the packet.
+    // The packet sender is responsible for "unwrapping" the 32-bit FPGA timestamp to 64 bits.
+    // Must be divisible by fpga_counts_per_sample.
+    uint64_t    fpga_count;
+
+    uint16_t    nbeam;          // number of beams in packet
+    uint16_t    nfreq_coarse;   // number of "FPGA" frequency channels between 0 and 1024
+    uint16_t    nupfreq;        // upsampling factor (probably either 1 or 16)
+    uint16_t    ntsamp;         // number of time samples in packet
+
+    // Beam IDs in the data packet, numbered from 0-1023. 
+    // It is not assumed that the 8 beams processed on each frbsearch node are consecutive. 
+    // The mapping between beam ids and sky locations is currently undefined.
+    uint16_t    beam_ids[nbeam];
+
+    // Coarse frequency ids (i.e. 390 kHZ), between 0-1023, not assumed consecutive.
+    // The frequencies are assumed ordered from highest to lowest, i.e. index zero is 800 MHz.
+    uint16_t    coarse_freq_ids[nfreq_coarse];
+    
+    // The 'scale' and 'offset' parameters are used for 8-bit encoding of intensities:
+    //    Floating-point intensity = scale * (raw 8-bit value) + offset
+    //
+    // A design decision: what granularity should the scale and offset parameters have?
+    // In this version of the protocol, we use assume that they can depend on beam and
+    // coarse frequency index, but are the same for each of the 16 upchannelized frequencies
+    // comprising a coarse frequency, and are the same for each of the 16 time samples in
+    // a packet.  Thus the scale of offset arrays have shape (nbeam, nfreq_coarse).
+
+    float32     scale[nbeam * nfreq_coarse];   // byte offset (32 + 2*nbeam + 2*nfreq_coarse)
+    float32     offset[nbeam * nfreq_coarse];  // byte offset (32 + 2*nbeam + 2*nfreq_coarse + 2*nbeam*nfreq_coarse)
+
+    // The uncompressed data array has shape (nbeam, nfreq_coarse, nupfreq, ntsamp),
+    // ordered so that the fastest changing index is the time dimension, i.e. each
+    // timeseries is contiguous.  Compression will change the size of the array, but
+    // the ordering will be the same after decompression.
+    //
+    // Thus in full chime, the uncompressed data array has shape
+    //
+    //  uint8 data[8][4][16][16]
+    //             |  |   |   |
+    //             |  |   |   +-- 16x 1-ms time samples
+    //             |  |   +------ 16x 24 kHz frequency channels 
+    //             |  +---------- 4x frequency bands (may not be consecutive in frequency)
+    //             +------------- 8x on-sky beams
+    //
+    // We need a sentinel value to indicate "this entry in the array is invalid".
+    // We currently take both endpoint values to be sentinels, i.e. if a byte is either
+    // 0x00 or 0xff, it should be treated as masked.
+
+    uint8_t     data[ abs(data_nbytes) ];
+};

--- a/lib/utils/frb_functions.h
+++ b/lib/utils/frb_functions.h
@@ -8,25 +8,7 @@ extern "C" {
 #endif
 
 #pragma pack(push, 1)
-struct FRBHeader {
-    uint32_t protocol_version;
-    int16_t data_nbytes;
-    uint16_t fpga_counts_per_sample;
-    uint64_t fpga0_ns;
-    uint64_t fpga_count;
-    uint16_t nbeams;
-    uint16_t nfreq_coarse;
-    uint16_t nupfreq;
-    uint16_t ntsamp;
-
-    /*Here are some dynamic paramters of the header
-      that I have to allocate in frbPostProcess.cpp*/
-
-    // uint16_t * beam_ids = nullptr; //size of [nbeams]
-    // uint16_t * coarse_freq_ids; //size of [nfreq_coarse];
-    // float *scale ; //size of [nbeams * nfreq_coarse];
-    // float *offset ; //size of [nbeams * nfreq_coarse] ;
-};
+#include "L0_L1_packet.hpp"
 #pragma pack(pop)
 
 

--- a/lib/utils/frb_functions.h
+++ b/lib/utils/frb_functions.h
@@ -8,7 +8,15 @@ extern "C" {
 #endif
 
 #pragma pack(push, 1)
+// trickey to get rename the structs without changing imported files
+#undef L0_L1_HEADER_VARIABLE_SIZE_PART
+#define L0_L1_header FRBHeader
+#define nbeam nbeams
+#define fpga_frame0_ns fpga0_ns
 #include "L0_L1_packet.hpp"
+#undef fpga_frame0_ns
+#undef nbeam
+#undef L0_L1_header
 #pragma pack(pop)
 
 

--- a/lib/utils/tx_utils.cpp
+++ b/lib/utils/tx_utils.cpp
@@ -1,5 +1,7 @@
 #include "tx_utils.hpp"
 
+#include "kotekanLogging.hpp" // for FATAL_ERROR_NON_OO
+
 #include <cstring>   // for strlen
 #include <stdexcept> // for runtime_error
 #include <stdlib.h>  // for atoi, malloc
@@ -134,36 +136,12 @@ void add_nsec(struct timespec& temp, long nsec) {
 }
 
 int get_vlan_from_ip(const char* ip_address) {
-    int len = 0;
-    int location = 0;
-    char* temp;
-    int vlan = 0;
-    int flag = 0;
-    for (unsigned int i = 0; i < std::strlen(ip_address); i++) {
-        if (ip_address[i] == '.' && flag == 0) {
-            location = i + 1;
-            flag = 1;
-        }
+    int a, b, c, d, n;
+    const int fields_parsed = sscanf(ip_address, "%d.%d.%d.%d%n", &a, &b, &c, &d, &n);
+    if (fields_parsed != 4 || (size_t)n != strlen(ip_address)) {
+        FATAL_ERROR_NON_OO("Could not parse {:s} as an IPv4 address", ip_address);
     }
-    flag = 0;
-    for (unsigned int i = location; i < std::strlen(ip_address); i++) {
-        if (ip_address[i] != '.' && flag == 0)
-            len++;
-        else
-            flag = 1;
-    }
-
-    temp = new char[len];
-    flag = 0;
-    for (unsigned int i = location; i < std::strlen(ip_address); i++) {
-        if (ip_address[i] != '.' && flag == 0)
-            temp[i - location] = ip_address[i];
-        else
-            flag = 1;
-    }
-
-    vlan = atoi(temp);
-    return vlan;
+    return b;
 }
 
 

--- a/lib/utils/visUtil.hpp
+++ b/lib/utils/visUtil.hpp
@@ -465,13 +465,18 @@ parse_reorder_default(kotekan::Config& config, const std::string base_path);
 
 /**
  * @brief Fixed mapping from CHIME cylinder ordering to beamformer ordering.
- * @return Array of indices mapping cylinder order to beamformer oreder.
+ * @return Array of indices mapping cylinder order to beamformer order.
+ *         The array is indexed by the station in beamformer order and returns
+ *         the station's index in cylinder order.
  */
 constexpr std::array<size_t, 2048> get_cylinder_to_beamformer_reorder_table() {
     std::array<size_t, 2048> mapping{};
 
-    for (size_t i = 0; i < 2048; ++i) {
-        mapping[i] = 256 * (i / 1024) + 2 * (256 * (i / 256) % 1024) + (i % 256);
+    for (size_t beamformer_idx = 0; beamformer_idx < 2048; ++beamformer_idx) {
+        const int polarization = beamformer_idx / 1024;
+        const int cylinder = (beamformer_idx % 1024) / 256;
+        const int dish = (beamformer_idx % 1024) % 256;
+        mapping[beamformer_idx] = cylinder * 512 + polarization * 256 + dish;
     }
 
     return mapping;
@@ -828,10 +833,10 @@ public:
     /**
      * @brief Create a new modular number.
      **/
-    modulo(Tu n) : _n(n){};
+    modulo(Tu n) : _n(n) {};
 
     // Default constructor
-    modulo() : modulo(0){};
+    modulo() : modulo(0) {};
 
     /// Assignment of a number into the modular number.
     modulo<T>& operator=(const T& i) {

--- a/python/kotekan/frbbuffer.py
+++ b/python/kotekan/frbbuffer.py
@@ -49,8 +49,20 @@ class FrbPacket(ctypes.Structure):
         with io.FileIO(filename, "rb") as fh:
             fh.readinto(buf)
 
-        header = FrbPacketHeader.from_buffer(buf[4:])
-        struct_name = "FrbPacket_" + filename
+        return from_buffer(cls, buf[4:], max_packets, filename)
+
+    @classmethod
+    def from_buffer(cls, buffer, max_packets=None, name=None):
+        """Load a list of frbPackets from a bytes buffer.
+
+        FrbPostProcess stores packets for all 256 streams into a single frame,
+        one after the other, so they ought to appear like that in the dumped
+        buffer.
+
+        """
+
+        header = FrbPacketHeader.from_buffer(buffer)
+        struct_name = "FrbPacket_" + name if name else "FrbPacket"
         struct = type(struct_name, (FrbPacket,), {})
         struct._fields_ = [
             ("header", FrbPacketHeader),
@@ -61,10 +73,10 @@ class FrbPacket(ctypes.Structure):
             ("data", ctypes.c_ubyte * header.nbytes),
         ]
 
-        npkts = (len(buf) - 4) // ctypes.sizeof(struct)
+        npkts = len(buffer) // ctypes.sizeof(struct)
         if max_packets:
             npkts = min(npkts, max_packets)
-        return (struct * npkts).from_buffer(buf[4:])
+        return (struct * npkts).from_buffer(buffer)
 
     @classmethod
     def load_files(cls, pattern):

--- a/python/kotekan/frbbuffer.py
+++ b/python/kotekan/frbbuffer.py
@@ -19,6 +19,7 @@ class FrbPacketHeader(ctypes.Structure):
         ("version", ctypes.c_uint32),
         ("nbytes", ctypes.c_int16),
         ("fpga_counts_per_sample", ctypes.c_uint16),
+        ("fpga0_ns", ctypes.c_uint64),
         ("fpga_seq_num", ctypes.c_uint64),
         ("nbeams", ctypes.c_uint16),
         ("nfreq", ctypes.c_uint16),

--- a/tests/test_parseReorderDefault.py
+++ b/tests/test_parseReorderDefault.py
@@ -10,6 +10,8 @@ if not runner.has_hdf5():
 
 parseReorderDefault_params = {
     "out_buf": "reorder_buffer",
+    "input_order": "correlator",
+    "output_order": "beamformer",
     "name": "scatter_indices",
 }
 
@@ -71,12 +73,12 @@ def scatter_indices(tmpdir_factory):
     )
     test.run()
 
-    yield h5py.File(fname, "r")["reorder_buffer"], adc_ids
+    yield h5py.File(fname, "r")["reorder_buffer"], station_ids, adc_ids
 
 
 def test_scatter_indices(scatter_indices):
 
-    reorder_buffer, adc_ids = scatter_indices
+    reorder_buffer, station_ids, adc_ids = scatter_indices
 
     # metadata and array description
     assert reorder_buffer.attrs["name"] == "scatter_indices"
@@ -86,10 +88,17 @@ def test_scatter_indices(scatter_indices):
     assert reorder_buffer.dtype == np.int32
 
     # payload
-    inverse_mapping = np.empty_like(reorder_buffer)
-    inverse_mapping[:] = -1
+    mapping = np.empty_like(reorder_buffer)
+    mapping[:] = -1
     for el in range(2048):
         adc_id = adc_ids[el]
-        inverse_mapping[adc_id // 1024][adc_id % 1024] = el
-    assert np.all(inverse_mapping != -1)
-    assert np.all(inverse_mapping == reorder_buffer)
+        station_id = station_ids[el]
+        # beamformer order from station_id (cylinder order index)
+        cylinder = station_id // 512
+        polarization = (station_id % 512) // 256
+        dish = (station_id % 512) % 256
+        mapping[adc_id // 1024][adc_id % 1024] = (
+            polarization * 1024 + cylinder * 256 + dish
+        )
+    assert np.all(mapping != -1)
+    assert np.all(mapping == reorder_buffer)

--- a/tools/lint.sh
+++ b/tools/lint.sh
@@ -127,7 +127,7 @@ fi
 
 # clang-format
 echo "Running clang-format..."
-find $KOTEKAN_DIR -type d \( -name "build-iwyu" -o -name "build" -o -name "external" -o -name ".venv" -o -name "scratch" \) -prune -o -type f -regex '.*\.\(cpp\|hpp\|c\|h\)' -exec $CLANG_FORMAT -style=file -i {} \;
+find $KOTEKAN_DIR -type d \( -name "build-iwyu" -o -name "build" -o -name "external" -o -name ".venv" -o -name "scratch" \) -prune -o -type f -not -name L0_L1_packet.hpp -regex '.*\.\(cpp\|hpp\|c\|h\)' -exec echo $CLANG_FORMAT -style=file -i {} \;
 if ! git diff --exit-code; then
     echo "Error: clang-format found formatting issues" >&2
     ERROR=1


### PR DESCRIPTION
* 519e9e1b - test_parseReorderDefault: test mapping to beamformer order
* 4076fb21 - parseReorderDefault: simplify logic, correct use of reorder table
* a96bdf37 - get_cylinder_to_beamformer_reorder_table: be more verbose describing it
* 2e554780 - parseReorderDefault: add a bit of type-safety
* 14698197 - parseReorderDefault: generalize input and output ordering
* d1c5536d - calcFRB2Weights: remove dependency on CHORDTelescope
* eb5494ca - Config: work around unsigned(-1) == unsigned_max issue
* bb5b11d0 - UpchannelizationSchedule: remove assumption that Telescope is CHORD
* 90510b28 - lint.sh: exempt L0_L1 struct documentation file
* 2209ec2e - FrbPacket: add from_buffer method
* 7f67daea - frbbuffer.py: add fpga0_ns field
* a34b3d47 - frb_functions: add kludge code to make pseudo-C++ compile, add missing fields
* eba37a92 - frb_functions: import packet structure declaration from CHIMEFRB project
* 2ba4193e - tx_utils: use sscanf when parsing IPv4 address strings

before I accumulate ever more private changes, here's a pull request for (hopefully) the more straightforward changes.