### PR TITLE
Make block num calcs consistent

### DIFF
--- a/config/chime_upgrade_n2.j2
+++ b/config/chime_upgrade_n2.j2
@@ -827,13 +827,13 @@ n2k_num_subintegrations: n2k_samples_per_data_set / n2k_sub_integration_ntime
 
 n2k_correlation_blocksize: 16
 n2k_correlation_num_elements: num_dishes * num_polarizations
-n2k_correlation_linear_num_blocks: (n2k_correlation_num_elements + 1) / n2k_correlation_blocksize
+n2k_correlation_linear_num_blocks: (n2k_correlation_num_elements + n2k_correlation_blocksize - 1) / n2k_correlation_blocksize
 n2k_correlation_triangle_num_blocks: n2k_correlation_linear_num_blocks * (n2k_correlation_linear_num_blocks + 1) / 2
 n2k_correlation_triangle_size: n2k_correlation_blocksize * n2k_correlation_blocksize * n2k_correlation_triangle_num_blocks
 
 n2k_counts_blocksize: 8
 n2k_counts_num_elements: num_dishes / 8 * num_polarizations
-n2k_counts_linear_num_blocks: (n2k_counts_num_elements + 1) / n2k_counts_blocksize
+n2k_counts_linear_num_blocks: (n2k_counts_num_elements + n2k_counts_blocksize - 1) / n2k_counts_blocksize
 n2k_counts_triangle_num_blocks: n2k_counts_linear_num_blocks * (n2k_counts_linear_num_blocks + 1) / 2
 n2k_counts_triangle_size: n2k_counts_blocksize * n2k_counts_blocksize * n2k_counts_triangle_num_blocks
 

--- a/lib/cuda/cudaCorrelator.cpp
+++ b/lib/cuda/cudaCorrelator.cpp
@@ -19,7 +19,7 @@
 #include "cudaCommand.hpp"          // for cudaCommand, REGISTER_CUDA_COMMAND, _factory_aliascud...
 #include "cudaDeviceInterface.hpp"  // for cudaDeviceInterface
 #include "cudaUtils.hpp"            // for CHECK_CUDA_ERROR
-#include "div.hpp"                  // for div_noremainder, mod
+#include "div.hpp"                  // for div_noremainder, mod, num_triangle_blocks
 #include "gpuCommand.hpp"           // for gpuCommandType
 #include "kotekanLogging.hpp"       // for DEBUG
 #include "n2k/Correlator.hpp"       // for Correlator
@@ -29,6 +29,7 @@ using kotekan::bufferContainer;
 using kotekan::Config;
 using kotekan::div_noremainder;
 using kotekan::mod;
+using kotekan::num_triangle_blocks;
 
 REGISTER_CUDA_COMMAND(cudaCorrelator);
 
