### PR TITLE
FIX: buffer size check for n2 -> vis conversion

### DIFF
--- a/config/ci-tests/cpu_batch/run_n2accum_chime.yaml
+++ b/config/ci-tests/cpu_batch/run_n2accum_chime.yaml
@@ -1,0 +1,226 @@
+---
+type: config
+# Logging level can be one of:
+# OFF, ERROR, WARN, INFO, DEBUG, DEBUG2 (case insensitive)
+# Note DEBUG and DEBUG2 require a build with (-DCMAKE_BUILD_TYPE=Debug)
+log_level: INFO
+
+buffer_depth: 4
+cpu_affinity: [2]  # [2,3,4,5,8,9,10,11]
+sizeof_float: 4
+frame_arrival_period: 2.56e-6 * samples_per_data_set
+sizeof_int: 4
+
+# For faster CHIME testing, we're using...
+sub_integration_ntime: 2048
+samples_per_data_set: 4096
+rfi_downsampling_factor: 256
+num_times: samples_per_data_set
+num_polarizations: 2
+num_dishes: 64
+num_elements: num_polarizations * num_dishes
+num_local_freq: 16
+num_ev: 0
+
+num_subintegrations_per_bin: 4
+
+#counts matrix size
+counts_blocksize: 8
+counts_num_blocks_lin: (num_elements / 8) / counts_blocksize
+counts_num_blocks: (counts_num_blocks_lin * (counts_num_blocks_lin + 1)) / 2
+
+# vis matrix size
+vis_blocksize: 16
+vis_num_blocks_lin: num_elements / vis_blocksize
+vis_num_blocks: vis_num_blocks_lin * (vis_num_blocks_lin + 1) / 2
+
+frames_to_generate: 8 * buffer_depth  # must be at least n2_frames_to_write * num_subintegrations_per_bin
+n2_frames_to_write: 2 * buffer_depth
+
+GIGA: 1000000000
+start_time_s: 1760000000
+
+telescope:
+  name: CHIMETelescope
+  require_gps: False
+
+gps_time:
+  frame0_nano: start_time_s * GIGA
+
+dataset_manager:
+  use_dataset_broker: False
+
+# Pool
+main_pool:
+    kotekan_metadata_pool: chordMetadata
+    num_metadata_objects: 3 * buffer_depth
+
+n2_pool:
+    kotekan_metadata_pool: N2Metadata
+    num_metadata_objects: 16 * buffer_depth
+
+vis_pool:
+    kotekan_metadata_pool: VisMetadata
+    num_metadata_objects: num_local_freq * buffer_depth
+
+fake_correlation_buffer:
+    kotekan_buffer: standard
+    num_frames: buffer_depth
+    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * vis_num_blocks * vis_blocksize * vis_blocksize * 2 * sizeof_int
+    metadata_pool: main_pool
+
+fake_counts_buffer:
+    kotekan_buffer: standard
+    num_frames: buffer_depth
+    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * counts_num_blocks * counts_blocksize * counts_blocksize * sizeof_int
+    metadata_pool: main_pool
+
+fake_rfimask_buffer:
+    kotekan_buffer: standard
+    num_frames: buffer_depth
+    frame_size: (samples_per_data_set * num_local_freq) / 8
+    metadata_pool: main_pool
+
+fake_rficounts_buffer:
+    kotekan_buffer: standard
+    num_frames: buffer_depth
+    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * sizeof_int
+    metadata_pool: main_pool
+
+fake_plcounts_buffer:
+    kotekan_buffer: standard
+    num_frames: buffer_depth
+    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * sizeof_int
+    metadata_pool: main_pool
+
+fake_rfi_frame_mask_buffer:
+    kotekan_buffer: standard
+    num_frames: buffer_depth
+    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq
+    metadata_pool: main_pool
+
+n2_buffer:
+    kotekan_buffer: N2
+    n2_layout: "FullUpperTri"
+    num_frames: buffer_depth * num_local_freq
+    metadata_pool: n2_pool
+
+vis_buffer:
+    kotekan_buffer: vis
+    num_ev: 0
+    num_frames: buffer_depth * num_local_freq
+    metadata_pool: vis_pool
+
+
+gen_fake_rfi_RFImask:
+    type: random1x8
+    value: 255
+    kotekan_stage: testDataGen
+    out_buf: fake_rfimask_buffer
+    name: "RFImask"
+    array_shape: [ 4, 16, 128 ]  # [samples_per_data_set / 1024, num_local_freq, 128]
+    dim_name: ["T8hi128", "F", "T8lo128"]
+    num_frames: frames_to_generate
+    meta_time_downsample_factor: 1024  # The number of time samples represented by each coarse time index.
+
+gen_RFI_frame_mask:
+    kotekan_stage: testRFIFrameMaskGen
+    out_buf: fake_rfi_frame_mask_buffer
+    type: random
+    num_frames: frames_to_generate
+
+gen_pl_lost_counts:
+    kotekan_stage: testLostCountsGen
+    in_buf: fake_counts_buffer
+    out_buf: fake_plcounts_buffer
+    name: "pl_lost_counts_scalar"
+    type: random
+    num_frames: frames_to_generate
+    use_n2k_counts: True
+
+gen_fake_corr_counts:
+    kotekan_stage: testN2kGen
+    out_buf: fake_correlation_buffer
+    out_counts_buf: fake_counts_buffer
+    in_rfimask_buf: fake_rfimask_buffer
+    correlation_type: "f_times_ee"
+    counts_type: "random_scalar"
+    correlation_value: [ 1, -1 ]
+    counts_value: sub_integration_ntime
+    counts_min: 0
+    counts_max: sub_integration_ntime
+    mul_correlation_by_counts: True
+    num_frames: frames_to_generate
+    freq_ids: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+
+RFImask_sum:
+    kotekan_stage: RfiMaskSum
+    in_buf: fake_rfimask_buffer
+    out_buf: fake_rficounts_buffer
+
+N2_accumulate:
+    kotekan_stage: N2Accumulate
+    in_buf: fake_correlation_buffer
+    in_counts_buf: fake_counts_buffer
+    in_rficounts_buf: fake_rficounts_buffer
+    in_plcounts_buf: fake_plcounts_buffer
+    in_rfiframemask_buf: fake_rfi_frame_mask_buffer
+    out_buf: n2_buffer
+    num_freq_per_n2k_frame: num_local_freq
+    packet_loss_is_scalar: True
+    variance_mode: CHIMEv1
+    bin_in_ERA: False
+    do_fringestop: False
+
+vis_convert:
+    kotekan_stage: n2FrameToVisFrame
+    n2_buf: n2_buffer
+    vis_buf: vis_buffer
+
+writers:
+    base_dir: fake_data
+    prefix_hostname: false
+    skip_writing: false
+    max_frames: -1  # buffer_depth
+
+    write_fake_correlation:
+        kotekan_stage: hdf5FileWrite
+        file_name: n2k_corr
+        in_buf: fake_correlation_buffer
+
+    write_fake_counts:
+        kotekan_stage: hdf5FileWrite
+        file_name: n2k_counts
+        in_buf: fake_counts_buffer
+
+    write_fake_rfimask:
+        kotekan_stage: hdf5FileWrite
+        file_name: n2k_rfimask
+        in_buf: fake_rfimask_buffer
+
+    write_fake_rficounts:
+        kotekan_stage: hdf5FileWrite
+        file_name: n2k_rficounts
+        in_buf: fake_rficounts_buffer
+
+    write_fake_plcounts:
+        kotekan_stage: hdf5FileWrite
+        file_name: n2k_plcounts
+        in_buf: fake_plcounts_buffer
+
+    write_fake_rfi_frame_mask:
+        kotekan_stage: hdf5FileWrite
+        file_name: n2k_rfiframemask
+        in_buf: fake_rfi_frame_mask_buffer
+
+    write_N2:
+        kotekan_stage: hdf5FileWrite
+        file_name: n2_vis_posdef
+        in_buf: n2_buffer
+        max_frames: num_local_freq * n2_frames_to_write # Will trigger exit after writing this many frames
+
+    write_vis:
+        kotekan_stage: rawFileWrite
+        file_name: vis
+        in_buf: vis_buffer
+        file_ext: raw

