### PR TITLE
N2 metadata update

### DIFF
--- a/lib/metadata/N2Metadata.cpp
+++ b/lib/metadata/N2Metadata.cpp
@@ -41,8 +41,8 @@ size_t N2Metadata::set_from_bytes(const char* bytes, [[maybe_unused]] size_t len
     bin_eop = fmt->bin_eop;
     bin_start_ERA_deg = fmt->bin_start_ERA_deg;
     bin_end_ERA_deg = fmt->bin_end_ERA_deg;
-    bin_start_ERAL = fmt->bin_start_ERAL;
-    bin_end_ERAL = fmt->bin_end_ERAL;
+    bin_start_ERAL_deg = fmt->bin_start_ERAL_deg;
+    bin_end_ERAL_deg = fmt->bin_end_ERAL_deg;
 
     rfi_frame_excision_enabled = fmt->rfi_frame_excision_enabled;
     rfi_frame_excision_num = fmt->rfi_frame_excision_num;
@@ -71,8 +71,8 @@ size_t N2Metadata::serialize(char* bytes) {
     fmt->bin_eop = bin_eop;
     fmt->bin_start_ERA_deg = bin_start_ERA_deg;
     fmt->bin_end_ERA_deg = bin_end_ERA_deg;
-    fmt->bin_start_ERAL = bin_start_ERAL;
-    fmt->bin_end_ERAL = bin_end_ERAL;
+    fmt->bin_start_ERAL_deg = bin_start_ERAL_deg;
+    fmt->bin_end_ERAL_deg = bin_end_ERAL_deg;
 
     fmt->rfi_frame_excision_enabled = rfi_frame_excision_enabled;
     fmt->rfi_frame_excision_num = rfi_frame_excision_num;
@@ -129,8 +129,8 @@ void to_json(nlohmann::json& j, const N2Metadata& m) {
     j.emplace("bin_eop", m.bin_eop);
     j.emplace("bin_start_ERA_deg", m.bin_start_ERA_deg);
     j.emplace("bin_end_ERA_deg", m.bin_end_ERA_deg);
-    j.emplace("bin_start_ERAL", m.bin_start_ERAL);
-    j.emplace("bin_end_ERAL", m.bin_end_ERAL);
+    j.emplace("bin_start_ERAL_deg", m.bin_start_ERAL_deg);
+    j.emplace("bin_end_ERAL_deg", m.bin_end_ERAL_deg);
 
     j.emplace("rfi_frame_excision_enabled", m.rfi_frame_excision_enabled);
     j.emplace("rfi_frame_excision_num", m.rfi_frame_excision_num);
@@ -156,8 +156,8 @@ void from_json(const nlohmann::json& j, N2Metadata& m) {
     m.bin_eop = j.at("bin_eop");
     m.bin_start_ERA_deg = j.at("bin_start_ERA_deg");
     m.bin_end_ERA_deg = j.at("bin_end_ERA_deg");
-    m.bin_start_ERAL = j.at("bin_start_ERAL");
-    m.bin_end_ERAL = j.at("bin_end_ERAL");
+    m.bin_start_ERAL_deg = j.at("bin_start_ERAL_deg");
+    m.bin_end_ERAL_deg = j.at("bin_end_ERAL_deg");
 
     m.rfi_frame_excision_enabled = j.at("rfi_frame_excision_enabled");
     m.rfi_frame_excision_num = j.at("rfi_frame_excision_num");

--- a/lib/metadata/N2Metadata.hpp
+++ b/lib/metadata/N2Metadata.hpp
@@ -39,10 +39,10 @@ struct N2MetadataFormat {
     /// Earth Orientation Parameters within an integration/accumulation bin
     struct EOP bin_eop = eop_null;
     // bin start/end info for convenience
-    double bin_start_ERA_deg = 0.0; /// Earth Rotation Angle at start of bin
-    double bin_end_ERA_deg = 0.0;   /// Earth Rotation Angle at end of bin
-    double bin_start_ERAL = 0.0;    /// local apparent sidereal time (nanoseconds) at start of bin
-    double bin_end_ERAL = 0.0;      /// local apparent sidereal time (nanoseconds) at end of bin
+    double bin_start_ERA_deg = 0.0;  /// Earth Rotation Angle at start of bin
+    double bin_end_ERA_deg = 0.0;    /// Earth Rotation Angle at end of bin
+    double bin_start_ERAL_deg = 0.0; /// local apparent sidereal time (nanoseconds) at start of bin
+    double bin_end_ERAL_deg = 0.0;   /// local apparent sidereal time (nanoseconds) at end of bin
 
     /// The sequence number of the first FPGA frame integrated into this visibility frame
     uint64_t fpga_start_tick = 0;

--- a/lib/stages/N2Accumulate.cpp
+++ b/lib/stages/N2Accumulate.cpp
@@ -942,8 +942,8 @@ bool N2Accumulate::output_and_reset(frameID& in_frame_id, frameID& in_rfiframema
 
         meta->bin_start_ERA_deg = ERA_deg_start;
         meta->bin_end_ERA_deg = ERA_deg_end;
-        meta->bin_start_ERAL = ERAL_deg_start; // TODO: update
-        meta->bin_end_ERAL = ERAL_deg_end;     // TODO: update
+        meta->bin_start_ERAL_deg = ERAL_deg_start; // TODO: update
+        meta->bin_end_ERAL_deg = ERAL_deg_end;     // TODO: update
 
         meta->fpga_start_tick = _accum_fpga_start_tick;
         meta->frame_start_time_ns = accum_start_time_ns;

--- a/lib/stages/N2FringeStop.cpp
+++ b/lib/stages/N2FringeStop.cpp
@@ -108,10 +108,10 @@ void N2FringeStop::main_thread() {
         // Set the target EOP.
         output_frame.time_center_eop = eop_null; // TODO: update
         output_frame.bin_eop = eop_target;
-        output_frame.bin_start_ERA_deg = -1; // TODO: update
-        output_frame.bin_end_ERA_deg = -1;   // TODO: update
-        output_frame.bin_start_ERAL = -1;    // TODO: update
-        output_frame.bin_end_ERAL = -1;      // TODO: update
+        output_frame.bin_start_ERA_deg = -1;  // TODO: update
+        output_frame.bin_end_ERA_deg = -1;    // TODO: update
+        output_frame.bin_start_ERAL_deg = -1; // TODO: update
+        output_frame.bin_end_ERAL_deg = -1;   // TODO: update
 
         if (fringestop_mode > 0)
             tel.fill_fringestop_phases_1d(in_frame.freq_MHz, eop, eop_target, fringe_phase);

--- a/lib/stages/N2TimeDownsample.cpp
+++ b/lib/stages/N2TimeDownsample.cpp
@@ -213,8 +213,8 @@ void N2TimeDownsample::main_thread() {
             output_frame.bin_eop = eop_target;
             output_frame.bin_start_ERA_deg = era_deg_lo;
             output_frame.bin_end_ERA_deg = era_deg_hi;
-            output_frame.bin_start_ERAL = -1; // TODO: update
-            output_frame.bin_end_ERAL = -1;   // TODO: update
+            output_frame.bin_start_ERAL_deg = -1; // TODO: update
+            output_frame.bin_end_ERAL_deg = -1;   // TODO: update
 
             // Set the output absolute time index, from the difference between the current ERA bin
             // and the ERA bin at startup

--- a/lib/stages/hdf5FileWrite.cpp
+++ b/lib/stages/hdf5FileWrite.cpp
@@ -437,8 +437,8 @@ public:
         file.createAttribute("bin_eop.yp_as", frame.bin_eop.yp_as);
         file.createAttribute("bin_start_ERA_deg", frame.bin_start_ERA_deg);
         file.createAttribute("bin_end_ERA_deg", frame.bin_end_ERA_deg);
-        file.createAttribute("bin_start_ERAL", frame.bin_start_ERAL);
-        file.createAttribute("bin_end_ERAL", frame.bin_end_ERAL);
+        file.createAttribute("bin_start_ERAL_deg", frame.bin_start_ERAL_deg);
+        file.createAttribute("bin_end_ERAL_deg", frame.bin_end_ERAL_deg);
         file.createAttribute("fpga_start_tick", frame.fpga_start_tick);
         file.createAttribute("frame_start_time_ns", frame.frame_start_time_ns);
         file.createAttribute("frame_length_fpga_ticks", frame.frame_length_fpga_ticks);

--- a/lib/stages/hdf5N2Write.cpp
+++ b/lib/stages/hdf5N2Write.cpp
@@ -561,6 +561,8 @@ std::unique_ptr<HighFive::File> N2FileData::_open_or_create_file(const std::stri
                               HighFive::create_datatype<uint64_t>(), props_empty);
         _check_create_dataset(*file, "/frame_length_fpga_ticks", {num_file_t_}, {"time"},
                               HighFive::create_datatype<uint64_t>(), props_empty);
+        _check_create_dataset(*file, "/abs_time_index", {num_file_t_}, {"time"},
+                              HighFive::create_datatype<uint64_t>(), props_empty);
 
         _check_create_dataset(*file, "/time_center_t_inst_ns", {num_file_t_}, {"time"},
                               HighFive::create_datatype<int64_t>(), props_empty);
@@ -582,9 +584,9 @@ std::unique_ptr<HighFive::File> N2FileData::_open_or_create_file(const std::stri
                               HighFive::create_datatype<double>(), props_empty);
         _check_create_dataset(*file, "/bin_end_ERA_deg", {num_file_t_}, {"time"},
                               HighFive::create_datatype<double>(), props_empty);
-        _check_create_dataset(*file, "/bin_start_ERAL", {num_file_t_}, {"time"},
+        _check_create_dataset(*file, "/bin_start_ERAL_deg", {num_file_t_}, {"time"},
                               HighFive::create_datatype<double>(), props_empty);
-        _check_create_dataset(*file, "/bin_end_ERAL", {num_file_t_}, {"time"},
+        _check_create_dataset(*file, "/bin_end_ERAL_deg", {num_file_t_}, {"time"},
                               HighFive::create_datatype<double>(), props_empty);
         _check_create_dataset(*file, "/rfi_frame_excision_enabled", {num_file_t_}, {"time"},
                               HighFive::create_datatype<bool>(), props_empty);
@@ -698,6 +700,7 @@ N2FileData::N2FileData(FileMode file_mode_, uint64_t num_file_t_, const N2FrameV
     // Additional metadata
     fpga_start_tick.assign(num_file_t, 0);
     frame_length_fpga_ticks.assign(num_file_t, 0);
+    abs_time_index.assign(num_file_t, std::numeric_limits<uint64_t>::max());
     time_center_t_inst_ns.assign(num_file_t, 0.0);
     time_center_ut1_ns.assign(num_file_t, 0.0);
     bin_t_inst_ns.assign(num_file_t, 0.0);
@@ -708,8 +711,8 @@ N2FileData::N2FileData(FileMode file_mode_, uint64_t num_file_t_, const N2FrameV
     bin_yp_as.assign(num_file_t, -DBL_MAX);
     bin_start_ERA_deg.assign(num_file_t, 0.0);
     bin_end_ERA_deg.assign(num_file_t, 0.0);
-    bin_start_ERAL.assign(num_file_t, 0.0);
-    bin_end_ERAL.assign(num_file_t, 0.0);
+    bin_start_ERAL_deg.assign(num_file_t, 0.0);
+    bin_end_ERAL_deg.assign(num_file_t, 0.0);
     rfi_frame_excision_enabled.assign(num_file_t, false);
     rfi_frame_excision_num.assign(num_file_t, 0);
     rfi_frame_excision_threshold.assign(num_file_t * MAX_NUM_RFI_THRESHOLDS, 0.0f);
@@ -790,6 +793,10 @@ N2FileData::AddFrameStatus N2FileData::add_frame(const N2FrameView& fv, size_t t
         add_failure(fmt::format("frame_length_fpga_ticks[t={}] mismatch: stored {} != incoming {}",
                                 t_index, frame_length_fpga_ticks[t_index],
                                 fv.frame_length_fpga_ticks));
+    if (abs_time_index[t_index] < std::numeric_limits<uint64_t>::max()
+        && abs_time_index[t_index] != fv.abs_time_idx)
+        add_failure(fmt::format("abs_time_index[t={}] mismatch: stored {} != incoming {}", t_index,
+                                abs_time_index[t_index], fv.abs_time_idx));
     if (fv.rfi_frame_excision_num < 0)
         add_failure(fmt::format("rfi_frame_excision_num negative: {}", fv.rfi_frame_excision_num));
     if (fv.rfi_frame_excision_num > MAX_NUM_RFI_THRESHOLDS)
@@ -887,6 +894,7 @@ N2FileData::AddFrameStatus N2FileData::add_frame(const N2FrameView& fv, size_t t
     // Store per-time metadata
     fpga_start_tick[t_index] = fv.fpga_start_tick;
     frame_length_fpga_ticks[t_index] = fv.frame_length_fpga_ticks;
+    abs_time_index[t_index] = fv.abs_time_idx;
     time_center_t_inst_ns[t_index] = fv.time_center_eop.t_inst_ns;
     time_center_ut1_ns[t_index] = fv.time_center_eop.t_ut1_ns;
     bin_t_inst_ns[t_index] = fv.bin_eop.t_inst_ns;
@@ -897,8 +905,8 @@ N2FileData::AddFrameStatus N2FileData::add_frame(const N2FrameView& fv, size_t t
     bin_yp_as[t_index] = fv.bin_eop.yp_as;
     bin_start_ERA_deg[t_index] = fv.bin_start_ERA_deg;
     bin_end_ERA_deg[t_index] = fv.bin_end_ERA_deg;
-    bin_start_ERAL[t_index] = fv.bin_start_ERAL;
-    bin_end_ERAL[t_index] = fv.bin_end_ERAL;
+    bin_start_ERAL_deg[t_index] = fv.bin_start_ERAL_deg;
+    bin_end_ERAL_deg[t_index] = fv.bin_end_ERAL_deg;
     rfi_frame_excision_enabled[t_index] = fv.rfi_frame_excision_enabled;
     rfi_frame_excision_num[t_index] = fv.rfi_frame_excision_num;
     std::copy(fv.rfi_frame_excision_threshold.begin(), fv.rfi_frame_excision_threshold.end(),
@@ -1050,6 +1058,7 @@ bool N2FileData::flush_to_disk() {
 
         h5_file->getDataSet("/fpga_start_tick").write(fpga_start_tick);
         h5_file->getDataSet("/frame_length_fpga_ticks").write(frame_length_fpga_ticks);
+        h5_file->getDataSet("/abs_time_index").write(abs_time_index);
         h5_file->getDataSet("/time_center_t_inst_ns").write(time_center_t_inst_ns);
         h5_file->getDataSet("/time_center_ut1_ns").write(time_center_ut1_ns);
         h5_file->getDataSet("/bin_t_inst_ns").write(bin_t_inst_ns);
@@ -1060,8 +1069,8 @@ bool N2FileData::flush_to_disk() {
         h5_file->getDataSet("/bin_yp_as").write(bin_yp_as);
         h5_file->getDataSet("/bin_start_ERA_deg").write(bin_start_ERA_deg);
         h5_file->getDataSet("/bin_end_ERA_deg").write(bin_end_ERA_deg);
-        h5_file->getDataSet("/bin_start_ERAL").write(bin_start_ERAL);
-        h5_file->getDataSet("/bin_end_ERAL").write(bin_end_ERAL);
+        h5_file->getDataSet("/bin_start_ERAL_deg").write(bin_start_ERAL_deg);
+        h5_file->getDataSet("/bin_end_ERAL_deg").write(bin_end_ERAL_deg);
         h5_file->getDataSet("/rfi_frame_excision_enabled").write(rfi_frame_excision_enabled);
         h5_file->getDataSet("/rfi_frame_excision_num").write(rfi_frame_excision_num);
         h5_file->getDataSet("/rfi_frame_excision_threshold")

--- a/lib/stages/hdf5N2Write.cpp
+++ b/lib/stages/hdf5N2Write.cpp
@@ -561,7 +561,7 @@ std::unique_ptr<HighFive::File> N2FileData::_open_or_create_file(const std::stri
                               HighFive::create_datatype<uint64_t>(), props_empty);
         _check_create_dataset(*file, "/frame_length_fpga_ticks", {num_file_t_}, {"time"},
                               HighFive::create_datatype<uint64_t>(), props_empty);
-        _check_create_dataset(*file, "/abs_time_index", {num_file_t_}, {"time"},
+        _check_create_dataset(*file, "/bin_abs_index", {num_file_t_}, {"time"},
                               HighFive::create_datatype<uint64_t>(), props_empty);
 
         _check_create_dataset(*file, "/time_center_t_inst_ns", {num_file_t_}, {"time"},
@@ -700,7 +700,7 @@ N2FileData::N2FileData(FileMode file_mode_, uint64_t num_file_t_, const N2FrameV
     // Additional metadata
     fpga_start_tick.assign(num_file_t, 0);
     frame_length_fpga_ticks.assign(num_file_t, 0);
-    abs_time_index.assign(num_file_t, std::numeric_limits<uint64_t>::max());
+    bin_abs_index.assign(num_file_t, std::numeric_limits<uint64_t>::max());
     time_center_t_inst_ns.assign(num_file_t, 0.0);
     time_center_ut1_ns.assign(num_file_t, 0.0);
     bin_t_inst_ns.assign(num_file_t, 0.0);
@@ -793,10 +793,10 @@ N2FileData::AddFrameStatus N2FileData::add_frame(const N2FrameView& fv, size_t t
         add_failure(fmt::format("frame_length_fpga_ticks[t={}] mismatch: stored {} != incoming {}",
                                 t_index, frame_length_fpga_ticks[t_index],
                                 fv.frame_length_fpga_ticks));
-    if (abs_time_index[t_index] < std::numeric_limits<uint64_t>::max()
-        && abs_time_index[t_index] != fv.abs_time_idx)
-        add_failure(fmt::format("abs_time_index[t={}] mismatch: stored {} != incoming {}", t_index,
-                                abs_time_index[t_index], fv.abs_time_idx));
+    if (bin_abs_index[t_index] < std::numeric_limits<uint64_t>::max()
+        && bin_abs_index[t_index] != fv.abs_time_idx)
+        add_failure(fmt::format("bin_abs_index[t={}] mismatch: stored {} != incoming {}", t_index,
+                                bin_abs_index[t_index], fv.abs_time_idx));
     if (fv.rfi_frame_excision_num < 0)
         add_failure(fmt::format("rfi_frame_excision_num negative: {}", fv.rfi_frame_excision_num));
     if (fv.rfi_frame_excision_num > MAX_NUM_RFI_THRESHOLDS)
@@ -894,7 +894,7 @@ N2FileData::AddFrameStatus N2FileData::add_frame(const N2FrameView& fv, size_t t
     // Store per-time metadata
     fpga_start_tick[t_index] = fv.fpga_start_tick;
     frame_length_fpga_ticks[t_index] = fv.frame_length_fpga_ticks;
-    abs_time_index[t_index] = fv.abs_time_idx;
+    bin_abs_index[t_index] = fv.abs_time_idx;
     time_center_t_inst_ns[t_index] = fv.time_center_eop.t_inst_ns;
     time_center_ut1_ns[t_index] = fv.time_center_eop.t_ut1_ns;
     bin_t_inst_ns[t_index] = fv.bin_eop.t_inst_ns;
@@ -1058,7 +1058,7 @@ bool N2FileData::flush_to_disk() {
 
         h5_file->getDataSet("/fpga_start_tick").write(fpga_start_tick);
         h5_file->getDataSet("/frame_length_fpga_ticks").write(frame_length_fpga_ticks);
-        h5_file->getDataSet("/abs_time_index").write(abs_time_index);
+        h5_file->getDataSet("/bin_abs_index").write(bin_abs_index);
         h5_file->getDataSet("/time_center_t_inst_ns").write(time_center_t_inst_ns);
         h5_file->getDataSet("/time_center_ut1_ns").write(time_center_ut1_ns);
         h5_file->getDataSet("/bin_t_inst_ns").write(bin_t_inst_ns);

--- a/lib/stages/hdf5N2Write.hpp
+++ b/lib/stages/hdf5N2Write.hpp
@@ -121,6 +121,7 @@ protected:
     // t-dependent metadata
     std::vector<uint64_t> fpga_start_tick;           // (t)
     std::vector<uint64_t> frame_length_fpga_ticks;   // (t)
+    std::vector<uint64_t> abs_time_index;            // (t)
     std::vector<int64_t> time_center_t_inst_ns;      // (t)
     std::vector<int64_t> time_center_ut1_ns;         // (t)
     std::vector<int64_t> bin_t_inst_ns;              // (t)
@@ -131,8 +132,8 @@ protected:
     std::vector<double> bin_yp_as;                   // (t)
     std::vector<double> bin_start_ERA_deg;           // (t)
     std::vector<double> bin_end_ERA_deg;             // (t)
-    std::vector<double> bin_start_ERAL;              // (t)
-    std::vector<double> bin_end_ERAL;                // (t)
+    std::vector<double> bin_start_ERAL_deg;          // (t)
+    std::vector<double> bin_end_ERAL_deg;            // (t)
     std::vector<bool> rfi_frame_excision_enabled;    // (t)
     std::vector<int32_t> rfi_frame_excision_num;     // (t)
     std::vector<float> rfi_frame_excision_threshold; // (t, k)

--- a/lib/stages/hdf5N2Write.hpp
+++ b/lib/stages/hdf5N2Write.hpp
@@ -121,7 +121,7 @@ protected:
     // t-dependent metadata
     std::vector<uint64_t> fpga_start_tick;           // (t)
     std::vector<uint64_t> frame_length_fpga_ticks;   // (t)
-    std::vector<uint64_t> abs_time_index;            // (t)
+    std::vector<uint64_t> bin_abs_index;             // (t)
     std::vector<int64_t> time_center_t_inst_ns;      // (t)
     std::vector<int64_t> time_center_ut1_ns;         // (t)
     std::vector<int64_t> bin_t_inst_ns;              // (t)

--- a/lib/testing/FakeN2.cpp
+++ b/lib/testing/FakeN2.cpp
@@ -205,12 +205,12 @@ void FakeN2::main_thread() {
 
             struct EOP bin_start_eop = tel.get_EOP_at_time(tel.to_time(fpga_seq + t * delta_seq));
             meta->bin_start_ERA_deg = bin_start_eop.ERA_deg;
-            meta->bin_start_ERAL = -1;
+            meta->bin_start_ERAL_deg = tel.get_ERAL_deg(bin_start_eop);
 
             struct EOP bin_end_eop =
                 tel.get_EOP_at_time(tel.to_time(fpga_seq + t * delta_seq + delta_seq));
             meta->bin_end_ERA_deg = bin_end_eop.ERA_deg;
-            meta->bin_end_ERAL = -1;
+            meta->bin_end_ERAL_deg = tel.get_ERAL_deg(bin_end_eop);
 
             DEBUG("Creating N2FrameView.");
             DEBUG("  N2Meta: n_el {}, n_prod {}, n_ev {}", num_elements,

--- a/lib/utils/N2FrameView.cpp
+++ b/lib/utils/N2FrameView.cpp
@@ -37,7 +37,8 @@ N2FrameView::N2FrameView(Buffer* buf, int frame_id) :
 
     time_center_eop(_metadata->time_center_eop), bin_eop(_metadata->bin_eop),
     bin_start_ERA_deg(_metadata->bin_start_ERA_deg), bin_end_ERA_deg(_metadata->bin_end_ERA_deg),
-    bin_start_ERAL(_metadata->bin_start_ERAL), bin_end_ERAL(_metadata->bin_end_ERAL),
+    bin_start_ERAL_deg(_metadata->bin_start_ERAL_deg),
+    bin_end_ERAL_deg(_metadata->bin_end_ERAL_deg),
 
     fpga_start_tick(_metadata->fpga_start_tick),
     frame_start_time_ns(_metadata->frame_start_time_ns),

--- a/lib/utils/N2FrameView.hpp
+++ b/lib/utils/N2FrameView.hpp
@@ -71,8 +71,8 @@ public:
     struct EOP& bin_eop;
     double& bin_start_ERA_deg;
     double& bin_end_ERA_deg;
-    double& bin_start_ERAL;
-    double& bin_end_ERAL;
+    double& bin_start_ERAL_deg;
+    double& bin_end_ERAL_deg;
 
     /// The sequence number of the first FPGA frame integrated into this
     /// visibility frame (time<0> in VisFrameView)

--- a/python/kotekan/n2buffer.py
+++ b/python/kotekan/n2buffer.py
@@ -29,8 +29,8 @@ class N2Metadata(ctypes.Structure):
         ("bin_eop", telescope.EOP),
         ("bin_start_ERA_deg", ctypes.c_double),
         ("bin_end_ERA_deg", ctypes.c_double),
-        ("bin_start_ERAL", ctypes.c_double),
-        ("bin_end_ERAL", ctypes.c_double),
+        ("bin_start_ERAL_deg", ctypes.c_double),
+        ("bin_end_ERAL_deg", ctypes.c_double),
         # FPGA timing
         ("fpga_start_tick", ctypes.c_uint64),
         ("frame_start_time_ns", ctypes.c_uint64),

--- a/tests/boost/test_hdf5N2Write.cpp
+++ b/tests/boost/test_hdf5N2Write.cpp
@@ -91,8 +91,8 @@ static void fill_n2_frame_with_abs_freq(Buffer* buf, int frame_id, size_t num_in
     meta->freq_id = get_abs_freq_id(f_index);
     // Keep ERAL within the valid bounds enforced by add_frame bounds checks
     meta->bin_end_ERA_deg = 7.89 + double(t_index);
-    meta->bin_start_ERAL = 1.23 + double(t_index);
-    meta->bin_end_ERAL = 4.56 + double(t_index);
+    meta->bin_start_ERAL_deg = 1.23 + double(t_index);
+    meta->bin_end_ERAL_deg = 4.56 + double(t_index);
 }
 
 

--- a/tests/boost/test_utils.hpp
+++ b/tests/boost/test_utils.hpp
@@ -367,8 +367,8 @@ make_writer_config(const std::string& unique_name, const std::string& in_buf,
     meta->bin_eop.ERA_deg = 9.87 + double(t_index);
     meta->bin_start_ERA_deg = 1.23 + double(t_index);
     meta->bin_end_ERA_deg = 4.56 + double(t_index);
-    meta->bin_start_ERAL = 1000000 + int64_t(t_index) * 1000;
-    meta->bin_end_ERAL = 2000000 + int64_t(t_index) * 1000;
+    meta->bin_start_ERAL_deg = 1000000 + int64_t(t_index) * 1000;
+    meta->bin_end_ERAL_deg = 2000000 + int64_t(t_index) * 1000;
 
     N2FrameView fv(buf, frame_id);
     fv.zero_frame();

--- a/tests/test_n2_accumulate.py
+++ b/tests/test_n2_accumulate.py
@@ -1191,11 +1191,11 @@ def test_eop_meta(setup, accum_setup, accum_data, accum_list):
             <= ERA_TOL
         )
         assert (
-            abs(frame.metadata.bin_start_ERAL - accum_list[t]["bin_start_ERAL_deg"])
+            abs(frame.metadata.bin_start_ERAL_deg - accum_list[t]["bin_start_ERAL_deg"])
             <= ERAL_TOL
         )
         assert (
-            abs(frame.metadata.bin_end_ERAL - accum_list[t]["bin_end_ERAL_deg"])
+            abs(frame.metadata.bin_end_ERAL_deg - accum_list[t]["bin_end_ERAL_deg"])
             <= ERAL_TOL
         )
 


### PR DESCRIPTION
- adds `abs_time_index` field to N2 files
- refactored `ERAL` to `ERAL_deg` in metadata, N2 files, and tests.