@@ -57,8 +58,7 @@ cudaCorrelator::cudaCorrelator(Config& config, const std::string& unique_name,
         // aka "nt_outer" in n2k.hpp
         const int num_subintegrations = div_noremainder(_num_times, _sub_integration_ntime);
         const int blocksize = 16;
-        const int linear_num_blocks = (_num_elements + 1) / blocksize;
-        const int triangle_num_blocks = linear_num_blocks * (linear_num_blocks + 1) / 2;
+        const int triangle_num_blocks = num_triangle_blocks(_num_elements, blocksize);
         const std::array<std::ptrdiff_t, 6> n2k_lengths{
             num_subintegrations, _num_local_freq, triangle_num_blocks, blocksize, blocksize, 2};
         const std::array<std::string, 6> n2k_dimnames{"Tc", "F", "DPhi", "DPlo1", "DPlo2", "C"};

--- a/lib/cuda/cudaCorrelator.hpp
+++ b/lib/cuda/cudaCorrelator.hpp
@@ -43,7 +43,7 @@
  * @gpu_mem Output complex correlation values
  *   num_subintegrations := samples_per_data_set / sub_integration_ntime
  *   blocksize           := 16
- *   linear_num_blocks   := ceil(num_elements, / blocksize)
+ *   linear_num_blocks   := ceil(num_elements / blocksize)
  *   triangle_num_blocks := linear_num_blocks * (linear_num_blocks + 1) / 2
  *   @gpu_mem_buffer    @c standard
  *   @gpu_mem_quantity  @c n2k_correlation

--- a/lib/cuda/cudaPL1bitCorrelator.cpp
+++ b/lib/cuda/cudaPL1bitCorrelator.cpp
@@ -19,13 +19,14 @@
 #include "cudaCommand.hpp"          // for cudaCommand, cudaPipelineState, REGISTER_CUDA_COMMAND
 #include "cudaDeviceInterface.hpp"  // for cudaDeviceInterface
 #include "cudaMemsetInt.hpp"        // for cudaMemsetInt
-#include "div.hpp"                  // for div_noremainder, round_down
+#include "div.hpp"                  // for div_noremainder, num_triangle_blocks, round_down
 #include "gpuCommand.hpp"           // for gpuCommandType
 #include "kotekanLogging.hpp"       // for DEBUG, ERROR
 #include "n2k/pl_kernels.hpp"       // for launch_pl_1bit_correlator
 #include "fmt.hpp"                  // for compile_string_to_view
 
 using kotekan::div_noremainder;
+using kotekan::num_triangle_blocks;
 using kotekan::round_down;
 
 namespace {} // namespace
@@ -139,8 +140,8 @@ cudaPL1bitCorrelator::cudaPL1bitCorrelator(kotekan::Config& config, const std::s
         // aka "nt_outer" in n2k.hpp
         const int num_subintegrations = div_noremainder(num_times, n2k_sub_integration_ntime);
         const int blocksize = 8;
-        const int linear_num_blocks = (num_polarizations * num_dishes / 8 + 1) / blocksize;
-        const int triangle_num_blocks = linear_num_blocks * (linear_num_blocks + 1) / 2;
+        const int triangle_num_blocks =
+            num_triangle_blocks(num_polarizations * num_dishes / 8, blocksize);
         const std::array<std::ptrdiff_t, 5> n2k_lengths{num_subintegrations, num_frequencies,
                                                         triangle_num_blocks, blocksize, blocksize};
         const std::array<std::string, 5> n2k_dimnames{"Tc", "F", "D8Phi", "D8Plo1", "D8Plo2"};

--- a/lib/opencl/clCorrelatorKernel.cpp
+++ b/lib/opencl/clCorrelatorKernel.cpp
@@ -1,5 +1,7 @@
 #include "clCorrelatorKernel.hpp"
 
+#include "div.hpp" // for div_ceil, num_triangle_blocks
+
 #include <string>
 using std::string;
 
@@ -103,6 +105,17 @@ cl_event clCorrelatorKernel::execute(cl_event pre_event) {
 
 void clCorrelatorKernel::defineOutputDataMap() {
     cl_int err;
+
+    // The config-provided num_blocks must match the block tiling of the matrix.
+    int largest_num_blocks_1D = kotekan::div_ceil(_num_elements, _block_size);
+    if (kotekan::num_triangle_blocks(_num_elements, _block_size) != _num_blocks) {
+        FATAL_ERROR("num_blocks ({:d}) does not match the {:d} blocks required to tile "
+                    "num_elements ({:d}) with block_size ({:d}).",
+                    _num_blocks, kotekan::num_triangle_blocks(_num_elements, _block_size),
+                    _num_elements, _block_size);
+        return;
+    }
+
     // Create lookup tables
 
     // upper triangular address mapping --converting 1d addresses to 2d addresses
@@ -112,7 +125,6 @@ void clCorrelatorKernel::defineOutputDataMap() {
     // TODO: p260 OpenCL in Action has a clever while loop that changes 1 D addresses to X & Y
     // indices for an upper triangle.
     // Time Test kernels using them compared to the lookup tables for NUM_ELEM = 256
-    int largest_num_blocks_1D = _num_elements / _block_size;
     int index_1D = 0;
     for (int j = 0; j < largest_num_blocks_1D; j++) {
         for (int i = j; i < largest_num_blocks_1D; i++) {

--- a/lib/opencl/clKVCorr.cpp
+++ b/lib/opencl/clKVCorr.cpp
@@ -1,5 +1,7 @@
 #include "clKVCorr.hpp"
 
+#include "div.hpp" // for div_ceil, num_triangle_blocks
+
 #include <string>
 using std::string;
 
@@ -168,6 +170,17 @@ cl_event clKVCorr::execute(cl_event pre_event) {
 
 void clKVCorr::defineOutputDataMap() {
     cl_int err;
+
+    // The config-provided num_blocks must match the block tiling of the matrix.
+    int largest_num_blocks_1D = kotekan::div_ceil(_num_elements, _block_size);
+    if (kotekan::num_triangle_blocks(_num_elements, _block_size) != _num_blocks) {
+        FATAL_ERROR("num_blocks ({:d}) does not match the {:d} blocks required to tile "
+                    "num_elements ({:d}) with block_size ({:d}).",
+                    _num_blocks, kotekan::num_triangle_blocks(_num_elements, _block_size),
+                    _num_elements, _block_size);
+        return;
+    }
+
     // Create lookup tables
 
     // upper triangular address mapping --converting 1d addresses to 2d addresses
@@ -177,7 +190,6 @@ void clKVCorr::defineOutputDataMap() {
     // TODO: p260 OpenCL in Action has a clever while loop that changes 1 D addresses to X & Y
     // indices for an upper triangle.
     // Time Test kernels using them compared to the lookup tables for NUM_ELEM = 256
-    int largest_num_blocks_1D = _num_elements / _block_size;
     int index_1D = 0;
     for (int j = 0; j < largest_num_blocks_1D; j++) {
         for (int i = j; i < largest_num_blocks_1D; i++) {

--- a/lib/opencl/clPreseedKernel.cpp
+++ b/lib/opencl/clPreseedKernel.cpp
@@ -1,5 +1,7 @@
 #include "clPreseedKernel.hpp"
 
+#include "div.hpp" // for div_ceil, num_triangle_blocks
+
 using kotekan::bufferContainer;
 using kotekan::Config;
 
@@ -85,6 +87,17 @@ cl_event clPreseedKernel::execute(cl_event pre_event) {
 }
 void clPreseedKernel::defineOutputDataMap() {
     cl_int err;
+
+    // The config-provided num_blocks must match the block tiling of the matrix.
+    int largest_num_blocks_1D = kotekan::div_ceil(_num_elements, _block_size);
+    if (kotekan::num_triangle_blocks(_num_elements, _block_size) != _num_blocks) {
+        FATAL_ERROR("num_blocks ({:d}) does not match the {:d} blocks required to tile "
+                    "num_elements ({:d}) with block_size ({:d}).",
+                    _num_blocks, kotekan::num_triangle_blocks(_num_elements, _block_size),
+                    _num_elements, _block_size);
+        return;
+    }
+
     // Create lookup tables
 
     // upper triangular address mapping --converting 1d addresses to 2d addresses
@@ -94,7 +107,6 @@ void clPreseedKernel::defineOutputDataMap() {
     // TODO: p260 OpenCL in Action has a clever while loop that changes 1 D addresses to X & Y
     // indices for an upper triangle.
     // Time Test kernels using them compared to the lookup tables for NUM_ELEM = 256
-    int largest_num_blocks_1D = _num_elements / _block_size;
     int index_1D = 0;
     for (int j = 0; j < largest_num_blocks_1D; j++) {
         for (int i = j; i < largest_num_blocks_1D; i++) {

--- a/lib/stages/EigenN2Iter.cpp
+++ b/lib/stages/EigenN2Iter.cpp
@@ -8,6 +8,7 @@
 #include "N2Util.hpp"            // for cfloat, frameID
 #include "StageFactory.hpp"      // for REGISTER_KOTEKAN_STAGE, StageMakerTemplate
 #include "buffer.hpp"            // for allocate_new_metadata_object, mark_frame_empty, mark_fr...
+#include "div.hpp"               // for div_ceil
 #include "kotekanLogging.hpp"    // for DEBUG
 #include "prometheusMetrics.hpp" // for Counter, Gauge, Metrics, MetricFamily
 
@@ -332,7 +333,7 @@ DynamicHermitian<float> EigenN2Iter::calculate_mask(size_t num_elements) const {
 
     // Zero out blocks on the diagonal if requested
     if (_block_fill_size > 0) {
-        unsigned int nb = num_elements / _block_fill_size;
+        unsigned int nb = kotekan::div_ceil(num_elements, _block_fill_size);
         for (unsigned int ii = 0; ii < nb; ii++) {
             unsigned int start = ii * _block_fill_size;
             unsigned int width = std::min(num_elements - start, _block_fill_size);

--- a/lib/stages/EigenVisIter.cpp
+++ b/lib/stages/EigenVisIter.cpp
@@ -6,6 +6,7 @@
 #include "StageFactory.hpp"      // for REGISTER_KOTEKAN_STAGE, StageMakerTemplate
 #include "buffer.hpp"            // for allocate_new_metadata_object, mark_frame_empty, mark_fr...
 #include "datasetState.hpp"      // for datasetState, eigenvalueState, state_uptr
+#include "div.hpp"               // for div_ceil
 #include "kotekanLogging.hpp"    // for DEBUG
 #include "prometheusMetrics.hpp" // for Gauge, Metrics, MetricFamily
 #include "visBuffer.hpp"         // for VisFrameView, VisField, VisField::erms, VisField::eval
@@ -248,7 +249,7 @@ DynamicHermitian<float> EigenVisIter::calculate_mask(uint32_t num_elements) cons
 
     // Zero out blocks on the diagonal if requested
     if (_block_fill_size > 0) {
-        unsigned int nb = num_elements / _block_fill_size;
+        unsigned int nb = kotekan::div_ceil(num_elements, _block_fill_size);
         for (unsigned int ii = 0; ii < nb; ii++) {
             unsigned int start = ii * _block_fill_size;
             unsigned int width = std::min(num_elements - start, _block_fill_size);

--- a/lib/stages/N2Accumulate.cpp
+++ b/lib/stages/N2Accumulate.cpp
@@ -30,6 +30,7 @@
 #include "N2FrameDesc.hpp"        // for N2FrameDesc
 #include "N2Layout.hpp"           // for N2Layout
 #include "dataset.hpp"            // for dset_id_t
+#include "div.hpp"                // for div_ceil, num_triangle_blocks
 #include "jsonMetadata.hpp"       // for MAX_NUM_RFI_THRESHOLDS
 #ifdef WITH_OMP
 #include <omp.h>
@@ -159,9 +160,9 @@ N2Accumulate::N2Accumulate(Config& config, const std::string& unique_name,
                   "_n_fpga_samples_per_n2k_correlation");
 
         // sizes for blocked input correlation matrix
-        _n2k_correlation_lin_blocks = _num_elements / _n2k_correlation_blocksize;
+        _n2k_correlation_lin_blocks = kotekan::div_ceil(_num_elements, _n2k_correlation_blocksize);
         _n2k_correlation_num_blocks =
-            (_n2k_correlation_lin_blocks * (_n2k_correlation_lin_blocks + 1)) / 2;
+            kotekan::num_triangle_blocks(_num_elements, _n2k_correlation_blocksize);
 
         // Total number of correlation values per time & frequency,
         // because of blocking this will include some redundant values.
@@ -169,8 +170,9 @@ N2Accumulate::N2Accumulate(Config& config, const std::string& unique_name,
             _n2k_correlation_num_blocks * _n2k_correlation_blocksize * _n2k_correlation_blocksize;
 
         // sizes for blocked input counts matrix
-        _n2k_counts_lin_blocks = _num_elements / (8 * _n2k_counts_blocksize);
-        _n2k_counts_num_blocks = (_n2k_counts_lin_blocks * (_n2k_counts_lin_blocks + 1)) / 2;
+        _n2k_counts_lin_blocks = kotekan::div_ceil(_num_elements / 8, _n2k_counts_blocksize);
+        _n2k_counts_num_blocks =
+            kotekan::num_triangle_blocks(_num_elements / 8, _n2k_counts_blocksize);
 
         // Total number of counts values per time & frequency,
         // because of blocking this will include some redundant values.

--- a/lib/stages/lostSamplesToN2Counts.cpp
+++ b/lib/stages/lostSamplesToN2Counts.cpp
@@ -13,6 +13,7 @@
 #include "bufferContainer.hpp"  // for bufferContainer
 #include "chordMetadata.hpp"    // for chordMetadata, get_chord_metadata
 #include "json.hpp"             // for basic_json, json, iter_impl
+#include "div.hpp"              // for num_triangle_blocks
 #include "fmt.hpp"              // for compile_string_to_view, format
 #include "kotekanLogging.hpp"   // for FATAL_ERROR, DEBUG
 
@@ -104,8 +105,8 @@ lostSamplesToN2Counts::lostSamplesToN2Counts(Config& config, const std::string& 
     _num_subintegrations = samples_per_data_set / sub_integration_ntime;
     // Number of instrument elements and the corresponding stride
     // to take in the `counts` array
-    _counts_ntiles = (num_elements / (COUNTS_BLOCK_SIZE * COUNTS_ELEMENT_DOWNSAMPLE))
-                     * (1 + num_elements / (COUNTS_BLOCK_SIZE * COUNTS_ELEMENT_DOWNSAMPLE)) / 2;
+    _counts_ntiles =
+        kotekan::num_triangle_blocks(num_elements / COUNTS_ELEMENT_DOWNSAMPLE, COUNTS_BLOCK_SIZE);
     _counts_stride = _counts_ntiles * COUNTS_BLOCK_SIZE * COUNTS_BLOCK_SIZE;
 
     // Check counts frame size against expectations. counts has type int32

--- a/lib/stages/pyPlotN2.cpp
+++ b/lib/stages/pyPlotN2.cpp
@@ -13,6 +13,7 @@
 #include "StageFactory.hpp"     // for REGISTER_KOTEKAN_STAGE
 #include "buffer.hpp"           // for Buffer
 #include "bufferContainer.hpp"  // for bufferContainer
+#include "div.hpp"              // for num_triangle_blocks
 #include "restServer.hpp"       // for restServer, HTTP_RESPONSE, connectionInstance
 #include "json.hpp"             // for json_ref, json
 #include "fmt.hpp"              // for format
@@ -96,7 +97,7 @@ void pyPlotN2::make_plot(void) {
     { // N^2
         uint num_elements = config.get<uint>(unique_name, "num_elements");
         uint block_dim = 32;
-        uint num_blocks = (num_elements / block_dim) * (num_elements / block_dim + 1) / 2;
+        uint num_blocks = kotekan::num_triangle_blocks(num_elements, block_dim);
         uint block_size = block_dim * block_dim * 2; // real, complex
 
         usleep(10000);

--- a/lib/stages/visAccumulate.cpp
+++ b/lib/stages/visAccumulate.cpp
@@ -88,8 +88,7 @@ visAccumulate::visAccumulate(Config& config, const std::string& unique_name,
     float low_sample_fraction = config.get_default<float>(unique_name, "low_sample_fraction", 0.01);
     minimum_samples = (size_t)(low_sample_fraction * num_gpu_frames * samples_per_data_set);
 
-    size_t nb = num_elements / block_size;
-    num_prod_gpu = num_freq_in_frame * nb * (nb + 1) * block_size * block_size / 2;
+    num_prod_gpu = num_freq_in_frame * gpu_N2_size(num_elements, block_size);
 
     // Get everything we need for registering dataset states
 

--- a/lib/testing/fakeGpuPattern.cpp
+++ b/lib/testing/fakeGpuPattern.cpp
@@ -2,6 +2,7 @@
 
 #include "Config.hpp"        // for Config
 #include "chordMetadata.hpp" // for chordMetadata
+#include "div.hpp"           // for num_triangle_blocks
 #include "visUtil.hpp"       // for prod_index
 
 #include "fmt.hpp"      // for compile_string_to_view
@@ -42,8 +43,7 @@ void BlockGpuPattern::fill(gsl_lite::span<int32_t>& data, chordMetadata* metadat
     (void)freq_id;
     (void)frame_number;
 
-    unsigned int nb1 = _num_elements / _block_size;
-    unsigned int num_blocks = nb1 * (nb1 + 1) / 2;
+    unsigned int num_blocks = kotekan::num_triangle_blocks(_num_elements, _block_size);
 
     DEBUG2("Block size %i, num blocks %i", _block_size, num_blocks);
 

--- a/lib/testing/gpuSimulateN2kCorr.cpp
+++ b/lib/testing/gpuSimulateN2kCorr.cpp
@@ -6,6 +6,7 @@
 #include "buffer.hpp"          // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
 #include "chordMetadata.hpp"   // for chordMetadata, metadata_is_chord, get_chord_metadata, CHO...
+#include "div.hpp"             // for div_ceil, num_triangle_blocks
 #include "kotekanLogging.hpp"  // for FATAL_ERROR, INFO, DEBUG
 #include "metadata.hpp"        // for metadataObject
 
@@ -20,6 +21,8 @@
 
 using kotekan::bufferContainer;
 using kotekan::Config;
+using kotekan::div_ceil;
+using kotekan::num_triangle_blocks;
 using kotekan::Stage;
 
 REGISTER_KOTEKAN_STAGE(gpuSimulateN2kCorr);
@@ -81,8 +84,7 @@ gpuSimulateN2kCorr::gpuSimulateN2kCorr(Config& config, const std::string& unique
         sizeof(char) * _num_elements * _num_local_freq * _samples_per_data_set;
     size_t rfimask_frame_size = _num_local_freq * _samples_per_data_set / 8;
 
-    size_t num_blocks_lin = _num_elements / _corr_blocksize;
-    size_t num_blocks = (num_blocks_lin * (num_blocks_lin + 1)) / 2;
+    size_t num_blocks = num_triangle_blocks(_num_elements, _corr_blocksize);
     size_t num_correlations = _samples_per_data_set / _sub_integration_ntime;
 
     size_t corr_frame_size = 2 * sizeof(int) * _corr_blocksize * _corr_blocksize * num_blocks
@@ -110,7 +112,7 @@ gpuSimulateN2kCorr::gpuSimulateN2kCorr(Config& config, const std::string& unique
     int nt_outer = _samples_per_data_set / nt_inner;
     output_buf->allocate_ndarray_frame_desc<kotekan::GetType<kotekan::int32>::type, 6>(
         "n2k_correlation",
-        {nt_outer, _num_local_freq, (_num_elements / 16) * (_num_elements / 16 + 1) / 2, 16, 16, 2},
+        {nt_outer, _num_local_freq, num_triangle_blocks(_num_elements, _corr_blocksize), 16, 16, 2},
         {"Tc", "F", "DPhi", "DPlo1", "DPlo2", "C"});
 }
 
@@ -142,8 +144,8 @@ void gpuSimulateN2kCorr::main_thread() {
         int nt_inner = _sub_integration_ntime;
         int nt_outer = _samples_per_data_set / nt_inner;
 
-        int num_blocks_lin = _num_elements / _corr_blocksize;
-        int num_blocks = (num_blocks_lin * (num_blocks_lin + 1)) / 2;
+        int num_blocks_lin = div_ceil(_num_elements, _corr_blocksize);
+        int num_blocks = num_triangle_blocks(_num_elements, _corr_blocksize);
 
         int fstride = _corr_blocksize * _corr_blocksize * num_blocks;
         int tstride = _num_local_freq * fstride;
@@ -155,8 +157,8 @@ void gpuSimulateN2kCorr::main_thread() {
         for (int tout = 0; tout < nt_outer; ++tout) {
             for (int f = 0; f < _num_local_freq; ++f) {
                 // loop through blocks
-                for (int jhi = 0; jhi < _num_elements / _corr_blocksize; jhi++) {
-                    for (int ihi = jhi; ihi < _num_elements / _corr_blocksize; ihi++) {
+                for (int jhi = 0; jhi < num_blocks_lin; jhi++) {
+                    for (int ihi = jhi; ihi < num_blocks_lin; ihi++) {
                         for (int jlo = 0; jlo < _corr_blocksize; jlo++) {
                             for (int ilo = 0; ilo < _corr_blocksize; ilo++) {
                                 int real = 0;
@@ -274,7 +276,7 @@ void gpuSimulateN2kCorr::main_thread() {
         assert(meta_out->dims <= CHORD_META_MAX_DIM);
         meta_out->set_array_dimension(0, nt_outer, "Tc");
         meta_out->set_array_dimension(1, _num_local_freq, "F");
-        meta_out->set_array_dimension(2, (_num_elements / 16) * (_num_elements / 16 + 1) / 2,
+        meta_out->set_array_dimension(2, num_triangle_blocks(_num_elements, _corr_blocksize),
                                       "DPhi");
         meta_out->set_array_dimension(3, 16, "DPlo1");
         meta_out->set_array_dimension(4, 16, "DPlo2");

--- a/lib/testing/gpuSimulateN2kPL1bitCorr.cpp
+++ b/lib/testing/gpuSimulateN2kPL1bitCorr.cpp
@@ -6,7 +6,7 @@
 #include "buffer.hpp"          // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
 #include "chordMetadata.hpp"   // for chordMetadata, metadata_is_chord, get_chord_metadata, CHO...
-#include "div.hpp"             // for div_noremainder
+#include "div.hpp"             // for div_ceil, div_noremainder, num_triangle_blocks
 #include "kotekanLogging.hpp"  // for FATAL_ERROR, INFO, DEBUG
 #include "metadata.hpp"        // for metadataObject
 
@@ -22,7 +22,9 @@
 
 using kotekan::bufferContainer;
 using kotekan::Config;
+using kotekan::div_ceil;
 using kotekan::div_noremainder;
+using kotekan::num_triangle_blocks;
 using kotekan::Stage;
 
 REGISTER_KOTEKAN_STAGE(gpuSimulateN2kPL1bitCorr);
@@ -67,9 +69,9 @@ gpuSimulateN2kPL1bitCorr::gpuSimulateN2kPL1bitCorr(Config& config, const std::st
                     _samples_per_data_set);
         std::abort();
     }
-    if (_num_elements % _blocksize != 0) {
-        FATAL_ERROR("num_elements ({:d}) is not a multiple of _blocksize ({:d}).", _num_elements,
-                    _blocksize);
+    if (_num_elements % (8 * _blocksize) != 0) {
+        FATAL_ERROR("num_elements ({:d}) / 8 is not a multiple of _blocksize ({:d}).",
+                    _num_elements, _blocksize);
         std::abort();
     }
 
@@ -84,8 +86,7 @@ gpuSimulateN2kPL1bitCorr::gpuSimulateN2kPL1bitCorr(Config& config, const std::st
     int n_integrations = _samples_per_data_set / _sub_integration_ntime;
     int nf = _num_local_freq;
     int ne = _num_elements / 8;
-    int n_block_lin = ne / _blocksize;
-    int n_blocks = (n_block_lin * (n_block_lin + 1)) / 2;
+    int n_blocks = num_triangle_blocks(ne, _blocksize);
     output_buf->allocate_ndarray_frame_desc<kotekan::GetType<kotekan::int32>::type, 5>(
         "n2k_counts", {n_integrations, nf, n_blocks, _blocksize, _blocksize},
         {"Tc", "F", "D8Phi", "D8Plo1", "D8Plo2"});
@@ -132,8 +133,8 @@ void gpuSimulateN2kPL1bitCorr::main_thread() {
         int nf = _num_local_freq;
         int ne = _num_elements / 8;
 
-        int n_block_lin = ne / _blocksize;
-        int n_blocks = (n_block_lin * (n_block_lin + 1)) / 2;
+        int n_block_lin = div_ceil(ne, _blocksize);
+        int n_blocks = num_triangle_blocks(ne, _blocksize);
 
         // Strides into the (expanded) PL mask (as uint64_t's)
         int df_pl = ne;      // freq stride

--- a/lib/testing/testLostCountsGen.cpp
+++ b/lib/testing/testLostCountsGen.cpp
@@ -5,6 +5,7 @@
 #include "buffer.hpp"          // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
 #include "chordMetadata.hpp"   // for chordMetadata, metadata_is_chord, CHORD_META_MAX_DIM, CHO...
+#include "div.hpp"             // for div_ceil, num_triangle_blocks
 #include "kotekanLogging.hpp"  // for FATAL_ERROR, DEBUG, INFO
 #include "metadata.hpp"        // for metadataObject
 
@@ -117,8 +118,8 @@ testLostCountsGen::testLostCountsGen(Config& config, const std::string& unique_n
     repeat_count(config.get_default<int64_t>(unique_name, "repeat_count", 0)),
     num_integrations(samples_per_data_set / sub_integration_ntime),
     num_entries(num_integrations * num_local_freq),
-    n2k_counts_lin_blocks(num_elements / (8 * n2k_counts_blocksize)),
-    n2k_counts_num_blocks((n2k_counts_lin_blocks * (n2k_counts_lin_blocks + 1)) / 2),
+    n2k_counts_lin_blocks(kotekan::div_ceil(num_elements / 8, n2k_counts_blocksize)),
+    n2k_counts_num_blocks(kotekan::num_triangle_blocks(num_elements / 8, n2k_counts_blocksize)),
     n2k_counts_num_prod(n2k_counts_num_blocks * n2k_counts_blocksize * n2k_counts_blocksize) {
 
     // Get buffers

--- a/lib/testing/testN2kGen.cpp
+++ b/lib/testing/testN2kGen.cpp
@@ -6,6 +6,7 @@
 #include "buffer.hpp"          // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
 #include "chordMetadata.hpp"   // for chordMetadata, metadata_is_chord, CHORD_META_MAX_DIM, CHO...
+#include "div.hpp"             // for div_ceil, num_triangle_blocks
 #include "kotekanLogging.hpp"  // for FATAL_ERROR, DEBUG, INFO
 #include "metadata.hpp"        // for metadataObject
 #include "visUtil.hpp"         // for frameID, modulo
@@ -26,6 +27,8 @@
 
 using kotekan::bufferContainer;
 using kotekan::Config;
+using kotekan::div_ceil;
+using kotekan::num_triangle_blocks;
 using kotekan::Stage;
 
 REGISTER_KOTEKAN_STAGE(testN2kGen);
@@ -134,11 +137,11 @@ testN2kGen::testN2kGen(Config& config, const std::string& unique_name,
 
     num_integrations = samples_per_data_set / sub_integration_ntime;
 
-    corr_lin_blocks = num_elements / corr_blocksize;
-    count_lin_blocks = (num_elements / 8) / count_blocksize;
+    corr_lin_blocks = div_ceil(num_elements, corr_blocksize);
+    count_lin_blocks = div_ceil(num_elements / 8, count_blocksize);
 
-    corr_num_blocks = (corr_lin_blocks * (corr_lin_blocks + 1)) / 2;
-    count_num_blocks = (count_lin_blocks * (count_lin_blocks + 1)) / 2;
+    corr_num_blocks = num_triangle_blocks(num_elements, corr_blocksize);
+    count_num_blocks = num_triangle_blocks(num_elements / 8, count_blocksize);
 
     corr_num_entries =
         2 * corr_blocksize * corr_blocksize * corr_num_blocks * num_local_freq * num_integrations;

--- a/lib/utils/N2Util.hpp
+++ b/lib/utils/N2Util.hpp
@@ -6,6 +6,7 @@
 #define N2_UTIL_HPP
 
 #include "buffer.hpp"
+#include "div.hpp" // for div_ceil
 #include "timeUtil.hpp"
 
 #include <cmath>
@@ -101,7 +102,7 @@ inline prod_ctype icmap(uint32_t k, uint16_t n) {
  * @return       Index into blocked array.
  */
 inline uint32_t prod_index(uint32_t i, uint32_t j, uint32_t block, uint32_t N) {
-    uint32_t num_blocks1 = ((N - 1) / block) + 1; // Blocks needed to tile 1D
+    uint32_t num_blocks1 = kotekan::div_ceil(N, block); // Blocks needed to tile 1D
     uint32_t b_ix = cmap(i / block, j / block, num_blocks1);
 
     return block * block * b_ix + (i % block) * block + (j % block);

--- a/lib/utils/div.hpp
+++ b/lib/utils/div.hpp
@@ -2,6 +2,7 @@
 #define DIV_HPP
 
 #include <cassert>
+#include <stdexcept>
 
 namespace kotekan {
 
@@ -24,6 +25,30 @@ auto div_noremainder(T x, U y) {
     assert(x % y == 0);
     auto r = x / y;
     return r;
+}
+
+// Calculate `ceil(x / y)`, i.e. the number of size-`y` blocks needed to tile `x`
+template<typename T, typename U>
+constexpr auto div_ceil(T x, U y) {
+    if (y == 0)
+        throw std::invalid_argument("div_ceil: y must be nonzero");
+    assert(x >= 0);
+    assert(y > 0);
+    // Unlike `(x - 1) / y + 1` this is correct for x == 0 (no unsigned
+    // wraparound), and unlike `(x + y - 1) / y` it cannot overflow.
+    auto r = x / y + (x % y != 0 ? 1 : 0);
+    assert(r * y >= x && (r == 0 || (r - 1) * y < x));
+    return r;
+}
+
+// Number of blocks in a blocked triangular (e.g. visibility) matrix:
+// an `n` x `n` matrix tiled by `block` x `block` blocks, keeping only the
+// blocks on one side of the diagonal, has nb * (nb + 1) / 2 blocks for
+// nb = div_ceil(n, block) blocks per side.
+template<typename T, typename U>
+constexpr auto num_triangle_blocks(T n, U block) {
+    auto nb = div_ceil(n, block);
+    return nb * (nb + 1) / 2;
 }
 
 // Calculate `x div y`

--- a/lib/utils/visUtil.hpp
+++ b/lib/utils/visUtil.hpp
@@ -11,7 +11,6 @@
 #ifndef VIS_UTIL_HPP
 #define VIS_UTIL_HPP
 
-
 #include <algorithm>      // for copy, max
 #include <array>          // for array
 #include <chrono>         // for system_clock
@@ -24,6 +23,7 @@
 #include "DataType.hpp"   // for KOTEKAN_FLOAT16, float16_t
 #include "Telescope.hpp"  // for stream_t
 #include "buffer.hpp"     // for Buffer
+#include "div.hpp"        // for div_ceil, num_triangle_blocks
 #include "fmt.hpp"        // for appender, format, format_string, formatter, format_context
 #include "gsl-lite.hpp"   // for span
 #include "json.hpp"       // for json, value_t
@@ -262,7 +262,7 @@ inline prod_ctype icmap(uint32_t k, uint16_t n) {
  * @return       Index into blocked array.
  */
 inline uint32_t prod_index(uint32_t i, uint32_t j, uint32_t block, uint32_t N) {
-    uint32_t num_blocks1 = ((N - 1) / block) + 1; // Blocks needed to tile 1D
+    uint32_t num_blocks1 = kotekan::div_ceil(N, block); // Blocks needed to tile 1D
     uint32_t b_ix = cmap(i / block, j / block, num_blocks1);
 
     return block * block * b_ix + (i % block) * block + (j % block);
@@ -408,9 +408,7 @@ inline double current_time() {
  * @return        The size of the packd GPU data.
  **/
 inline constexpr uint32_t gpu_N2_size(uint32_t N, uint32_t block) {
-    const auto num_blocks1 = ((N - 1) / block) + 1;               // Blocks per side
-    const auto num_blocks2 = num_blocks1 * (num_blocks1 + 1) / 2; // ... triangle
-    return (num_blocks2 * block * block);                         // Total size
+    return kotekan::num_triangle_blocks(N, block) * block * block;
 }
 
 

--- a/tests/boost/CMakeLists.txt
+++ b/tests/boost/CMakeLists.txt
@@ -132,6 +132,9 @@ target_link_libraries(test_NDArray libexternal kotekan_metadata)
 add_executable(test_Symbol test_Symbol.cpp)
 target_link_libraries(test_Symbol libexternal kotekan_metadata)
 
+add_executable(test_div test_div.cpp)
+target_link_libraries(test_div PRIVATE kotekan_utils)
+
 add_executable(test_timeUtil test_timeUtil.cpp)
 target_link_libraries(test_timeUtil PRIVATE kotekan_utils)
 target_compile_definitions(test_timeUtil PRIVATE TEST_SCRIPT_DIR="${PROJECT_BINARY_DIR}")

--- a/tests/boost/test_div.cpp
+++ b/tests/boost/test_div.cpp
@@ -1,0 +1,64 @@
+#define BOOST_TEST_MODULE "test_div"
+
+#include "div.hpp"
+
+#include <boost/test/included/unit_test.hpp>
+#include <cstddef>
+#include <stdexcept>
+
+using kotekan::div_ceil;
+using kotekan::num_triangle_blocks;
+
+BOOST_AUTO_TEST_CASE(div_ceil_exact_multiples) {
+    // Exact multiples reduce to plain division
+    BOOST_CHECK_EQUAL(div_ceil(2048, 16), 128);
+    BOOST_CHECK_EQUAL(div_ceil(2048u, 32u), 64u);
+    BOOST_CHECK_EQUAL(div_ceil((size_t)1024, 16), (size_t)64);
+    BOOST_CHECK_EQUAL(div_ceil(16, 16), 1);
+}
+
+BOOST_AUTO_TEST_CASE(div_ceil_partial_blocks) {
+    // A partial block is still a block
+    BOOST_CHECK_EQUAL(div_ceil(1, 16), 1);
+    BOOST_CHECK_EQUAL(div_ceil(15, 16), 1);
+    BOOST_CHECK_EQUAL(div_ceil(17, 16), 2);
+    BOOST_CHECK_EQUAL(div_ceil(31u, 16u), 2u);
+}
+
+BOOST_AUTO_TEST_CASE(div_ceil_zero_numerator) {
+    // Zero elements need zero blocks. (The old `((N - 1) / b) + 1` idiom
+    // wrapped around for unsigned N == 0.)
+    BOOST_CHECK_EQUAL(div_ceil(0, 16), 0);
+    BOOST_CHECK_EQUAL(div_ceil(0u, 16u), 0u);
+}
+
+BOOST_AUTO_TEST_CASE(div_ceil_zero_divisor_throws) {
+    BOOST_CHECK_THROW(div_ceil(16, 0), std::invalid_argument);
+    BOOST_CHECK_THROW(div_ceil(16u, 0u), std::invalid_argument);
+    BOOST_CHECK_THROW(div_ceil(0, 0), std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE(num_triangle_blocks_deployed_sizes) {
+    // CHIME N2: 2048 elements in 32-element blocks, 64 per side
+    BOOST_CHECK_EQUAL(num_triangle_blocks(2048, 32), 64 * 65 / 2);
+    // n2k correlation: 16-element blocks
+    BOOST_CHECK_EQUAL(num_triangle_blocks(2048, 16), 128 * 129 / 2);
+    BOOST_CHECK_EQUAL(num_triangle_blocks(1024, 16), 64 * 65 / 2);
+    BOOST_CHECK_EQUAL(num_triangle_blocks(128, 16), 8 * 9 / 2);
+    // n2k counts: 8x8 tiles over num_elements / 8
+    BOOST_CHECK_EQUAL(num_triangle_blocks(2048 / 8, 8), 32 * 33 / 2);
+    BOOST_CHECK_EQUAL(num_triangle_blocks(128 / 8, 8), 2 * 3 / 2);
+}
+
+BOOST_AUTO_TEST_CASE(num_triangle_blocks_partial_blocks) {
+    // A partial block row/column still counts
+    BOOST_CHECK_EQUAL(num_triangle_blocks(17, 16), 3); // 2 per side
+    BOOST_CHECK_EQUAL(num_triangle_blocks(15, 16), 1); // 1 per side
+    BOOST_CHECK_EQUAL(num_triangle_blocks(0, 16), 0);
+    BOOST_CHECK_THROW(num_triangle_blocks(16, 0), std::invalid_argument);
+}
+
+// Both helpers must remain usable in constant expressions (e.g. gpu_N2_size)
+static_assert(kotekan::div_ceil(2048, 16) == 128, "div_ceil is constexpr");
+static_assert(kotekan::num_triangle_blocks(2048, 16) == 128 * 129 / 2,
+              "num_triangle_blocks is constexpr");


### PR DESCRIPTION
Currently number of blocks calcs are inconsistent for triangular matrices (unexpressed bug).

Use `(N + b - 1)/b` everywhere, not `N/b` or `(N+1)/b` for blocksize `b` and matrix size `N x N`.