--- a/lib/stages/N2FrameToVisFrame.cpp
+++ b/lib/stages/N2FrameToVisFrame.cpp
@@ -1,6 +1,7 @@
 #include "N2FrameToVisFrame.hpp"
 
-#include "Config.hpp" // for Config
+#include "Config.hpp"      // for Config
+#include "N2FrameDesc.hpp" // for N2FrameDesc
 #include "N2FrameView.hpp"
 #include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
 #include "buffer.hpp"          // for Buffer
@@ -30,12 +31,26 @@ n2FrameToVisFrame::n2FrameToVisFrame(Config& config, const std::string& unique_n
     vis_buf = get_buffer("vis_buf");
     vis_buf->register_producer(unique_name);
 
-    // cannot check on num_ev, num_elements, or num_prod which are used only to
-    // calculate the frame size in BufferFactory but not stored
-    if (n2_buf->frame_size != vis_buf->frame_size) {
-        FATAL_ERROR(
-            "Frame sizes between N2FrameView and VisFrameView must be identical, but got {} and {}",
-            n2_buf->frame_size, vis_buf->frame_size);
+    // N2FrameView and VisFrameView have different data fields, so extract the basic
+    // size parameters from the N2 buffer and compute the size of VisFrameView they correspond
+    // to.
+    // N2FrameDesc's are constructed on buffer creation (before stages) so this object will
+    // exist with the correct data.
+    const std::shared_ptr<const kotekan::N2FrameDesc> n2_frame_desc =
+        std::dynamic_pointer_cast<const kotekan::N2FrameDesc>(n2_buf->get_frame_description());
+    if (!n2_frame_desc) {
+        FATAL_ERROR("n2_buf does not have N2 Frame Descriptor");
+    }
+    uint32_t n2_ne = n2_frame_desc->get_num_elements();
+    uint32_t n2_np = n2_frame_desc->get_num_products();
+    uint32_t n2_nev = n2_frame_desc->get_num_ev();
+    size_t n2_conv_frame_size = VisFrameView::calculate_frame_size(n2_ne, n2_np, n2_nev);
+
+    // Check the sizes are equivalent
+    if (n2_conv_frame_size != vis_buf->frame_size) {
+        FATAL_ERROR("Frame sizes between converted N2FrameView and VisFrameView must be identical, "
+                    "but got {} (converted) and {}",
+                    n2_conv_frame_size, vis_buf->frame_size);
     }
 
     fake_git_tag = config.get_default<std::string>(unique_name, "fake_git_tag", std::string());


### PR DESCRIPTION
N2FrameView now have more data fields than VisFrameViews.  When checking N2 and Vis buffers are compatible, have to convert the N2 shape into the equivalent Vis shape.  