### PR TITLE
Kv/airspy crosscorr fix

### DIFF
--- a/config/airspy_autocorr.yaml
+++ b/config/airspy_autocorr.yaml
@@ -27,13 +27,14 @@ one: 1
 two: 2
 sizeof_float: 4
 
-meta_pool:
-  kotekan_metadata_pool: chordMetadata
-  num_metadata_objects: 5 * buffer_depth
+# No stage in the airspy pipeline reads, writes, or passes frame metadata,
+# so the buffers below declare `metadata_pool: none` and there is no
+# metadata-pool block at all (rather than the heavyweight, CHORD-specific
+# chordMetadata pool the forward-port inherited).
 
 input_buf:
   kotekan_buffer: standard
-  metadata_pool: meta_pool
+  metadata_pool: none
   num_frames: buffer_depth
   frame_size: samples_per_data_set * bytes_per_sample
 
@@ -56,7 +57,7 @@ spectrum_output:
 
   post_fengine_buf:
     kotekan_buffer: standard
-    metadata_pool: meta_pool
+    metadata_pool: none
     num_frames: buffer_depth
     frame_size: samples_per_data_set * sizeof_float # * 2 for complex / 2 for half-size
 
@@ -69,7 +70,7 @@ spectrum_output:
 
   post_corr_buf:
     kotekan_buffer: standard
-    metadata_pool: meta_pool
+    metadata_pool: none
     num_frames: buffer_depth
     frame_size: ( spectrum_length + one ) * sizeof_float
 

--- a/config/airspy_autocorr.yaml
+++ b/config/airspy_autocorr.yaml
@@ -28,7 +28,7 @@ two: 2
 sizeof_float: 4
 
 meta_pool:
-  kotekan_metadata_pool: chimeMetadata
+  kotekan_metadata_pool: chordMetadata
   num_metadata_objects: 5 * buffer_depth
 
 input_buf:
@@ -46,6 +46,8 @@ airspy_input:
   gain_mix: 10 #0-15
   gain_if:  10 #0-15
   biast_power: false
+  autostart: true
+#  serial: 0x03A464C834658167  # uncomment & edit to pick a specific dongle
 
 spectrum_output:
   integration_length: 64
@@ -60,6 +62,8 @@ spectrum_output:
 
   fengine:
     kotekan_stage: fftwEngine
+    # airspyInput now produces real (RAW) int16 samples; use the real-input FFT.
+    input_type: real
     in_buf: input_buf
     out_buf: post_fengine_buf
 

--- a/config/airspy_crosscorr.yaml
+++ b/config/airspy_crosscorr.yaml
@@ -28,19 +28,20 @@ one: 1
 two: 2
 sizeof_float: 4
 
-meta_pool:
-  kotekan_metadata_pool: chordMetadata
-  num_metadata_objects: 5 * buffer_depth
+# No stage in the airspy pipeline reads, writes, or passes frame metadata,
+# so the buffers below declare `metadata_pool: none` and there is no
+# metadata-pool block at all (rather than the heavyweight, CHORD-specific
+# chordMetadata pool the forward-port inherited).
 
 input_bufA:
   kotekan_buffer: standard
-  metadata_pool: meta_pool
+  metadata_pool: none
   num_frames: buffer_depth
   frame_size: samples_per_data_set * bytes_per_sample
 
 input_bufB:
   kotekan_buffer: standard
-  metadata_pool: meta_pool
+  metadata_pool: none
   num_frames: buffer_depth
   frame_size: samples_per_data_set * bytes_per_sample
 
@@ -79,12 +80,12 @@ integration_length: 1024
 
 post_fengine_bufA:
   kotekan_buffer: standard
-  metadata_pool: meta_pool
+  metadata_pool: none
   num_frames: buffer_depth
   frame_size: samples_per_data_set * sizeof_float
 post_fengine_bufB:
   kotekan_buffer: standard
-  metadata_pool: meta_pool
+  metadata_pool: none
   num_frames: buffer_depth
   frame_size: samples_per_data_set * sizeof_float
 
@@ -110,7 +111,7 @@ correlation_output:
   # general-purpose.
   post_corr_buf:
     kotekan_buffer: standard
-    metadata_pool: meta_pool
+    metadata_pool: none
     num_frames: buffer_depth
     frame_size: ( spectrum_length + one ) * 4 * sizeof_float
 

--- a/config/airspy_crosscorr.yaml
+++ b/config/airspy_crosscorr.yaml
@@ -1,0 +1,126 @@
+##########################################
+#
+# airspy_crosscorr.yaml
+#
+# A two-airspy cross-correlation config. Streams from two AirSpy dongles,
+# channelizes both, aligns them (via AirspyAlign's REST endpoint), and
+# cross-correlates the results. Output is streamed as a power-spectrum-like
+# packet (four channels per spectral bin: AA, BB, Re{AB*}, Im{AB*}) to a
+# local listener.
+#
+# Author: Keith Vanderlinde
+#
+##########################################
+---
+type: config
+# Logging level can be one of:
+# OFF, ERROR, WARN, INFO, DEBUG, DEBUG2 (case insensitive)
+log_level: info
+
+instrument_name: airspy
+
+samples_per_data_set: 32768
+bytes_per_sample: 2
+buffer_depth: 10
+cpu_affinity: [4,5,6,7]
+num_elements: 2
+one: 1
+two: 2
+sizeof_float: 4
+
+meta_pool:
+  kotekan_metadata_pool: chordMetadata
+  num_metadata_objects: 5 * buffer_depth
+
+input_bufA:
+  kotekan_buffer: standard
+  metadata_pool: meta_pool
+  num_frames: buffer_depth
+  frame_size: samples_per_data_set * bytes_per_sample
+
+input_bufB:
+  kotekan_buffer: standard
+  metadata_pool: meta_pool
+  num_frames: buffer_depth
+  frame_size: samples_per_data_set * bytes_per_sample
+
+sample_bw: 10. #MHz, must be float
+freq: 1422.    #MHz
+gain_lna: 4 #0-14
+gain_mix: 5 #0-15
+gain_if:  5 #0-15
+biast_power: false
+autostart: true
+
+# Two airspy producers. Edit the serials to match your hardware (see
+# `airspy_info` from libairspy-tools) or remove them to take whichever
+# devices the OS enumerates first.
+airspy_inputA:
+  kotekan_stage: airspyInput
+  out_buf: input_bufA
+#  serial: 0x03A464C834658167
+
+airspy_inputB:
+  kotekan_stage: airspyInput
+  out_buf: input_bufB
+#  serial: 0x440464C8394C614F
+
+# Estimate the sample-level lag between the two streams over a window of
+# samples. Lag is exposed via REST and can be applied back to airspyInput's
+# `add_lag` to compensate.
+lag_align:
+  kotekan_stage: AirspyAlign
+  in_bufA: input_bufA
+  in_bufB: input_bufB
+  lag_window: 1048576
+
+spectrum_length: 1024
+integration_length: 1024
+
+post_fengine_bufA:
+  kotekan_buffer: standard
+  metadata_pool: meta_pool
+  num_frames: buffer_depth
+  frame_size: samples_per_data_set * sizeof_float
+post_fengine_bufB:
+  kotekan_buffer: standard
+  metadata_pool: meta_pool
+  num_frames: buffer_depth
+  frame_size: samples_per_data_set * sizeof_float
+
+spectrum_output:
+  fengineA:
+    kotekan_stage: fftwEngine
+    input_type: real
+    in_buf: input_bufA
+    out_buf: post_fengine_bufA
+
+  fengineB:
+    kotekan_stage: fftwEngine
+    input_type: real
+    in_buf: input_bufB
+    out_buf: post_fengine_bufB
+
+correlation_output:
+  # Four floats per bin (AA, BB, Re{AB*}, Im{AB*}) + one uint count per integration.
+  post_corr_buf:
+    kotekan_buffer: standard
+    metadata_pool: meta_pool
+    num_frames: buffer_depth
+    frame_size: ( spectrum_length * 4 + one ) * sizeof_float
+
+  xengine:
+    kotekan_stage: SimpleCrosscorr
+    in_bufA: post_fengine_bufA
+    in_bufB: post_fengine_bufB
+    out_buf: post_corr_buf
+
+  power_stream:
+    kotekan_stage: networkPowerStream
+    num_elements: 4
+    num_freq: spectrum_length
+    power_integration_length: integration_length
+    destination_port: 23401
+    destination_ip: "127.0.0.1"
+    destination_protocol: TCP
+    in_buf: post_corr_buf

--- a/config/airspy_crosscorr.yaml
+++ b/config/airspy_crosscorr.yaml
@@ -102,12 +102,17 @@ spectrum_output:
     out_buf: post_fengine_bufB
 
 correlation_output:
-  # Four floats per bin (AA, BB, Re{AB*}, Im{AB*}) + one uint count per integration.
+  # Per-element layout: ``[freqs floats, 1 uint count]`` repeated once per
+  # visibility stream (AA, BB, Re{AB*}, Im{AB*}). That's the layout
+  # ``networkPowerStream`` expects when ``num_elements == 4``; the redundant
+  # per-element count (all four equal the same integration tick) costs an
+  # extra 12 B per integration in exchange for keeping the network stage
+  # general-purpose.
   post_corr_buf:
     kotekan_buffer: standard
     metadata_pool: meta_pool
     num_frames: buffer_depth
-    frame_size: ( spectrum_length * 4 + one ) * sizeof_float
+    frame_size: ( spectrum_length + one ) * 4 * sizeof_float
 
   xengine:
     kotekan_stage: SimpleCrosscorr
@@ -120,6 +125,13 @@ correlation_output:
     num_elements: 4
     num_freq: spectrum_length
     power_integration_length: integration_length
+    # Override the file-global ``samples_per_data_set`` so ``times`` lands
+    # at 1 -- ``SimpleCrosscorr`` writes one integration per frame, but
+    # without this override ``networkPowerStream`` would inherit the
+    # 32768-sample value (from the airspy input stage) and try to read
+    # ``32`` integrations out of each frame, walking past the end and
+    # segfaulting.
+    samples_per_data_set: integration_length
     destination_port: 23401
     destination_ip: "127.0.0.1"
     destination_protocol: TCP

--- a/docs/sphinx/user/processes/AirspyAlign.rst
+++ b/docs/sphinx/user/processes/AirspyAlign.rst
@@ -1,0 +1,5 @@
+*************
+AirspyAlign
+*************
+
+.. doxygenclass:: AirspyAlign

--- a/docs/sphinx/user/processes/SampleAutocorr.rst
+++ b/docs/sphinx/user/processes/SampleAutocorr.rst
@@ -1,0 +1,5 @@
+****************
+SampleAutocorr
+****************
+
+.. doxygenclass:: SampleAutocorr

--- a/docs/sphinx/user/processes/SimpleCrosscorr.rst
+++ b/docs/sphinx/user/processes/SimpleCrosscorr.rst
@@ -1,0 +1,5 @@
+*****************
+SimpleCrosscorr
+*****************
+
+.. doxygenclass:: SimpleCrosscorr

--- a/lib/core/Stage.cpp
+++ b/lib/core/Stage.cpp
@@ -8,7 +8,7 @@
 #include "fmt.hpp" // for compile_string_to_view, format, format_string
 
 #include <algorithm>     // for max, find, copy
-#include <chrono>       // for seconds
+#include <chrono>        // for seconds
 #include <cstdlib>       // for abort
 #include <future>        // for async, future, future_status, launch
 #include <pthread.h>     // for pthread_setaffinity_np, pthread_setname_np

--- a/lib/core/Stage.cpp
+++ b/lib/core/Stage.cpp
@@ -8,7 +8,7 @@
 #include "fmt.hpp" // for compile_string_to_view, format, format_string
 
 #include <algorithm>     // for max, find, copy
-#include <bits/chrono.h> // for seconds
+#include <chrono>       // for seconds
 #include <cstdlib>       // for abort
 #include <future>        // for async, future, future_status, launch
 #include <pthread.h>     // for pthread_setaffinity_np, pthread_setname_np

--- a/lib/core/Stage.hpp
+++ b/lib/core/Stage.hpp
@@ -17,8 +17,6 @@
 
 #ifdef MAC_OSX
 #include "osxBindCPU.hpp"
-
-#include <immintrin.h>
 #endif
 
 namespace kotekan {

--- a/lib/core/basebandApiManager.cpp
+++ b/lib/core/basebandApiManager.cpp
@@ -9,7 +9,7 @@
 
 #include "fmt.hpp" // for compile_string_to_view, format, fmt
 
-#include <bits/chrono.h> // for duration_cast, system_clock, duration, milliseconds
+#include <chrono>       // for duration_cast, system_clock, duration, milliseconds
 #include <ctime>         // for localtime_r, time_t, tm, timespec
 #include <exception>     // for exception
 #include <functional>    // for bind, _1, function, _2

--- a/lib/core/basebandApiManager.cpp
+++ b/lib/core/basebandApiManager.cpp
@@ -9,17 +9,17 @@
 
 #include "fmt.hpp" // for compile_string_to_view, format, fmt
 
-#include <chrono>       // for duration_cast, system_clock, duration, milliseconds
-#include <ctime>         // for localtime_r, time_t, tm, timespec
-#include <exception>     // for exception
-#include <functional>    // for bind, _1, function, _2
-#include <iomanip>       // for operator<<, put_time
-#include <memory>        // for shared_ptr, unique_ptr, __shared_ptr_access
-#include <sstream>       // for basic_ostream, basic_ostringstream, ostringstream
-#include <string>        // for basic_string, char_traits, operator<, to_string
-#include <type_traits>   // for enable_if<>::type  // IWYU pragma: keep
-#include <utility>       // for pair
-#include <vector>        // for vector
+#include <chrono>      // for duration_cast, system_clock, duration, milliseconds
+#include <ctime>       // for localtime_r, time_t, tm, timespec
+#include <exception>   // for exception
+#include <functional>  // for bind, _1, function, _2
+#include <iomanip>     // for operator<<, put_time
+#include <memory>      // for shared_ptr, unique_ptr, __shared_ptr_access
+#include <sstream>     // for basic_ostream, basic_ostringstream, ostringstream
+#include <string>      // for basic_string, char_traits, operator<, to_string
+#include <type_traits> // for enable_if<>::type  // IWYU pragma: keep
+#include <utility>     // for pair
+#include <vector>      // for vector
 
 using nlohmann::json;
 

--- a/lib/core/basebandReadoutManager.hpp
+++ b/lib/core/basebandReadoutManager.hpp
@@ -12,15 +12,15 @@
 #include "SynchronizedQueue.hpp" // for SynchronizedQueue
 
 #include <chrono>       // for system_clock
-#include <forward_list>  // for forward_list
-#include <functional>    // for reference_wrapper
-#include <memory>        // for allocator, shared_ptr, unique_ptr
-#include <mutex>         // for mutex
-#include <stdint.h>      // for int64_t, uint32_t, uint64_t
-#include <string>        // for basic_string, string
-#include <time.h>        // for size_t
-#include <utility>       // for pair
-#include <vector>        // for vector
+#include <forward_list> // for forward_list
+#include <functional>   // for reference_wrapper
+#include <memory>       // for allocator, shared_ptr, unique_ptr
+#include <mutex>        // for mutex
+#include <stdint.h>     // for int64_t, uint32_t, uint64_t
+#include <string>       // for basic_string, string
+#include <time.h>       // for size_t
+#include <utility>      // for pair
+#include <vector>       // for vector
 
 namespace kotekan {
 

--- a/lib/core/basebandReadoutManager.hpp
+++ b/lib/core/basebandReadoutManager.hpp
@@ -11,7 +11,7 @@
 
 #include "SynchronizedQueue.hpp" // for SynchronizedQueue
 
-#include <bits/chrono.h> // for system_clock
+#include <chrono>       // for system_clock
 #include <forward_list>  // for forward_list
 #include <functional>    // for reference_wrapper
 #include <memory>        // for allocator, shared_ptr, unique_ptr

--- a/lib/core/buffer.cpp
+++ b/lib/core/buffer.cpp
@@ -1,7 +1,7 @@
 #include "buffer.hpp"
 
 #include <assert.h>      // for assert
-#include <bits/chrono.h> // for duration, operator+, nanoseconds, seconds, system_clock
+#include <chrono>       // for duration, operator+, nanoseconds, seconds, system_clock
 #include <errno.h>       // for errno
 #include <pthread.h>     // for pthread_create, pthread_detach, pthread_exit, pthread_seta...
 #include <sched.h>       // for CPU_SET, CPU_ZERO, cpu_set_t

--- a/lib/core/buffer.cpp
+++ b/lib/core/buffer.cpp
@@ -1,15 +1,15 @@
 #include "buffer.hpp"
 
-#include <assert.h>      // for assert
-#include <chrono>       // for duration, operator+, nanoseconds, seconds, system_clock
-#include <errno.h>       // for errno
-#include <pthread.h>     // for pthread_create, pthread_detach, pthread_exit, pthread_seta...
-#include <sched.h>       // for CPU_SET, CPU_ZERO, cpu_set_t
-#include <stdexcept>     // for runtime_error
-#include <stdlib.h>      // for free, malloc
-#include <string.h>      // for strerror, memset, memcpy
-#include <sys/mman.h>    // for mmap, munmap, MAP_FAILED
-#include <utility>       // for pair
+#include <assert.h>   // for assert
+#include <chrono>     // for duration, operator+, nanoseconds, seconds, system_clock
+#include <errno.h>    // for errno
+#include <pthread.h>  // for pthread_create, pthread_detach, pthread_exit, pthread_seta...
+#include <sched.h>    // for CPU_SET, CPU_ZERO, cpu_set_t
+#include <stdexcept>  // for runtime_error
+#include <stdlib.h>   // for free, malloc
+#include <string.h>   // for strerror, memset, memcpy
+#include <sys/mman.h> // for mmap, munmap, MAP_FAILED
+#include <utility>    // for pair
 
 // IWYU pragma: no_include <asm/mman-common.h>
 // IWYU pragma: no_include <asm/mman.h>

--- a/lib/core/buffer.hpp
+++ b/lib/core/buffer.hpp
@@ -31,8 +31,6 @@
 
 #ifdef MAC_OSX
 #include "osxBindCPU.hpp"
-
-#include <immintrin.h>
 #endif
 
 /// The system page size, this might become more dynamic someday

--- a/lib/core/cpuMonitor.cpp
+++ b/lib/core/cpuMonitor.cpp
@@ -6,16 +6,16 @@
 #include "fmt.hpp"  // for compile_string_to_view
 #include "json.hpp" // for basic_json, json
 
-#include <chrono>       // for operator""ms
-#include <exception>     // for exception
-#include <functional>    // for bind, _1, function
-#include <math.h>        // for floor
-#include <pthread.h>     // for pthread_setaffinity_np
-#include <sched.h>       // for cpu_set_t, CPU_SET, CPU_ZERO
-#include <stdio.h>       // for fclose, fopen, fscanf, FILE, snprintf
-#include <unistd.h>      // for sysconf, _SC_NPROCESSORS_ONLN
-#include <utility>       // for pair
-#include <vector>        // for vector
+#include <chrono>     // for operator""ms
+#include <exception>  // for exception
+#include <functional> // for bind, _1, function
+#include <math.h>     // for floor
+#include <pthread.h>  // for pthread_setaffinity_np
+#include <sched.h>    // for cpu_set_t, CPU_SET, CPU_ZERO
+#include <stdio.h>    // for fclose, fopen, fscanf, FILE, snprintf
+#include <unistd.h>   // for sysconf, _SC_NPROCESSORS_ONLN
+#include <utility>    // for pair
+#include <vector>     // for vector
 
 using namespace std::chrono_literals;
 using namespace std::placeholders;

--- a/lib/core/cpuMonitor.cpp
+++ b/lib/core/cpuMonitor.cpp
@@ -6,7 +6,7 @@
 #include "fmt.hpp"  // for compile_string_to_view
 #include "json.hpp" // for basic_json, json
 
-#include <bits/chrono.h> // for operator""ms
+#include <chrono>       // for operator""ms
 #include <exception>     // for exception
 #include <functional>    // for bind, _1, function
 #include <math.h>        // for floor

--- a/lib/core/juliaManager.cpp
+++ b/lib/core/juliaManager.cpp
@@ -6,18 +6,18 @@
 #include <julia_fasttls.h> // for JULIA_DEFINE_FAST_TLS
 #pragma GCC diagnostic pop
 
-#include <algorithm>     // for copy
-#include <any>           // for any
-#include <chrono>       // for operator""ms
-#include <cassert>       // for assert
-#include <cstdio>        // for fflush
-#include <cstdlib>       // for abort
-#include <errors.h>      // for INFO_F, DEBUG_F
-#include <future>        // for promise, future
-#include <mutex>         // for unique_lock, mutex
-#include <queue>         // for queue
-#include <thread>        // for thread, sleep_for
-#include <utility>       // for move
+#include <algorithm> // for copy
+#include <any>       // for any
+#include <cassert>   // for assert
+#include <chrono>    // for operator""ms
+#include <cstdio>    // for fflush
+#include <cstdlib>   // for abort
+#include <errors.h>  // for INFO_F, DEBUG_F
+#include <future>    // for promise, future
+#include <mutex>     // for unique_lock, mutex
+#include <queue>     // for queue
+#include <thread>    // for thread, sleep_for
+#include <utility>   // for move
 
 // Only define this once, in an executable (not in a shared library) if you want fast code.
 JULIA_DEFINE_FAST_TLS

--- a/lib/core/juliaManager.cpp
+++ b/lib/core/juliaManager.cpp
@@ -8,7 +8,7 @@
 
 #include <algorithm>     // for copy
 #include <any>           // for any
-#include <bits/chrono.h> // for operator""ms
+#include <chrono>       // for operator""ms
 #include <cassert>       // for assert
 #include <cstdio>        // for fflush
 #include <cstdlib>       // for abort

--- a/lib/core/kotekanTrackers.cpp
+++ b/lib/core/kotekanTrackers.cpp
@@ -5,7 +5,7 @@
 #include "fmt.hpp"  // for compile_string_to_view, format, fmt
 #include "json.hpp" // for json, operator<<
 
-#include <bits/chrono.h> // for system_clock
+#include <chrono>       // for system_clock
 #include <cstdio>        // for snprintf
 #include <ctime>         // for tm, localtime_r, time_t
 #include <errno.h>       // for errno

--- a/lib/core/kotekanTrackers.cpp
+++ b/lib/core/kotekanTrackers.cpp
@@ -5,16 +5,16 @@
 #include "fmt.hpp"  // for compile_string_to_view, format, fmt
 #include "json.hpp" // for json, operator<<
 
-#include <chrono>       // for system_clock
-#include <cstdio>        // for snprintf
-#include <ctime>         // for tm, localtime_r, time_t
-#include <errno.h>       // for errno
-#include <fstream>       // for basic_ofstream, basic_ostream, ofstream
-#include <functional>    // for bind, _1, function
-#include <stdexcept>     // for runtime_error
-#include <stdlib.h>      // for exit
-#include <unistd.h>      // for gethostname
-#include <utility>       // for pair
+#include <chrono>     // for system_clock
+#include <cstdio>     // for snprintf
+#include <ctime>      // for tm, localtime_r, time_t
+#include <errno.h>    // for errno
+#include <fstream>    // for basic_ofstream, basic_ostream, ofstream
+#include <functional> // for bind, _1, function
+#include <stdexcept>  // for runtime_error
+#include <stdlib.h>   // for exit
+#include <unistd.h>   // for gethostname
+#include <utility>    // for pair
 
 namespace kotekan {
 

--- a/lib/stages/AirspyAlign.cpp
+++ b/lib/stages/AirspyAlign.cpp
@@ -4,6 +4,7 @@
 #include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
 #include "buffer.hpp"          // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
+#include "fftwPlannerLock.hpp" // for fftw_planner_mutex
 #include "kotekanLogging.hpp"  // for DEBUG
 
 #include <algorithm>          // for min
@@ -73,15 +74,21 @@ void AirspyAlign::start_callback(kotekan::connectionInstance& conn, bool send_co
 
     float* samplesA = (float*)fftwf_malloc(sizeof(float) * fft_len);
     fftwf_complex* spectrumA = (fftwf_complex*)fftwf_malloc(sizeof(fftwf_complex) * n_bins);
-    fftwf_plan fft_planA = fftwf_plan_dft_r2c_1d(fft_len, samplesA, spectrumA, FFTW_ESTIMATE);
-
     float* samplesB = (float*)fftwf_malloc(sizeof(float) * fft_len);
     fftwf_complex* spectrumB = (fftwf_complex*)fftwf_malloc(sizeof(fftwf_complex) * n_bins);
-    fftwf_plan fft_planB = fftwf_plan_dft_r2c_1d(fft_len, samplesB, spectrumB, FFTW_ESTIMATE);
-
     float* samplesC = (float*)fftwf_malloc(sizeof(float) * fft_len);
     fftwf_complex* spectrumC = (fftwf_complex*)fftwf_malloc(sizeof(fftwf_complex) * n_bins);
-    fftwf_plan fft_planC = fftwf_plan_dft_c2r_1d(fft_len, spectrumC, samplesC, FFTW_ESTIMATE);
+
+    // FFTW's planner is not thread-safe; this callback runs on a REST
+    // handler thread and can race other stages' plan create/destroy.
+    // Serialize plan creation (fftwf_malloc above is thread-safe).
+    fftwf_plan fft_planA, fft_planB, fft_planC;
+    {
+        std::lock_guard<std::mutex> planner_lock(fftw_planner_mutex());
+        fft_planA = fftwf_plan_dft_r2c_1d(fft_len, samplesA, spectrumA, FFTW_ESTIMATE);
+        fft_planB = fftwf_plan_dft_r2c_1d(fft_len, samplesB, spectrumB, FFTW_ESTIMATE);
+        fft_planC = fftwf_plan_dft_c2r_1d(fft_len, spectrumC, samplesC, FFTW_ESTIMATE);
+    }
 
     for (uint32_t i = 0; i < _lag_window; i++) {
         samplesA[i] = localA[i];
@@ -120,7 +127,11 @@ void AirspyAlign::start_callback(kotekan::connectionInstance& conn, bool send_co
         meanval += val;
         corr_pos.push_back(val);
 
-        val = fabs(samplesC[fft_len - i] / norm);
+        // Negative-lag side of the circular correlation: lag -i lives at
+        // index (fft_len - i). The modulo keeps i==0 in-bounds (it maps to
+        // index 0, i.e. lag 0, the same sample as the positive side) --
+        // without it, i==0 reads samplesC[fft_len], one past the end.
+        val = fabs(samplesC[(fft_len - i) % fft_len] / norm);
         if (val > maxval) {
             lag = -i;
             maxval = val;
@@ -133,7 +144,7 @@ void AirspyAlign::start_callback(kotekan::connectionInstance& conn, bool send_co
         float norm = (float)_lag_window - i;
         float val = fabs(samplesC[i] / norm) - meanval;
         var += val * val;
-        val = fabs(samplesC[fft_len - i] / norm) - meanval;
+        val = fabs(samplesC[(fft_len - i) % fft_len] / norm) - meanval;
         var += val * val;
     }
     var /= (_lag_window - edge_truncate) * 2;
@@ -161,9 +172,12 @@ void AirspyAlign::start_callback(kotekan::connectionInstance& conn, bool send_co
     fftwf_free(spectrumA);
     fftwf_free(spectrumB);
     fftwf_free(spectrumC);
-    fftwf_destroy_plan(fft_planA);
-    fftwf_destroy_plan(fft_planB);
-    fftwf_destroy_plan(fft_planC);
+    {
+        std::lock_guard<std::mutex> planner_lock(fftw_planner_mutex());
+        fftwf_destroy_plan(fft_planA);
+        fftwf_destroy_plan(fft_planB);
+        fftwf_destroy_plan(fft_planC);
+    }
 }
 
 void AirspyAlign::main_thread() {

--- a/lib/stages/AirspyAlign.cpp
+++ b/lib/stages/AirspyAlign.cpp
@@ -35,10 +35,8 @@ AirspyAlign::AirspyAlign(Config& config, const std::string& unique_name,
 
     // Both inputs are int16 1-D airspy sample streams; set_frame_desc
     // records or cross-checks against airspyInput's earlier assertion.
-    buf_inA->set_frame_desc(
-        kotekan_airspy::make_input_desc(buf_inA->frame_size / sizeof(short)));
-    buf_inB->set_frame_desc(
-        kotekan_airspy::make_input_desc(buf_inB->frame_size / sizeof(short)));
+    buf_inA->set_frame_desc(kotekan_airspy::make_input_desc(buf_inA->frame_size / sizeof(short)));
+    buf_inB->set_frame_desc(kotekan_airspy::make_input_desc(buf_inB->frame_size / sizeof(short)));
 
     _lag_window = config.get_default<uint32_t>(unique_name, "lag_window",
                                                buf_inA->frame_size / sizeof(short));

--- a/lib/stages/AirspyAlign.cpp
+++ b/lib/stages/AirspyAlign.cpp
@@ -2,6 +2,7 @@
 
 #include "Config.hpp"          // for Config
 #include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
+#include "airspyFrameDesc.hpp" // for make_input_desc
 #include "buffer.hpp"          // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
 #include "fftwPlannerLock.hpp" // for fftw_planner_mutex
@@ -31,6 +32,13 @@ AirspyAlign::AirspyAlign(Config& config, const std::string& unique_name,
     buf_inA->register_consumer(unique_name);
     buf_inB = get_buffer("in_bufB");
     buf_inB->register_consumer(unique_name);
+
+    // Both inputs are int16 1-D airspy sample streams; set_frame_desc
+    // records or cross-checks against airspyInput's earlier assertion.
+    buf_inA->set_frame_desc(
+        kotekan_airspy::make_input_desc(buf_inA->frame_size / sizeof(short)));
+    buf_inB->set_frame_desc(
+        kotekan_airspy::make_input_desc(buf_inB->frame_size / sizeof(short)));
 
     _lag_window = config.get_default<uint32_t>(unique_name, "lag_window",
                                                buf_inA->frame_size / sizeof(short));

--- a/lib/stages/AirspyAlign.cpp
+++ b/lib/stages/AirspyAlign.cpp
@@ -1,0 +1,214 @@
+#include "AirspyAlign.hpp"
+
+#include "Config.hpp"          // for Config
+#include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
+#include "buffer.hpp"          // for Buffer
+#include "bufferContainer.hpp" // for bufferContainer
+#include "kotekanLogging.hpp"  // for DEBUG
+
+#include <algorithm>          // for min
+#include <condition_variable> // for condition_variable
+#include <fftw3.h>            // for fftwf_*
+#include <functional>         // for bind, _1
+#include <math.h>             // for sqrt, fabs
+#include <mutex>              // for unique_lock, lock_guard
+#include <stdint.h>           // for uint32_t
+#include <stdlib.h>           // for malloc, free
+#include <string.h>           // for memcpy, memset
+
+using kotekan::bufferContainer;
+using kotekan::Config;
+using kotekan::Stage;
+
+REGISTER_KOTEKAN_STAGE(AirspyAlign);
+
+AirspyAlign::AirspyAlign(Config& config, const std::string& unique_name,
+                         bufferContainer& buffer_container) :
+    Stage(config, unique_name, buffer_container, std::bind(&AirspyAlign::main_thread, this)) {
+
+    buf_inA = get_buffer("in_bufA");
+    buf_inA->register_consumer(unique_name);
+    buf_inB = get_buffer("in_bufB");
+    buf_inB->register_consumer(unique_name);
+
+    _lag_window = config.get_default<uint32_t>(unique_name, "lag_window",
+                                               buf_inA->frame_size / sizeof(short));
+    localA = (short*)malloc(_lag_window * sizeof(short));
+    localB = (short*)malloc(_lag_window * sizeof(short));
+}
+
+AirspyAlign::~AirspyAlign() {
+    free(localA);
+    free(localB);
+}
+
+void AirspyAlign::cal_lag_callback(kotekan::connectionInstance& conn) {
+    start_callback(conn, false);
+}
+
+void AirspyAlign::get_correlation_callback(kotekan::connectionInstance& conn) {
+    start_callback(conn, true);
+}
+
+void AirspyAlign::start_callback(kotekan::connectionInstance& conn, bool send_corr) {
+    {
+        std::unique_lock<std::mutex> lock(going_mutex);
+        if (going) {
+            conn.send_error("Lag capture already in progress.",
+                            kotekan::HTTP_RESPONSE::BAD_REQUEST);
+            return;
+        }
+        going = true;
+        going_cv.wait(lock, [this] { return !going || stop_thread; });
+        if (stop_thread) {
+            going = false;
+            lock.unlock();
+            conn.send_error("Stage shutting down.", kotekan::HTTP_RESPONSE::INTERNAL_ERROR);
+            return;
+        }
+    }
+
+    const uint32_t fft_len = _lag_window * 2;
+    const uint32_t n_bins = fft_len / 2 + 1;
+
+    float* samplesA = (float*)fftwf_malloc(sizeof(float) * fft_len);
+    fftwf_complex* spectrumA = (fftwf_complex*)fftwf_malloc(sizeof(fftwf_complex) * n_bins);
+    fftwf_plan fft_planA = fftwf_plan_dft_r2c_1d(fft_len, samplesA, spectrumA, FFTW_ESTIMATE);
+
+    float* samplesB = (float*)fftwf_malloc(sizeof(float) * fft_len);
+    fftwf_complex* spectrumB = (fftwf_complex*)fftwf_malloc(sizeof(fftwf_complex) * n_bins);
+    fftwf_plan fft_planB = fftwf_plan_dft_r2c_1d(fft_len, samplesB, spectrumB, FFTW_ESTIMATE);
+
+    float* samplesC = (float*)fftwf_malloc(sizeof(float) * fft_len);
+    fftwf_complex* spectrumC = (fftwf_complex*)fftwf_malloc(sizeof(fftwf_complex) * n_bins);
+    fftwf_plan fft_planC = fftwf_plan_dft_c2r_1d(fft_len, spectrumC, samplesC, FFTW_ESTIMATE);
+
+    for (uint32_t i = 0; i < _lag_window; i++) {
+        samplesA[i] = localA[i];
+        samplesB[i] = localB[i];
+    }
+    memset(&samplesA[_lag_window], 0, _lag_window * sizeof(float));
+    memset(&samplesB[_lag_window], 0, _lag_window * sizeof(float));
+
+    fftwf_execute(fft_planA);
+    fftwf_execute(fft_planB);
+
+    // A x conj(B), bin-by-bin.
+    for (uint32_t i = 0; i < n_bins; i++) {
+        float Ar = spectrumA[i][0];
+        float Ai = spectrumA[i][1];
+        float Br = spectrumB[i][0];
+        float Bi = spectrumB[i][1];
+        spectrumC[i][0] = Ar * Br + Ai * Bi;
+        spectrumC[i][1] = Ai * Br - Bi * Ar;
+    }
+    fftwf_execute(fft_planC);
+
+    float maxval = 0, meanval = 0, var = 0;
+    int lag = 0;
+    nlohmann::json corr_pos = nlohmann::json::array();
+    nlohmann::json corr_neg = nlohmann::json::array();
+
+    const uint32_t edge_truncate = _lag_window * 0.1;
+    for (uint32_t i = 0; i < _lag_window - edge_truncate; i++) {
+        float norm = (float)_lag_window - i;
+        float val = fabs(samplesC[i] / norm);
+        if (val > maxval) {
+            lag = i;
+            maxval = val;
+        }
+        meanval += val;
+        corr_pos.push_back(val);
+
+        val = fabs(samplesC[fft_len - i] / norm);
+        if (val > maxval) {
+            lag = -i;
+            maxval = val;
+        }
+        meanval += val;
+        corr_neg.push_back(val);
+    }
+    meanval /= (_lag_window - edge_truncate) * 2;
+    for (uint32_t i = 0; i < _lag_window - edge_truncate; i++) {
+        float norm = (float)_lag_window - i;
+        float val = fabs(samplesC[i] / norm) - meanval;
+        var += val * val;
+        val = fabs(samplesC[fft_len - i] / norm) - meanval;
+        var += val * val;
+    }
+    var /= (_lag_window - edge_truncate) * 2;
+    float std_dev = sqrt(var);
+
+    DEBUG("Align: Max: {}, Mean: {}, RMS: {}", maxval, meanval, std_dev);
+
+    nlohmann::json reply;
+    if (maxval > meanval + std_dev) {
+        DEBUG("Lag found: {}", lag);
+        reply["lag"] = lag;
+    } else {
+        DEBUG("No lag found.");
+        reply["lag"] = 0;
+    }
+    if (send_corr) {
+        reply["corr_pos"] = corr_pos;
+        reply["corr_neg"] = corr_neg;
+    }
+    conn.send_json_reply(reply);
+
+    fftwf_free(samplesA);
+    fftwf_free(samplesB);
+    fftwf_free(samplesC);
+    fftwf_free(spectrumA);
+    fftwf_free(spectrumB);
+    fftwf_free(spectrumC);
+    fftwf_destroy_plan(fft_planA);
+    fftwf_destroy_plan(fft_planB);
+    fftwf_destroy_plan(fft_planC);
+}
+
+void AirspyAlign::main_thread() {
+    using namespace std::placeholders;
+    kotekan::restServer& rest_server = kotekan::restServer::instance();
+    rest_server.register_get_callback(unique_name + "/cal_lag",
+                                      std::bind(&AirspyAlign::cal_lag_callback, this, _1));
+    rest_server.register_get_callback(unique_name + "/get_correlation",
+                                      std::bind(&AirspyAlign::get_correlation_callback, this, _1));
+
+    frame_inA = 0;
+    frame_inB = 0;
+    uint32_t copied = 0;
+    const uint32_t samples_per_frame = buf_inA->frame_size / sizeof(short);
+
+    // Assumes the two input buffers are aligned frame-for-frame.
+    while (!stop_thread) {
+        short* inA = (short*)buf_inA->wait_for_full_frame(unique_name, frame_inA);
+        short* inB = (short*)buf_inB->wait_for_full_frame(unique_name, frame_inB);
+        if (inA == nullptr || inB == nullptr)
+            break;
+
+        bool completed = false;
+        {
+            std::lock_guard<std::mutex> lock(going_mutex);
+            if (going) {
+                uint32_t copylen = std::min(_lag_window - copied, samples_per_frame);
+                memcpy(localA + copied, inA, copylen * sizeof(short));
+                memcpy(localB + copied, inB, copylen * sizeof(short));
+                copied += copylen;
+                if (copied >= _lag_window) {
+                    copied = 0;
+                    going = false;
+                    completed = true;
+                }
+            }
+        }
+        if (completed)
+            going_cv.notify_one();
+
+        buf_inA->mark_frame_empty(unique_name, frame_inA);
+        buf_inB->mark_frame_empty(unique_name, frame_inB);
+        frame_inA = (frame_inA + 1) % buf_inA->num_frames;
+        frame_inB = (frame_inB + 1) % buf_inB->num_frames;
+    }
+    // Wake any REST callback waiting on a pending capture so it doesn't deadlock on shutdown.
+    going_cv.notify_all();
+}

--- a/lib/stages/AirspyAlign.hpp
+++ b/lib/stages/AirspyAlign.hpp
@@ -1,0 +1,84 @@
+/**
+ * @file
+ * @brief Stage that measures the time-lag between two airspy streams via FFT cross-correlation.
+ *  - AirspyAlign : public kotekan::Stage
+ */
+
+#ifndef AIRSPY_ALIGN_HPP
+#define AIRSPY_ALIGN_HPP
+
+#include "Config.hpp"          // for Config
+#include "Stage.hpp"           // for Stage
+#include "buffer.hpp"          // for Buffer
+#include "bufferContainer.hpp" // for bufferContainer
+#include "restServer.hpp"      // for connectionInstance
+
+#include <condition_variable> // for condition_variable
+#include <mutex>              // for mutex
+#include <string>             // for string
+
+/**
+ * @class AirspyAlign
+ * @brief Kotekan stage to measure the time-lag between two real input streams.
+ *
+ * Consumes raw @c short samples from two airspy producers. On REST request the
+ * stage captures @c lag_window samples from each input, then in the callback
+ * performs zero-padded FFT cross-correlation to estimate the integer sample
+ * lag between A and B. The lag, and optionally the full correlation magnitudes,
+ * are returned as JSON.
+ *
+ * @par Buffers
+ * @buffer in_bufA Input kotekan buffer A.
+ *     @buffer_format Array of @c short
+ *     @buffer_metadata none
+ * @buffer in_bufB Input kotekan buffer B.
+ *     @buffer_format Array of @c short
+ *     @buffer_metadata none
+ *
+ * @par REST endpoints
+ *  - GET @c <unique_name>/cal_lag         — returns @c {"lag": int}
+ *  - GET @c <unique_name>/get_correlation — returns @c {"lag": int, "corr_pos": [...], "corr_neg":
+ * [...]}
+ *
+ * @conf   lag_window   UInt (default: input frame size in samples). Number of samples to capture.
+ *
+ * @author Keith Vanderlinde
+ */
+class AirspyAlign : public kotekan::Stage {
+public:
+    AirspyAlign(kotekan::Config& config, const std::string& unique_name,
+                kotekan::bufferContainer& buffer_container);
+    ~AirspyAlign() override;
+
+    void main_thread() override;
+
+    void cal_lag_callback(kotekan::connectionInstance& conn);
+    void get_correlation_callback(kotekan::connectionInstance& conn);
+
+private:
+    /// Shared implementation for the two callbacks.
+    void start_callback(kotekan::connectionInstance& conn, bool send_corr);
+
+    /// Input buffers.
+    Buffer* buf_inA;
+    Buffer* buf_inB;
+
+    /// Local capture buffers, length @c lag_window each.
+    short* localA;
+    short* localB;
+
+    /// Guards @c going and the contents of @c localA / @c localB during a capture.
+    std::mutex going_mutex;
+    /// Signalled by main_thread when it transitions @c going from true back to false.
+    std::condition_variable going_cv;
+    /// Flag flipped by REST callback to request a capture; cleared by main_thread once filled.
+    bool going = false;
+    /// Capture length in samples.
+    uint32_t _lag_window;
+
+    /// Frame indices.
+    int frame_inA;
+    int frame_inB;
+};
+
+#endif

--- a/lib/stages/BasebandWriter.cpp
+++ b/lib/stages/BasebandWriter.cpp
@@ -9,7 +9,7 @@
 #include "fmt.hpp" // for compile_string_to_view, format, format_string
 
 #include <algorithm>     // for max
-#include <bits/chrono.h> // for duration, operator-, operator/, operator>, seconds, ste...
+#include <chrono>       // for duration, operator-, operator/, operator>, seconds, ste...
 #include <functional>    // for bind, function
 #include <math.h>        // for round
 #include <memory>        // for __shared_ptr_access, shared_ptr

--- a/lib/stages/BasebandWriter.cpp
+++ b/lib/stages/BasebandWriter.cpp
@@ -8,17 +8,17 @@
 
 #include "fmt.hpp" // for compile_string_to_view, format, format_string
 
-#include <algorithm>     // for max
-#include <chrono>       // for duration, operator-, operator/, operator>, seconds, ste...
-#include <functional>    // for bind, function
-#include <math.h>        // for round
-#include <memory>        // for __shared_ptr_access, shared_ptr
-#include <ratio>         // for ratio
-#include <stddef.h>      // for size_t
-#include <sys/stat.h>    // for mkdir, S_IRGRP, S_IROTH, S_IRWXU, S_IXGRP, S_IXOTH
-#include <thread>        // for sleep_for, thread
-#include <tuple>         // for forward_as_tuple
-#include <utility>       // for pair, piecewise_construct
+#include <algorithm>  // for max
+#include <chrono>     // for duration, operator-, operator/, operator>, seconds, ste...
+#include <functional> // for bind, function
+#include <math.h>     // for round
+#include <memory>     // for __shared_ptr_access, shared_ptr
+#include <ratio>      // for ratio
+#include <stddef.h>   // for size_t
+#include <sys/stat.h> // for mkdir, S_IRGRP, S_IROTH, S_IRWXU, S_IXGRP, S_IXOTH
+#include <thread>     // for sleep_for, thread
+#include <tuple>      // for forward_as_tuple
+#include <utility>    // for pair, piecewise_construct
 
 using kotekan::bufferContainer;
 using kotekan::Config;

--- a/lib/stages/CMakeLists.txt
+++ b/lib/stages/CMakeLists.txt
@@ -40,6 +40,8 @@ add_library(
     bufferSend.cpp
     bufferRecv.cpp
     simpleAutocorr.cpp
+    SampleAutocorr.cpp
+    SimpleCrosscorr.cpp
     freqSplit.cpp
     FreqSubset.cpp
     prodSubset.cpp
@@ -122,6 +124,10 @@ if(LIBAIRSPY_FOUND)
     target_include_directories(kotekan_stages SYSTEM PRIVATE ${LIBAIRSPY_INCLUDE_DIR})
     target_include_directories(kotekan_stages SYSTEM PRIVATE ${FFTW_INCLUDES})
     target_link_libraries(kotekan_stages PRIVATE ${LIBAIRSPY_LIBRARIES})
+    if(FFTW_FOUND)
+        target_sources(kotekan_stages PRIVATE AirspyAlign.cpp)
+        target_link_libraries(kotekan_stages PRIVATE ${FFTW_LIBRARIES})
+    endif()
 endif()
 
 if(FFTW_FOUND)

--- a/lib/stages/ReadGain.cpp
+++ b/lib/stages/ReadGain.cpp
@@ -12,7 +12,7 @@
 
 #include "fmt.hpp" // for compile_string_to_view
 
-#include <bits/chrono.h> // for seconds
+#include <chrono>       // for seconds
 #include <exception>     // for exception
 #include <functional>    // for bind, function, _1
 #include <memory>        // for __shared_ptr_access, shared_ptr

--- a/lib/stages/ReadGain.cpp
+++ b/lib/stages/ReadGain.cpp
@@ -12,15 +12,15 @@
 
 #include "fmt.hpp" // for compile_string_to_view
 
-#include <chrono>       // for seconds
-#include <exception>     // for exception
-#include <functional>    // for bind, function, _1
-#include <memory>        // for __shared_ptr_access, shared_ptr
-#include <stdexcept>     // for runtime_error
-#include <stdio.h>       // for fclose, fopen, fread, snprintf, FILE
-#include <stdlib.h>      // for free, malloc
-#include <string.h>      // for memcpy
-#include <sys/types.h>   // for uint
+#include <chrono>      // for seconds
+#include <exception>   // for exception
+#include <functional>  // for bind, function, _1
+#include <memory>      // for __shared_ptr_access, shared_ptr
+#include <stdexcept>   // for runtime_error
+#include <stdio.h>     // for fclose, fopen, fread, snprintf, FILE
+#include <stdlib.h>    // for free, malloc
+#include <string.h>    // for memcpy
+#include <sys/types.h> // for uint
 
 
 using kotekan::bufferContainer;

--- a/lib/stages/SampleAutocorr.cpp
+++ b/lib/stages/SampleAutocorr.cpp
@@ -1,0 +1,128 @@
+#include "SampleAutocorr.hpp"
+
+#include "Config.hpp"          // for Config
+#include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
+#include "buffer.hpp"          // for Buffer
+#include "bufferContainer.hpp" // for bufferContainer
+#include "kotekanLogging.hpp"  // for INFO
+#include "restServer.hpp"      // for connectionInstance, restServer, HTTP_RESPONSE
+
+#include <condition_variable> // for condition_variable
+#include <functional>         // for bind, _1, _2
+#include <mutex>              // for unique_lock, lock_guard
+#include <stdlib.h>           // for calloc, free
+#include <string.h>           // for memset
+
+using kotekan::bufferContainer;
+using kotekan::Config;
+using kotekan::Stage;
+
+REGISTER_KOTEKAN_STAGE(SampleAutocorr);
+
+SampleAutocorr::SampleAutocorr(Config& config, const std::string& unique_name,
+                               bufferContainer& buffer_container) :
+    Stage(config, unique_name, buffer_container, std::bind(&SampleAutocorr::main_thread, this)) {
+
+    buf_in = get_buffer("in_buf");
+    buf_in->register_consumer(unique_name);
+
+    _spectrum_length = config.get_default<int>(unique_name, "spectrum_length", 1024);
+    _integration_length = config.get_default<int>(unique_name, "integration_length", 1024);
+
+    spectrum_out = (float*)calloc(_spectrum_length, sizeof(float));
+
+    endpoint = unique_name + "/spectrum";
+}
+
+SampleAutocorr::~SampleAutocorr() {
+    kotekan::restServer::instance().remove_json_callback(endpoint);
+    free(spectrum_out);
+}
+
+void SampleAutocorr::rest_callback(kotekan::connectionInstance& conn,
+                                   nlohmann::json& json_request) {
+    int requested_length;
+    try {
+        requested_length = json_request["integration_length"];
+    } catch (...) {
+        conn.send_error("Couldn't parse sample request parameters.",
+                        kotekan::HTTP_RESPONSE::BAD_REQUEST);
+        return;
+    }
+
+    std::unique_lock<std::mutex> lock(sample_mutex);
+    if (sample_active || sample_ready) {
+        conn.send_error("Concurrent sample request in progress.",
+                        kotekan::HTTP_RESPONSE::BAD_REQUEST);
+        return;
+    }
+    _integration_length = requested_length;
+    INFO("Recording spectrum of length {:d}, integration length {:d}", _spectrum_length,
+         _integration_length);
+
+    sample_active = true;
+    sample_cv.wait(lock, [this] { return sample_ready || stop_thread; });
+    if (stop_thread) {
+        sample_active = false;
+        lock.unlock();
+        conn.send_error("Stage shutting down.", kotekan::HTTP_RESPONSE::INTERNAL_ERROR);
+        return;
+    }
+
+    nlohmann::json reply;
+    reply["stokes_i"] = nlohmann::json::array({});
+    for (int i = 0; i < _spectrum_length; i++)
+        reply["stokes_i"].push_back(spectrum_out[i]);
+    memset(spectrum_out, 0, _spectrum_length * sizeof(float));
+    sample_ready = false;
+
+    lock.unlock();
+    conn.send_json_reply(reply);
+}
+
+void SampleAutocorr::main_thread() {
+    using namespace std::placeholders;
+    kotekan::restServer& rest_server = kotekan::restServer::instance();
+    rest_server.register_post_callback(endpoint,
+                                       std::bind(&SampleAutocorr::rest_callback, this, _1, _2));
+
+    frame_in = 0;
+    int integration_ct = 0;
+
+    int samples_per_frame = buf_in->frame_size / (2 * sizeof(float));
+
+    while (!stop_thread) {
+        float* in_local = (float*)buf_in->wait_for_full_frame(unique_name, frame_in);
+        if (in_local == nullptr)
+            break;
+
+        bool just_completed = false;
+        {
+            std::lock_guard<std::mutex> lock(sample_mutex);
+            if (sample_active) {
+                for (int j = 0; j < samples_per_frame; j += _spectrum_length) {
+                    for (int i = 0; i < _spectrum_length; i++) {
+                        float re = in_local[(i + j) * 2];
+                        float im = in_local[(i + j) * 2 + 1];
+                        spectrum_out[i] += (re * re + im * im) / _integration_length;
+                    }
+                    integration_ct++;
+                    if (integration_ct >= _integration_length) {
+                        integration_ct = 0;
+                        sample_active = false;
+                        sample_ready = true;
+                        just_completed = true;
+                        break;
+                    }
+                }
+            }
+        }
+        if (just_completed)
+            sample_cv.notify_one();
+
+        buf_in->mark_frame_empty(unique_name, frame_in);
+        frame_in = (frame_in + 1) % buf_in->num_frames;
+    }
+    // Wake any REST callback waiting on a pending sample so it doesn't deadlock on shutdown.
+    sample_cv.notify_all();
+}

--- a/lib/stages/SampleAutocorr.cpp
+++ b/lib/stages/SampleAutocorr.cpp
@@ -2,6 +2,7 @@
 
 #include "Config.hpp"          // for Config
 #include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
+#include "airspyFrameDesc.hpp" // for make_fengine_desc
 #include "buffer.hpp"          // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
 #include "kotekanLogging.hpp"  // for INFO
@@ -25,6 +26,10 @@ SampleAutocorr::SampleAutocorr(Config& config, const std::string& unique_name,
 
     buf_in = get_buffer("in_buf");
     buf_in->register_consumer(unique_name);
+
+    // Input: cfloat32 1-D fengine spectra (consumer-only; no out_buf).
+    buf_in->set_frame_desc(
+        kotekan_airspy::make_fengine_desc(buf_in->frame_size / (2 * sizeof(float))));
 
     _spectrum_length = config.get_default<int>(unique_name, "spectrum_length", 1024);
     _integration_length = config.get_default<int>(unique_name, "integration_length", 1024);

--- a/lib/stages/SampleAutocorr.hpp
+++ b/lib/stages/SampleAutocorr.hpp
@@ -1,0 +1,84 @@
+/**
+ * @file
+ * @brief A simple autocorrelator (sum-sq) stage with REST one-shot sampling.
+ *  - SampleAutocorr : public kotekan::Stage
+ */
+
+#ifndef SAMPLE_AUTOCORR_HPP
+#define SAMPLE_AUTOCORR_HPP
+
+#include "Config.hpp"          // for Config
+#include "Stage.hpp"           // for Stage
+#include "buffer.hpp"          // for Buffer
+#include "bufferContainer.hpp" // for bufferContainer
+#include "restServer.hpp"      // for connectionInstance
+
+#include "json.hpp" // for json
+
+#include <condition_variable> // for condition_variable
+#include <mutex>              // for mutex
+#include <string>             // for string
+
+/**
+ * @class SampleAutocorr
+ * @brief Kotekan stage to accumulate the modulus-squared of a complex
+ *        sample stream into a power spectrum, served on demand via REST.
+ *
+ * Consumes complex @c float pairs from a single input buffer.
+ * When a client POSTs to the stage's @c /spectrum endpoint with an
+ * @c integration_length value, the stage integrates that many sample-frames
+ * worth of |x|^2, then returns the resulting power spectrum as JSON.
+ * The stage has no output buffer.
+ *
+ * @par Buffers
+ * @buffer in_buf Input kotekan buffer, to be consumed from.
+ *     @buffer_format Array of <tt>complex float</tt> (interleaved float pairs)
+ *     @buffer_metadata none
+ *
+ * @par REST endpoints
+ *  - POST @c <unique_name>/spectrum with @c {"integration_length": N}
+ *    returns @c {"stokes_i": [...]} once integration completes.
+ *
+ * @conf   spectrum_length      Int (default 1024). Number of samples in the spectrum.
+ * @conf   integration_length   Int (default 1024). Default number of time samples to sum.
+ *
+ * @author Keith Vanderlinde
+ */
+class SampleAutocorr : public kotekan::Stage {
+public:
+    SampleAutocorr(kotekan::Config& config, const std::string& unique_name,
+                   kotekan::bufferContainer& buffer_container);
+    ~SampleAutocorr() override;
+
+    void main_thread() override;
+
+    void rest_callback(kotekan::connectionInstance& conn, nlohmann::json& json_request);
+
+private:
+    /// Input buffer; complex float pairs.
+    Buffer* buf_in;
+
+    /// Frame index for the input buffer.
+    int frame_in;
+
+    /// Length of the spectrum being autocorrelated.
+    int _spectrum_length;
+    /// Number of samples to integrate per output.
+    int _integration_length;
+    /// Buffer for accumulating and staging the output spectrum.
+    float* spectrum_out;
+
+    /// REST endpoint path.
+    std::string endpoint;
+
+    /// Guards @c sample_active / @c sample_ready / @c spectrum_out and the integration counter.
+    std::mutex sample_mutex;
+    /// Signalled by main_thread when @c sample_ready transitions to true.
+    std::condition_variable sample_cv;
+    /// Set by REST thread to request a sample; cleared by main_thread when integration completes.
+    bool sample_active = false;
+    /// Set by main_thread when integration is complete; cleared by REST thread on consume.
+    bool sample_ready = false;
+};
+
+#endif

--- a/lib/stages/SimpleCrosscorr.cpp
+++ b/lib/stages/SimpleCrosscorr.cpp
@@ -76,9 +76,17 @@ void SimpleCrosscorr::main_thread() {
                 if (out_local == nullptr)
                     return;
 
-                for (uint32_t i = 0; i < _spectrum_length * 4; i++)
-                    out_local[out_loc++] = spectrum_out[i];
-                ((uint32_t*)out_local)[out_loc++] = integration_ct;
+                // Per-element layout: ``[freqs floats, 1 uint count]`` repeated
+                // once per visibility stream (AA, BB, Re{AB*}, Im{AB*}). That's
+                // the format ``networkPowerStream`` expects to see when
+                // ``num_elements == 4``; without the per-element count slot
+                // it indexes past the end of the frame and crashes on the
+                // first integration.
+                for (uint32_t e = 0; e < 4; e++) {
+                    for (uint32_t i = 0; i < _spectrum_length; i++)
+                        out_local[out_loc++] = spectrum_out[i + _spectrum_length * e];
+                    ((uint32_t*)out_local)[out_loc++] = integration_ct;
+                }
 
                 if (out_loc * sizeof(uint32_t) == (uint32_t)buf_out->frame_size) {
                     buf_out->mark_frame_full(unique_name, frame_out);

--- a/lib/stages/SimpleCrosscorr.cpp
+++ b/lib/stages/SimpleCrosscorr.cpp
@@ -2,6 +2,7 @@
 
 #include "Config.hpp"          // for Config
 #include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
+#include "airspyFrameDesc.hpp" // for make_fengine_desc, make_power_corr_desc
 #include "buffer.hpp"          // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
 #include "kotekanLogging.hpp"  // for DEBUG
@@ -32,6 +33,17 @@ SimpleCrosscorr::SimpleCrosscorr(Config& config, const std::string& unique_name,
     _integration_length = config.get_default<uint32_t>(unique_name, "integration_length", 1024);
 
     spectrum_out = (float*)calloc(_spectrum_length * 4, sizeof(float));
+
+    // Inputs: cfloat32 1-D fengine spectra. Output (power_corr) descriptor
+    // is *not* set here: rawFileWrite refuses NDArray-tagged buffers (it
+    // can only round-trip raw bytes, not the layout metadata), and the
+    // crosscorr unit test captures buf_out via rawFileWrite. networkPowerStream
+    // asserts the expected power_corr layout on its consumer side, so the
+    // contract is still documented in code.
+    buf_inA->set_frame_desc(
+        kotekan_airspy::make_fengine_desc(buf_inA->frame_size / (2 * sizeof(float))));
+    buf_inB->set_frame_desc(
+        kotekan_airspy::make_fengine_desc(buf_inB->frame_size / (2 * sizeof(float))));
 }
 
 SimpleCrosscorr::~SimpleCrosscorr() {

--- a/lib/stages/SimpleCrosscorr.cpp
+++ b/lib/stages/SimpleCrosscorr.cpp
@@ -1,0 +1,100 @@
+#include "SimpleCrosscorr.hpp"
+
+#include "Config.hpp"          // for Config
+#include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
+#include "buffer.hpp"          // for Buffer
+#include "bufferContainer.hpp" // for bufferContainer
+#include "kotekanLogging.hpp"  // for DEBUG
+
+#include <functional> // for bind
+#include <stdint.h>   // for uint32_t
+#include <stdlib.h>   // for calloc, free
+#include <string.h>   // for memset
+
+using kotekan::bufferContainer;
+using kotekan::Config;
+using kotekan::Stage;
+
+REGISTER_KOTEKAN_STAGE(SimpleCrosscorr);
+
+SimpleCrosscorr::SimpleCrosscorr(Config& config, const std::string& unique_name,
+                                 bufferContainer& buffer_container) :
+    Stage(config, unique_name, buffer_container, std::bind(&SimpleCrosscorr::main_thread, this)) {
+
+    buf_inA = get_buffer("in_bufA");
+    buf_inA->register_consumer(unique_name);
+    buf_inB = get_buffer("in_bufB");
+    buf_inB->register_consumer(unique_name);
+    buf_out = get_buffer("out_buf");
+    buf_out->register_producer(unique_name);
+
+    _spectrum_length = config.get_default<uint32_t>(unique_name, "spectrum_length", 1024);
+    _integration_length = config.get_default<uint32_t>(unique_name, "integration_length", 1024);
+
+    spectrum_out = (float*)calloc(_spectrum_length * 4, sizeof(float));
+}
+
+SimpleCrosscorr::~SimpleCrosscorr() {
+    free(spectrum_out);
+}
+
+void SimpleCrosscorr::main_thread() {
+    float* out_local = nullptr;
+
+    frame_inA = 0;
+    frame_inB = 0;
+    frame_out = 0;
+    uint32_t integration_ct = 0;
+    int out_loc = 0;
+
+    const int samples_per_frame = buf_inA->frame_size / (2 * sizeof(float));
+
+    // Assumes the two input buffers are aligned frame-for-frame.
+    while (!stop_thread) {
+        float* inA_local = (float*)buf_inA->wait_for_full_frame(unique_name, frame_inA);
+        float* inB_local = (float*)buf_inB->wait_for_full_frame(unique_name, frame_inB);
+        if (inA_local == nullptr || inB_local == nullptr)
+            break;
+
+        for (int j = 0; j < samples_per_frame; j += _spectrum_length) {
+            for (uint32_t i = 0; i < _spectrum_length; i++) {
+                float Ar = inA_local[(i + j) * 2];
+                float Ai = inA_local[(i + j) * 2 + 1];
+                float Br = inB_local[(i + j) * 2];
+                float Bi = inB_local[(i + j) * 2 + 1];
+
+                spectrum_out[i + _spectrum_length * 0] += (Ar * Ar + Ai * Ai) / _integration_length;
+                spectrum_out[i + _spectrum_length * 1] += (Br * Br + Bi * Bi) / _integration_length;
+                spectrum_out[i + _spectrum_length * 2] += (Ar * Br + Ai * Bi) / _integration_length;
+                spectrum_out[i + _spectrum_length * 3] += (Ai * Br - Bi * Ar) / _integration_length;
+            }
+            integration_ct++;
+
+            if (integration_ct >= _integration_length) {
+                if (out_loc == 0)
+                    out_local = (float*)buf_out->wait_for_empty_frame(unique_name, frame_out);
+                if (out_local == nullptr)
+                    return;
+
+                for (uint32_t i = 0; i < _spectrum_length * 4; i++)
+                    out_local[out_loc++] = spectrum_out[i];
+                ((uint32_t*)out_local)[out_loc++] = integration_ct;
+
+                if (out_loc * sizeof(uint32_t) == (uint32_t)buf_out->frame_size) {
+                    buf_out->mark_frame_full(unique_name, frame_out);
+                    frame_out = (frame_out + 1) % buf_out->num_frames;
+                    out_loc = 0;
+                    DEBUG("Finished integrating a frame!");
+                }
+
+                memset(spectrum_out, 0, _spectrum_length * sizeof(float) * 4);
+                integration_ct = 0;
+            }
+        }
+
+        buf_inA->mark_frame_empty(unique_name, frame_inA);
+        buf_inB->mark_frame_empty(unique_name, frame_inB);
+        frame_inA = (frame_inA + 1) % buf_inA->num_frames;
+        frame_inB = (frame_inB + 1) % buf_inB->num_frames;
+    }
+}

--- a/lib/stages/SimpleCrosscorr.hpp
+++ b/lib/stages/SimpleCrosscorr.hpp
@@ -1,0 +1,71 @@
+/**
+ * @file
+ * @brief A simple two-input cross-correlator stage.
+ *  - SimpleCrosscorr : public kotekan::Stage
+ */
+
+#ifndef SIMPLE_CROSSCORR_HPP
+#define SIMPLE_CROSSCORR_HPP
+
+#include "Config.hpp"          // for Config
+#include "Stage.hpp"           // for Stage
+#include "buffer.hpp"          // for Buffer
+#include "bufferContainer.hpp" // for bufferContainer
+
+#include <string> // for string
+
+/**
+ * @class SimpleCrosscorr
+ * @brief Kotekan stage to compute four spectral products (AA, BB, Re{AB*},
+ *        Im{AB*}) from two complex-float input streams and integrate over time.
+ *
+ * Both input buffers' frame lengths must be integer multiples of the spectrum
+ * length. Per integration the stage emits @c 4 * spectrum_length floats
+ * followed by a single @c uint32_t holding the integration count, into the
+ * output buffer.
+ *
+ * @par Buffers
+ * @buffer in_bufA Input kotekan buffer A.
+ *     @buffer_format Array of <tt>complex float</tt> (interleaved float pairs)
+ *     @buffer_metadata none
+ * @buffer in_bufB Input kotekan buffer B.
+ *     @buffer_format Array of <tt>complex float</tt> (interleaved float pairs)
+ *     @buffer_metadata none
+ * @buffer out_buf Output kotekan buffer.
+ *     @buffer_format Array of <tt>float</tt> + trailing @c uint32_t per integration
+ *     @buffer_metadata none
+ *
+ * @conf   spectrum_length      Int (default 1024). Number of samples in the spectrum.
+ * @conf   integration_length   Int (default 1024). Number of time samples to sum.
+ *
+ * @author Keith Vanderlinde
+ */
+class SimpleCrosscorr : public kotekan::Stage {
+public:
+    SimpleCrosscorr(kotekan::Config& config, const std::string& unique_name,
+                    kotekan::bufferContainer& buffer_container);
+    ~SimpleCrosscorr() override;
+
+    void main_thread() override;
+
+private:
+    /// Input buffers; complex float pairs.
+    Buffer* buf_inA;
+    Buffer* buf_inB;
+    /// Output buffer; AA, BB, Re{AB*}, Im{AB*} per spectral bin, plus count.
+    Buffer* buf_out;
+
+    /// Frame indices.
+    int frame_inA;
+    int frame_inB;
+    int frame_out;
+
+    /// Length of the spectrum being correlated.
+    uint32_t _spectrum_length;
+    /// Number of time samples summed per output.
+    uint32_t _integration_length;
+    /// Accumulator buffer: spectrum_length * 4 floats.
+    float* spectrum_out;
+};
+
+#endif

--- a/lib/stages/Transpose.hpp
+++ b/lib/stages/Transpose.hpp
@@ -17,7 +17,7 @@
 
 #include "json.hpp" // for json
 
-#include <bits/chrono.h> // for duration
+#include <chrono>       // for duration
 #include <stddef.h>      // for size_t
 #include <stdint.h>      // for uint32_t, uint64_t
 #include <string>        // for string, basic_string

--- a/lib/stages/Transpose.hpp
+++ b/lib/stages/Transpose.hpp
@@ -17,12 +17,12 @@
 
 #include "json.hpp" // for json
 
-#include <chrono>       // for duration
-#include <stddef.h>      // for size_t
-#include <stdint.h>      // for uint32_t, uint64_t
-#include <string>        // for string, basic_string
-#include <tuple>         // for tuple
-#include <vector>        // for vector
+#include <chrono>   // for duration
+#include <stddef.h> // for size_t
+#include <stdint.h> // for uint32_t, uint64_t
+#include <string>   // for string, basic_string
+#include <tuple>    // for tuple
+#include <vector>   // for vector
 
 
 /**

--- a/lib/stages/airspyFrameDesc.hpp
+++ b/lib/stages/airspyFrameDesc.hpp
@@ -1,0 +1,79 @@
+#ifndef AIRSPY_FRAME_DESC_HPP
+#define AIRSPY_FRAME_DESC_HPP
+
+#include "DataType.hpp" // for DataType
+#include "NDArray.hpp"  // for GenericNDArray
+
+#include <cstddef> // for ptrdiff_t
+#include <memory>  // for shared_ptr
+
+/**
+ * @file
+ * @brief Frame-descriptor builders for the airspy autocorr / crosscorr pipelines.
+ *
+ * Uses the *buffer-level* FrameDesc mechanism (Buffer::set_frame_desc /
+ * get_frame_description) -- independent of the metadata pool, which these
+ * pipelines run with set to "none". The convention: every airspy
+ * producer/consumer stage calls @c buf->set_frame_desc on each buffer it
+ * touches via one of these helpers. The first call records the descriptor;
+ * subsequent calls compare via @c FrameDesc::operator== and ERROR on
+ * mismatch -- so producer/consumer construction order is irrelevant, and a
+ * future rewiring that conflicts with the expected layout is caught at
+ * framework init rather than as silent garbage downstream.
+ *
+ * @note GenericNDArray models a single dtype, so the @c post_corr_buf
+ * layout @c [spectrum_length float32 bins, 1 uint32 integration count] per
+ * element is described as a pure-float32 array of the right total size
+ * (the trailing count word is type-tagged float32 in the descriptor). The
+ * byte-size and dtype of the spectra are accurately validated; only the
+ * count slot's reported dtype is cosmetically wrong. A future
+ * @c MixedNDArray descriptor could model the heterogeneous record
+ * faithfully -- filed as a separate framework follow-up.
+ */
+namespace kotekan_airspy {
+
+/// Raw airspy samples: int16 1-D buffer of length @p n_samples.
+inline std::shared_ptr<kotekan::GenericNDArray>
+make_input_desc(std::ptrdiff_t n_samples) {
+    return kotekan::GenericNDArray::create(kotekan::DataType::int16, "airspy_samples",
+                                           {n_samples}, {"sample"}, nullptr);
+}
+
+/// fftwEngine output spectra: cfloat32 1-D buffer of length @p n_complex.
+/// Same shape regardless of how many FFTs are packed per frame -- the
+/// descriptor records total complex elements, the consumers' indexing
+/// arithmetic comes from their own config.
+inline std::shared_ptr<kotekan::GenericNDArray>
+make_fengine_desc(std::ptrdiff_t n_complex) {
+    return kotekan::GenericNDArray::create(kotekan::DataType::cfloat32, "fengine_spectra",
+                                           {n_complex}, {"bin"}, nullptr);
+}
+
+/// SimpleCrosscorr / simpleAutocorr -> networkPowerStream layout. Per
+/// element: @p spectrum_length float32 bins followed by a uint32
+/// integration-count word (see file note above). Shape is 1-D for
+/// single-element (autocorr) and 2-D [num_elements, spectrum_length + 1]
+/// for multi-element (crosscorr), to match what the producers actually
+/// emit and what networkPowerStream walks for each element/time index.
+///
+/// @note Only networkPowerStream (the consumer) calls set_frame_desc with
+/// this; the producers (simpleAutocorr / SimpleCrosscorr) deliberately
+/// leave their out_buf untagged so the corr-buffer round-trip tests that
+/// use rawFileWrite still work (rawFileWrite refuses NDArray-tagged
+/// buffers). The consumer-side assertion still documents the expected
+/// layout in code; cross-checks are preserved on input_buf and
+/// post_fengine_buf where they don't collide with the test infrastructure.
+inline std::shared_ptr<kotekan::GenericNDArray>
+make_power_corr_desc(std::ptrdiff_t num_elements, std::ptrdiff_t spectrum_length) {
+    if (num_elements == 1) {
+        return kotekan::GenericNDArray::create(kotekan::DataType::float32, "power_corr",
+                                               {spectrum_length + 1}, {"bin"}, nullptr);
+    }
+    return kotekan::GenericNDArray::create(kotekan::DataType::float32, "power_corr",
+                                           {num_elements, spectrum_length + 1},
+                                           {"elem", "bin"}, nullptr);
+}
+
+} // namespace kotekan_airspy
+
+#endif // AIRSPY_FRAME_DESC_HPP

--- a/lib/stages/airspyFrameDesc.hpp
+++ b/lib/stages/airspyFrameDesc.hpp
@@ -33,18 +33,16 @@
 namespace kotekan_airspy {
 
 /// Raw airspy samples: int16 1-D buffer of length @p n_samples.
-inline std::shared_ptr<kotekan::GenericNDArray>
-make_input_desc(std::ptrdiff_t n_samples) {
-    return kotekan::GenericNDArray::create(kotekan::DataType::int16, "airspy_samples",
-                                           {n_samples}, {"sample"}, nullptr);
+inline std::shared_ptr<kotekan::GenericNDArray> make_input_desc(std::ptrdiff_t n_samples) {
+    return kotekan::GenericNDArray::create(kotekan::DataType::int16, "airspy_samples", {n_samples},
+                                           {"sample"}, nullptr);
 }
 
 /// fftwEngine output spectra: cfloat32 1-D buffer of length @p n_complex.
 /// Same shape regardless of how many FFTs are packed per frame -- the
 /// descriptor records total complex elements, the consumers' indexing
 /// arithmetic comes from their own config.
-inline std::shared_ptr<kotekan::GenericNDArray>
-make_fengine_desc(std::ptrdiff_t n_complex) {
+inline std::shared_ptr<kotekan::GenericNDArray> make_fengine_desc(std::ptrdiff_t n_complex) {
     return kotekan::GenericNDArray::create(kotekan::DataType::cfloat32, "fengine_spectra",
                                            {n_complex}, {"bin"}, nullptr);
 }
@@ -70,8 +68,8 @@ make_power_corr_desc(std::ptrdiff_t num_elements, std::ptrdiff_t spectrum_length
                                                {spectrum_length + 1}, {"bin"}, nullptr);
     }
     return kotekan::GenericNDArray::create(kotekan::DataType::float32, "power_corr",
-                                           {num_elements, spectrum_length + 1},
-                                           {"elem", "bin"}, nullptr);
+                                           {num_elements, spectrum_length + 1}, {"elem", "bin"},
+                                           nullptr);
 }
 
 } // namespace kotekan_airspy

--- a/lib/stages/airspyInput.cpp
+++ b/lib/stages/airspyInput.cpp
@@ -1,15 +1,23 @@
 #include "airspyInput.hpp"
 
-#include "Config.hpp"         // for Config
-#include "StageFactory.hpp"   // for REGISTER_KOTEKAN_STAGE
-#include "kotekanLogging.hpp" // for ERROR, INFO, DEBUG, FATAL_ERROR
+#include "Config.hpp"          // for Config
+#include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
+#include "buffer.hpp"          // for Buffer
+#include "bufferContainer.hpp" // for bufferContainer
+#include "kotekanLogging.hpp"  // for ERROR, INFO, DEBUG, FATAL_ERROR
+#include "restServer.hpp"      // for connectionInstance, restServer
 
 #include "fmt.hpp" // for compile_string_to_view
 
-#include <functional> // for bind, function
-#include <stdint.h>   // for uint32_t, uint8_t
-#include <stdlib.h>   // for malloc
-#include <string.h>   // for memcpy
+#include <condition_variable> // for condition_variable
+#include <fcntl.h>            // for open, O_RDWR
+#include <functional>         // for bind, function
+#include <math.h>             // for sqrt
+#include <mutex>              // for unique_lock, lock_guard
+#include <stdint.h>           // for uint32_t, uint8_t
+#include <stdlib.h>           // for abs, malloc, free
+#include <string.h>           // for memcpy
+#include <unistd.h>           // for close, usleep
 
 using kotekan::bufferContainer;
 using kotekan::Config;
@@ -24,12 +32,16 @@ airspyInput::airspyInput(Config& config, const std::string& unique_name,
     buf = get_buffer("out_buf");
     buf->register_producer(unique_name);
 
-    freq = config.get_default<float>(unique_name, "freq", 1420) * 1000000;          // MHz
-    sample_bw = config.get_default<float>(unique_name, "sample_bw", 2.5) * 1000000; // BW in Hz
-    gain_lna = config.get_default<int>(unique_name, "gain_lna", 5);                 // MAX: 14
-    gain_if = config.get_default<int>(unique_name, "gain_if", 5);                   // MAX: 15
-    gain_mix = config.get_default<int>(unique_name, "gain_mix", 5);                 // MAX: 15
-    biast_power = config.get_default<bool>(unique_name, "biast_power", false) ? 1 : 0;
+    freq = config.get_default<float>(unique_name, "freq", 1420) * 1e6;             // MHz
+    _sample_rate = config.get_default<float>(unique_name, "sample_bw", 2.5) * 1e6; // MSPS
+    _gain_lna = config.get_default<int>(unique_name, "gain_lna", 5);               // 0-14
+    _gain_if = config.get_default<int>(unique_name, "gain_if", 5);                 // 0-15
+    _gain_mix = config.get_default<int>(unique_name, "gain_mix", 5);               // 0-15
+    _biast_power = config.get_default<bool>(unique_name, "biast_power", false) ? 1 : 0;
+
+    _airspy_sn = config.get_default<long>(unique_name, "serial", 0);
+    _airspy_fn = config.get_default<std::string>(unique_name, "airspy_file", "");
+    _autostart = config.get_default<bool>(unique_name, "autostart", true);
 }
 
 airspyInput::~airspyInput() {
@@ -37,21 +49,172 @@ airspyInput::~airspyInput() {
         airspy_stop_rx(a_device);
         airspy_close(a_device);
     }
-    airspy_exit();
+    if (airspy_opened)
+        airspy_exit();
+    // Wake any REST callback waiting on a pending adcstat request.
+    adcstat_cv.notify_all();
 }
 
-void airspyInput::main_thread() {
-    frame_id = 0;
-    frame_loc = 0;
-    recv_busy = PTHREAD_MUTEX_INITIALIZER;
+void airspyInput::get_config_callback(kotekan::connectionInstance& conn) {
+    nlohmann::json reply;
+    reply["lna_gain"] = _gain_lna;
+    reply["mix_gain"] = _gain_mix;
+    reply["if_gain"] = _gain_if;
+    reply["samplerate"] = _sample_rate;
+    reply["freq"] = freq;
+    reply["airspy_sn"] = _airspy_sn;
+    conn.send_json_reply(reply);
+}
 
-    airspy_init();
+void airspyInput::adcstat_callback(kotekan::connectionInstance& conn) {
+    std::unique_lock<std::mutex> lock(adcstat_mutex);
+    dump_adcstat = true;
+    adcstat_cv.wait(lock, [this] { return adcstat_ready || stop_thread; });
+    if (stop_thread) {
+        lock.unlock();
+        conn.send_error("Stage shutting down.", kotekan::HTTP_RESPONSE::INTERNAL_ERROR);
+        return;
+    }
+
+    nlohmann::json reply;
+    reply["rms"] = adcrms;
+    reply["mean"] = adcmean;
+    reply["railfrac"] = adcrailfrac;
+    adcstat_ready = false;
+    lock.unlock();
+
+    conn.send_json_reply(reply);
+}
+
+void airspyInput::restart_callback(kotekan::connectionInstance& conn) {
+    if (a_device != nullptr) {
+        airspy_stop_rx(a_device);
+        airspy_close(a_device);
+        a_device = nullptr;
+    }
     a_device = init_device();
     if (a_device == nullptr) {
         FATAL_ERROR("Error in airspyInput. Cannot find device.");
         return;
     }
-    airspy_start_rx(a_device, airspy_callback, static_cast<void*>(this));
+    int err = airspy_start_rx(a_device, airspy_callback, static_cast<void*>(this));
+    if (err != AIRSPY_SUCCESS) {
+        ERROR("airspy_start_rx() failed: {:s} ({:d})", airspy_error_name((enum airspy_error)err),
+              err);
+    }
+
+    nlohmann::json reply;
+    reply["status"] = (err == AIRSPY_SUCCESS);
+    conn.send_json_reply(reply);
+}
+
+void airspyInput::set_config_callback(kotekan::connectionInstance& conn,
+                                      nlohmann::json& json_request) {
+    int err;
+    bool success = false;
+
+    // Each setting is optional; missing keys throw and are caught silently.
+    try {
+        freq = ((float)json_request["freq"]) * 1e6;
+        INFO("Updating airspy LO frequency to {:d}", freq);
+        err = airspy_set_freq(a_device, freq);
+        if (err != AIRSPY_SUCCESS)
+            ERROR("airspy_set_freq() failed: {:s} ({:d})",
+                  airspy_error_name((enum airspy_error)err), err);
+        else
+            success = true;
+    } catch (...) {
+    }
+    try {
+        _gain_lna = json_request["gain_lna"];
+        INFO("Updating airspy LNA gain to {:d}", _gain_lna);
+        err = airspy_set_lna_gain(a_device, _gain_lna);
+        if (err != AIRSPY_SUCCESS)
+            ERROR("airspy_set_lna_gain() failed: {:s} ({:d})",
+                  airspy_error_name((enum airspy_error)err), err);
+        else
+            success = true;
+    } catch (...) {
+    }
+    try {
+        _gain_mix = json_request["gain_mix"];
+        INFO("Updating airspy mixer gain to {:d}", _gain_mix);
+        err = airspy_set_mixer_gain(a_device, _gain_mix);
+        if (err != AIRSPY_SUCCESS)
+            ERROR("airspy_set_mixer_gain() failed: {:s} ({:d})",
+                  airspy_error_name((enum airspy_error)err), err);
+        else
+            success = true;
+    } catch (...) {
+    }
+    try {
+        _gain_if = json_request["gain_if"];
+        INFO("Updating airspy IF gain to {:d}", _gain_if);
+        err = airspy_set_vga_gain(a_device, _gain_if);
+        if (err != AIRSPY_SUCCESS)
+            ERROR("airspy_set_vga_gain() failed: {:s} ({:d})",
+                  airspy_error_name((enum airspy_error)err), err);
+        else
+            success = true;
+    } catch (...) {
+    }
+    try {
+        int add_lag = json_request["add_lag"];
+        INFO("Updating airspy lag by {:d}", add_lag);
+        pthread_mutex_lock(&recv_busy);
+        lag += add_lag * BYTES_PER_SAMPLE;
+        pthread_mutex_unlock(&recv_busy);
+        success = true;
+    } catch (...) {
+    }
+
+    if (success) {
+        usleep(10000);
+        conn.send_empty_reply(kotekan::HTTP_RESPONSE::OK);
+    } else {
+        conn.send_error("Couldn't parse airspy rx parameters.",
+                        kotekan::HTTP_RESPONSE::BAD_REQUEST);
+    }
+}
+
+void airspyInput::main_thread() {
+    using namespace std::placeholders;
+    kotekan::restServer& rest_server = kotekan::restServer::instance();
+    rest_server.register_post_callback(unique_name + "/set_config",
+                                       std::bind(&airspyInput::set_config_callback, this, _1, _2));
+    rest_server.register_get_callback(unique_name + "/adcstat",
+                                      std::bind(&airspyInput::adcstat_callback, this, _1));
+    rest_server.register_get_callback(unique_name + "/get_config",
+                                      std::bind(&airspyInput::get_config_callback, this, _1));
+    rest_server.register_get_callback(unique_name + "/restart",
+                                      std::bind(&airspyInput::restart_callback, this, _1));
+
+    frame_id = 0;
+    frame_loc = 0;
+    recv_busy = (pthread_mutex_t)PTHREAD_MUTEX_INITIALIZER;
+
+    int err = airspy_init();
+    if (err != AIRSPY_SUCCESS) {
+        INFO("airspy_init() failed: {:s} ({:d}); proceeding without it.",
+             airspy_error_name((enum airspy_error)err), err);
+        airspy_opened = false;
+    } else {
+        airspy_opened = true;
+    }
+
+    a_device = init_device();
+    if (a_device == nullptr) {
+        FATAL_ERROR("Error in airspyInput. Cannot find device.");
+        return;
+    }
+
+    if (_autostart) {
+        err = airspy_start_rx(a_device, airspy_callback, static_cast<void*>(this));
+        if (err != AIRSPY_SUCCESS) {
+            ERROR("airspy_start_rx() failed: {:s} ({:d})",
+                  airspy_error_name((enum airspy_error)err), err);
+        }
+    }
 }
 
 int airspyInput::airspy_callback(airspy_transfer_t* transfer) {
@@ -59,13 +222,26 @@ int airspyInput::airspy_callback(airspy_transfer_t* transfer) {
     proc->airspy_producer(transfer);
     return 0;
 }
+
 void airspyInput::airspy_producer(airspy_transfer_t* transfer) {
-    // make sure two callbacks don't run at once
+    // Serialise overlapping callbacks; libairspy can in principle deliver them concurrently.
     pthread_mutex_lock(&recv_busy);
 
     void* in = transfer->samples;
     size_t bt = transfer->sample_count * BYTES_PER_SAMPLE;
     while (bt > 0) {
+        // Skip past any pending alignment lag.
+        if (lag > 0) {
+            if (lag >= bt) {
+                lag -= bt;
+                bt = 0;
+                continue;
+            }
+            bt -= lag;
+            in = (void*)((char*)in + lag);
+            lag = 0;
+        }
+
         if (frame_loc == 0) {
             DEBUG("Airspy waiting for frame_id {:d}", frame_id);
             frame_ptr = (unsigned char*)buf->wait_for_empty_frame(unique_name, frame_id);
@@ -73,15 +249,57 @@ void airspyInput::airspy_producer(airspy_transfer_t* transfer) {
                 break;
         }
 
-        size_t copy_length = bt < buf->frame_size ? bt : buf->frame_size;
-        DEBUG("Filling Buffer {:d} With {:d} Data Samples", frame_id, copy_length / 2 / 2);
-        // FILL THE BUFFER
+        size_t copy_length = std::min<size_t>(bt, buf->frame_size - frame_loc);
+        DEBUG("Filling Buffer {:d} With {:d} Data Samples ({})", frame_id,
+              copy_length / BYTES_PER_SAMPLE, transfer->sample_count);
+
         memcpy(frame_ptr + frame_loc, in, copy_length);
         bt -= copy_length;
+        in = (void*)((char*)in + copy_length);
         frame_loc = (frame_loc + copy_length) % buf->frame_size;
 
         if (frame_loc == 0) {
             DEBUG("Airspy Buffer {:d} Full", frame_id);
+
+            short* fr = (short*)frame_ptr;
+            const uint32_t n_samples = buf->frame_size / BYTES_PER_SAMPLE;
+
+            // Read dump_adcstat without locking (single bool, set under lock by REST thread).
+            // If true, compute stats then publish under the mutex.
+            if (dump_adcstat) {
+                float mean = 0, rms = 0, rail = 0;
+                for (uint32_t i = 0; i < n_samples; i++)
+                    if (abs(fr[i] - 2048) >= (2 << 10))
+                        rail++;
+                rail /= n_samples;
+                for (uint32_t i = 0; i < n_samples; i++)
+                    mean += (float)fr[i];
+                mean /= n_samples;
+                for (uint32_t i = 0; i < n_samples; i++)
+                    rms += ((float)fr[i] - mean) * ((float)fr[i] - mean);
+                rms = sqrt(rms / n_samples);
+
+                {
+                    std::lock_guard<std::mutex> lock(adcstat_mutex);
+                    adcrailfrac = rail;
+                    adcrms = rms;
+                    adcmean = mean - 2048;
+                    adcstat_ready = true;
+                    dump_adcstat = false;
+                }
+                adcstat_cv.notify_one();
+                INFO("Airspy ADC mean: {:f}, RMS: {:f}, rail fraction {:f}", adcmean, adcrms,
+                     adcrailfrac);
+            }
+
+            // RAW samples are unsigned 12-bit centred on 2048: subtract DC bias.
+            // Also flip the sign on every other sample to shift the spectrum into
+            // the first Nyquist zone (multiply by (-1)^idx).
+            for (uint32_t i = 0; i < n_samples; i += 2) {
+                fr[i] = fr[i] - 2048;
+                fr[i + 1] = 2048 - fr[i + 1];
+            }
+
             buf->mark_frame_full(unique_name, frame_id);
             frame_id = (frame_id + 1) % buf->num_frames;
         }
@@ -91,21 +309,34 @@ void airspyInput::airspy_producer(airspy_transfer_t* transfer) {
 
 struct airspy_device* airspyInput::init_device() {
     int result;
+    struct airspy_device* dev = nullptr;
     uint8_t board_id = AIRSPY_BOARD_ID_INVALID;
 
-    struct airspy_device* dev;
-    result = airspy_open(&dev);
+    if (_airspy_sn) {
+        result = airspy_open_sn(&dev, _airspy_sn);
+    } else if (!_airspy_fn.empty()) {
+        int airspy_fd = open(_airspy_fn.c_str(), O_RDWR);
+        if (airspy_fd == -1) {
+            ERROR("Error opening file: {:s}", _airspy_fn);
+            return nullptr;
+        }
+        // libairspy accepts a file descriptor through the same _sn entrypoint.
+        result = airspy_open_sn(&dev, airspy_fd);
+        close(airspy_fd);
+    } else {
+        result = airspy_open(&dev);
+    }
     if (result != AIRSPY_SUCCESS) {
         ERROR("airspy_open() failed: {:s} ({:d})", airspy_error_name((enum airspy_error)result),
               result);
         return nullptr;
     }
 
-    { // get the viable sample rates, compare to the config, and set choose the appropriate one
+    { // pick a supported samplerate that matches the config
         uint32_t supported_samplerate_count;
         result = airspy_get_samplerates(dev, &supported_samplerate_count, 0);
         if (result != AIRSPY_SUCCESS) {
-            ERROR("airspy_set_samplerate() failed: {:s} ({:d})",
+            ERROR("airspy_get_samplerates() failed: {:s} ({:d})",
                   airspy_error_name((enum airspy_error)result), result);
             return nullptr;
         }
@@ -113,21 +344,23 @@ struct airspy_device* airspyInput::init_device() {
             (uint32_t*)malloc(supported_samplerate_count * sizeof(uint32_t));
         result = airspy_get_samplerates(dev, supported_samplerates, supported_samplerate_count);
         if (result != AIRSPY_SUCCESS) {
-            ERROR("airspy_set_samplerate() failed: {:s} ({:d})",
+            ERROR("airspy_get_samplerates() failed: {:s} ({:d})",
                   airspy_error_name((enum airspy_error)result), result);
+            free(supported_samplerates);
             return nullptr;
         }
         int samplerate_idx = -1;
-        for (uint i = 0; i < supported_samplerate_count; i++) {
+        for (uint32_t i = 0; i < supported_samplerate_count; i++) {
             INFO("Samplerate: idx {:d} = {:d} Hz", i, supported_samplerates[i]);
-            if (supported_samplerates[i] == sample_bw)
+            if (supported_samplerates[i] == _sample_rate)
                 samplerate_idx = i;
         }
+        free(supported_samplerates);
         if (samplerate_idx < 0) {
-            ERROR("Unsupported sample rate: {:f} Hz", sample_bw);
+            ERROR("Unsupported sample rate: {:d} Hz", _sample_rate);
             return nullptr;
         }
-        INFO("Selected sample rate: {:d} Hz -> idx {:d}", sample_bw, samplerate_idx);
+        INFO("Selected sample rate: {:d} Hz -> idx {:d}", _sample_rate, samplerate_idx);
         result = airspy_set_samplerate(dev, samplerate_idx);
         if (result != AIRSPY_SUCCESS) {
             ERROR("airspy_set_samplerate() failed: {:s} ({:d})",
@@ -136,7 +369,7 @@ struct airspy_device* airspyInput::init_device() {
         }
     }
 
-    result = airspy_set_sample_type(dev, AIRSPY_SAMPLE_INT16_IQ);
+    result = airspy_set_sample_type(dev, AIRSPY_SAMPLE_RAW);
     if (result != AIRSPY_SUCCESS) {
         ERROR("airspy_set_sample_type() failed: {:s} ({:d})",
               airspy_error_name((enum airspy_error)result), result);
@@ -150,35 +383,34 @@ struct airspy_device* airspyInput::init_device() {
         return nullptr;
     }
 
-    result = airspy_set_vga_gain(dev, gain_if);
+    result = airspy_set_vga_gain(dev, _gain_if);
     if (result != AIRSPY_SUCCESS) {
         ERROR("airspy_set_vga_gain() failed: {:s} ({:d})",
               airspy_error_name((enum airspy_error)result), result);
         return nullptr;
     }
 
-    result = airspy_set_mixer_gain(dev, gain_mix);
+    result = airspy_set_mixer_gain(dev, _gain_mix);
     if (result != AIRSPY_SUCCESS) {
         ERROR("airspy_set_mixer_gain() failed: {:s} ({:d})",
               airspy_error_name((enum airspy_error)result), result);
         return nullptr;
     }
-    result = airspy_set_mixer_agc(dev, 0); // Auto gain control: 0/1
+    result = airspy_set_mixer_agc(dev, 0); // disable mixer AGC
     if (result != AIRSPY_SUCCESS) {
         ERROR("airspy_set_mixer_agc() failed: {:s} ({:d})",
               airspy_error_name((enum airspy_error)result), result);
         return nullptr;
     }
 
-    result = airspy_set_lna_gain(dev, gain_lna);
+    result = airspy_set_lna_gain(dev, _gain_lna);
     if (result != AIRSPY_SUCCESS) {
         ERROR("airspy_set_lna_gain() failed: {:s} ({:d})",
               airspy_error_name((enum airspy_error)result), result);
         return nullptr;
     }
 
-
-    result = airspy_set_rf_bias(dev, biast_power);
+    result = airspy_set_rf_bias(dev, _biast_power);
     if (result != AIRSPY_SUCCESS) {
         ERROR("airspy_set_rf_bias() failed: {:s} ({:d})",
               airspy_error_name((enum airspy_error)result), result);
@@ -205,6 +437,8 @@ struct airspy_device* airspyInput::init_device() {
          read_partid_serialno.part_id[1]);
     INFO("Serial Number: {:#08X}{:08X}", read_partid_serialno.serial_no[2],
          read_partid_serialno.serial_no[3]);
+    _airspy_sn =
+        (((long)read_partid_serialno.serial_no[2]) << 32) + read_partid_serialno.serial_no[3];
 
     return dev;
 }

--- a/lib/stages/airspyInput.cpp
+++ b/lib/stages/airspyInput.cpp
@@ -2,6 +2,7 @@
 
 #include "Config.hpp"          // for Config
 #include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
+#include "airspyFrameDesc.hpp" // for make_input_desc
 #include "buffer.hpp"          // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
 #include "kotekanLogging.hpp"  // for ERROR, INFO, DEBUG, FATAL_ERROR
@@ -43,6 +44,11 @@ airspyInput::airspyInput(Config& config, const std::string& unique_name,
                     buf->frame_size / BYTES_PER_SAMPLE);
         return;
     }
+
+    // Buffer carries int16 1-D samples. set_frame_desc validates byte size
+    // against buf->frame_size and either records the descriptor or compares
+    // against an earlier assertion -- see airspyFrameDesc.hpp.
+    buf->set_frame_desc(kotekan_airspy::make_input_desc(buf->frame_size / BYTES_PER_SAMPLE));
 
     freq = config.get_default<float>(unique_name, "freq", 1420) * 1e6;             // MHz
     _sample_rate = config.get_default<float>(unique_name, "sample_bw", 2.5) * 1e6; // MSPS

--- a/lib/stages/airspyInput.cpp
+++ b/lib/stages/airspyInput.cpp
@@ -32,6 +32,18 @@ airspyInput::airspyInput(Config& config, const std::string& unique_name,
     buf = get_buffer("out_buf");
     buf->register_producer(unique_name);
 
+    // The DC-subtract / Nyquist-flip pass in main_thread walks samples two
+    // at a time (fr[i], fr[i+1]); an odd sample count would read one past
+    // the frame. Sample count = frame_size / BYTES_PER_SAMPLE, so the frame
+    // must be a multiple of 2*BYTES_PER_SAMPLE.
+    if ((buf->frame_size / BYTES_PER_SAMPLE) % 2 != 0) {
+        FATAL_ERROR("airspyInput: out_buf frame_size ({:d} B) must yield an even sample "
+                    "count (multiple of {:d} B); got {:d} samples.",
+                    buf->frame_size, 2 * BYTES_PER_SAMPLE,
+                    buf->frame_size / BYTES_PER_SAMPLE);
+        return;
+    }
+
     freq = config.get_default<float>(unique_name, "freq", 1420) * 1e6;             // MHz
     _sample_rate = config.get_default<float>(unique_name, "sample_bw", 2.5) * 1e6; // MSPS
     _gain_lna = config.get_default<int>(unique_name, "gain_lna", 5);               // 0-14

--- a/lib/stages/airspyInput.cpp
+++ b/lib/stages/airspyInput.cpp
@@ -40,8 +40,7 @@ airspyInput::airspyInput(Config& config, const std::string& unique_name,
     if ((buf->frame_size / BYTES_PER_SAMPLE) % 2 != 0) {
         FATAL_ERROR("airspyInput: out_buf frame_size ({:d} B) must yield an even sample "
                     "count (multiple of {:d} B); got {:d} samples.",
-                    buf->frame_size, 2 * BYTES_PER_SAMPLE,
-                    buf->frame_size / BYTES_PER_SAMPLE);
+                    buf->frame_size, 2 * BYTES_PER_SAMPLE, buf->frame_size / BYTES_PER_SAMPLE);
         return;
     }
 

--- a/lib/stages/airspyInput.cpp
+++ b/lib/stages/airspyInput.cpp
@@ -276,8 +276,9 @@ void airspyInput::airspy_producer(airspy_transfer_t* transfer) {
             short* fr = (short*)frame_ptr;
             const uint32_t n_samples = buf->frame_size / BYTES_PER_SAMPLE;
 
-            // Read dump_adcstat without locking (single bool, set under lock by REST thread).
-            // If true, compute stats then publish under the mutex.
+            // Lock-free atomic read on the hot path (dump_adcstat is
+            // std::atomic<bool>); if a dump was requested, compute stats and
+            // publish them under adcstat_mutex below.
             if (dump_adcstat) {
                 float mean = 0, rms = 0, rail = 0;
                 for (uint32_t i = 0; i < n_samples; i++)

--- a/lib/stages/airspyInput.hpp
+++ b/lib/stages/airspyInput.hpp
@@ -11,20 +11,23 @@
 #include "Stage.hpp"           // for Stage
 #include "buffer.hpp"          // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
+#include "restServer.hpp"      // for connectionInstance
 
-#include <airspy.h>    // for airspy_transfer_t
-#include <pthread.h>   // for pthread_mutex_t
-#include <sys/types.h> // for uint
+#include "json.hpp" // for json
+
+#include <airspy.h>           // for airspy_transfer_t
+#include <condition_variable> // for condition_variable
+#include <mutex>              // for mutex
+#include <pthread.h>          // for pthread_mutex_t
+#include <string>             // for string
+#include <sys/types.h>        // for uint
 
 #define BYTES_PER_SAMPLE 2
-
-#include <string> // for string
 
 /**
  * @class airspyInput
  * @brief Producer ``kotekan::Stage`` which streams radio data from an AirSpy SDR device
- * into a
- * ``Buffer``.
+ *        into a ``Buffer``.
  *
  * This is a simple producer which initializes an AirSpy dongle (https://airspy.com)
  * in streaming mode, filling samples into the provided kotekan buffer.
@@ -33,117 +36,115 @@
  * An internal sub-frame pointer is used to position data in subsequent callbacks within frames.
  * A pthread mutex is used to ensure callbacks don't clobber one another.
  *
+ * Samples are read in @c AIRSPY_SAMPLE_RAW mode (real 12-bit ADC values, packed in 16-bit
+ * shorts). On each completed frame the producer subtracts the 2048-count ADC offset and
+ * applies an alternating-sign multiplication to shift the spectrum into the first Nyquist
+ * zone, then marks the frame full.
+ *
  * This producer depends on ``libairspy``.
  *
  * @par Buffers
- * @buffer out_buf The kotekan buffer which will be fed, can be any size.
- *     @buffer_format Array of @c shorts
+ * @buffer out_buf The kotekan buffer which will be fed; any size.
+ *     @buffer_format Array of @c shorts (real samples, DC-corrected and Nyquist-shifted)
  *     @buffer_metadata none
  *
- * @conf   freq        Float (default 1420.0). LO tuning frequency, in MHz.
- * @conf   sample_bw   Float (default 2.5). Bandwidth to sample from the airspy, in MHz.
- * @conf   gain_lna    Int (default 5). Gain setting of the LNA, in the range 0-14.
- * @conf   gain_mix    Int (default 5). Gain setting of the mixer amplifier, from 0-15.
- * @conf   gain_if     Int (default 5). Gain setting of the IF amplifier, from 0-15.
- * @conf   biast_power Bool (default false). Whether or not to enable the 4.5V DC bias on the AirSpy
- * RF input.
+ * @par REST endpoints (registered under @c <unique_name>/)
+ *  - GET  @c /get_config  — returns current gain/freq/samplerate as JSON.
+ *  - GET  @c /adcstat     — triggers a one-shot ADC stats sample (mean, RMS, rail fraction).
+ *  - GET  @c /restart     — stops, re-opens, and re-starts the airspy device.
+ *  - POST @c /set_config  — updates @c freq, @c gain_lna, @c gain_mix, @c gain_if, or @c add_lag.
  *
- * @warning Just realized that if things bog down and new 2 callbacks come while one is active,
- *          the order of the others will be undefined. This stage may produce out-of-order
- *          samples.
- * @remark  Only operates in I/Q mode currently, and only with packed int16_t samples.
- *          No support for raw samples, etc.
- * @todo    Only handles one device currently -- add checks and index handling.
- *          Undefined behaviour (segfault) if it doesn't exist or is already in use.
+ * @conf   freq         Float (default 1420.0). LO tuning frequency, in MHz.
+ * @conf   sample_bw    Float (default 2.5). Sample rate (samples/s), in MHz. Must be a value
+ *                      reported by @c airspy_get_samplerates() for the connected device
+ *                      (typically 2.5 or 10).
+ * @conf   gain_lna     Int (default 5). Gain setting of the LNA, in the range 0-14.
+ * @conf   gain_mix     Int (default 5). Gain setting of the mixer amplifier, from 0-15.
+ * @conf   gain_if      Int (default 5). Gain setting of the IF amplifier, from 0-15.
+ * @conf   biast_power  Bool (default false). Enable 4.5V DC bias on the RF input.
+ * @conf   serial       Long (default 0). Specific airspy serial-number to open; 0 = any.
+ * @conf   airspy_file  String (default ""). Read from this file instead of a real device; for
+ *                      offline testing. Ignored if @c serial is set.
+ * @conf   autostart    Bool (default true). Start streaming immediately. If false, the device
+ *                      is initialised but waits for a REST @c /restart to begin RX.
+ *
+ * @warning If incoming USB transfers ever overlap, sample ordering becomes undefined.
  *
  * @author Keith Vanderlinde
- *
  */
 class airspyInput : public kotekan::Stage {
 public:
-    /// Constructor, also initializes internal variables from config.
     airspyInput(kotekan::Config& config, const std::string& unique_name,
                 kotekan::bufferContainer& buffer_container);
+    ~airspyInput() override;
 
-    /// Destructor, cleans up local allocs.
-    virtual ~airspyInput();
-
-    /// Primary loop to wait for buffers, stuff in data, mark full, lather, rinse and repeat.
     void main_thread() override;
 
-    /// Initializes the airspy device.
-    /// Also configures runtime parameters: gains, LO tuning, samplerate, and sample type.
+    /// Initialises the airspy device. Also configures gains, LO tuning,
+    /// samplerate, and sample type.
     struct airspy_device* init_device();
 
-    /**
-     * Static function to service the callback generated by the AirSpy after
-     * data has been read and returned.
-     * This function immediately passes processing off to the airspyInput object
-     * controlling the AirSpy device which produced it,
-     * no processing of any sort is done here.
-     * @param transfer Contains the airspy transfer buffer, defined in liairspy/airspy.h
-     *                 Useful portions of the transfer object include:
-     *                 @li @c samples - pointer to the raw stream of samples),
-     *                 @li @c ctx - pointer to the object which called it), and
-     *                 @li @c sample_count - number of samples included in the buffer)
-     * @warning Nobody should ever call this directly, it's only meant to service the
-     *          data-ready AirSpy callback.
-     */
+    /// libairspy DMA-callback trampoline; forwards to @c airspy_producer on the @c ctx instance.
     static int airspy_callback(airspy_transfer_t* transfer);
 
-    /**
-     * Function which actually processes the data returned from the airspy.
-     * Waits for an available frame from @c buf, then copies data into it
-     * until either the entire set of samples is transferred, or the frame is filled.
-     * In the latter case, marks the frame full, waits for a new one, and continues.
-     * @c frame_loc is updated after copying each chunk of data.
-     * Locks the @c recv_busy mutex before beginning, and only releases it after all
-     * samples are copied to into @c buf.
-     * @param transfer Contains the airspy transfer buffer, defined in liairspy/airspy.h
-     *                 Useful portions of the transfer object include:
-     *                 @li @c samples - pointer to the raw stream of samples),
-     *                 @li @c ctx - pointer to the object which called it), and
-     *                 @li @c sample_count - number of samples included in the buffer)
-     * @warning        Nobody should ever call this directly, it's only meant to service the
-     *                 data-ready AirSpy callback.
-     */
+    /// Fills kotekan buffer frames from one USB transfer. See class doc.
     void airspy_producer(airspy_transfer_t* transfer);
 
+    /// REST callbacks.
+    void get_config_callback(kotekan::connectionInstance& conn);
+    void set_config_callback(kotekan::connectionInstance& conn, nlohmann::json& json_request);
+    void adcstat_callback(kotekan::connectionInstance& conn);
+    void restart_callback(kotekan::connectionInstance& conn);
 
 private:
-    /// kotekan buffer object which will be fed
+    /// Kotekan buffer object which will be fed.
     Buffer* buf;
-    /// handle to the airspy device itself
-    struct airspy_device* a_device;
+    /// Handle to the airspy device.
+    struct airspy_device* a_device = nullptr;
 
-    /// pointer to the current frame's memory
-    unsigned char* frame_ptr;
-    /// memory offset from the start of the current frame
-    /// where the next incoming data will go
-    unsigned int frame_loc;
-    /// index of the current frame
+    /// Pointer to the current frame's memory.
+    unsigned char* frame_ptr = nullptr;
+    /// Memory offset from the start of the current frame.
+    uint32_t frame_loc;
+    /// Index of the current frame.
     int frame_id;
-    /// mutex to keep multiple callbacks from clobbering one another:
-    /// this forces subsequent callbacks to wait their turn before writing to memory,
-    /// marking buffers full, and/or incrementing the relevant counters
+    /// Pending byte-count of samples to skip before next copy (for inter-device alignment).
+    uint32_t lag = 0;
+    /// Whether @c airspy_init() succeeded (gates @c airspy_exit() in the destructor).
+    bool airspy_opened = false;
+    /// Mutex serialising producer-callback invocations.
     pthread_mutex_t recv_busy;
 
-
     // options
-    /// Frequency of the LO, in Hz
-    uint freq;
-    /// Sampling bandwidth, in Hz. Should be 2500000 or 10000000
-    uint sample_bw;
-    /// Gain of the LNA, should be an integer in the range 0-14
-    int gain_lna;
-    /// Gain of the mixer amp, should be an integer in the range 0-15
-    int gain_mix;
-    /// Gain of the IF amp, should be an integer in the range 0-15
-    int gain_if;
-    /// Whether or not the AirSpy should apply 4.5V DC bias on the RF line.
-    /// Binary flag, should be 0 or 1.
-    int biast_power;
-};
+    /// Frequency of the LO, in Hz.
+    uint32_t freq;
+    /// Sample rate, in samples/s. Should be 2500000 or 10000000.
+    uint32_t _sample_rate;
+    /// Gain of the LNA, 0-14.
+    int _gain_lna;
+    /// Gain of the mixer amp, 0-15.
+    int _gain_mix;
+    /// Gain of the IF amp, 0-15.
+    int _gain_if;
+    /// 4.5V DC bias on the RF input (0/1).
+    int _biast_power;
+    /// Optional specific device serial-number; 0 means open any.
+    long _airspy_sn;
+    /// Optional file path to read raw samples from instead of a device.
+    std::string _airspy_fn;
+    /// Whether to begin streaming immediately on startup.
+    bool _autostart;
 
+    // ADC statistics. The REST adcstat handler sets @c dump_adcstat under @c adcstat_mutex and
+    // waits on @c adcstat_cv until the producer fills @c adc{rms,mean,railfrac} on the next
+    // frame and flips @c adcstat_ready.
+    std::mutex adcstat_mutex;
+    std::condition_variable adcstat_cv;
+    bool dump_adcstat = false;
+    bool adcstat_ready = false;
+    float adcrms = 0;
+    float adcmean = 0;
+    float adcrailfrac = 0;
+};
 
 #endif

--- a/lib/stages/airspyInput.hpp
+++ b/lib/stages/airspyInput.hpp
@@ -16,6 +16,7 @@
 #include "json.hpp" // for json
 
 #include <airspy.h>           // for airspy_transfer_t
+#include <atomic>             // for atomic
 #include <condition_variable> // for condition_variable
 #include <mutex>              // for mutex
 #include <pthread.h>          // for pthread_mutex_t
@@ -135,12 +136,16 @@ private:
     /// Whether to begin streaming immediately on startup.
     bool _autostart;
 
-    // ADC statistics. The REST adcstat handler sets @c dump_adcstat under @c adcstat_mutex and
-    // waits on @c adcstat_cv until the producer fills @c adc{rms,mean,railfrac} on the next
-    // frame and flips @c adcstat_ready.
+    // ADC statistics. The REST adcstat handler requests a dump and waits on
+    // @c adcstat_cv until the producer fills @c adc{rms,mean,railfrac} on the
+    // next frame and flips @c adcstat_ready (published under @c adcstat_mutex).
+    // @c dump_adcstat is atomic so the producer's hot-path check is a
+    // well-defined lock-free read rather than a (technically UB) plain-bool
+    // race against the REST writer; @c adcstat_mutex still guards the
+    // multi-field stats publish/consume.
     std::mutex adcstat_mutex;
     std::condition_variable adcstat_cv;
-    bool dump_adcstat = false;
+    std::atomic<bool> dump_adcstat{false};
     bool adcstat_ready = false;
     float adcrms = 0;
     float adcmean = 0;

--- a/lib/stages/applyGains.cpp
+++ b/lib/stages/applyGains.cpp
@@ -21,7 +21,7 @@
 
 #include <algorithm>                // for max, copy
 #include <assert.h>                 // for assert
-#include <chrono>                  // for operator""s
+#include <chrono>                   // for operator""s
 #include <cmath>                    // for pow, abs
 #include <complex>                  // for operator*, complex, operator+, abs, conj, operator==
 #include <cstring>                  // for memcpy

--- a/lib/stages/applyGains.cpp
+++ b/lib/stages/applyGains.cpp
@@ -21,7 +21,7 @@
 
 #include <algorithm>                // for max, copy
 #include <assert.h>                 // for assert
-#include <bits/chrono.h>            // for operator""s
+#include <chrono>                  // for operator""s
 #include <cmath>                    // for pow, abs
 #include <complex>                  // for operator*, complex, operator+, abs, conj, operator==
 #include <cstring>                  // for memcpy

--- a/lib/stages/basebandReadout.cpp
+++ b/lib/stages/basebandReadout.cpp
@@ -15,7 +15,7 @@
 
 #include <algorithm>     // for max, copy, equal, min
 #include <assert.h>      // for assert
-#include <bits/chrono.h> // for system_clock, nanoseconds
+#include <chrono>       // for system_clock, nanoseconds
 #include <cstdint>       // for int64_t, uint32_t, uint64_t, uint8_t
 #include <cstdio>        // for snprintf
 #include <ctime>         // for timespec

--- a/lib/stages/basebandReadout.cpp
+++ b/lib/stages/basebandReadout.cpp
@@ -13,21 +13,21 @@
 
 #include "fmt.hpp" // for compile_string_to_view, join
 
-#include <algorithm>     // for max, copy, equal, min
-#include <assert.h>      // for assert
-#include <chrono>       // for system_clock, nanoseconds
-#include <cstdint>       // for int64_t, uint32_t, uint64_t, uint8_t
-#include <cstdio>        // for snprintf
-#include <ctime>         // for timespec
-#include <functional>    // for bind, function
-#include <math.h>        // for fmod
-#include <memory>        // for shared_ptr, unique_ptr, make_shared, make_unique
-#include <stdexcept>     // for runtime_error
-#include <string.h>      // for memcpy, memset
-#include <sys/time.h>    // for timeval, timeradd
-#include <thread>        // for thread, sleep_for
-#include <tuple>         // for get
-#include <utility>       // for pair
+#include <algorithm>  // for max, copy, equal, min
+#include <assert.h>   // for assert
+#include <chrono>     // for system_clock, nanoseconds
+#include <cstdint>    // for int64_t, uint32_t, uint64_t, uint8_t
+#include <cstdio>     // for snprintf
+#include <ctime>      // for timespec
+#include <functional> // for bind, function
+#include <math.h>     // for fmod
+#include <memory>     // for shared_ptr, unique_ptr, make_shared, make_unique
+#include <stdexcept>  // for runtime_error
+#include <string.h>   // for memcpy, memset
+#include <sys/time.h> // for timeval, timeradd
+#include <thread>     // for thread, sleep_for
+#include <tuple>      // for get
+#include <utility>    // for pair
 
 
 using kotekan::basebandApiManager;

--- a/lib/stages/bufferSend.cpp
+++ b/lib/stages/bufferSend.cpp
@@ -11,18 +11,18 @@
 
 #include "fmt.hpp" // for compile_string_to_view, format, format_string, fmt
 
-#include <arpa/inet.h>   // for htons, inet_addr
+#include <arpa/inet.h>  // for htons, inet_addr
+#include <cerrno>       // for errno
 #include <chrono>       // for seconds
-#include <cerrno>        // for errno
-#include <cstring>       // for strerror, size_t
-#include <functional>    // for bind, ref, function
-#include <memory>        // for __shared_ptr_access, shared_ptr
-#include <stdexcept>     // for runtime_error
-#include <strings.h>     // for bzero
-#include <sys/socket.h>  // for send, MSG_NOSIGNAL, AF_INET, connect, setsockopt, socket
-#include <sys/time.h>    // for timeval
-#include <thread>        // for thread
-#include <unistd.h>      // for close, sleep
+#include <cstring>      // for strerror, size_t
+#include <functional>   // for bind, ref, function
+#include <memory>       // for __shared_ptr_access, shared_ptr
+#include <stdexcept>    // for runtime_error
+#include <strings.h>    // for bzero
+#include <sys/socket.h> // for send, MSG_NOSIGNAL, AF_INET, connect, setsockopt, socket
+#include <sys/time.h>   // for timeval
+#include <thread>       // for thread
+#include <unistd.h>     // for close, sleep
 
 // Some systems don't support MSG_NOSIGNAL and don't include it in socket.h
 #ifndef MSG_NOSIGNAL

--- a/lib/stages/bufferSend.cpp
+++ b/lib/stages/bufferSend.cpp
@@ -12,7 +12,7 @@
 #include "fmt.hpp" // for compile_string_to_view, format, format_string, fmt
 
 #include <arpa/inet.h>   // for htons, inet_addr
-#include <bits/chrono.h> // for seconds
+#include <chrono>       // for seconds
 #include <cerrno>        // for errno
 #include <cstring>       // for strerror, size_t
 #include <functional>    // for bind, ref, function

--- a/lib/stages/configTrackerWriter.cpp
+++ b/lib/stages/configTrackerWriter.cpp
@@ -7,12 +7,12 @@
 #include "fmt.hpp" // for compile_string_to_view
 
 #include <chrono>       // for operator""ms
-#include <exception>     // for exception
-#include <filesystem>    // for path, absolute, create_directories, exists, is_directory
-#include <functional>    // for bind, function
-#include <stddef.h>      // for size_t
-#include <system_error>  // for error_code
-#include <thread>        // for sleep_for
+#include <exception>    // for exception
+#include <filesystem>   // for path, absolute, create_directories, exists, is_directory
+#include <functional>   // for bind, function
+#include <stddef.h>     // for size_t
+#include <system_error> // for error_code
+#include <thread>       // for sleep_for
 
 using kotekan::Config;
 using kotekan::Stage;

--- a/lib/stages/configTrackerWriter.cpp
+++ b/lib/stages/configTrackerWriter.cpp
@@ -6,7 +6,7 @@
 
 #include "fmt.hpp" // for compile_string_to_view
 
-#include <bits/chrono.h> // for operator""ms
+#include <chrono>       // for operator""ms
 #include <exception>     // for exception
 #include <filesystem>    // for path, absolute, create_directories, exists, is_directory
 #include <functional>    // for bind, function

--- a/lib/stages/fftwEngine.cpp
+++ b/lib/stages/fftwEngine.cpp
@@ -1,14 +1,16 @@
 #include "fftwEngine.hpp"
 
-#include "Config.hpp"          // for Config
-#include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
-#include "buffer.hpp"          // for Buffer
-#include "bufferContainer.hpp" // for bufferContainer
-#include "kotekanLogging.hpp"  // for DEBUG, FATAL_ERROR
+#include "Config.hpp"           // for Config
+#include "StageFactory.hpp"     // for REGISTER_KOTEKAN_STAGE
+#include "buffer.hpp"           // for Buffer
+#include "bufferContainer.hpp"  // for bufferContainer
+#include "fftwPlannerLock.hpp"  // for fftw_planner_mutex
+#include "kotekanLogging.hpp"   // for DEBUG, FATAL_ERROR
 
 #include "fmt.hpp" // for compile_string_to_view
 
 #include <functional> // for bind
+#include <mutex>      // for lock_guard
 #include <stdint.h>   // for int16_t
 #include <string.h>   // for memcpy
 
@@ -28,7 +30,7 @@ fftwEngine::fftwEngine(Config& config, const std::string& unique_name,
     out_buf = get_buffer("out_buf");
     out_buf->register_producer(unique_name);
 
-    _spectrum_length = config.get_default<int>(unique_name, "spectrum_length", 1024);
+    _spectrum_length = config.get_default<int>(unique_name, "spectrum_length", 128);
 
     std::string input_type = config.get_default<std::string>(unique_name, "input_type", "complex");
     if (input_type == "real") {
@@ -41,6 +43,8 @@ fftwEngine::fftwEngine(Config& config, const std::string& unique_name,
         return;
     }
 
+    // fftwf_malloc is thread-safe; only the planner call needs the lock.
+    std::lock_guard<std::mutex> planner_lock(fftw_planner_mutex());
     if (_real_input) {
         const int fft_len = _spectrum_length * 2;
         real_samples = (float*)fftwf_malloc(sizeof(float) * fft_len);
@@ -55,8 +59,10 @@ fftwEngine::fftwEngine(Config& config, const std::string& unique_name,
 }
 
 fftwEngine::~fftwEngine() {
-    if (fft_plan)
+    if (fft_plan) {
+        std::lock_guard<std::mutex> planner_lock(fftw_planner_mutex());
         fftwf_destroy_plan(fft_plan);
+    }
     if (real_samples)
         fftwf_free(real_samples);
     if (complex_samples)

--- a/lib/stages/fftwEngine.cpp
+++ b/lib/stages/fftwEngine.cpp
@@ -2,6 +2,7 @@
 
 #include "Config.hpp"           // for Config
 #include "StageFactory.hpp"     // for REGISTER_KOTEKAN_STAGE
+#include "airspyFrameDesc.hpp"  // for make_fengine_desc
 #include "buffer.hpp"           // for Buffer
 #include "bufferContainer.hpp"  // for bufferContainer
 #include "fftwPlannerLock.hpp"  // for fftw_planner_mutex
@@ -29,6 +30,12 @@ fftwEngine::fftwEngine(Config& config, const std::string& unique_name,
     in_buf->register_consumer(unique_name);
     out_buf = get_buffer("out_buf");
     out_buf->register_producer(unique_name);
+
+    // Output is cfloat32 1-D regardless of input_type (we accept either
+    // int16 reals or cint16 IQ pairs upstream, so in_buf's descriptor is
+    // intentionally left for the upstream producer to assert).
+    out_buf->set_frame_desc(
+        kotekan_airspy::make_fengine_desc(out_buf->frame_size / sizeof(fftwf_complex)));
 
     _spectrum_length = config.get_default<int>(unique_name, "spectrum_length", 128);
 

--- a/lib/stages/fftwEngine.cpp
+++ b/lib/stages/fftwEngine.cpp
@@ -1,12 +1,12 @@
 #include "fftwEngine.hpp"
 
-#include "Config.hpp"           // for Config
-#include "StageFactory.hpp"     // for REGISTER_KOTEKAN_STAGE
-#include "airspyFrameDesc.hpp"  // for make_fengine_desc
-#include "buffer.hpp"           // for Buffer
-#include "bufferContainer.hpp"  // for bufferContainer
-#include "fftwPlannerLock.hpp"  // for fftw_planner_mutex
-#include "kotekanLogging.hpp"   // for DEBUG, FATAL_ERROR
+#include "Config.hpp"          // for Config
+#include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
+#include "airspyFrameDesc.hpp" // for make_fengine_desc
+#include "buffer.hpp"          // for Buffer
+#include "bufferContainer.hpp" // for bufferContainer
+#include "fftwPlannerLock.hpp" // for fftw_planner_mutex
+#include "kotekanLogging.hpp"  // for DEBUG, FATAL_ERROR
 
 #include "fmt.hpp" // for compile_string_to_view
 

--- a/lib/stages/fftwEngine.cpp
+++ b/lib/stages/fftwEngine.cpp
@@ -1,12 +1,14 @@
 #include "fftwEngine.hpp"
 
-#include "Config.hpp"         // for Config
-#include "StageFactory.hpp"   // for REGISTER_KOTEKAN_STAGE
-#include "kotekanLogging.hpp" // for DEBUG
+#include "Config.hpp"          // for Config
+#include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
+#include "buffer.hpp"          // for Buffer
+#include "bufferContainer.hpp" // for bufferContainer
+#include "kotekanLogging.hpp"  // for DEBUG, FATAL_ERROR
 
 #include "fmt.hpp" // for compile_string_to_view
 
-#include <functional> // for bind, function
+#include <functional> // for bind
 #include <stdint.h>   // for int16_t
 #include <string.h>   // for memcpy
 
@@ -18,57 +20,96 @@ REGISTER_KOTEKAN_STAGE(fftwEngine);
 
 fftwEngine::fftwEngine(Config& config, const std::string& unique_name,
                        bufferContainer& buffer_container) :
-    Stage(config, unique_name, buffer_container, std::bind(&fftwEngine::main_thread, this)) {
+    Stage(config, unique_name, buffer_container, std::bind(&fftwEngine::main_thread, this)),
+    real_samples(nullptr), complex_samples(nullptr), spectrum(nullptr), fft_plan(nullptr) {
 
     in_buf = get_buffer("in_buf");
     in_buf->register_consumer(unique_name);
     out_buf = get_buffer("out_buf");
     out_buf->register_producer(unique_name);
 
-    spectrum_length = config.get_default<int>(unique_name, "spectrum_length", 1024);
+    _spectrum_length = config.get_default<int>(unique_name, "spectrum_length", 1024);
 
-    samples = (fftwf_complex*)fftwf_malloc(sizeof(fftwf_complex) * spectrum_length);
-    spectrum = (fftwf_complex*)fftwf_malloc(sizeof(fftwf_complex) * spectrum_length);
-    fft_plan =
-        (fftwf_plan_s*)fftwf_plan_dft_1d(spectrum_length, samples, spectrum, -1, FFTW_ESTIMATE);
+    std::string input_type = config.get_default<std::string>(unique_name, "input_type", "complex");
+    if (input_type == "real") {
+        _real_input = true;
+    } else if (input_type == "complex") {
+        _real_input = false;
+    } else {
+        FATAL_ERROR("fftwEngine: unknown input_type '{:s}'; expected 'complex' or 'real'.",
+                    input_type);
+        return;
+    }
+
+    if (_real_input) {
+        const int fft_len = _spectrum_length * 2;
+        real_samples = (float*)fftwf_malloc(sizeof(float) * fft_len);
+        spectrum = (fftwf_complex*)fftwf_malloc(sizeof(fftwf_complex) * (fft_len / 2 + 1));
+        fft_plan = fftwf_plan_dft_r2c_1d(fft_len, real_samples, spectrum, FFTW_ESTIMATE);
+    } else {
+        complex_samples = (fftwf_complex*)fftwf_malloc(sizeof(fftwf_complex) * _spectrum_length);
+        spectrum = (fftwf_complex*)fftwf_malloc(sizeof(fftwf_complex) * _spectrum_length);
+        fft_plan =
+            fftwf_plan_dft_1d(_spectrum_length, complex_samples, spectrum, -1, FFTW_ESTIMATE);
+    }
 }
 
 fftwEngine::~fftwEngine() {
-    fftwf_free(samples);
-    fftwf_free(spectrum);
-    fftwf_free(fft_plan);
+    if (fft_plan)
+        fftwf_destroy_plan(fft_plan);
+    if (real_samples)
+        fftwf_free(real_samples);
+    if (complex_samples)
+        fftwf_free(complex_samples);
+    if (spectrum)
+        fftwf_free(spectrum);
 }
 
 void fftwEngine::main_thread() {
-    int16_t* in_local;
-    fftwf_complex* out_local;
-
     frame_in = 0;
     frame_out = 0;
 
-    int BYTES_PER_SAMPLE = 2;
-    int samples_per_input_frame = in_buf->frame_size / BYTES_PER_SAMPLE;
+    constexpr int BYTES_PER_SAMPLE = 2; // int16_t
 
     while (!stop_thread) {
-        in_local = (short*)in_buf->wait_for_full_frame(unique_name, frame_in);
+        int16_t* in_local = (int16_t*)in_buf->wait_for_full_frame(unique_name, frame_in);
         if (in_local == nullptr)
             break;
-        out_local = (fftwf_complex*)out_buf->wait_for_empty_frame(unique_name, frame_out);
+        fftwf_complex* out_local =
+            (fftwf_complex*)out_buf->wait_for_empty_frame(unique_name, frame_out);
         if (out_local == nullptr)
             break;
 
-        for (int j = 0; j < samples_per_input_frame / 2; j += spectrum_length) {
-            DEBUG("Running FFT, {:i}", in_local[2 * j]);
-            for (int i = 0; i < spectrum_length; i++) {
-                samples[i][0] = in_local[2 * (i + j)];
-                samples[i][1] = in_local[2 * (i + j) + 1];
+        const int samples_per_input_frame = in_buf->frame_size / BYTES_PER_SAMPLE;
+
+        if (_real_input) {
+            const int fft_len = _spectrum_length * 2;
+            for (int j = 0; j < samples_per_input_frame; j += fft_len) {
+                DEBUG("Running real FFT, {:d}", in_local[j]);
+                for (int i = 0; i < fft_len; i++) {
+                    real_samples[i] = (float)in_local[i + j] / _spectrum_length;
+                }
+                fftwf_execute(fft_plan);
+                // r2c gives fft_len/2+1 = _spectrum_length+1 bins; we drop Nyquist.
+                memcpy(out_local, spectrum, sizeof(fftwf_complex) * _spectrum_length);
+                out_local += _spectrum_length;
             }
-            fftwf_execute(fft_plan);
-            memcpy(out_local, spectrum + spectrum_length / 2,
-                   sizeof(fftwf_complex) * spectrum_length / 2);
-            memcpy(out_local + spectrum_length / 2, spectrum,
-                   sizeof(fftwf_complex) * spectrum_length / 2);
-            out_local += spectrum_length;
+        } else {
+            // Complex IQ: each input sample is an int16 pair, so step by 2*_spectrum_length ints.
+            for (int j = 0; j < samples_per_input_frame / 2; j += _spectrum_length) {
+                DEBUG("Running complex FFT, {:d}", in_local[2 * j]);
+                for (int i = 0; i < _spectrum_length; i++) {
+                    complex_samples[i][0] = in_local[2 * (i + j)];
+                    complex_samples[i][1] = in_local[2 * (i + j) + 1];
+                }
+                fftwf_execute(fft_plan);
+                // Shift DC into the centre.
+                memcpy(out_local, spectrum + _spectrum_length / 2,
+                       sizeof(fftwf_complex) * _spectrum_length / 2);
+                memcpy(out_local + _spectrum_length / 2, spectrum,
+                       sizeof(fftwf_complex) * _spectrum_length / 2);
+                out_local += _spectrum_length;
+            }
         }
 
         in_buf->mark_frame_empty(unique_name, frame_in);

--- a/lib/stages/fftwEngine.hpp
+++ b/lib/stages/fftwEngine.hpp
@@ -26,10 +26,14 @@
  * Two input formats are supported, selectable via @c input_type:
  *  - @c complex (default): packed int16 I/Q pairs. Each FFT consumes
  *    @c spectrum_length complex samples and emits @c spectrum_length complex
- *    bins, with DC shifted into the centre.
+ *    bins. The output is fftshifted -- the two halves of the raw FFT are
+ *    swapped (memcpy of @c spectrum_length/2 bins each way) so DC lands at
+ *    index @c spectrum_length/2 and bins run monotonically from -Fs/2 up to
+ *    +Fs/2.
  *  - @c real: packed int16 real samples. Each FFT consumes
  *    @c 2*spectrum_length real samples and emits @c spectrum_length complex
- *    bins (the first half of an r2c transform; Nyquist bin discarded).
+ *    bins (the first half of an r2c transform; Nyquist bin discarded). No
+ *    fftshift here -- bins run 0 (DC) up to just below Fs/2.
  *
  * Depends on libfftw3.
  *
@@ -41,7 +45,7 @@
  *     @buffer_format Array of @c fftwf_complex
  *     @buffer_metadata none
  *
- * @conf   spectrum_length  Int (default 1024). Number of complex bins per output spectrum.
+ * @conf   spectrum_length  Int (default 128). Number of complex bins per output spectrum.
  * @conf   input_type       String (default "complex"). One of "complex" or "real".
  *
  * @author Keith Vanderlinde

--- a/lib/stages/fftwEngine.hpp
+++ b/lib/stages/fftwEngine.hpp
@@ -6,6 +6,7 @@
 
 #ifndef FFTW_ENGINE_HPP
 #define FFTW_ENGINE_HPP
+
 #include "Config.hpp"          // for Config
 #include "Stage.hpp"           // for Stage
 #include "buffer.hpp"          // for Buffer
@@ -16,66 +17,65 @@
 
 /**
  * @class fftwEngine
- * @brief Kotekan Stage to Fourier Transform an input stream.
+ * @brief Kotekan Stage to Fourier Transform an input stream of samples.
  *
- * This is a simple signal processing stage which takes (complex) data from an input buffer,
- * Fourier Transforms it with FFTW, and stuffs the results into an output buffer.
- * Both input and output buffers' frame lengths should be integer multiples of the FFT length,
- * though they need not be the same length as each other.
- * Assumes I/Q (complex) data at the input.
+ * Reads samples from an input buffer, FFTs them with FFTW, and writes the
+ * resulting complex spectra into an output buffer. Both input and output
+ * buffers' frame lengths must be integer multiples of one FFT's worth of data.
  *
- * This producer depends on libfftw3.
+ * Two input formats are supported, selectable via @c input_type:
+ *  - @c complex (default): packed int16 I/Q pairs. Each FFT consumes
+ *    @c spectrum_length complex samples and emits @c spectrum_length complex
+ *    bins, with DC shifted into the centre.
+ *  - @c real: packed int16 real samples. Each FFT consumes
+ *    @c 2*spectrum_length real samples and emits @c spectrum_length complex
+ *    bins (the first half of an r2c transform; Nyquist bin discarded).
+ *
+ * Depends on libfftw3.
  *
  * @par Buffers
- * @buffer in_buf Input kotekan buffer, to be consumed from.
- *     @buffer_format Array of @c shorts
+ * @buffer in_buf Input kotekan buffer.
+ *     @buffer_format Array of @c int16_t (real samples, or interleaved I/Q pairs)
  *     @buffer_metadata none
- * @buffer out_buf Output kotekan buffer, to be produced into.
+ * @buffer out_buf Output kotekan buffer.
  *     @buffer_format Array of @c fftwf_complex
  *     @buffer_metadata none
  *
- * @conf   spectrum_length Int. Number of samples in the input spectrum. Defaults to 1024.
- *
- * @todo    Add checking to make sure the input and output buffers' frames are
- *          appropriately sized, i.e. integer multiples of spectrum_length.
- * @todo    Add a flag to allow real inputs.
- * @todo    Add some metadata to allow different data types for in/out.
+ * @conf   spectrum_length  Int (default 1024). Number of complex bins per output spectrum.
+ * @conf   input_type       String (default "complex"). One of "complex" or "real".
  *
  * @author Keith Vanderlinde
- *
  */
 class fftwEngine : public kotekan::Stage {
 public:
-    /// Constructor, also initializes FFTW and values from config yaml.
     fftwEngine(kotekan::Config& config, const std::string& unique_name,
                kotekan::bufferContainer& buffer_container);
-    /// Destructor, frees local allocs and exits FFTW.
-    virtual ~fftwEngine();
-    /// Primary loop, which waits on input frames, FFTs, and dumps to output.
+    ~fftwEngine() override;
+
     void main_thread() override;
 
 private:
-    /// Kotekan buffer which this stage consumes from.
-    /// Data should be packed as int16_t values, [r,i] in each 32b value.
+    /// Input buffer. Format depends on @c input_type (complex int16 pairs or real int16).
     Buffer* in_buf;
-    /// Kotekan buffer which this stage produces into.
+    /// Output buffer of @c fftwf_complex bins.
     Buffer* out_buf;
 
-    /// Frame index for the input buffer.
+    /// Frame indices.
     int frame_in;
-    /// Frame index for the output buffer.
     int frame_out;
 
-    // options
-    /// FFTW buffer for staging the input samples.
-    fftwf_complex* samples;
-    /// FFTW buffer which returns the FFT'd results.
-    fftwf_complex* spectrum;
-    /// FFTW object containing information about the transform
-    fftwf_plan fft_plan;
-    /// Length of the FFT to run
-    int spectrum_length;
-};
+    /// Number of complex output bins per FFT.
+    int _spectrum_length;
+    /// Whether the input is real or complex.
+    bool _real_input;
 
+    /// FFTW work buffers; @c real_samples is used in real mode, @c complex_samples in complex mode.
+    float* real_samples;
+    fftwf_complex* complex_samples;
+    /// Output of the FFT (size depends on mode).
+    fftwf_complex* spectrum;
+    /// FFTW plan for the configured mode.
+    fftwf_plan fft_plan;
+};
 
 #endif

--- a/lib/stages/fftwPlannerLock.hpp
+++ b/lib/stages/fftwPlannerLock.hpp
@@ -1,0 +1,25 @@
+#ifndef FFTW_PLANNER_LOCK_HPP
+#define FFTW_PLANNER_LOCK_HPP
+
+#include <mutex>
+
+/**
+ * @brief Process-wide lock serializing FFTW planner calls.
+ *
+ * FFTW's planner routines (``fftwf_plan_*`` and ``fftwf_destroy_plan``)
+ * mutate shared global state and are explicitly NOT thread-safe; only
+ * ``fftwf_execute`` may run concurrently. Stage construction is serial so
+ * ctor plan creation is already safe, but plan *destruction* (stage dtors
+ * at shutdown) and AirspyAlign's per-REST-callback plan create/destroy run
+ * on other threads and can race each other and any concurrent stage dtor.
+ *
+ * Every fftwf plan create/destroy across all stages must take this one
+ * lock. It's a Meyers singleton in an inline function so all translation
+ * units share a single mutex without a separate .cpp.
+ */
+inline std::mutex& fftw_planner_mutex() {
+    static std::mutex m;
+    return m;
+}
+
+#endif // FFTW_PLANNER_LOCK_HPP

--- a/lib/stages/frbNetworkProcess.hpp
+++ b/lib/stages/frbNetworkProcess.hpp
@@ -16,7 +16,7 @@
 #include "json.hpp" // for json
 
 #include <atomic>             // for atomic_bool
-#include <bits/chrono.h>      // for operator==, operator>, seconds, steady_clock, time_point
+#include <chrono>            // for operator==, operator>, seconds, steady_clock, time_point
 #include <condition_variable> // for condition_variable
 #include <functional>         // for reference_wrapper
 #include <map>                // for map

--- a/lib/stages/frbNetworkProcess.hpp
+++ b/lib/stages/frbNetworkProcess.hpp
@@ -16,7 +16,7 @@
 #include "json.hpp" // for json
 
 #include <atomic>             // for atomic_bool
-#include <chrono>            // for operator==, operator>, seconds, steady_clock, time_point
+#include <chrono>             // for operator==, operator>, seconds, steady_clock, time_point
 #include <condition_variable> // for condition_variable
 #include <functional>         // for reference_wrapper
 #include <map>                // for map

--- a/lib/stages/networkPowerStream.cpp
+++ b/lib/stages/networkPowerStream.cpp
@@ -2,6 +2,7 @@
 
 #include "Config.hpp"          // for Config
 #include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
+#include "airspyFrameDesc.hpp" // for make_power_corr_desc
 #include "buffer.hpp"          // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
 #include "kotekanLogging.hpp"  // for ERROR, INFO
@@ -44,6 +45,15 @@ networkPowerStream::networkPowerStream(Config& config, const std::string& unique
             / config.get<int>(unique_name, "power_integration_length");
     freqs = config.get<int>(unique_name, "num_freq");
     elems = config.get<int>(unique_name, "num_elements");
+
+    // Per integration the upstream emits [freqs float32 bins, 1 uint32 count]
+    // per element; we expect ``times`` integrations packed into one frame.
+    // The descriptor folds the count word into the float32 array (see
+    // airspyFrameDesc.hpp). When set_frame_desc has already been called by
+    // the producer (simpleAutocorr / SimpleCrosscorr), this becomes a
+    // cross-check via FrameDesc::operator==; otherwise it just records
+    // the expected layout for any later consumer/producer.
+    in_buf->set_frame_desc(kotekan_airspy::make_power_corr_desc(elems * times, freqs));
 
     freq0 = config.get_default<float>(unique_name, "freq", 600.) * 1e6;
     sample_bw = config.get_default<float>(unique_name, "sample_bw", 200.) * 1e6;

--- a/lib/stages/networkPowerStream.cpp
+++ b/lib/stages/networkPowerStream.cpp
@@ -19,6 +19,11 @@
 #include <sys/types.h>  // for uint
 #include <unistd.h>     // for close
 
+#ifndef MSG_NOSIGNAL
+// macOS uses SO_NOSIGPIPE on the socket instead (set up below); make sendto() portable.
+#define MSG_NOSIGNAL 0
+#endif
+
 
 using kotekan::bufferContainer;
 using kotekan::Config;
@@ -117,7 +122,7 @@ void networkPowerStream::main_thread() {
                            freqs * sizeof(uint));
                     // Send data to remote server.
                     uint32_t bytes_sent =
-                        sendto(socket_fd, packet_buffer, packet_length, 0,
+                        sendto(socket_fd, packet_buffer, packet_length, MSG_NOSIGNAL,
                                (struct sockaddr*)&saddr_remote, sizeof(sockaddr_in));
                     if (bytes_sent != packet_length)
                         ERROR("SOMETHING WENT WRONG IN UDP TRANSMIT");

--- a/lib/stages/simpleAutocorr.cpp
+++ b/lib/stages/simpleAutocorr.cpp
@@ -2,6 +2,7 @@
 
 #include "Config.hpp"          // for Config
 #include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
+#include "airspyFrameDesc.hpp" // for make_fengine_desc, make_power_corr_desc
 #include "buffer.hpp"          // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
 #include "kotekanLogging.hpp"  // for DEBUG
@@ -33,6 +34,15 @@ simpleAutocorr::simpleAutocorr(Config& config, const std::string& unique_name,
     spectrum_length = config.get_default<int>(unique_name, "spectrum_length", 1024);
     spectrum_out = (float*)calloc(spectrum_length, sizeof(float));
     integration_length = config.get_default<int>(unique_name, "integration_length", 1024);
+
+    // Input: cfloat32 1-D fengine spectra. Output (power_corr) descriptor
+    // is *not* set here: rawFileWrite refuses NDArray-tagged buffers (it
+    // can only round-trip raw bytes, not the layout metadata), and the
+    // test pipeline captures buf_out through rawFileWrite. networkPowerStream
+    // asserts the expected power_corr layout on its consumer side, so the
+    // contract is still documented in code.
+    buf_in->set_frame_desc(
+        kotekan_airspy::make_fengine_desc(buf_in->frame_size / (2 * sizeof(float))));
 }
 
 simpleAutocorr::~simpleAutocorr() {

--- a/lib/testing/testCHORDTelescope.cpp
+++ b/lib/testing/testCHORDTelescope.cpp
@@ -10,14 +10,14 @@
 #include "fmt.hpp"  // for compile_string_to_view
 #include "json.hpp" // for json
 
-#include <algorithm>     // for max
-#include <array>         // for array
-#include <chrono>       // for milliseconds
-#include <functional>    // for bind, function
-#include <stdint.h>      // for int64_t
-#include <thread>        // for sleep_for
-#include <time.h>        // for timespec, time_t
-#include <vector>        // for vector
+#include <algorithm>  // for max
+#include <array>      // for array
+#include <chrono>     // for milliseconds
+#include <functional> // for bind, function
+#include <stdint.h>   // for int64_t
+#include <thread>     // for sleep_for
+#include <time.h>     // for timespec, time_t
+#include <vector>     // for vector
 
 // Include the classes we will be using
 using kotekan::bufferContainer;

--- a/lib/testing/testCHORDTelescope.cpp
+++ b/lib/testing/testCHORDTelescope.cpp
@@ -12,7 +12,7 @@
 
 #include <algorithm>     // for max
 #include <array>         // for array
-#include <bits/chrono.h> // for milliseconds
+#include <chrono>       // for milliseconds
 #include <functional>    // for bind, function
 #include <stdint.h>      // for int64_t
 #include <thread>        // for sleep_for

--- a/lib/utils/datasetManager.hpp
+++ b/lib/utils/datasetManager.hpp
@@ -15,7 +15,7 @@
 #include "json.hpp" // for json, operator!=, basic_json, input_adapter
 
 #include <atomic>             // for atomic, __atomic_base
-#include <chrono>            // for milliseconds
+#include <chrono>             // for milliseconds
 #include <condition_variable> // for condition_variable
 #include <exception>          // for exception
 #include <functional>         // for function

--- a/lib/utils/datasetManager.hpp
+++ b/lib/utils/datasetManager.hpp
@@ -15,7 +15,7 @@
 #include "json.hpp" // for json, operator!=, basic_json, input_adapter
 
 #include <atomic>             // for atomic, __atomic_base
-#include <bits/chrono.h>      // for milliseconds
+#include <chrono>            // for milliseconds
 #include <condition_variable> // for condition_variable
 #include <exception>          // for exception
 #include <functional>         // for function

--- a/lib/utils/restClient.cpp
+++ b/lib/utils/restClient.cpp
@@ -4,7 +4,7 @@
 
 #include "fmt.hpp" // for compile_string_to_view
 
-#include <chrono>                     // for operator+, seconds, system_clock
+#include <chrono>                      // for operator+, seconds, system_clock
 #include <condition_variable>          // for condition_variable
 #include <cstring>                     // for memcpy
 #include <event2/buffer.h>             // for iovec, evbuffer_iovec, evbuffer, evbuffer_peek

--- a/lib/utils/restClient.cpp
+++ b/lib/utils/restClient.cpp
@@ -4,7 +4,7 @@
 
 #include "fmt.hpp" // for compile_string_to_view
 
-#include <bits/chrono.h>               // for operator+, seconds, system_clock
+#include <chrono>                     // for operator+, seconds, system_clock
 #include <condition_variable>          // for condition_variable
 #include <cstring>                     // for memcpy
 #include <event2/buffer.h>             // for iovec, evbuffer_iovec, evbuffer, evbuffer_peek

--- a/lib/utils/visUtil.hpp
+++ b/lib/utils/visUtil.hpp
@@ -23,7 +23,7 @@
 
 #include <algorithm>     // for max
 #include <array>         // for array
-#include <bits/chrono.h> // for system_clock
+#include <chrono>        // for system_clock
 #include <complex>       // for complex, imag, real
 #include <cstdint>       // for uint32_t, int8_t, uint16_t, uint8_t, int64_t, uint64_t, int32_t
 #include <cstdlib>       // for size_t, div

--- a/lib/utils/visUtil.hpp
+++ b/lib/utils/visUtil.hpp
@@ -21,12 +21,12 @@
 #include "gsl-lite.hpp" // for span
 #include "json.hpp"     // for json
 
-#include <algorithm>     // for max
-#include <array>         // for array
-#include <chrono>        // for system_clock
-#include <complex>       // for complex, imag, real
-#include <cstdint>       // for uint32_t, int8_t, uint16_t, uint8_t, int64_t, uint64_t, int32_t
-#include <cstdlib>       // for size_t, div
+#include <algorithm> // for max
+#include <array>     // for array
+#include <chrono>    // for system_clock
+#include <complex>   // for complex, imag, real
+#include <cstdint>   // for uint32_t, int8_t, uint16_t, uint8_t, int64_t, uint64_t, int32_t
+#include <cstdlib>   // for size_t, div
 #ifdef WITH_CUDA
 #include <cuda_fp16.h> // for __half::operator float
 #endif
@@ -828,10 +828,10 @@ public:
     /**
      * @brief Create a new modular number.
      **/
-    modulo(Tu n) : _n(n){};
+    modulo(Tu n) : _n(n) {};
 
     // Default constructor
-    modulo() : modulo(0){};
+    modulo() : modulo(0) {};
 
     /// Assignment of a number into the modular number.
     modulo<T>& operator=(const T& i) {

--- a/lib/utils/visUtil.hpp
+++ b/lib/utils/visUtil.hpp
@@ -828,10 +828,10 @@ public:
     /**
      * @brief Create a new modular number.
      **/
-    modulo(Tu n) : _n(n) {};
+    modulo(Tu n) : _n(n){};
 
     // Default constructor
-    modulo() : modulo(0) {};
+    modulo() : modulo(0){};
 
     /// Assignment of a number into the modular number.
     modulo<T>& operator=(const T& i) {

--- a/tests/test_sample_autocorr.py
+++ b/tests/test_sample_autocorr.py
@@ -1,0 +1,90 @@
+# === Start Python 2/3 compatibility
+from __future__ import absolute_import, division, print_function, unicode_literals
+from future.builtins import *  # noqa  pylint: disable=W0401, W0614
+from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
+
+# === End Python 2/3 compatibility
+
+"""SampleAutocorr is a REST-triggered one-shot stage; its compute kernel is the
+single-channel reduction of SimpleCrosscorr (AA only), which is covered
+end-to-end in ``test_simple_crosscorr.py``. The test here is therefore a
+minimal smoke test: confirm the stage registers, consumes frames, and the
+REST endpoint accepts a POST without crashing kotekan. We do not verify the
+returned spectrum here because ``KotekanRunner`` discards REST responses.
+"""
+
+import os
+import struct
+
+import numpy as np
+
+from kotekan import runner
+
+
+SPECTRUM_LENGTH = 16
+INTEGRATION_LENGTH = 4
+SAMPLES_PER_FRAME = SPECTRUM_LENGTH * INTEGRATION_LENGTH
+# Provide a generous supply of input frames so the REST request completes
+# before rawFileRead runs out and interrupts kotekan.
+NUM_FRAMES = 50
+
+
+def _write_raw_frames(path_dir, file_name, complex_data, num_frames):
+    os.makedirs(str(path_dir), exist_ok=True)
+    flat = np.empty(complex_data.size * 2, dtype=np.float32)
+    flat[0::2] = complex_data.real
+    flat[1::2] = complex_data.imag
+    frame_bytes = flat.tobytes()
+    path = os.path.join(str(path_dir), "%s_%07d.raw" % (file_name, 0))
+    with open(path, "wb") as f:
+        for _ in range(num_frames):
+            f.write(struct.pack("<I", 0))
+            f.write(frame_bytes)
+    return path
+
+
+def test_sample_autocorr_smoke(tmpdir):
+    in_dir = tmpdir.mkdir("in")
+
+    A = np.ones(SAMPLES_PER_FRAME, dtype=np.complex64)
+    _write_raw_frames(in_dir, "in", A, NUM_FRAMES)
+
+    in_frame_size = SAMPLES_PER_FRAME * 2 * 4
+
+    buffers = {
+        "in_buf": {
+            "kotekan_buffer": "standard",
+            "metadata_pool": "main_pool",
+            "num_frames": "buffer_depth",
+            "frame_size": in_frame_size,
+        },
+    }
+    stages = {
+        "read_in": {
+            "kotekan_stage": "rawFileRead",
+            "buf": "in_buf",
+            "base_dir": str(in_dir),
+            "file_name": "in",
+            "file_ext": "raw",
+            "end_interrupt": True,
+        },
+        "sa": {
+            "kotekan_stage": "SampleAutocorr",
+            "in_buf": "in_buf",
+            "spectrum_length": SPECTRUM_LENGTH,
+            "integration_length": INTEGRATION_LENGTH,
+        },
+    }
+    config = {
+        "buffer_depth": 4,
+        "log_level": "info",
+        "instrument_name": "test",
+    }
+    rest_commands = [
+        ("post", "sa/spectrum", {"integration_length": INTEGRATION_LENGTH}),
+    ]
+    r = runner.KotekanRunner(
+        buffers=buffers, stages=stages, config=config, rest_commands=rest_commands
+    )
+    r.run()
+    # If we got here without an exception, kotekan exited cleanly.

--- a/tests/test_sample_autocorr.py
+++ b/tests/test_sample_autocorr.py
@@ -5,7 +5,7 @@ from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
 
 # === End Python 2/3 compatibility
 
-"""SampleAutocorr is a REST-triggered one-shot stage; its compute kernel is the
+"""SampleAutocorr is a REST-triggered on-demand stage; its compute kernel is the
 single-channel reduction of SimpleCrosscorr (AA only), which is covered
 end-to-end in ``test_simple_crosscorr.py``. The test here is therefore a
 minimal smoke test: confirm the stage registers, consumes frames, and the

--- a/tests/test_simple_crosscorr.py
+++ b/tests/test_simple_crosscorr.py
@@ -62,7 +62,9 @@ def _run_crosscorr(tmpdir, A, B):
     _write_raw_frames(in_dir, "inB", B, NUM_FRAMES)
 
     in_frame_size = SAMPLES_PER_FRAME * 2 * 4  # complex float pairs
-    out_frame_size = (SPECTRUM_LENGTH * 4 + 1) * 4  # AA, BB, ReAB*, ImAB*, count
+    # Per-element layout: ``[freqs floats, 1 uint count]`` repeated once per
+    # visibility stream. Same layout networkPowerStream consumes.
+    out_frame_size = (SPECTRUM_LENGTH + 1) * 4 * 4
 
     buffers = {
         "in_bufA": {
@@ -130,15 +132,24 @@ def _run_crosscorr(tmpdir, A, B):
 
 
 def _unpack_output(raw):
-    """Unpack a SimpleCrosscorr output frame into (AA, BB, ReABstar, ImABstar, count)."""
-    nfloats = SPECTRUM_LENGTH * 4
-    floats = np.frombuffer(raw[: nfloats * 4], dtype=np.float32)
-    count = struct.unpack("<I", raw[nfloats * 4 : nfloats * 4 + 4])[0]
-    AA = floats[0 * SPECTRUM_LENGTH : 1 * SPECTRUM_LENGTH]
-    BB = floats[1 * SPECTRUM_LENGTH : 2 * SPECTRUM_LENGTH]
-    ReAB = floats[2 * SPECTRUM_LENGTH : 3 * SPECTRUM_LENGTH]
-    ImAB = floats[3 * SPECTRUM_LENGTH : 4 * SPECTRUM_LENGTH]
-    return AA, BB, ReAB, ImAB, count
+    """Unpack a SimpleCrosscorr output frame into (AA, BB, ReABstar, ImABstar, count).
+
+    Format: ``[freqs floats, 1 uint count]`` repeated once per visibility
+    stream (AA, BB, Re{AB*}, Im{AB*}). All four counts are equal -- we read
+    the AA one and assert the others match.
+    """
+    block_floats = SPECTRUM_LENGTH + 1   # ``+1`` is the trailing count
+    flat = np.frombuffer(raw, dtype=np.float32, count=block_floats * 4)
+    AA   = flat[0 * block_floats : 0 * block_floats + SPECTRUM_LENGTH]
+    BB   = flat[1 * block_floats : 1 * block_floats + SPECTRUM_LENGTH]
+    ReAB = flat[2 * block_floats : 2 * block_floats + SPECTRUM_LENGTH]
+    ImAB = flat[3 * block_floats : 3 * block_floats + SPECTRUM_LENGTH]
+    counts = [
+        struct.unpack_from("<I", raw, (e * block_floats + SPECTRUM_LENGTH) * 4)[0]
+        for e in range(4)
+    ]
+    assert counts[0] == counts[1] == counts[2] == counts[3], counts
+    return AA, BB, ReAB, ImAB, counts[0]
 
 
 def test_simple_crosscorr_identical(tmpdir):

--- a/tests/test_simple_crosscorr.py
+++ b/tests/test_simple_crosscorr.py
@@ -1,0 +1,199 @@
+# === Start Python 2/3 compatibility
+from __future__ import absolute_import, division, print_function, unicode_literals
+from future.builtins import *  # noqa  pylint: disable=W0401, W0614
+from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
+
+# === End Python 2/3 compatibility
+
+import os
+import struct
+
+import numpy as np
+import pytest
+
+from kotekan import runner
+
+
+# Spectrum length must divide samples per frame. Keep small for fast tests.
+SPECTRUM_LENGTH = 16
+INTEGRATION_LENGTH = 4
+SAMPLES_PER_FRAME = SPECTRUM_LENGTH * INTEGRATION_LENGTH
+NUM_FRAMES = 1
+
+
+def _write_raw_frames(path_dir, file_name, complex_data, num_frames):
+    """Write a Python complex-float array to kotekan's rawFileWrite format.
+
+    Each file in the format has, per frame, a 4-byte metadata_size (0 for no
+    metadata) followed by frame_size bytes of payload. We pack one frame per
+    file at file index 0000000.
+    """
+    os.makedirs(str(path_dir), exist_ok=True)
+    # Pack as interleaved float32 (re, im, re, im, ...).
+    flat = np.empty(complex_data.size * 2, dtype=np.float32)
+    flat[0::2] = complex_data.real
+    flat[1::2] = complex_data.imag
+    frame_bytes = flat.tobytes()
+    path = os.path.join(str(path_dir), "%s_%07d.raw" % (file_name, 0))
+    with open(path, "wb") as f:
+        for _ in range(num_frames):
+            f.write(struct.pack("<I", 0))  # metadata_size = 0
+            f.write(frame_bytes)
+    return path
+
+
+def _read_raw_frame(path_dir, file_name, frame_size):
+    """Read the first frame from a rawFileWrite output file."""
+    path = os.path.join(str(path_dir), "%s_%07d.raw" % (file_name, 0))
+    with open(path, "rb") as f:
+        metadata_size = struct.unpack("<I", f.read(4))[0]
+        if metadata_size:
+            f.read(metadata_size)
+        return f.read(frame_size)
+
+
+def _run_crosscorr(tmpdir, A, B):
+    """Run kotekan with two complex-float inputs through SimpleCrosscorr and
+    return the output frame as a raw byte string."""
+    in_dir = tmpdir.mkdir("in")
+    out_dir = tmpdir.mkdir("out")
+
+    _write_raw_frames(in_dir, "inA", A, NUM_FRAMES)
+    _write_raw_frames(in_dir, "inB", B, NUM_FRAMES)
+
+    in_frame_size = SAMPLES_PER_FRAME * 2 * 4  # complex float pairs
+    out_frame_size = (SPECTRUM_LENGTH * 4 + 1) * 4  # AA, BB, ReAB*, ImAB*, count
+
+    buffers = {
+        "in_bufA": {
+            "kotekan_buffer": "standard",
+            "metadata_pool": "main_pool",
+            "num_frames": "buffer_depth",
+            "frame_size": in_frame_size,
+        },
+        "in_bufB": {
+            "kotekan_buffer": "standard",
+            "metadata_pool": "main_pool",
+            "num_frames": "buffer_depth",
+            "frame_size": in_frame_size,
+        },
+        "out_buf": {
+            "kotekan_buffer": "standard",
+            "metadata_pool": "main_pool",
+            "num_frames": "buffer_depth",
+            "frame_size": out_frame_size,
+        },
+    }
+    stages = {
+        "readA": {
+            "kotekan_stage": "rawFileRead",
+            "buf": "in_bufA",
+            "base_dir": str(in_dir),
+            "file_name": "inA",
+            "file_ext": "raw",
+            "end_interrupt": True,
+        },
+        "readB": {
+            "kotekan_stage": "rawFileRead",
+            "buf": "in_bufB",
+            "base_dir": str(in_dir),
+            "file_name": "inB",
+            "file_ext": "raw",
+        },
+        "xcorr": {
+            "kotekan_stage": "SimpleCrosscorr",
+            "in_bufA": "in_bufA",
+            "in_bufB": "in_bufB",
+            "out_buf": "out_buf",
+            "spectrum_length": SPECTRUM_LENGTH,
+            "integration_length": INTEGRATION_LENGTH,
+        },
+        "write_out": {
+            "kotekan_stage": "rawFileWrite",
+            "in_buf": "out_buf",
+            "base_dir": str(out_dir),
+            "file_name": "xcorr",
+            "file_ext": "raw",
+            "prefix_hostname": False,
+            "num_frames_per_file": 1,
+            "exit_after_n_files": 1,
+        },
+    }
+    config = {
+        "buffer_depth": 4,
+        "log_level": "info",
+        "instrument_name": "test",
+    }
+    r = runner.KotekanRunner(buffers=buffers, stages=stages, config=config)
+    r.run()
+    return _read_raw_frame(out_dir, "xcorr", out_frame_size)
+
+
+def _unpack_output(raw):
+    """Unpack a SimpleCrosscorr output frame into (AA, BB, ReABstar, ImABstar, count)."""
+    nfloats = SPECTRUM_LENGTH * 4
+    floats = np.frombuffer(raw[: nfloats * 4], dtype=np.float32)
+    count = struct.unpack("<I", raw[nfloats * 4 : nfloats * 4 + 4])[0]
+    AA = floats[0 * SPECTRUM_LENGTH : 1 * SPECTRUM_LENGTH]
+    BB = floats[1 * SPECTRUM_LENGTH : 2 * SPECTRUM_LENGTH]
+    ReAB = floats[2 * SPECTRUM_LENGTH : 3 * SPECTRUM_LENGTH]
+    ImAB = floats[3 * SPECTRUM_LENGTH : 4 * SPECTRUM_LENGTH]
+    return AA, BB, ReAB, ImAB, count
+
+
+def test_simple_crosscorr_identical(tmpdir):
+    """A == B: AA, BB, Re{AB*} all equal 1; Im{AB*} zero."""
+    A = np.ones(SAMPLES_PER_FRAME, dtype=np.complex64)
+    raw = _run_crosscorr(tmpdir, A, A.copy())
+    AA, BB, ReAB, ImAB, count = _unpack_output(raw)
+    np.testing.assert_allclose(AA, 1.0, atol=1e-5)
+    np.testing.assert_allclose(BB, 1.0, atol=1e-5)
+    np.testing.assert_allclose(ReAB, 1.0, atol=1e-5)
+    np.testing.assert_allclose(ImAB, 0.0, atol=1e-5)
+    assert count == INTEGRATION_LENGTH
+
+
+def test_simple_crosscorr_orthogonal(tmpdir):
+    """A = real-only, B = imag-only: cross sees a pure imaginary -1 in Im{AB*}."""
+    A = np.full(SAMPLES_PER_FRAME, 1 + 0j, dtype=np.complex64)
+    B = np.full(SAMPLES_PER_FRAME, 0 + 1j, dtype=np.complex64)
+    raw = _run_crosscorr(tmpdir, A, B)
+    AA, BB, ReAB, ImAB, count = _unpack_output(raw)
+    np.testing.assert_allclose(AA, 1.0, atol=1e-5)
+    np.testing.assert_allclose(BB, 1.0, atol=1e-5)
+    np.testing.assert_allclose(ReAB, 0.0, atol=1e-5)
+    np.testing.assert_allclose(ImAB, -1.0, atol=1e-5)
+    assert count == INTEGRATION_LENGTH
+
+
+@pytest.mark.parametrize("seed", [0, 1, 7])
+def test_simple_crosscorr_random_matches_numpy(tmpdir, seed):
+    """Random complex inputs: result must match the numpy reference computation."""
+    rng = np.random.default_rng(seed)
+    A = (rng.standard_normal(SAMPLES_PER_FRAME) + 1j * rng.standard_normal(SAMPLES_PER_FRAME)).astype(
+        np.complex64
+    )
+    B = (rng.standard_normal(SAMPLES_PER_FRAME) + 1j * rng.standard_normal(SAMPLES_PER_FRAME)).astype(
+        np.complex64
+    )
+    raw = _run_crosscorr(tmpdir, A, B)
+    AA, BB, ReAB, ImAB, count = _unpack_output(raw)
+
+    # Reference: integrate over INTEGRATION_LENGTH time samples per spectral bin.
+    AA_ref = np.zeros(SPECTRUM_LENGTH, dtype=np.float32)
+    BB_ref = np.zeros(SPECTRUM_LENGTH, dtype=np.float32)
+    ReAB_ref = np.zeros(SPECTRUM_LENGTH, dtype=np.float32)
+    ImAB_ref = np.zeros(SPECTRUM_LENGTH, dtype=np.float32)
+    for t in range(INTEGRATION_LENGTH):
+        a = A[t * SPECTRUM_LENGTH : (t + 1) * SPECTRUM_LENGTH]
+        b = B[t * SPECTRUM_LENGTH : (t + 1) * SPECTRUM_LENGTH]
+        AA_ref += (a.real ** 2 + a.imag ** 2) / INTEGRATION_LENGTH
+        BB_ref += (b.real ** 2 + b.imag ** 2) / INTEGRATION_LENGTH
+        ReAB_ref += (a.real * b.real + a.imag * b.imag) / INTEGRATION_LENGTH
+        ImAB_ref += (a.imag * b.real - b.imag * a.real) / INTEGRATION_LENGTH
+
+    np.testing.assert_allclose(AA, AA_ref, atol=1e-4)
+    np.testing.assert_allclose(BB, BB_ref, atol=1e-4)
+    np.testing.assert_allclose(ReAB, ReAB_ref, atol=1e-4)
+    np.testing.assert_allclose(ImAB, ImAB_ref, atol=1e-4)
+    assert count == INTEGRATION_LENGTH

--- a/tests/test_simple_crosscorr.py
+++ b/tests/test_simple_crosscorr.py
@@ -138,10 +138,10 @@ def _unpack_output(raw):
     stream (AA, BB, Re{AB*}, Im{AB*}). All four counts are equal -- we read
     the AA one and assert the others match.
     """
-    block_floats = SPECTRUM_LENGTH + 1   # ``+1`` is the trailing count
+    block_floats = SPECTRUM_LENGTH + 1  # ``+1`` is the trailing count
     flat = np.frombuffer(raw, dtype=np.float32, count=block_floats * 4)
-    AA   = flat[0 * block_floats : 0 * block_floats + SPECTRUM_LENGTH]
-    BB   = flat[1 * block_floats : 1 * block_floats + SPECTRUM_LENGTH]
+    AA = flat[0 * block_floats : 0 * block_floats + SPECTRUM_LENGTH]
+    BB = flat[1 * block_floats : 1 * block_floats + SPECTRUM_LENGTH]
     ReAB = flat[2 * block_floats : 2 * block_floats + SPECTRUM_LENGTH]
     ImAB = flat[3 * block_floats : 3 * block_floats + SPECTRUM_LENGTH]
     counts = [
@@ -181,12 +181,14 @@ def test_simple_crosscorr_orthogonal(tmpdir):
 def test_simple_crosscorr_random_matches_numpy(tmpdir, seed):
     """Random complex inputs: result must match the numpy reference computation."""
     rng = np.random.default_rng(seed)
-    A = (rng.standard_normal(SAMPLES_PER_FRAME) + 1j * rng.standard_normal(SAMPLES_PER_FRAME)).astype(
-        np.complex64
-    )
-    B = (rng.standard_normal(SAMPLES_PER_FRAME) + 1j * rng.standard_normal(SAMPLES_PER_FRAME)).astype(
-        np.complex64
-    )
+    A = (
+        rng.standard_normal(SAMPLES_PER_FRAME)
+        + 1j * rng.standard_normal(SAMPLES_PER_FRAME)
+    ).astype(np.complex64)
+    B = (
+        rng.standard_normal(SAMPLES_PER_FRAME)
+        + 1j * rng.standard_normal(SAMPLES_PER_FRAME)
+    ).astype(np.complex64)
     raw = _run_crosscorr(tmpdir, A, B)
     AA, BB, ReAB, ImAB, count = _unpack_output(raw)
 


### PR DESCRIPTION
With Claude's help, I *finally* got around to pulling the little airspy producer forward to modern kotekan.

This is the first of 2 PRs, getting basic airspy things working, both auto-and cross-corr. The second PR will add the html / javascript viewer, all cleaned up for airspy ops; should in principle work for ARO ops as well, though that may take some downstream debugging.

These largely leave the core kotekan untouched, though definitely worth double-checking!
