### PR TITLE
Add ndarray buffer type

### DIFF
--- a/config/airspy_autocorr.yaml
+++ b/config/airspy_autocorr.yaml
@@ -43,10 +43,11 @@ sizeof_float: 4
 # chordMetadata pool the forward-port inherited).
 
 input_buf:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
+    value_type: int16
+    extents: [samples_per_data_set]
     metadata_pool: none
     num_frames: buffer_depth
-    frame_size: samples_per_data_set * bytes_per_sample
 
 sample_bw: 10. #MHz, must be float?
 freq: 1421.    #MHz
@@ -66,10 +67,11 @@ spectrum_output:
     spectrum_length: 1024
 
     post_fengine_buf:
-        kotekan_buffer: standard
+        kotekan_buffer: ndarray
+        value_type: cfloat32
+        extents: [samples_per_data_set * sizeof_float / 8]
         metadata_pool: none
         num_frames: buffer_depth
-        frame_size: samples_per_data_set * sizeof_float # * 2 for complex / 2 for half-size
 
     fengine:
         kotekan_stage: fftwEngine

--- a/config/airspy_crosscorr.yaml
+++ b/config/airspy_crosscorr.yaml
@@ -45,16 +45,18 @@ sizeof_float: 4
 # chordMetadata pool the forward-port inherited).
 
 input_bufA:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
+    value_type: int16
+    extents: [samples_per_data_set]
     metadata_pool: none
     num_frames: buffer_depth
-    frame_size: samples_per_data_set * bytes_per_sample
 
 input_bufB:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
+    value_type: int16
+    extents: [samples_per_data_set]
     metadata_pool: none
     num_frames: buffer_depth
-    frame_size: samples_per_data_set * bytes_per_sample
 
 sample_bw: 2.5 #MHz, must be float
 freq: 1422.    #MHz
@@ -100,15 +102,17 @@ spectrum_length: 1024
 integration_length: 1024
 
 post_fengine_bufA:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
+    value_type: cfloat32
+    extents: [samples_per_data_set * sizeof_float / 8]
     metadata_pool: none
     num_frames: buffer_depth
-    frame_size: samples_per_data_set * sizeof_float
 post_fengine_bufB:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
+    value_type: cfloat32
+    extents: [samples_per_data_set * sizeof_float / 8]
     metadata_pool: none
     num_frames: buffer_depth
-    frame_size: samples_per_data_set * sizeof_float
 
 spectrum_output:
     fengineA:

--- a/config/chime_upgrade_n2.j2
+++ b/config/chime_upgrade_n2.j2
@@ -149,14 +149,16 @@ vis_pool:
 
 host_voltage_buffers:
   num_frames: baseband_buffer_depth
-  frame_size: samples_per_data_set * num_elements * num_freq_host_buf
+  value_type: int4x2_swapped_withoffset
+  extents: [1, samples_per_data_set * num_elements * num_freq_host_buf / 2048, 2048]
+  dimnames: [F, T, E]
   metadata_pool: main_pool
   use_hugepages: true
   numa_0:
     numa_node: 0
 {%- for id in range(num_freq_gpu_buf) %}
     host_voltage_buffer_{{ id }}:
-      kotekan_buffer: standard
+      kotekan_buffer: ndarray
 {%- endfor %}
 host_voltage_ringbuffer:
   kotekan_buffer: ring
@@ -165,9 +167,10 @@ host_voltage_ringbuffer:
 
 {%- for id in range(num_freq_gpu_buf // 4) %}
 lost_samples_buffer_{{ id }}:
-  kotekan_buffer: standard
+  kotekan_buffer: ndarray
   num_frames: 2 * host_buffer_depth
-  frame_size: samples_per_data_set
+  value_type: uint8
+  extents: [samples_per_data_set]
   metadata_pool: main_pool
 {%- endfor %}
 
@@ -336,15 +339,18 @@ baseband_merge:
 # Buffers
 
 host_bf_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_int8 * num_dishes * num_polarizations
+    value_type: int8
+    extents: [num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 host_pl_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_buffer_depth
-    frame_size: (64 / 8) * (num_dishes / 8) * num_polarizations * (num_freq_gpu_buf / 4) * (samples_per_data_set / 2 / 64)
+    value_type: uint1x8
+    # produced by lostSamplesToPLMask (also asserted by CountLostPLSamplesScalar consumer)
+    extents: [samples_per_data_set / 2 / 64, num_freq_gpu_buf / 4, num_polarizations, num_dishes / 8, 64 / 8]
     metadata_pool: main_pool
 host_pl_mask_ringbuffer:
     kotekan_buffer: ring
@@ -453,10 +459,12 @@ set_scatter_indices:
 
 # Buffers
 
+# Produced by parseReorderDefault (set_scatter_indices): int32 "scatter_indices".
 host_scatter_indices_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_int32 * num_dishes * num_polarizations
+    value_type: int32
+    extents: [num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 host_xposed_voltage_ringbuffer:
@@ -538,12 +546,12 @@ host_rfi_S012tilde_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_SKtilde_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: gpu_buffer_depth
-    frame_size: sizeof_float32 * 3 * num_freq_gpu_buf * rfi_num_times
-    type: float32
-    dimnames: ["Trfi", "F", "S"]
-    shape: [rfi_num_times, num_freq_gpu_buf, 3]
+    value_type: float32
+    # GPU producer cudaRFISKtilde rfi_SKtilde (leading extent = per-frame rfi_num_times);
+    # also validated by RfiFrameMask in_buf as {Trfi, F, SK}.
+    extents: [rfi_num_times, num_freq_gpu_buf, 3]
     metadata_pool: main_pool
 host_rfi_SKtilde_ringbuffer:
     kotekan_buffer: ring
@@ -555,12 +563,12 @@ host_rfi_SKtilde_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_RFImask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: gpu_buffer_depth
-    frame_size: num_freq_gpu_buf * samples_per_data_set / 8
-    type: uint1x8
-    dimnames: ["T8hi128", "F", "T8lo128"]
-    shape: [samples_per_data_set / 8 / 128, num_freq_gpu_buf, 128]
+    value_type: uint1x8
+    # GPU producer cudaRFISKtilde rfi_RFImask (leading = per-frame samples/(8*128));
+    # also validated by RfiMaskSum/lostSamplesToN2Counts/cudaCorrelator as RFImask.
+    extents: [samples_per_data_set / 8 / 128, num_freq_gpu_buf, 128]
     metadata_pool: main_pool
 host_rfi_RFImask_ringbuffer:
     kotekan_buffer: ring
@@ -572,12 +580,11 @@ host_rfi_RFImask_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_SKbar_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: gpu_buffer_depth
-    frame_size: sizeof_float32 * num_dishes * num_polarizations * 3 * num_freq_gpu_buf * rfi_num_times_bar
-    type: float32
-    dimnames: ["Trfi", "F", "S", "P", "D"]
-    shape: [rfi_num_times_bar, num_freq_gpu_buf, 3, num_polarizaions, num_dishes]
+    value_type: float32
+    # GPU producer cudaRFISKbar rfi_SKbar (leading = per-frame rfi_num_times_bar).
+    extents: [rfi_num_times_bar, num_freq_gpu_buf, 3, num_polarizations, num_dishes]
     metadata_pool: main_pool
 host_rfi_SKbar_ringbuffer:
     kotekan_buffer: ring
@@ -589,12 +596,11 @@ host_rfi_SKbar_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_SKbartilde_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: gpu_buffer_depth
-    frame_size: sizeof_float32 * 3 * num_freq_gpu_buf * rfi_num_times_bar
-    type: float32
-    dimnames: ["Trfi", "F", "S"]
-    shape: [rfi_num_times_bar, num_freq_gpu_buf, 3]
+    value_type: float32
+    # GPU producer cudaRFISKbar rfi_SKbartilde (leading = per-frame rfi_num_times_bar).
+    extents: [rfi_num_times_bar, num_freq_gpu_buf, 3]
     metadata_pool: main_pool
 host_rfi_SKbartilde_ringbuffer:
     kotekan_buffer: ring
@@ -607,9 +613,11 @@ host_rfi_SKbartilde_ringbuffer:
 
 # The mask for second stage RFI excision.
 host_rfi_RFIframemask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: gpu_buffer_depth
-    frame_size: (samples_per_data_set / n2k_sub_integration_ntime) * num_local_freq
+    value_type: uint8
+    # produced by RfiFrameMask (out_buf): {num_integrations, num_local_freq}
+    extents: [samples_per_data_set / n2k_sub_integration_ntime, num_local_freq]
     zero_new_frames: true
     zero_value: 0xFF
     metadata_pool: main_pool
@@ -836,28 +844,41 @@ n2k_counts_triangle_num_blocks: n2k_counts_linear_num_blocks * (n2k_counts_linea
 n2k_counts_triangle_size: n2k_counts_blocksize * n2k_counts_blocksize * n2k_counts_triangle_num_blocks
 
 host_n2k_correlation_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: gpu_buffer_depth
     use_hugepages: true
-    frame_size: sizeof_int32 * num_components * n2k_correlation_triangle_size * num_freq_gpu_buf * n2k_num_subintegrations
+    value_type: int32
+    # produced by cudaCorrelator (n2k_correlation): NDArrayBuffer<int32,6>
+    # cudaCorrelator uses (num_elements+1)/16 = (2048+1)/16 = 128 blocks, same as
+    # CPU num_elements/16 = 128 (num_elements=2048 is a multiple of 16; no triangle divergence).
+    extents: [n2k_num_subintegrations, num_freq_gpu_buf, n2k_correlation_triangle_num_blocks, n2k_correlation_blocksize, n2k_correlation_blocksize, num_components]
     metadata_pool: main_pool
 
 host_n2k_counts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: gpu_buffer_depth
-    frame_size: sizeof_int32 * n2k_counts_triangle_size * num_freq_gpu_buf * n2k_num_subintegrations
+    value_type: int32
+    # produced by lostSamplesToN2Counts (n2k_counts): NDArrayBuffer<int32,5>
+    # ntiles = (num_elements/64)*(1+num_elements/64)/2 = 32*33/2 = 528, matches
+    # config n2k_counts_triangle_num_blocks (= (n2k_counts_num_elements+1)/8 triangle) since
+    # num_elements=2048 makes both = 528 (no divergence).
+    extents: [n2k_num_subintegrations, num_freq_gpu_buf, n2k_counts_triangle_num_blocks, n2k_counts_blocksize, n2k_counts_blocksize]
     metadata_pool: main_pool
 
 host_n2k_RFIcounts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: gpu_buffer_depth
-    frame_size: sizeof_int32 * num_freq_gpu_buf * n2k_num_subintegrations
+    value_type: int32
+    # produced by RfiMaskSum (out_buf): {num_integrations, num_local_freq}
+    extents: [samples_per_data_set / n2k_sub_integration_ntime, num_freq_gpu_buf]
     metadata_pool: main_pool
 
 host_n2k_PLcounts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: gpu_buffer_depth
-    frame_size: sizeof_int32 * num_freq_gpu_buf * n2k_num_subintegrations
+    value_type: int32
+    # produced by CountLostPLSamplesScalar (out_buf): {num_integrations, num_local_freq}
+    extents: [samples_per_data_set / n2k_sub_integration_ntime, num_freq_gpu_buf]
     metadata_pool: main_pool
 
 # Stages

--- a/config/chime_upgrade_test_gains.j2
+++ b/config/chime_upgrade_test_gains.j2
@@ -303,9 +303,10 @@ dbg_read_lostsamples_{{ id }}:
 # Buffers
 
 host_bf_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_int8 * num_dishes * num_polarizations
+    value_type: int8
+    extents: [num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 host_pl_mask_buffer:

--- a/config/chord_pathfinder.j2
+++ b/config/chord_pathfinder.j2
@@ -197,20 +197,23 @@ n2_pool:
     num_metadata_objects: 16 * buffer_depth
 
 # Bad feed mask - marks which feeds to exclude from RFI calculations
-# Shape: [P, D] = [2, num_dishes] - all ones means all feeds are good
+# Produced by inventBFMask: int8 "bf_mask" [P, D] = [num_polarizations, num_dishes].
+# All ones (0xFF) means all feeds are good.
 host_bf_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_int8 * num_dishes * num_polarizations
+    value_type: int8
+    extents: [num_polarizations, num_dishes]
     metadata_pool: main_pool
     zero_new_frames: true
     zero_value: 0xFF
     numa_node: 0
 
 host_bf_mask_buffer_1:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_int8 * num_dishes * num_polarizations
+    value_type: int8
+    extents: [num_polarizations, num_dishes]
     metadata_pool: main_pool
     zero_new_frames: true
     zero_value: 0xFF
@@ -222,8 +225,9 @@ network_input_buffers:
     frame_size: dpdk_output_frame_size
     metadata_pool: main_pool
     use_hugepages: true
-    
-    # The workers share an output buffer
+
+    # The workers share an output buffer.
+    # Fed by dpdkCore (crs16BoardCaptureWorker handler) -> leave standard.
     network_input_buffer_0:
         zero_new_frames: true
         numa_node: 0
@@ -234,13 +238,32 @@ network_input_buffers:
         numa_node: 1
         zero_value: 0x88
         kotekan_buffer: standard
-    # Main voltage buffer after transpose
-    host_voltage_buffer_0:
-        kotekan_buffer: standard
-        numa_node: 0
-    host_voltage_buffer_1:
-        kotekan_buffer: standard
-        numa_node: 1
+
+# Main voltage buffer after transpose.
+# Produced by TransposeBasebandArray: int4x2_swapped_withoffset "E"
+# [timesamples_per_frame, NUM_LOCAL_FREQ, 2, NUM_ELEMENTS/2] = [samples_per_data_set, 384, 2, 64].
+# The stage uses compile-time macros NUM_LOCAL_FREQ=384, NUM_ELEMENTS=128 (it fatally checks the
+# config num_local_freq/num_elements equal them); this config sets num_local_freq=384,
+# num_elements=128, so the static extents below are valid. These live outside the
+# network_input_buffers group: that group's frame_size is for the dpdk buffers, while
+# ndarray buffers derive their size from the descriptor.
+host_voltage_buffer_0:
+    kotekan_buffer: ndarray
+    num_frames: host_side_buffer_depth
+    value_type: int4x2_swapped_withoffset
+    extents: [samples_per_data_set, num_local_freq, 2, num_elements / 2]
+    metadata_pool: main_pool
+    use_hugepages: true
+    numa_node: 0
+
+host_voltage_buffer_1:
+    kotekan_buffer: ndarray
+    num_frames: host_side_buffer_depth
+    value_type: int4x2_swapped_withoffset
+    extents: [samples_per_data_set, num_local_freq, 2, num_elements / 2]
+    metadata_pool: main_pool
+    use_hugepages: true
+    numa_node: 1
 
 
 packet_receipt_bitmap_buffers:
@@ -264,125 +287,157 @@ packet_receipt_bitmap_buffers:
         kotekan_buffer: standard
         numa_node: 1
 
-# These are the dummy RFI masks produced by DPDK
+# These are the dummy RFI masks produced by ProcessPacketMask (rfi_mask_buf).
+# uint1x8 "RFImask" [samples_per_data_set/1024, num_local_freq, 128] {T8hi128, F, T8lo128}.
 host_rfi_RFImask_dummy_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: num_local_freq * samples_per_data_set / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 1024, num_local_freq, 128]
     zero_new_frames: true
     zero_value: 0xFF
     metadata_pool: main_pool
 
 host_rfi_RFImask_dummy_buffer_1:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: num_local_freq * samples_per_data_set / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 1024, num_local_freq, 128]
     zero_new_frames: true
     zero_value: 0xFF
     numa_node: 1
     metadata_pool: main_pool
 
-# Note this is the expanded version of the pl_mask, produced by DPDK. It will be compressed to
-# the normal PL mask before being sent to the GPU.
+# Note this is the expanded version of the pl_mask, produced by ProcessPacketMask (pl_mask_buf).
+# It will be compressed to the normal PL mask before being sent to the GPU.
+# uint1x8 "pl_mask_exp" [samples_per_data_set/64, num_local_freq, 2, num_elements/8/2, 8]
+# {Thi64, F, P, D8, Tlo64}.
 host_pl_mask_exp_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / 64) * (num_local_freq) * (num_elements / 8) * 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 64, num_local_freq, 2, num_elements / 8 / 2, 8]
     metadata_pool: main_pool
 
 host_pl_mask_exp_buffer_1:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / 64) * (num_local_freq) * (num_elements / 8) * 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 64, num_local_freq, 2, num_elements / 8 / 2, 8]
     metadata_pool: main_pool
     numa_node: 1
 
 # This is the PL mask, sent to GPU and used for n2k_counts and the RFI SK system.
+# Produced by PLMaskExpandedToCompact (out_buf): uint1x8 "pl_mask"
+# [samples_per_data_set/128, (num_local_freq+3)/4, 2, (num_elements/8)/2, 8]
+# {T2hi64, F4, P, D8, T2lo64}. num_local_freq=384 -> (384+3)/4 = 96 = num_local_freq/4.
 host_pl_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / 128) * (num_local_freq/4) * (num_elements / 8) * 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 128, (num_local_freq + 3) / 4, 2, (num_elements / 8) / 2, 8]
     metadata_pool: main_pool
 
 host_pl_mask_buffer_1:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / 128) * (num_local_freq/4) * (num_elements / 8) * 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 128, (num_local_freq + 3) / 4, 2, (num_elements / 8) / 2, 8]
     metadata_pool: main_pool
     numa_node: 1
 
 # This contains the SK statistics averaged over elements.
+# GPU output (cudaCopyFromRingbuffer of cudaRFISKtilde rfi_SKtilde) and consumed by RfiFrameMask:
+# float32 "SKtilde" [samples_per_data_set/rfi_downsampling_factor, num_local_freq, 3] {Trfi, F, SK}.
 host_rfi_sktilde_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / rfi_downsampling_factor) * num_local_freq * 3 * sizeof_float32
+    value_type: float32
+    extents: [samples_per_data_set / rfi_downsampling_factor, num_local_freq, 3]
     metadata_pool: main_pool
 
 host_rfi_sktilde_buffer_1:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / rfi_downsampling_factor) * num_local_freq * 3 * sizeof_float32
+    value_type: float32
+    extents: [samples_per_data_set / rfi_downsampling_factor, num_local_freq, 3]
     metadata_pool: main_pool
     numa_node: 1
 
 # This is the RFI Mask recieved from the GPU, that was applied to produce n2k_correlation & n2k_counts.
 # It may contain either the dummy DPDK-generated mask or the real mask computed by SKtilde.
+# GPU output (cudaCopyFromRingbuffer of rfi_RFImask) and consumed by RfiMaskSum:
+# uint1x8 "RFImask" [samples_per_data_set/1024, num_local_freq, 128] {T8hi128, F, T8lo128}.
 host_rfi_RFImask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: num_local_freq * samples_per_data_set / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 1024, num_local_freq, 128]
     zero_new_frames: true
     zero_value: 0xFF
     metadata_pool: main_pool
 
 host_rfi_RFImask_buffer_1:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: num_local_freq * samples_per_data_set / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 1024, num_local_freq, 128]
     zero_new_frames: true
     zero_value: 0xFF
     numa_node: 1
     metadata_pool: main_pool
 
+# Produced by RfiMaskSum (out_buf): int32 "RFImask_counts"
+# [samples_per_data_set/sub_integration_ntime, num_local_freq] {Tc, F}.
 host_rfi_RFImask_counts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * sizeof_int32
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     metadata_pool: main_pool
 
 host_rfi_RFImask_counts_buffer_1:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * sizeof_int32
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     metadata_pool: main_pool
     numa_node: 1
 
+# Produced by CountLostPLSamplesScalar (out_buf): int32 "pl_lost_counts_scalar"
+# [samples_per_data_set/sub_integration_ntime, num_local_freq] {Tc, F}.
 host_pl_counts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * sizeof_int32
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     metadata_pool: main_pool
 
 host_pl_counts_buffer_1:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * sizeof_int32
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     metadata_pool: main_pool
     numa_node: 1
 
 # The mask for second stage RFI excision.
+# Produced by RfiFrameMask (out_buf): uint8 "RFIFrameMask"
+# [samples_per_data_set/sub_integration_ntime, num_local_freq] {Tc, F}.
 host_rfi_RFIframemask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq
+    value_type: uint8
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     zero_new_frames: true
     zero_value: 0xFF
     metadata_pool: main_pool
 
 host_rfi_RFIframemask_buffer_1:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq
+    value_type: uint8
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     zero_new_frames: true
     zero_value: 0xFF
     metadata_pool: main_pool
@@ -391,16 +446,23 @@ host_rfi_RFIframemask_buffer_1:
 vis_blocksize: 16
 vis_num_blocks_lin: num_elements / vis_blocksize
 vis_num_blocks: vis_num_blocks_lin * (vis_num_blocks_lin + 1) / 2
+# GPU output (cudaOutputData of cudaCorrelator n2k_correlation): int32 "n2k_correlation"
+# [samples_per_data_set/sub_integration_ntime, num_local_freq, vis_num_blocks, 16, 16, 2]
+# {Tc, F, DPhi, DPlo1, DPlo2, C}. Block-count note: cudaCorrelator uses (num_elements+1)/16
+# while the CPU side uses num_elements/16; at num_elements=128 both equal 8, so vis_num_blocks=36
+# matches the kernel's triangle_num_blocks.
 host_correlation_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: num_local_freq * (samples_per_data_set / sub_integration_ntime) * 16 * 16 * vis_num_blocks * 2 * sizeof_gpu_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, vis_num_blocks, vis_blocksize, vis_blocksize, 2]
     metadata_pool: main_pool
 
 host_correlation_buffer_1:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: num_local_freq * (samples_per_data_set / sub_integration_ntime) * 16 * 16 * vis_num_blocks * 2 * sizeof_gpu_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, vis_num_blocks, vis_blocksize, vis_blocksize, 2]
     metadata_pool: main_pool
     numa_node: 1
 
@@ -408,16 +470,23 @@ host_correlation_buffer_1:
 counts_blocksize: 8
 counts_num_blocks_lin: (num_elements / 8) / counts_blocksize
 counts_num_blocks: (counts_num_blocks_lin * (counts_num_blocks_lin + 1)) / 2
+# GPU output (cudaOutputData of cudaPL1bitCorrelator n2k_counts): int32 "n2k_counts"
+# [samples_per_data_set/sub_integration_ntime, num_local_freq, counts_num_blocks, 8, 8]
+# {Tc, F, D8Phi, D8Plo1, D8Plo2}. Block-count note: cudaPL1bitCorrelator uses
+# (num_elements/8+1)/8 while the CPU side uses (num_elements/8)/8; at num_elements=128 both equal 2,
+# so counts_num_blocks=3 matches the kernel's triangle_num_blocks.
 host_counts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * counts_num_blocks * counts_blocksize * counts_blocksize * sizeof_gpu_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, counts_num_blocks, counts_blocksize, counts_blocksize]
     metadata_pool: main_pool
 
 host_counts_buffer_1:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * counts_num_blocks * counts_blocksize * counts_blocksize * sizeof_gpu_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, counts_num_blocks, counts_blocksize, counts_blocksize]
     metadata_pool: main_pool
     numa_node: 1
 

--- a/config/chord_pathfinder_recv.j2
+++ b/config/chord_pathfinder_recv.j2
@@ -153,7 +153,6 @@ n2_pool:
 
 
 
-
 # Receive subset N2 buffer
 
 n2_recv_subset_buffer:

--- a/config/ci-tests/cpu_batch/run_n2accum.yaml
+++ b/config/ci-tests/cpu_batch/run_n2accum.yaml
@@ -90,39 +90,45 @@ n2_pool:
     num_metadata_objects: 16 * buffer_depth
 
 fake_correlation_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * vis_num_blocks * vis_blocksize * vis_blocksize * 2 * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, vis_num_blocks, vis_blocksize, vis_blocksize, 2]
     metadata_pool: main_pool
 
 fake_counts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * counts_num_blocks * counts_blocksize * counts_blocksize * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, counts_num_blocks, counts_blocksize, counts_blocksize]
     metadata_pool: main_pool
 
 fake_rfimask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set * num_local_freq) / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 1024, num_local_freq, 128]
     metadata_pool: main_pool
 
 fake_rficounts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     metadata_pool: main_pool
 
 fake_plcounts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     metadata_pool: main_pool
 
 fake_rfi_frame_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq
+    value_type: uint8
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     metadata_pool: main_pool
 
 n2_buffer:

--- a/config/ci-tests/cpu_batch/run_n2accum_chime.yaml
+++ b/config/ci-tests/cpu_batch/run_n2accum_chime.yaml
@@ -64,39 +64,45 @@ vis_pool:
     num_metadata_objects: num_local_freq * buffer_depth
 
 fake_correlation_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * vis_num_blocks * vis_blocksize * vis_blocksize * 2 * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, vis_num_blocks, vis_blocksize, vis_blocksize, 2]
     metadata_pool: main_pool
 
 fake_counts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * counts_num_blocks * counts_blocksize * counts_blocksize * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, counts_num_blocks, counts_blocksize, counts_blocksize]
     metadata_pool: main_pool
 
 fake_rfimask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set * num_local_freq) / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 1024, num_local_freq, 128]
     metadata_pool: main_pool
 
 fake_rficounts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     metadata_pool: main_pool
 
 fake_plcounts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     metadata_pool: main_pool
 
 fake_rfi_frame_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq
+    value_type: uint8
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     metadata_pool: main_pool
 
 n2_buffer:

--- a/config/ci-tests/cpu_batch/test_lostSamplesToPLMask.yaml
+++ b/config/ci-tests/cpu_batch/test_lostSamplesToPLMask.yaml
@@ -29,23 +29,29 @@ main_pool:
 # Buffers
 lost_samples_buffers:
     num_frames: buffer_depth
-    frame_size: num_frame_samples
     metadata_pool: main_pool
+    # Shared frame descriptor (scope-inherited by all three buffers)
+    value_type: uint8
+    extents: [num_frame_samples]
+    dimnames: ["T"]
     lost_samples_buffer_0:
-        kotekan_buffer: standard
+        kotekan_buffer: ndarray
     lost_samples_buffer_1:
-        kotekan_buffer: standard
+        kotekan_buffer: ndarray
     lost_samples_buffer_2:
-        kotekan_buffer: standard
+        kotekan_buffer: ndarray
 
 pl_mask_buffers:
     num_frames: buffer_depth
-    frame_size: num_frame_samples/pl_mask_downsampling_factor * num_dishes/pl_mask_dishes_per_bin * num_polarizations * num_freq_bins / 8
     metadata_pool: main_pool
+    # Shared frame descriptor (scope-inherited by both buffers)
+    value_type: uint1x8
+    extents: [num_frame_samples / pl_mask_downsampling_factor / pl_mask_hilo_split, num_freq_bins, num_polarizations, num_dishes / pl_mask_dishes_per_bin, pl_mask_hilo_split / 8]
+    dimnames: ["T2hi64", "F4", "P", "D8", "T2lo64"]
     out_pl_mask_buffer:
-        kotekan_buffer: standard
+        kotekan_buffer: ndarray
     cmp_pl_mask_buffer:
-        kotekan_buffer: standard
+        kotekan_buffer: ndarray
 
 # Kotekan stages
 gen_test_data:

--- a/config/ci-tests/cpu_batch/test_send_recv.yaml
+++ b/config/ci-tests/cpu_batch/test_send_recv.yaml
@@ -1,6 +1,8 @@
 ---
 #
-# Just a simple test pipeline that generates random data, does a send/recieve, for different buffer types.
+# A simple test pipeline that generates random data and does a send/receive,
+# for each buffer type: standard, N2, and ndarray (the latter both with and
+# without the optional descriptor labels declared in config).
 #
 type: config
 log_level: INFO
@@ -39,19 +41,23 @@ earth_rotation_data:
 # Pools
 main_pool:
     kotekan_metadata_pool: chordMetadata
-    num_metadata_objects: 4 * buffer_depth
+    num_metadata_objects: 8 * buffer_depth
 
 N2_pool:
     kotekan_metadata_pool: N2Metadata
     num_metadata_objects: 2 * buffer_depth
 
 # Buffers
+#
+# `standard` frames are opaque bytes (int4x2 is one byte per sample, so
+# frame_size == num_frame_samples). bufferRecv attaches whatever descriptor it
+# receives from the wire. The recv buffers mirror their send counterparts.
+
 send_buffer:
     kotekan_buffer: standard
     num_frames: buffer_depth
     frame_size: num_frame_samples
     metadata_pool: main_pool
-
 recv_buffer:
     kotekan_buffer: standard
     num_frames: buffer_depth
@@ -63,7 +69,6 @@ send_buffer_noCT:
     num_frames: buffer_depth
     frame_size: num_frame_samples
     metadata_pool: main_pool
-
 recv_buffer_noCT:
     kotekan_buffer: standard
     num_frames: buffer_depth
@@ -75,12 +80,46 @@ send_N2_buffer:
     metadata_pool: N2_pool
     n2_layout: "FullUpperTri"
     num_frames: buffer_depth
-
 recv_N2_buffer:
     kotekan_buffer: N2
     metadata_pool: N2_pool
     n2_layout: "FullUpperTri"
     num_frames: buffer_depth
+
+# ndarray with a full descriptor: the labels (quantity_name, dimnames) are
+# declared in config, so bufferRecv validates the received shape against them.
+send_ndarray_buffer:
+    kotekan_buffer: ndarray
+    num_frames: buffer_depth
+    value_type: int4x2
+    quantity_name: voltage
+    extents: [num_frame_samples]
+    dimnames: ["S"]
+    metadata_pool: main_pool
+recv_ndarray_buffer:
+    kotekan_buffer: ndarray
+    num_frames: buffer_depth
+    value_type: int4x2
+    quantity_name: voltage
+    extents: [num_frame_samples]
+    dimnames: ["S"]
+    metadata_pool: main_pool
+
+# ndarray with only the structural fields: the labels are omitted from config
+# and supplied by the producing stage (and, on the recv side, by the frame
+# received over the wire).
+send_ndarray_nolabel_buffer:
+    kotekan_buffer: ndarray
+    num_frames: buffer_depth
+    value_type: int4x2
+    extents: [num_frame_samples]
+    metadata_pool: main_pool
+recv_ndarray_nolabel_buffer:
+    kotekan_buffer: ndarray
+    num_frames: buffer_depth
+    value_type: int4x2
+    extents: [num_frame_samples]
+    metadata_pool: main_pool
 
 
 # Kotekan stages
@@ -89,12 +128,11 @@ recv_N2_buffer:
 
 gen_buffer_data:
     log_level: WARN
-    # type: const
-    # value: 34 # 1i # 34 # = 2 + 2i
     type: random_signed
     value: 1532
     kotekan_stage: testDataGen
     out_buf: send_buffer
+    name: voltage
     array_shape: [2048]
     dim_name: ["S"]
     num_frames: 6
@@ -116,12 +154,11 @@ buffer_recv_standard:
 
 gen_buffer_data_noCT:
     log_level: WARN
-    # type: const
-    # value: 34 # 1i # 34 # = 2 + 2i
     type: random_signed
     value: 1532
     kotekan_stage: testDataGen
     out_buf: send_buffer_noCT
+    name: voltage
     array_shape: [2048]
     dim_name: ["S"]
     num_frames: 6
@@ -169,7 +206,59 @@ buffer_recv_n2:
     buf: recv_N2_buffer
     listen_port: 11025
 
-# Verify buffers are the same.
+# ndarray buffer (labels declared in config): generate and send/recv
+
+gen_ndarray_data:
+    log_level: WARN
+    type: random_signed
+    value: 1532
+    kotekan_stage: testDataGen
+    out_buf: send_ndarray_buffer
+    name: voltage
+    array_shape: [2048]
+    dim_name: ["S"]
+    num_frames: 6
+
+buffer_send_ndarray:
+    kotekan_stage: bufferSend
+    buf: send_ndarray_buffer
+    server_ip: 127.0.0.1
+    server_port: 11027
+    retry_time: 1.0
+    drop_frames: false
+
+buffer_recv_ndarray:
+    kotekan_stage: bufferRecv
+    buf: recv_ndarray_buffer
+    listen_port: 11027
+
+# ndarray buffer (labels supplied by the stage, not config): generate and send/recv
+
+gen_ndarray_nolabel_data:
+    log_level: WARN
+    type: random_signed
+    value: 1532
+    kotekan_stage: testDataGen
+    out_buf: send_ndarray_nolabel_buffer
+    name: voltage
+    array_shape: [2048]
+    dim_name: ["S"]
+    num_frames: 6
+
+buffer_send_ndarray_nolabel:
+    kotekan_stage: bufferSend
+    buf: send_ndarray_nolabel_buffer
+    server_ip: 127.0.0.1
+    server_port: 11028
+    retry_time: 1.0
+    drop_frames: false
+
+buffer_recv_ndarray_nolabel:
+    kotekan_stage: bufferRecv
+    buf: recv_ndarray_nolabel_buffer
+    listen_port: 11028
+
+# Verify each recv buffer matches its send buffer (data and metadata).
 
 check_standard_send_recv:
     kotekan_stage: testDataCheckUchar
@@ -195,6 +284,22 @@ check_n2_send_recv:
     trigger_exit_on_pass: false
     check_metadata: true
 
+check_ndarray_send_recv:
+    kotekan_stage: testDataCheckUchar
+    first_buf: send_ndarray_buffer
+    second_buf: recv_ndarray_buffer
+    num_frames_to_test: buffer_depth
+    trigger_exit_on_pass: false
+    check_metadata: true
+
+check_ndarray_nolabel_send_recv:
+    kotekan_stage: testDataCheckUchar
+    first_buf: send_ndarray_nolabel_buffer
+    second_buf: recv_ndarray_nolabel_buffer
+    num_frames_to_test: buffer_depth
+    trigger_exit_on_pass: false
+    check_metadata: true
+
 # Monitor recv buffers for completion, shutdown after some inactivity if none.
 
 buffer_monitor:
@@ -206,4 +311,6 @@ buffer_monitor:
         - recv_buffer
         - recv_buffer_noCT
         - recv_N2_buffer
+        - recv_ndarray_buffer
+        - recv_ndarray_nolabel_buffer
     clean_exit_after_frames: 6 # Trigger success after this many frames have been seen

--- a/config/ci-tests/cpu_batch/verify_lost_samples_n2k_counts.yaml
+++ b/config/ci-tests/cpu_batch/verify_lost_samples_n2k_counts.yaml
@@ -45,31 +45,37 @@ main_pool:
 # Buffers
 lost_samples_buffers:
     num_frames: buffer_depth
-    frame_size: samples_per_data_set
     metadata_pool: main_pool
+    # Shared frame descriptor (scope-inherited by all three buffers)
+    value_type: uint8
+    extents: [samples_per_data_set]
+    dimnames: ["T"]
     lost_samples_buffer_0:
-        kotekan_buffer: standard
+        kotekan_buffer: ndarray
     lost_samples_buffer_1:
-        kotekan_buffer: standard
+        kotekan_buffer: ndarray
     lost_samples_buffer_2:
-        kotekan_buffer: standard
+        kotekan_buffer: ndarray
 
 host_rfi_RFImask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: samples_per_data_set * num_local_freq / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 1024, num_local_freq, 128]
     metadata_pool: main_pool
 
 host_pl_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: ((samples_per_data_set / pl_mask_downsampling_factor) * (num_local_freq / 4) * (num_elements / pl_mask_dishes_per_bin)) / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / pl_mask_downsampling_factor / 64, num_freq_bins, num_polarizations, num_dishes / pl_mask_dishes_per_bin, 8]
     metadata_pool: main_pool
 
 dummy_pl_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: ((samples_per_data_set / pl_mask_downsampling_factor) * (num_local_freq / 4) * (num_elements / 8)) / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / pl_mask_downsampling_factor / 64, num_freq_bins, num_polarizations, num_dishes / pl_mask_dishes_per_bin, 8]
     metadata_pool: main_pool
 
 # host_n2k_counts_buffer:
@@ -79,21 +85,24 @@ dummy_pl_mask_buffer:
 #     metadata_pool: main_pool
 
 host_ls_counts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * counts_num_blocks * counts_blocksize * counts_blocksize * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, counts_num_blocks, counts_blocksize, counts_blocksize]
     metadata_pool: main_pool
 
 simulated_pl_mask_exp_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set * (num_local_freq) * (num_elements / 8)) / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 64, num_local_freq, 2, num_elements / 8 / 2, 8]
     metadata_pool: main_pool
 
 simulated_n2k_counts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * counts_num_blocks * counts_blocksize * counts_blocksize * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, counts_num_blocks, counts_blocksize, counts_blocksize]
     metadata_pool: main_pool
 
 ###############################

--- a/config/ci-tests/gpu_batch/test_n2k_writeHDF5.yaml
+++ b/config/ci-tests/gpu_batch/test_n2k_writeHDF5.yaml
@@ -48,21 +48,24 @@ main_pool:
 
 # Buffers
 host_voltage_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: samples_per_data_set * num_elements * num_local_freq
+    value_type: int4x2_swapped_withoffset
+    extents: [samples_per_data_set, num_local_freq, 2, num_elements / 2]
     metadata_pool: main_pool
 
 host_rfi_RFImask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: num_local_freq * samples_per_data_set / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 1024, num_local_freq, 128]
     metadata_pool: main_pool
 
 host_correlation_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: num_local_freq * (samples_per_data_set / sub_integration_ntime) * 16 * 16 * num_vis_blocks * 2 * sizeof_int
+    value_type: int32
+    extents: [num_times / sub_integration_ntime, num_local_freq, num_vis_blocks, 16, 16, 2]
     metadata_pool: main_pool
 
 # Ringbuffer signalling buffer

--- a/config/ci-tests/gpu_batch/test_xpose2048.j2
+++ b/config/ci-tests/gpu_batch/test_xpose2048.j2
@@ -39,20 +39,22 @@ main_pool:
 # Buffers
 
 host_scatter_indices_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_int32 * num_dishes * num_polarizations
+    value_type: int32
+    extents: [num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 host_voltage_buffers:
   num_frames: host_buffer_depth
-  frame_size: samples_per_data_set * num_elements * num_freq_host_buf
   metadata_pool: main_pool
   numa_0:
     numa_node: 0
 {%- for id in range(num_freq_gpu_buf) %}
     host_voltage_buffer_{{ id }}:
-      kotekan_buffer: standard
+      kotekan_buffer: ndarray
+      value_type: int4x2_swapped_withoffset
+      extents: [num_freq_host_buf, samples_per_data_set, num_elements]
 {%- endfor %}
 
 host_voltage_ringbuffer:
@@ -67,17 +69,19 @@ host_xposed_voltage_ringbuffer:
 
 host_xposed_voltage_buffer:
   num_frames: host_buffer_depth
-  frame_size: samples_per_data_set * num_elements * num_freq_gpu_buf
   metadata_pool: main_pool
   host_xposed_voltage_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
+    value_type: int4x2_swapped_withoffset
+    extents: [samples_per_data_set, num_freq_gpu_buf, num_polarizations, num_dishes]
 
 cpu_xposed_voltage_buffer:
   num_frames: host_buffer_depth
-  frame_size: samples_per_data_set * num_elements * num_freq_gpu_buf
   metadata_pool: main_pool
   cpu_xposed_voltage_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
+    value_type: int4x2_swapped_withoffset
+    extents: [samples_per_data_set, num_freq_gpu_buf, num_polarizations, num_dishes]
 # Stages
 
 set_voltage:

--- a/config/ci-tests/gpu_batch/verify_cuda_n2k.yaml
+++ b/config/ci-tests/gpu_batch/verify_cuda_n2k.yaml
@@ -47,51 +47,59 @@ main_pool:
 
 # Buffers
 host_voltage_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: samples_per_data_set * num_local_freq * num_elements
+    value_type: int4x2_swapped_withoffset
+    extents: [samples_per_data_set, num_local_freq, num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 host_rfi_RFImask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: samples_per_data_set * num_local_freq / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 1024, num_local_freq, 128]
     metadata_pool: main_pool
 
 host_pl_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: ((samples_per_data_set / 2) * (num_local_freq / 4) * (num_elements / 8)) / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 128, num_local_freq / 4, num_polarizations, num_dishes / 8, 8]
     metadata_pool: main_pool
 
 host_correlation_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * vis_num_blocks * vis_blocksize * vis_blocksize * 2 * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, vis_num_blocks, vis_blocksize, vis_blocksize, 2]
     metadata_pool: main_pool
 
 host_counts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * counts_num_blocks * counts_blocksize * counts_blocksize * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, counts_num_blocks, counts_blocksize, counts_blocksize]
     metadata_pool: main_pool
 
 simulated_correlation_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * vis_num_blocks * vis_blocksize * vis_blocksize * 2 * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, vis_num_blocks, vis_blocksize, vis_blocksize, 2]
     metadata_pool: main_pool
 
 simulated_pl_mask_exp_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set * (num_local_freq) * (num_elements / 8)) / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 64, num_local_freq, num_polarizations, (num_elements / 8) / 2, 8]
     metadata_pool: main_pool
 
 simulated_counts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * counts_num_blocks * counts_blocksize * counts_blocksize * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, counts_num_blocks, counts_blocksize, counts_blocksize]
     metadata_pool: main_pool
 
 # Ringbuffer signalling buffer

--- a/config/ci-tests/gpu_batch/verify_cuda_n2k_corr.yaml
+++ b/config/ci-tests/gpu_batch/verify_cuda_n2k_corr.yaml
@@ -47,27 +47,31 @@ main_pool:
 
 # Buffers
 host_voltage_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: samples_per_data_set * num_local_freq * num_elements
+    value_type: int4x2_swapped_withoffset
+    extents: [samples_per_data_set, num_local_freq, num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 host_rfi_RFImask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: samples_per_data_set * num_local_freq / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 1024, num_local_freq, 128]
     metadata_pool: main_pool
 
 host_correlation_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * vis_num_blocks * vis_blocksize * vis_blocksize * 2 * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, vis_num_blocks, vis_blocksize, vis_blocksize, 2]
     metadata_pool: main_pool
 
 simulated_correlation_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * vis_num_blocks * vis_blocksize * vis_blocksize * 2 * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, vis_num_blocks, vis_blocksize, vis_blocksize, 2]
     metadata_pool: main_pool
 
 # Ringbuffer signalling buffer

--- a/config/ci-tests/gpu_batch/verify_cuda_n2k_pl1bitcorr.yaml
+++ b/config/ci-tests/gpu_batch/verify_cuda_n2k_pl1bitcorr.yaml
@@ -42,27 +42,31 @@ main_pool:
 
 # Buffers
 host_pl_mask_exp_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set * num_local_freq * (num_elements / 8)) / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 64, num_local_freq, num_polarizations, (num_elements / 8) / 2, 8]
     metadata_pool: main_pool
 
 host_rfi_RFImask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: num_local_freq * samples_per_data_set / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 1024, num_local_freq, 128]
     metadata_pool: main_pool
 
 host_counts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * counts_num_blocks * counts_blocksize * counts_blocksize * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, counts_num_blocks, counts_blocksize, counts_blocksize]
     metadata_pool: main_pool
 
 simulated_counts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * counts_num_blocks * counts_blocksize * counts_blocksize * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, counts_num_blocks, counts_blocksize, counts_blocksize]
     metadata_pool: main_pool
 
 # Ringbuffer signalling buffer

--- a/config/ci-tests/gpu_batch/verify_cuda_n2k_plexp.yaml
+++ b/config/ci-tests/gpu_batch/verify_cuda_n2k_plexp.yaml
@@ -37,21 +37,24 @@ main_pool:
 
 # Buffers
 host_pl_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: ((samples_per_data_set / 2) * (num_local_freq / 4) * (num_elements / 8)) / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 128, num_local_freq / 4, num_polarizations, num_dishes / 8, 8]
     metadata_pool: main_pool
 
 host_pl_mask_exp_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set * num_local_freq * (num_elements / 8)) / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 64, num_local_freq, num_polarizations, (num_elements / 8) / 2, 8]
     metadata_pool: main_pool
 
 simulated_pl_mask_exp_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set * num_local_freq * (num_elements / 8)) / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 64, num_local_freq, num_polarizations, (num_elements / 8) / 2, 8]
     metadata_pool: main_pool
 
 # Ringbuffer signalling buffer

--- a/config/ci-tests/gpu_batch/verify_cuda_pl_accum.yaml
+++ b/config/ci-tests/gpu_batch/verify_cuda_pl_accum.yaml
@@ -35,15 +35,17 @@ main_pool:
     num_metadata_objects: 20 * buffer_depth
 
 host_pl_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: ((samples_per_data_set / 2) * (num_local_freq / 4) * (num_elements / 8)) / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 128, num_local_freq / 4, num_polarizations, num_dishes / 8, 8]
     metadata_pool: main_pool
 
 host_pl_counts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * num_elements * sizeof_long
+    value_type: uint64
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 host_pl_lost_counts_buffer:
@@ -53,9 +55,10 @@ host_pl_lost_counts_buffer:
     metadata_pool: main_pool
 
 simulated_pl_counts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * num_elements * sizeof_long
+    value_type: uint64
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 

--- a/config/ci-tests/gpu_batch/verify_cuda_rfi_s012.yaml
+++ b/config/ci-tests/gpu_batch/verify_cuda_rfi_s012.yaml
@@ -36,33 +36,38 @@ main_pool:
 
 # Buffers
 raw_voltage_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: samples_per_data_set * num_local_freq * num_elements
+    value_type: int4x2_swapped_withoffset
+    extents: [samples_per_data_set, num_local_freq, num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 host_voltage_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: samples_per_data_set * num_local_freq * num_elements
+    value_type: int4x2_swapped_withoffset
+    extents: [samples_per_data_set, num_local_freq, 2, num_elements / 2]
     metadata_pool: main_pool
 
 host_pl_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: ((samples_per_data_set / 2) * (num_local_freq / 4) * (num_elements / 8)) / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 128, num_local_freq / 4, num_polarizations, num_dishes / 8, 8]
     metadata_pool: main_pool
 
 host_rfi_s012_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / rfi_downsampling_factor) * num_local_freq * 3 * num_elements * sizeof_long
+    value_type: uint64
+    extents: [samples_per_data_set / rfi_downsampling_factor, num_local_freq, 3, num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 simulated_rfi_s012_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / rfi_downsampling_factor) * num_local_freq * 3 * num_elements * sizeof_long
+    value_type: uint64
+    extents: [samples_per_data_set / rfi_downsampling_factor, num_local_freq, 3, num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 

--- a/config/ci-tests/gpu_batch/verify_cuda_rfi_s012bar.yaml
+++ b/config/ci-tests/gpu_batch/verify_cuda_rfi_s012bar.yaml
@@ -38,21 +38,24 @@ main_pool:
 # Buffers
 
 host_rfi_s012_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / rfi_downsampling_factor) * num_local_freq * 3 * num_elements * sizeof_long
+    value_type: uint64
+    extents: [samples_per_data_set / rfi_downsampling_factor, num_local_freq, 3, num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 host_rfi_s012bar_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / rfi_downsampling_factor / rfi_second_downsampling_factor) * num_local_freq * 3 * num_elements * sizeof_long
+    value_type: uint64
+    extents: [samples_per_data_set / rfi_downsampling_factor / rfi_second_downsampling_factor, num_local_freq, 3, num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 simulated_rfi_s012bar_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / rfi_downsampling_factor / rfi_second_downsampling_factor) * num_local_freq * 3 * num_elements * sizeof_long
+    value_type: uint64
+    extents: [samples_per_data_set / rfi_downsampling_factor / rfi_second_downsampling_factor, num_local_freq, 3, num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 

--- a/config/ci-tests/gpu_batch/verify_cuda_rfi_s012tilde.yaml
+++ b/config/ci-tests/gpu_batch/verify_cuda_rfi_s012tilde.yaml
@@ -37,27 +37,31 @@ main_pool:
 # Buffers
 
 host_bf_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: num_elements
+    value_type: int8
+    extents: [num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 host_rfi_s012_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / rfi_downsampling_factor) * num_local_freq * 3 * num_elements * sizeof_long
+    value_type: uint64
+    extents: [samples_per_data_set / rfi_downsampling_factor, num_local_freq, 3, num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 host_rfi_s012tilde_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / rfi_downsampling_factor) * num_local_freq * 3 * sizeof_long
+    value_type: uint64
+    extents: [samples_per_data_set / rfi_downsampling_factor, num_local_freq, 3]
     metadata_pool: main_pool
 
 simulated_rfi_s012tilde_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / rfi_downsampling_factor) * num_local_freq * 3 * sizeof_long
+    value_type: uint64
+    extents: [samples_per_data_set / rfi_downsampling_factor, num_local_freq, 3]
     metadata_pool: main_pool
 
 

--- a/config/ci-tests/gpu_batch/verify_cuda_rfi_skbar.yaml
+++ b/config/ci-tests/gpu_batch/verify_cuda_rfi_skbar.yaml
@@ -47,45 +47,52 @@ main_pool:
 # Buffers
 
 host_bf_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: num_elements
+    value_type: int8
+    extents: [num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 host_rfi_s012bar_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: rfi_num_times_bar * num_local_freq * 3 * num_elements * sizeof_long
+    value_type: uint64
+    extents: [rfi_num_times_bar, num_local_freq, 3, num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 host_rfi_skbar_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: rfi_num_times_bar * num_local_freq * 3 * num_elements * sizeof_float
+    value_type: float32
+    extents: [rfi_num_times_bar, num_local_freq, 3, num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 host_rfi_skbartilde_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: rfi_num_times_bar * num_local_freq * 3 * sizeof_float
+    value_type: float32
+    extents: [rfi_num_times_bar, num_local_freq, 3]
     metadata_pool: main_pool
 
 simulated_rfi_skbar_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: rfi_num_times_bar * num_local_freq * 3 * num_elements * sizeof_float
+    value_type: float32
+    extents: [rfi_num_times_bar, num_local_freq, 3, num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 simulated_rfi_skbartilde_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: rfi_num_times_bar * num_local_freq * 3 * sizeof_float
+    value_type: float32
+    extents: [rfi_num_times_bar, num_local_freq, 3]
     metadata_pool: main_pool
 
 simulated_rfi_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: samples_per_data_set * num_local_freq / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 1024, num_local_freq, 128]
     metadata_pool: main_pool
 
 

--- a/config/ci-tests/gpu_batch/verify_cuda_rfi_sktilde.yaml
+++ b/config/ci-tests/gpu_batch/verify_cuda_rfi_sktilde.yaml
@@ -50,45 +50,52 @@ main_pool:
 # Buffers
 
 host_bf_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: num_elements
+    value_type: int8
+    extents: [num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 host_rfi_s012_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / rfi_downsampling_factor) * num_local_freq * 3 * num_elements * sizeof_long
+    value_type: uint64
+    extents: [samples_per_data_set / rfi_downsampling_factor, num_local_freq, 3, num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 host_rfi_sktilde_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / rfi_downsampling_factor) * num_local_freq * 3 * sizeof_float
+    value_type: float32
+    extents: [samples_per_data_set / rfi_downsampling_factor, num_local_freq, 3]
     metadata_pool: main_pool
 
 host_rfi_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: samples_per_data_set * num_local_freq / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 1024, num_local_freq, 128]
     metadata_pool: main_pool
 
 simulated_rfi_sk_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / rfi_downsampling_factor) * num_local_freq * 3 * num_elements * sizeof_float
+    value_type: float32
+    extents: [samples_per_data_set / rfi_downsampling_factor, num_local_freq, 3, num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 simulated_rfi_sktilde_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / rfi_downsampling_factor) * num_local_freq * 3 * sizeof_float
+    value_type: float32
+    extents: [samples_per_data_set / rfi_downsampling_factor, num_local_freq, 3]
     metadata_pool: main_pool
 
 simulated_rfi_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: samples_per_data_set * num_local_freq / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 1024, num_local_freq, 128]
     metadata_pool: main_pool
 
 

--- a/config/ci-tests/gpu_batch/verify_fake_n2k.yaml
+++ b/config/ci-tests/gpu_batch/verify_fake_n2k.yaml
@@ -49,45 +49,52 @@ main_pool:
 
 # Buffers
 host_voltage_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: samples_per_data_set * num_local_freq * num_elements
+    value_type: int4x2_swapped_withoffset
+    extents: [samples_per_data_set, num_local_freq, num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 host_rfi_RFImask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: samples_per_data_set * num_local_freq / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 1024, num_local_freq, 128]
     metadata_pool: main_pool
 
 host_pl_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: ((samples_per_data_set / 2) * (num_local_freq / 4) * (num_elements / 8)) / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 128, num_local_freq / 4, num_polarizations, num_dishes / 8, 8]
     metadata_pool: main_pool
 
 host_correlation_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * vis_num_blocks * vis_blocksize * vis_blocksize * 2 * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, vis_num_blocks, vis_blocksize, vis_blocksize, 2]
     metadata_pool: main_pool
 
 host_counts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * counts_num_blocks * counts_blocksize * counts_blocksize * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, counts_num_blocks, counts_blocksize, counts_blocksize]
     metadata_pool: main_pool
 
 fake_correlation_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * vis_num_blocks * vis_blocksize * vis_blocksize * 2 * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, vis_num_blocks, vis_blocksize, vis_blocksize, 2]
     metadata_pool: main_pool
 
 fake_counts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * counts_num_blocks * counts_blocksize * counts_blocksize * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, counts_num_blocks, counts_blocksize, counts_blocksize]
     metadata_pool: main_pool
 
 # Ringbuffer signalling buffer

--- a/config/ci-tests/standalone/test_pipeline.j2
+++ b/config/ci-tests/standalone/test_pipeline.j2
@@ -147,39 +147,48 @@ n2_pool:
 
 # Buffers
 host_voltage_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: samples_per_data_set * num_elements * num_local_freq
+    value_type: int4x2_swapped_withoffset
+    extents: [samples_per_data_set, num_local_freq, num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 host_rfi_RFImask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: num_local_freq * samples_per_data_set / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 1024, num_local_freq, 128]
     metadata_pool: main_pool
 
 host_pl_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / 128) * (num_local_freq / 4) * 2 * (num_dishes / 8) * 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 128, num_local_freq / 4, num_polarizations, num_dishes / 8, 8]
     metadata_pool: main_pool
 
 vis_blocksize: 16
 vis_num_blocks_lin: num_elements / vis_blocksize
 vis_num_blocks: vis_num_blocks_lin * (vis_num_blocks_lin + 1) / 2
 host_correlation_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: num_local_freq * (samples_per_data_set / sub_integration_ntime) * 16 * 16 * vis_num_blocks * 2 * sizeof_gpu_int
+    value_type: int32
+    # num_elements=1024: cudaCorrelator (num_elements+1)/16=64 == N2Accumulate num_elements/16=64
+    # -> vis_num_blocks=2080 from both producer and consumer; safe to flip.
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, vis_num_blocks, vis_blocksize, vis_blocksize, 2]
     metadata_pool: main_pool
 
 counts_blocksize: 8
 counts_num_blocks_lin: (num_elements / 8) / counts_blocksize
 counts_num_blocks: (counts_num_blocks_lin * (counts_num_blocks_lin + 1)) / 2
 host_counts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * counts_num_blocks * counts_blocksize * counts_blocksize * sizeof_gpu_int
+    value_type: int32
+    # num_elements=1024: cudaPL1bitCorrelator (num_pol*num_dishes/8+1)/8=16 ==
+    # N2Accumulate num_elements/(8*counts_blocksize)=16 -> counts_num_blocks=136 from both; safe.
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, counts_num_blocks, counts_blocksize, counts_blocksize]
     metadata_pool: main_pool
 
 n2_buffer:
@@ -430,6 +439,7 @@ n2_accumulate:
     packet_loss_is_scalar: True
     num_subintegrations_per_bin: {{ num_subintegrations_per_bin }}
     input_order: CHORDBeamformer
+    variance_mode: EvenOddPosDef
 
 
 # Add eigen calculation

--- a/config/fengine/include/bb_charts.j2
+++ b/config/fengine/include/bb_charts.j2
@@ -21,27 +21,31 @@ bb_scale: 12
 # Buffers
 
 host_bb_beam_positions_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float32 * 2 * bb_num_beams
+    value_type: float32
+    extents: [bb_num_beams, 2]
     metadata_pool: main_pool
 
 host_bb_beam_ids_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_uint64 * bb_num_beams
+    value_type: uint64
+    extents: [bb_num_beams]
     metadata_pool: main_pool
 
 host_bb_phase_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: num_components * num_dishes * bb_num_beams * num_polarizations * num_frequencies
+    value_type: int8
+    extents: [num_frequencies, num_polarizations, bb_num_beams, num_dishes, num_components]
     metadata_pool: main_pool
 
 host_bb_shift_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_int32 * bb_num_beams * num_polarizations * num_frequencies
+    value_type: int32
+    extents: [num_frequencies, num_polarizations, bb_num_beams]
     metadata_pool: main_pool
 
 host_bb_beams_buffer:

--- a/config/fengine/include/bb_chime.j2
+++ b/config/fengine/include/bb_chime.j2
@@ -21,27 +21,31 @@ bb_scale: 12
 # Buffers
 
 host_bb_beam_positions_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float32 * 2 * bb_num_beams
+    value_type: float32
+    extents: [bb_num_beams, 2]
     metadata_pool: main_pool
 
 host_bb_beam_ids_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_uint64 * bb_num_beams
+    value_type: uint64
+    extents: [bb_num_beams]
     metadata_pool: main_pool
 
 host_bb_phase_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: num_components * num_dishes * bb_num_beams * num_polarizations * num_frequencies
+    value_type: int8
+    extents: [num_frequencies, num_polarizations, bb_num_beams, num_dishes, num_components]
     metadata_pool: main_pool
 
 host_bb_shift_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_int32 * bb_num_beams * num_polarizations * num_frequencies
+    value_type: int32
+    extents: [num_frequencies, num_polarizations, bb_num_beams]
     metadata_pool: main_pool
 
 host_bb_beams_buffer:

--- a/config/fengine/include/bb_chord.j2
+++ b/config/fengine/include/bb_chord.j2
@@ -21,27 +21,31 @@ bb_scale: 12
 # Buffers
 
 host_bb_beam_positions_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float32 * 2 * bb_num_beams
+    value_type: float32
+    extents: [bb_num_beams, 2]
     metadata_pool: main_pool
 
 host_bb_beam_ids_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_uint64 * bb_num_beams
+    value_type: uint64
+    extents: [bb_num_beams]
     metadata_pool: main_pool
 
 host_bb_phase_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: num_components * num_dishes * bb_num_beams * num_polarizations * num_frequencies
+    value_type: int8
+    extents: [num_frequencies, num_polarizations, bb_num_beams, num_dishes, num_components]
     metadata_pool: main_pool
 
 host_bb_shift_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_int32 * bb_num_beams * num_polarizations * num_frequencies
+    value_type: int32
+    extents: [num_frequencies, num_polarizations, bb_num_beams]
     metadata_pool: main_pool
 
 host_bb_beams_buffer:

--- a/config/fengine/include/bb_hirax.j2
+++ b/config/fengine/include/bb_hirax.j2
@@ -21,27 +21,31 @@ bb_scale: 12
 # Buffers
 
 host_bb_beam_positions_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float32 * 2 * bb_num_beams
+    value_type: float32
+    extents: [bb_num_beams, 2]
     metadata_pool: main_pool
 
 host_bb_beam_ids_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_uint64 * bb_num_beams
+    value_type: uint64
+    extents: [bb_num_beams]
     metadata_pool: main_pool
 
 host_bb_phase_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: num_components * num_dishes * bb_num_beams * num_polarizations * num_frequencies
+    value_type: int8
+    extents: [num_frequencies, num_polarizations, bb_num_beams, num_dishes, num_components]
     metadata_pool: main_pool
 
 host_bb_shift_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_int32 * bb_num_beams * num_polarizations * num_frequencies
+    value_type: int32
+    extents: [num_frequencies, num_polarizations, bb_num_beams]
     metadata_pool: main_pool
 
 host_bb_beams_buffer:

--- a/config/fengine/include/bb_pathfinder.j2
+++ b/config/fengine/include/bb_pathfinder.j2
@@ -21,27 +21,31 @@ bb_scale: 12
 # Buffers
 
 host_bb_beam_positions_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float32 * 2 * bb_num_beams
+    value_type: float32
+    extents: [bb_num_beams, 2]
     metadata_pool: main_pool
 
 host_bb_beam_ids_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_uint64 * bb_num_beams
+    value_type: uint64
+    extents: [bb_num_beams]
     metadata_pool: main_pool
 
 host_bb_phase_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: num_components * num_dishes * bb_num_beams * num_polarizations * num_frequencies
+    value_type: int8
+    extents: [num_frequencies, num_polarizations, bb_num_beams, num_dishes, num_components]
     metadata_pool: main_pool
 
 host_bb_shift_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_int32 * bb_num_beams * num_polarizations * num_frequencies
+    value_type: int32
+    extents: [num_frequencies, num_polarizations, bb_num_beams]
     metadata_pool: main_pool
 
 host_bb_beams_buffer:

--- a/config/fengine/include/fengine_charts.j2
+++ b/config/fengine/include/fengine_charts.j2
@@ -113,15 +113,17 @@ num_times: 16384                 # frame length is 16384 * 3.333 us = 54.613 ms
 # Buffers
 
 host_bf_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_int8 * num_dishes * num_polarizations
+    value_type: int8
+    extents: [num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 host_pl_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (64 / 8) * (num_dishes / 8) * num_polarizations * (num_frequencies / 4) * (num_times / 2 / 64)
+    value_type: uint1x8
+    extents: [num_times / 2 / 64, num_frequencies / 4, num_polarizations, num_dishes / 8, 64 / 8]
     metadata_pool: main_pool
 host_pl_mask_ringbuffer:
     kotekan_buffer: ring

--- a/config/fengine/include/fengine_chime.j2
+++ b/config/fengine/include/fengine_chime.j2
@@ -90,15 +90,17 @@ num_times: 16384                # frame length is 16384 * 2.56 us = 41.94304 ms
 # Buffers
 
 host_bf_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_int8 * num_dishes * num_polarizations
+    value_type: int8
+    extents: [num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 host_pl_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (64 / 8) * (num_dishes / 8) * num_polarizations * (num_frequencies / 4) * (num_times / 2 / 64)
+    value_type: uint1x8
+    extents: [num_times / 2 / 64, num_frequencies / 4, num_polarizations, num_dishes / 8, 64 / 8]
     metadata_pool: main_pool
 host_pl_mask_ringbuffer:
     kotekan_buffer: ring
@@ -106,9 +108,10 @@ host_pl_mask_ringbuffer:
     metadata_pool: main_pool
 
 host_pl_expanded_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (64 / 8) * (num_dishes / 8) * num_polarizations * num_frequencies * (num_times / 64)
+    value_type: uint1x8
+    extents: [num_times / 64, num_frequencies, num_polarizations, num_dishes / 8, 64 / 8]
     metadata_pool: main_pool
 host_pl_expanded_mask_ringbuffer:
     kotekan_buffer: ring
@@ -117,18 +120,21 @@ host_pl_expanded_mask_ringbuffer:
 
 host_voltage_buffers:
   num_frames: buffer_depth
-  frame_size: num_dishes * num_polarizations * num_times
+  value_type: int4x2_swapped_withoffset
+  extents: [1, num_times, num_polarizations * num_dishes]
+  dimnames: ["F", "T", "E"]
   metadata_pool: main_pool
   numa_0:
 {% for id in range(16) %}   # num_frequencies = 16
     host_voltage_buffer_{{ id }}:
-      kotekan_buffer: standard
+      kotekan_buffer: ndarray
 {% endfor %}
 
 host_voltage_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: num_dishes * num_polarizations * num_frequencies * num_times
+    value_type: int4x2_swapped_withoffset
+    extents: [num_times, num_frequencies, num_polarizations, num_dishes]
     metadata_pool: main_pool
 host_voltage_ringbuffer:
     kotekan_buffer: ring

--- a/config/fengine/include/fengine_chord.j2
+++ b/config/fengine/include/fengine_chord.j2
@@ -94,15 +94,17 @@ num_times: 8192                 # frame length is 8192 * 5.12 us = 41.94304 ms
 # Buffers
 
 host_bf_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_int8 * num_dishes * num_polarizations
+    value_type: int8
+    extents: [num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 host_pl_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (64 / 8) * (num_dishes / 8) * num_polarizations * (num_frequencies / 4) * (num_times / 2 / 64)
+    value_type: uint1x8
+    extents: [num_times / 2 / 64, num_frequencies / 4, num_polarizations, num_dishes / 8, 64 / 8]
     metadata_pool: main_pool
 host_pl_mask_ringbuffer:
     kotekan_buffer: ring
@@ -110,9 +112,10 @@ host_pl_mask_ringbuffer:
     metadata_pool: main_pool
 
 host_pl_expanded_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (64 / 8) * (num_dishes / 8) * num_polarizations * num_frequencies * (num_times / 64)
+    value_type: uint1x8
+    extents: [num_times / 64, num_frequencies, num_polarizations, num_dishes / 8, 64 / 8]
     metadata_pool: main_pool
 host_pl_expanded_mask_ringbuffer:
     kotekan_buffer: ring
@@ -120,9 +123,10 @@ host_pl_expanded_mask_ringbuffer:
     metadata_pool: main_pool
 
 host_voltage_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: num_dishes * num_polarizations * num_frequencies * num_times
+    value_type: int4x2_swapped_withoffset
+    extents: [num_times, num_frequencies, num_polarizations, num_dishes]
     metadata_pool: main_pool
 host_voltage_ringbuffer:
     kotekan_buffer: ring

--- a/config/fengine/include/fengine_hirax.j2
+++ b/config/fengine/include/fengine_hirax.j2
@@ -93,15 +93,17 @@ num_times: 16384                # frame length is 16384 * 2.56 us = 41.94304 ms
 # Buffers
 
 host_bf_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_int8 * num_dishes * num_polarizations
+    value_type: int8
+    extents: [num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 host_pl_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (64 / 8) * (num_dishes / 8) * num_polarizations * (num_frequencies / 4) * (num_times / 2 / 64)
+    value_type: uint1x8
+    extents: [num_times / 2 / 64, num_frequencies / 4, num_polarizations, num_dishes / 8, 64 / 8]
     metadata_pool: main_pool
 host_pl_mask_ringbuffer:
     kotekan_buffer: ring
@@ -109,9 +111,10 @@ host_pl_mask_ringbuffer:
     metadata_pool: main_pool
 
 host_pl_expanded_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (64 / 8) * (num_dishes / 8) * num_polarizations * num_frequencies * (num_times / 64)
+    value_type: uint1x8
+    extents: [num_times / 64, num_frequencies, num_polarizations, num_dishes / 8, 64 / 8]
     metadata_pool: main_pool
 host_pl_expanded_mask_ringbuffer:
     kotekan_buffer: ring
@@ -119,9 +122,10 @@ host_pl_expanded_mask_ringbuffer:
     metadata_pool: main_pool
 
 host_voltage_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: num_dishes * num_polarizations * num_frequencies * num_times
+    value_type: int4x2_swapped_withoffset
+    extents: [num_times, num_frequencies, num_polarizations, num_dishes]
     metadata_pool: main_pool
 host_voltage_ringbuffer:
     kotekan_buffer: ring

--- a/config/fengine/include/fengine_pathfinder.j2
+++ b/config/fengine/include/fengine_pathfinder.j2
@@ -126,15 +126,17 @@ num_times: 8192                 # frame length is 8192 * 5.12 us = 41.94304 ms
 # Buffers
 
 host_bf_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_int8 * num_dishes * num_polarizations
+    value_type: int8
+    extents: [num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 host_pl_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (64 / 8) * (num_dishes / 8) * num_polarizations * (num_frequencies / 4) * (num_times / 2 / 64)
+    value_type: uint1x8
+    extents: [num_times / 2 / 64, num_frequencies / 4, num_polarizations, num_dishes / 8, 64 / 8]
     metadata_pool: main_pool
 host_pl_mask_ringbuffer:
     kotekan_buffer: ring
@@ -142,9 +144,10 @@ host_pl_mask_ringbuffer:
     metadata_pool: main_pool
 
 host_pl_expanded_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (64 / 8) * (num_dishes / 8) * num_polarizations * num_frequencies * (num_times / 64)
+    value_type: uint1x8
+    extents: [num_times / 64, num_frequencies, num_polarizations, num_dishes / 8, 64 / 8]
     metadata_pool: main_pool
 host_pl_expanded_mask_ringbuffer:
     kotekan_buffer: ring
@@ -152,9 +155,10 @@ host_pl_expanded_mask_ringbuffer:
     metadata_pool: main_pool
 
 host_voltage_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: num_dishes * num_polarizations * num_frequencies * num_times
+    value_type: int4x2_swapped_withoffset
+    extents: [num_times, num_frequencies, num_polarizations, num_dishes]
     metadata_pool: main_pool
 host_voltage_ringbuffer:
     kotekan_buffer: ring

--- a/config/fengine/include/frb_charts.j2
+++ b/config/fengine/include/frb_charts.j2
@@ -25,27 +25,31 @@ frb_chunk_size: 256
 # Phases
 
 host_frb1_U32_phase_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * num_components * num_dishes_y * num_dishes_x * upchan_U32_max_num_channels * 32 * num_polarizations
+    value_type: float16
+    extents: [upchan_U32_max_num_channels * 32, num_polarizations, num_dishes_y, num_dishes_x, num_components]
     metadata_pool: main_pool
 
 host_frb2_beam_positions_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float32 * 2 * frb2_num_beams
+    value_type: float32
+    extents: [frb2_num_beams, 2]
     metadata_pool: main_pool
 
 host_frb2_beam_ids_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_uint64 * frb2_num_beams
+    value_type: uint64
+    extents: [frb2_num_beams]
     metadata_pool: main_pool
 
 host_frb2_weights_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * (2 * num_dishes_y) * (2 * num_dishes_x) * (frb2_num_beams_x * frb2_num_beams_y) * (upchan_all_max_output_channel - upchan_all_min_output_channel)
+    value_type: float16
+    extents: [upchan_all_max_output_channel - upchan_all_min_output_channel, frb2_num_beams, frb1_num_beams_Q, frb1_num_beams_P]
     metadata_pool: main_pool
 
 # Beams

--- a/config/fengine/include/frb_chime.j2
+++ b/config/fengine/include/frb_chime.j2
@@ -26,27 +26,31 @@ frb_chunk_size: 256
 # Phases
 
 host_frb1_U16_phase_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * num_components * num_dishes_y * num_dishes_x * upchan_U16_max_num_channels * 16 * num_polarizations
+    value_type: float16
+    extents: [upchan_U16_max_num_channels * 16, num_polarizations, num_dishes_x, num_dishes_y, num_components]
     metadata_pool: main_pool
 
 host_frb2_beam_positions_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float32 * 2 * frb2_num_beams
+    value_type: float32
+    extents: [frb2_num_beams, 2]
     metadata_pool: main_pool
 
 host_frb2_beam_ids_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_uint64 * frb2_num_beams
+    value_type: uint64
+    extents: [frb2_num_beams]
     metadata_pool: main_pool
 
 host_frb2_weights_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * (2 * num_dishes_y) * (2 * num_dishes_x) * (frb2_num_beams_x * frb2_num_beams_y) * (upchan_U16_max_output_channel - upchan_U16_min_output_channel)
+    value_type: float16
+    extents: [upchan_U16_max_output_channel - upchan_U16_min_output_channel, frb2_num_beams, frb1_num_beams_Q, frb1_num_beams_P]
     metadata_pool: main_pool
 
 # Beams

--- a/config/fengine/include/frb_chord.j2
+++ b/config/fengine/include/frb_chord.j2
@@ -25,63 +25,73 @@ frb_chunk_size: 256
 # Phases
 
 host_frb1_U1_phase_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * num_components * num_dishes_y * num_dishes_x * upchan_U1_max_num_channels * 1 * num_polarizations
+    value_type: float16
+    extents: [upchan_U1_max_num_channels * 1, num_polarizations, num_dishes_y, num_dishes_x, num_components]
     metadata_pool: main_pool
 
 host_frb1_U2_phase_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * num_components * num_dishes_y * num_dishes_x * upchan_U2_max_num_channels * 2 * num_polarizations
+    value_type: float16
+    extents: [upchan_U2_max_num_channels * 2, num_polarizations, num_dishes_y, num_dishes_x, num_components]
     metadata_pool: main_pool
 
 host_frb1_U4_phase_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * num_components * num_dishes_y * num_dishes_x * upchan_U4_max_num_channels * 4 * num_polarizations
+    value_type: float16
+    extents: [upchan_U4_max_num_channels * 4, num_polarizations, num_dishes_y, num_dishes_x, num_components]
     metadata_pool: main_pool
 
 host_frb1_U8_phase_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * num_components * num_dishes_y * num_dishes_x * upchan_U8_max_num_channels * 8 * num_polarizations
+    value_type: float16
+    extents: [upchan_U8_max_num_channels * 8, num_polarizations, num_dishes_y, num_dishes_x, num_components]
     metadata_pool: main_pool
 
 host_frb1_U16_phase_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * num_components * num_dishes_y * num_dishes_x * upchan_U16_max_num_channels * 16 * num_polarizations
+    value_type: float16
+    extents: [upchan_U16_max_num_channels * 16, num_polarizations, num_dishes_y, num_dishes_x, num_components]
     metadata_pool: main_pool
 
 host_frb1_U32_phase_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * num_components * num_dishes_y * num_dishes_x * upchan_U32_max_num_channels * 32 * num_polarizations
+    value_type: float16
+    extents: [upchan_U32_max_num_channels * 32, num_polarizations, num_dishes_y, num_dishes_x, num_components]
     metadata_pool: main_pool
 
 host_frb1_U64_phase_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * num_components * num_dishes_y * num_dishes_x * upchan_U64_max_num_channels * 64 * num_polarizations
+    value_type: float16
+    extents: [upchan_U64_max_num_channels * 64, num_polarizations, num_dishes_y, num_dishes_x, num_components]
     metadata_pool: main_pool
 
 host_frb2_beam_positions_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float32 * 2 * frb2_num_beams
+    value_type: float32
+    extents: [frb2_num_beams, 2]
     metadata_pool: main_pool
 
 host_frb2_beam_ids_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_uint64 * frb2_num_beams
+    value_type: uint64
+    extents: [frb2_num_beams]
     metadata_pool: main_pool
 
 host_frb2_weights_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * (2 * num_dishes_y) * (2 * num_dishes_x) * (frb2_num_beams_x * frb2_num_beams_y) * (upchan_all_max_output_channel - upchan_all_min_output_channel)
+    value_type: float16
+    extents: [upchan_all_max_output_channel - upchan_all_min_output_channel, frb2_num_beams, frb1_num_beams_Q, frb1_num_beams_P]
     metadata_pool: main_pool
 
 # Beams

--- a/config/fengine/include/frb_hirax.j2
+++ b/config/fengine/include/frb_hirax.j2
@@ -25,39 +25,45 @@ frb_chunk_size: 256
 # Phases
 
 host_frb1_U8_phase_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * num_components * num_dishes_y * num_dishes_x * upchan_U8_max_num_channels * 8 * num_polarizations
+    value_type: float16
+    extents: [upchan_U8_max_num_channels * 8, num_polarizations, num_dishes_y, num_dishes_x, num_components]
     metadata_pool: main_pool
 
 host_frb1_U16_phase_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * num_components * num_dishes_y * num_dishes_x * upchan_U16_max_num_channels * 16 * num_polarizations
+    value_type: float16
+    extents: [upchan_U16_max_num_channels * 16, num_polarizations, num_dishes_y, num_dishes_x, num_components]
     metadata_pool: main_pool
 
 host_frb1_U32_phase_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * num_components * num_dishes_y * num_dishes_x * upchan_U32_max_num_channels * 32 * num_polarizations
+    value_type: float16
+    extents: [upchan_U32_max_num_channels * 32, num_polarizations, num_dishes_y, num_dishes_x, num_components]
     metadata_pool: main_pool
 
 host_frb2_beam_positions_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float32 * 2 * frb2_num_beams
+    value_type: float32
+    extents: [frb2_num_beams, 2]
     metadata_pool: main_pool
 
 host_frb2_beam_ids_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_uint64 * frb2_num_beams
+    value_type: uint64
+    extents: [frb2_num_beams]
     metadata_pool: main_pool
 
 host_frb2_weights_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * (2 * num_dishes_y) * (2 * num_dishes_x) * (frb2_num_beams_x * frb2_num_beams_y) * (upchan_all_max_output_channel - upchan_all_min_output_channel)
+    value_type: float16
+    extents: [upchan_all_max_output_channel - upchan_all_min_output_channel, frb2_num_beams, frb1_num_beams_Q, frb1_num_beams_P]
     metadata_pool: main_pool
 
 # Beams

--- a/config/fengine/include/frb_pathfinder.j2
+++ b/config/fengine/include/frb_pathfinder.j2
@@ -25,63 +25,73 @@ frb_chunk_size: 256
 # Phases
 
 host_frb1_U1_phase_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * num_components * num_dishes_y * num_dishes_x * upchan_U1_max_num_channels * 1 * num_polarizations
+    value_type: float16
+    extents: [upchan_U1_max_num_channels * 1, num_polarizations, num_dishes_y, num_dishes_x, num_components]
     metadata_pool: main_pool
 
 host_frb1_U2_phase_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * num_components * num_dishes_y * num_dishes_x * upchan_U2_max_num_channels * 2 * num_polarizations
+    value_type: float16
+    extents: [upchan_U2_max_num_channels * 2, num_polarizations, num_dishes_y, num_dishes_x, num_components]
     metadata_pool: main_pool
 
 host_frb1_U4_phase_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * num_components * num_dishes_y * num_dishes_x * upchan_U4_max_num_channels * 4 * num_polarizations
+    value_type: float16
+    extents: [upchan_U4_max_num_channels * 4, num_polarizations, num_dishes_y, num_dishes_x, num_components]
     metadata_pool: main_pool
 
 host_frb1_U8_phase_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * num_components * num_dishes_y * num_dishes_x * upchan_U8_max_num_channels * 8 * num_polarizations
+    value_type: float16
+    extents: [upchan_U8_max_num_channels * 8, num_polarizations, num_dishes_y, num_dishes_x, num_components]
     metadata_pool: main_pool
 
 host_frb1_U16_phase_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * num_components * num_dishes_y * num_dishes_x * upchan_U16_max_num_channels * 16 * num_polarizations
+    value_type: float16
+    extents: [upchan_U16_max_num_channels * 16, num_polarizations, num_dishes_y, num_dishes_x, num_components]
     metadata_pool: main_pool
 
 host_frb1_U32_phase_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * num_components * num_dishes_y * num_dishes_x * upchan_U32_max_num_channels * 32 * num_polarizations
+    value_type: float16
+    extents: [upchan_U32_max_num_channels * 32, num_polarizations, num_dishes_y, num_dishes_x, num_components]
     metadata_pool: main_pool
 
 host_frb1_U64_phase_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * num_components * num_dishes_y * num_dishes_x * upchan_U64_max_num_channels * 64 * num_polarizations
+    value_type: float16
+    extents: [upchan_U64_max_num_channels * 64, num_polarizations, num_dishes_y, num_dishes_x, num_components]
     metadata_pool: main_pool
 
 host_frb2_beam_positions_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float32 * 2 * frb2_num_beams
+    value_type: float32
+    extents: [frb2_num_beams, 2]
     metadata_pool: main_pool
 
 host_frb2_beam_ids_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_uint64 * frb2_num_beams
+    value_type: uint64
+    extents: [frb2_num_beams]
     metadata_pool: main_pool
 
 host_frb2_weights_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * (2 * num_dishes_y) * (2 * num_dishes_x) * (frb2_num_beams_x * frb2_num_beams_y) * (upchan_all_max_output_channel - upchan_all_min_output_channel)
+    value_type: float16
+    extents: [upchan_all_max_output_channel - upchan_all_min_output_channel, frb2_num_beams, frb1_num_beams_Q, frb1_num_beams_P]
     metadata_pool: main_pool
 
 # Beams

--- a/config/fengine/include/hfb_chime.j2
+++ b/config/fengine/include/hfb_chime.j2
@@ -21,27 +21,31 @@ hfb2_beam_separation_y: 90.0 / 256
 # Phases
 
 host_hfb1_U128_phase_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * num_components * num_dishes_y * num_dishes_x * upchan_hfb_upchan_U128_max_num_channels * 128 * num_polarizations
+    value_type: float16
+    extents: [upchan_hfb_upchan_U128_max_num_channels * 128, num_polarizations, num_dishes_x, num_dishes_y, num_components]
     metadata_pool: main_pool
 
 host_hfb2_beam_positions_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float32 * 2 * hfb2_num_beams
+    value_type: float32
+    extents: [hfb2_num_beams, 2]
     metadata_pool: main_pool
 
 host_hfb2_beam_ids_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_uint64 * hfb2_num_beams
+    value_type: uint64
+    extents: [hfb2_num_beams]
     metadata_pool: main_pool
 
 host_hfb2_weights_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * (2 * num_dishes_y) * (2 * num_dishes_x) * (hfb2_num_beams_x * hfb2_num_beams_y) * upchan_hfb_upchan_U128_max_num_output_channels
+    value_type: float16
+    extents: [upchan_hfb_upchan_U128_max_num_output_channels, hfb2_num_beams, frb1_num_beams_Q, frb1_num_beams_P]
     metadata_pool: main_pool
 
 # Beams

--- a/config/fengine/include/n2k_charts.j2
+++ b/config/fengine/include/n2k_charts.j2
@@ -28,33 +28,38 @@ n2k_counts_triangle_num_blocks: n2k_counts_linear_num_blocks * (n2k_counts_linea
 n2k_counts_triangle_size: n2k_counts_blocksize * n2k_counts_blocksize * n2k_counts_triangle_num_blocks
 
 host_n2k_correlation_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: sizeof_int32 * num_components * n2k_correlation_triangle_size * num_frequencies * n2k_num_subintegrations
+    value_type: int32
+    extents: [n2k_num_subintegrations, num_frequencies, n2k_correlation_triangle_num_blocks, n2k_correlation_blocksize, n2k_correlation_blocksize, 2]
     metadata_pool: main_pool
 
 host_n2k_counts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: sizeof_int32 * n2k_counts_triangle_size * num_frequencies * n2k_num_subintegrations
+    value_type: int32
+    extents: [n2k_num_subintegrations, num_frequencies, n2k_counts_triangle_num_blocks, n2k_counts_blocksize, n2k_counts_blocksize]
     metadata_pool: main_pool
 
 host_n2k_plcounts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: sizeof_int32 * num_frequencies * n2k_num_subintegrations
+    value_type: int32
+    extents: [n2k_num_subintegrations, num_frequencies]
     metadata_pool: main_pool
 
 host_n2k_rficounts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: sizeof_int32 * num_frequencies * n2k_num_subintegrations
+    value_type: int32
+    extents: [n2k_num_subintegrations, num_frequencies]
     metadata_pool: main_pool
 
 host_n2k_rfiframemask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: sizeof_uint8 * num_frequencies * n2k_num_subintegrations
+    value_type: uint8
+    extents: [n2k_num_subintegrations, num_frequencies]
     metadata_pool: main_pool
 
 host_n2_vis_buffer:

--- a/config/fengine/include/n2k_chime.j2
+++ b/config/fengine/include/n2k_chime.j2
@@ -28,33 +28,38 @@ n2k_counts_triangle_num_blocks: n2k_counts_linear_num_blocks * (n2k_counts_linea
 n2k_counts_triangle_size: n2k_counts_blocksize * n2k_counts_blocksize * n2k_counts_triangle_num_blocks
 
 host_n2k_correlation_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: sizeof_int32 * num_components * n2k_correlation_triangle_size * num_frequencies * n2k_num_subintegrations
+    value_type: int32
+    extents: [n2k_num_subintegrations, num_frequencies, n2k_correlation_triangle_num_blocks, n2k_correlation_blocksize, n2k_correlation_blocksize, 2]
     metadata_pool: main_pool
 
 host_n2k_counts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: sizeof_int32 * n2k_counts_triangle_size * num_frequencies * n2k_num_subintegrations
+    value_type: int32
+    extents: [n2k_num_subintegrations, num_frequencies, n2k_counts_triangle_num_blocks, n2k_counts_blocksize, n2k_counts_blocksize]
     metadata_pool: main_pool
 
 host_n2k_plcounts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: sizeof_int32 * num_frequencies * n2k_num_subintegrations
+    value_type: int32
+    extents: [n2k_num_subintegrations, num_frequencies]
     metadata_pool: main_pool
 
 host_n2k_rficounts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: sizeof_int32 * num_frequencies * n2k_num_subintegrations
+    value_type: int32
+    extents: [n2k_num_subintegrations, num_frequencies]
     metadata_pool: main_pool
 
 host_n2k_rfiframemask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: sizeof_uint8 * num_frequencies * n2k_num_subintegrations
+    value_type: uint8
+    extents: [n2k_num_subintegrations, num_frequencies]
     metadata_pool: main_pool
 
 host_n2_vis_buffer:

--- a/config/fengine/include/n2k_chord.j2
+++ b/config/fengine/include/n2k_chord.j2
@@ -28,33 +28,38 @@ n2k_counts_triangle_num_blocks: n2k_counts_linear_num_blocks * (n2k_counts_linea
 n2k_counts_triangle_size: n2k_counts_blocksize * n2k_counts_blocksize * n2k_counts_triangle_num_blocks
 
 host_n2k_correlation_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: sizeof_int32 * num_components * n2k_correlation_triangle_size * num_frequencies * n2k_num_subintegrations
+    value_type: int32
+    extents: [n2k_num_subintegrations, num_frequencies, n2k_correlation_triangle_num_blocks, n2k_correlation_blocksize, n2k_correlation_blocksize, 2]
     metadata_pool: main_pool
 
 host_n2k_counts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: sizeof_int32 * n2k_counts_triangle_size * num_frequencies * n2k_num_subintegrations
+    value_type: int32
+    extents: [n2k_num_subintegrations, num_frequencies, n2k_counts_triangle_num_blocks, n2k_counts_blocksize, n2k_counts_blocksize]
     metadata_pool: main_pool
 
 host_n2k_plcounts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: sizeof_int32 * num_frequencies * n2k_num_subintegrations
+    value_type: int32
+    extents: [n2k_num_subintegrations, num_frequencies]
     metadata_pool: main_pool
 
 host_n2k_rficounts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: sizeof_int32 * num_frequencies * n2k_num_subintegrations
+    value_type: int32
+    extents: [n2k_num_subintegrations, num_frequencies]
     metadata_pool: main_pool
 
 host_n2k_rfiframemask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: sizeof_uint8 * num_frequencies * n2k_num_subintegrations
+    value_type: uint8
+    extents: [n2k_num_subintegrations, num_frequencies]
     metadata_pool: main_pool
 
 host_n2_vis_buffer:

--- a/config/fengine/include/n2k_hirax.j2
+++ b/config/fengine/include/n2k_hirax.j2
@@ -28,33 +28,38 @@ n2k_counts_triangle_num_blocks: n2k_counts_linear_num_blocks * (n2k_counts_linea
 n2k_counts_triangle_size: n2k_counts_blocksize * n2k_counts_blocksize * n2k_counts_triangle_num_blocks
 
 host_n2k_correlation_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_int32 * num_components * n2k_correlation_triangle_size * num_frequencies * n2k_num_subintegrations
+    value_type: int32
+    extents: [n2k_num_subintegrations, num_frequencies, n2k_correlation_triangle_num_blocks, n2k_correlation_blocksize, n2k_correlation_blocksize, 2]
     metadata_pool: main_pool
 
 host_n2k_counts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_int32 * n2k_counts_triangle_size * num_frequencies * n2k_num_subintegrations
+    value_type: int32
+    extents: [n2k_num_subintegrations, num_frequencies, n2k_counts_triangle_num_blocks, n2k_counts_blocksize, n2k_counts_blocksize]
     metadata_pool: main_pool
 
 host_n2k_plcounts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: sizeof_int32 * num_frequencies * n2k_num_subintegrations
+    value_type: int32
+    extents: [n2k_num_subintegrations, num_frequencies]
     metadata_pool: main_pool
 
 host_n2k_rficounts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: sizeof_int32 * num_frequencies * n2k_num_subintegrations
+    value_type: int32
+    extents: [n2k_num_subintegrations, num_frequencies]
     metadata_pool: main_pool
 
 host_n2k_rfiframemask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: sizeof_uint8 * num_frequencies * n2k_num_subintegrations
+    value_type: uint8
+    extents: [n2k_num_subintegrations, num_frequencies]
     metadata_pool: main_pool
 
 host_n2_vis_buffer:

--- a/config/fengine/include/n2k_pathfinder.j2
+++ b/config/fengine/include/n2k_pathfinder.j2
@@ -28,33 +28,38 @@ n2k_counts_triangle_num_blocks: n2k_counts_linear_num_blocks * (n2k_counts_linea
 n2k_counts_triangle_size: n2k_counts_blocksize * n2k_counts_blocksize * n2k_counts_triangle_num_blocks
 
 host_n2k_correlation_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: sizeof_int32 * num_components * n2k_correlation_triangle_size * num_frequencies * n2k_num_subintegrations
+    value_type: int32
+    extents: [n2k_num_subintegrations, num_frequencies, n2k_correlation_triangle_num_blocks, n2k_correlation_blocksize, n2k_correlation_blocksize, 2]
     metadata_pool: main_pool
 
 host_n2k_counts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: sizeof_int32 * n2k_counts_triangle_size * num_frequencies * n2k_num_subintegrations
+    value_type: int32
+    extents: [n2k_num_subintegrations, num_frequencies, n2k_counts_triangle_num_blocks, n2k_counts_blocksize, n2k_counts_blocksize]
     metadata_pool: main_pool
 
 host_n2k_plcounts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: sizeof_int32 * num_frequencies * n2k_num_subintegrations
+    value_type: int32
+    extents: [n2k_num_subintegrations, num_frequencies]
     metadata_pool: main_pool
 
 host_n2k_rficounts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: sizeof_int32 * num_frequencies * n2k_num_subintegrations
+    value_type: int32
+    extents: [n2k_num_subintegrations, num_frequencies]
     metadata_pool: main_pool
 
 host_n2k_rfiframemask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: sizeof_uint8 * num_frequencies * n2k_num_subintegrations
+    value_type: uint8
+    extents: [n2k_num_subintegrations, num_frequencies]
     metadata_pool: main_pool
 
 host_n2_vis_buffer:

--- a/config/fengine/include/n2k_smallfinder.j2
+++ b/config/fengine/include/n2k_smallfinder.j2
@@ -28,15 +28,17 @@ n2k_counts_triangle_num_blocks: n2k_counts_linear_num_blocks * (n2k_counts_linea
 n2k_counts_triangle_size: n2k_counts_blocksize * n2k_counts_blocksize * n2k_counts_triangle_num_blocks
 
 host_n2k_correlation_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_int32 * num_components * n2k_correlation_triangle_size * num_frequencies * n2k_num_subintegrations
+    value_type: int32
+    extents: [n2k_num_subintegrations, num_frequencies, n2k_correlation_triangle_num_blocks, n2k_correlation_blocksize, n2k_correlation_blocksize, 2]
     metadata_pool: main_pool
 
 host_n2k_counts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_int32 * n2k_counts_triangle_size * num_frequencies * n2k_num_subintegrations
+    value_type: int32
+    extents: [n2k_num_subintegrations, num_frequencies, n2k_counts_triangle_num_blocks, n2k_counts_blocksize, n2k_counts_blocksize]
     metadata_pool: main_pool
 
 ################################################################################

--- a/config/fengine/include/rfi_charts.j2
+++ b/config/fengine/include/rfi_charts.j2
@@ -74,12 +74,10 @@ host_rfi_S012tilde_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_SKtilde_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_float32 * 3 * num_frequencies * rfi_num_times
-    type: float32
-    dimnames: ["Trfi", "F", "S"]
-    shape: [rfi_num_times, num_frequencies, 3]
+    value_type: float32
+    extents: [rfi_num_times, num_frequencies, 3]
     metadata_pool: main_pool
 host_rfi_SKtilde_ringbuffer:
     kotekan_buffer: ring
@@ -91,12 +89,10 @@ host_rfi_SKtilde_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_RFImask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: num_frequencies * num_times / 8
-    type: uint1x8
-    dimnames: ["T8hi128", "F", "T8lo128"]
-    shape: [num_times / 8 / 128, num_frequencies, 128]
+    value_type: uint1x8
+    extents: [num_times / 8 / 128, num_frequencies, 128]
     metadata_pool: main_pool
 host_rfi_RFImask_ringbuffer:
     kotekan_buffer: ring

--- a/config/fengine/include/rfi_chime.j2
+++ b/config/fengine/include/rfi_chime.j2
@@ -26,12 +26,10 @@ rfi_num_times: 32               # 1.31072 ms cadence
 rfi_num_times_bar: 1            # 41.94304 ms cadence
 
 host_rfi_S012_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_uint64 * num_dishes * num_polarizations * 3 * num_frequencies * rfi_num_times
-    type: uint64
-    dimnames: ["Trfi", "F", "S", "P", "D"]
-    shape: [rfi_num_times, num_frequencies, 3, num_polarizations, num_dishes]
+    value_type: uint64
+    extents: [rfi_num_times, num_frequencies, 3, num_polarizations, num_dishes]
     metadata_pool: main_pool
 host_rfi_S012_ringbuffer:
     kotekan_buffer: ring
@@ -43,12 +41,10 @@ host_rfi_S012_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_S012bar_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_uint64 * num_dishes * num_polarizations * 3 * num_frequencies * rfi_num_times_bar
-    type: uint64
-    dimnames: ["Trfibar", "F", "S", "P", "D"]
-    shape: [rfi_num_times_bar, num_frequencies, 3, num_polarizations, num_dishes]
+    value_type: uint64
+    extents: [rfi_num_times_bar, num_frequencies, 3, num_polarizations, num_dishes]
     metadata_pool: main_pool
 host_rfi_S012bar_ringbuffer:
     kotekan_buffer: ring
@@ -60,12 +56,10 @@ host_rfi_S012bar_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_S012tilde_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_uint64 * 3 * num_frequencies * rfi_num_times
-    type: uint64
-    dimnames: ["Trfi", "F", "S"]
-    shape: [rfi_num_times, num_frequencies, 3]
+    value_type: uint64
+    extents: [rfi_num_times, num_frequencies, 3]
     metadata_pool: main_pool
 host_rfi_S012tilde_ringbuffer:
     kotekan_buffer: ring
@@ -77,12 +71,10 @@ host_rfi_S012tilde_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_SKtilde_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_float32 * 3 * num_frequencies * rfi_num_times
-    type: float32
-    dimnames: ["Trfi", "F", "S"]
-    shape: [rfi_num_times, num_frequencies, 3]
+    value_type: float32
+    extents: [rfi_num_times, num_frequencies, 3]
     metadata_pool: main_pool
 host_rfi_SKtilde_ringbuffer:
     kotekan_buffer: ring
@@ -94,12 +86,10 @@ host_rfi_SKtilde_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_RFImask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: num_frequencies * num_times / 8
-    type: uint1x8
-    dimnames: ["T8hi128", "F", "T8lo128"]
-    shape: [num_times / 8 / 128, num_frequencies, 128]
+    value_type: uint1x8
+    extents: [num_times / 8 / 128, num_frequencies, 128]
     metadata_pool: main_pool
 host_rfi_RFImask_ringbuffer:
     kotekan_buffer: ring
@@ -111,12 +101,10 @@ host_rfi_RFImask_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_SKbar_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_float32 * num_dishes * num_polarizations * 3 * num_frequencies * rfi_num_times_bar
-    type: float32
-    dimnames: ["Trfi", "F", "S", "P", "D"]
-    shape: [rfi_num_times_bar, num_frequencies, 3, num_polarizaions, num_dishes]
+    value_type: float32
+    extents: [rfi_num_times_bar, num_frequencies, 3, num_polarizations, num_dishes]
     metadata_pool: main_pool
 host_rfi_SKbar_ringbuffer:
     kotekan_buffer: ring
@@ -128,12 +116,10 @@ host_rfi_SKbar_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_SKbartilde_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_float32 * 3 * num_frequencies * rfi_num_times_bar
-    type: float32
-    dimnames: ["Trfi", "F", "S"]
-    shape: [rfi_num_times_bar, num_frequencies, 3]
+    value_type: float32
+    extents: [rfi_num_times_bar, num_frequencies, 3]
     metadata_pool: main_pool
 host_rfi_SKbartilde_ringbuffer:
     kotekan_buffer: ring

--- a/config/fengine/include/rfi_chord.j2
+++ b/config/fengine/include/rfi_chord.j2
@@ -25,12 +25,10 @@ rfi_num_times: 32               # 1.31072 ms cadence
 rfi_num_times_bar: 1            # 41.94304 ms cadence
 
 host_rfi_S012_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_uint64 * num_dishes * num_polarizations * 3 * num_frequencies * rfi_num_times
-    type: uint64
-    dimnames: ["Trfi", "F", "S", "P", "D"]
-    shape: [rfi_num_times, num_frequencies, 3, num_polarizations, num_dishes]
+    value_type: uint64
+    extents: [rfi_num_times, num_frequencies, 3, num_polarizations, num_dishes]
     metadata_pool: main_pool
 host_rfi_S012_ringbuffer:
     kotekan_buffer: ring
@@ -42,12 +40,10 @@ host_rfi_S012_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_S012bar_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_uint64 * num_dishes * num_polarizations * 3 * num_frequencies * rfi_num_times_bar
-    type: uint64
-    dimnames: ["Trfibar", "F", "S", "P", "D"]
-    shape: [rfi_num_times_bar, num_frequencies, 3, num_polarizations, num_dishes]
+    value_type: uint64
+    extents: [rfi_num_times_bar, num_frequencies, 3, num_polarizations, num_dishes]
     metadata_pool: main_pool
 host_rfi_S012bar_ringbuffer:
     kotekan_buffer: ring
@@ -59,12 +55,10 @@ host_rfi_S012bar_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_S012tilde_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_uint64 * 3 * num_frequencies * rfi_num_times
-    type: uint64
-    dimnames: ["Trfi", "F", "S"]
-    shape: [rfi_num_times, num_frequencies, 3]
+    value_type: uint64
+    extents: [rfi_num_times, num_frequencies, 3]
     metadata_pool: main_pool
 host_rfi_S012tilde_ringbuffer:
     kotekan_buffer: ring
@@ -76,12 +70,10 @@ host_rfi_S012tilde_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_SKtilde_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_float32 * 3 * num_frequencies * rfi_num_times
-    type: float32
-    dimnames: ["Trfi", "F", "S"]
-    shape: [rfi_num_times, num_frequencies, 3]
+    value_type: float32
+    extents: [rfi_num_times, num_frequencies, 3]
     metadata_pool: main_pool
 host_rfi_SKtilde_ringbuffer:
     kotekan_buffer: ring
@@ -93,12 +85,10 @@ host_rfi_SKtilde_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_RFImask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: num_frequencies * num_times / 8
-    type: uint1x8
-    dimnames: ["T8hi128", "F", "T8lo128"]
-    shape: [num_times / 8 / 128, num_frequencies, 128]
+    value_type: uint1x8
+    extents: [num_times / 8 / 128, num_frequencies, 128]
     metadata_pool: main_pool
 host_rfi_RFImask_ringbuffer:
     kotekan_buffer: ring
@@ -110,12 +100,10 @@ host_rfi_RFImask_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_SKbar_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_float32 * num_dishes * num_polarizations * 3 * num_frequencies * rfi_num_times_bar
-    type: float32
-    dimnames: ["Trfi", "F", "S", "P", "D"]
-    shape: [rfi_num_times_bar, num_frequencies, 3, num_polarizaions, num_dishes]
+    value_type: float32
+    extents: [rfi_num_times_bar, num_frequencies, 3, num_polarizations, num_dishes]
     metadata_pool: main_pool
 host_rfi_SKbar_ringbuffer:
     kotekan_buffer: ring
@@ -127,12 +115,10 @@ host_rfi_SKbar_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_SKbartilde_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_float32 * 3 * num_frequencies * rfi_num_times_bar
-    type: float32
-    dimnames: ["Trfi", "F", "S"]
-    shape: [rfi_num_times_bar, num_frequencies, 3]
+    value_type: float32
+    extents: [rfi_num_times_bar, num_frequencies, 3]
     metadata_pool: main_pool
 host_rfi_SKbartilde_ringbuffer:
     kotekan_buffer: ring

--- a/config/fengine/include/rfi_hirax.j2
+++ b/config/fengine/include/rfi_hirax.j2
@@ -25,12 +25,10 @@ rfi_num_times: 32               # 1.31072 ms cadence
 rfi_num_times_bar: 1            # 41.94304 ms cadence
 
 host_rfi_S012_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_uint64 * num_dishes * num_polarizations * 3 * num_frequencies * rfi_num_times
-    type: uint64
-    dimnames: ["Trfi", "F", "S", "P", "D"]
-    shape: [rfi_num_times, num_frequencies, 3, num_polarizations, num_dishes]
+    value_type: uint64
+    extents: [rfi_num_times, num_frequencies, 3, num_polarizations, num_dishes]
     metadata_pool: main_pool
 host_rfi_S012_ringbuffer:
     kotekan_buffer: ring
@@ -42,12 +40,10 @@ host_rfi_S012_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_S012bar_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_uint64 * num_dishes * num_polarizations * 3 * num_frequencies * rfi_num_times_bar
-    type: uint64
-    dimnames: ["Trfibar", "F", "S", "P", "D"]
-    shape: [rfi_num_times_bar, num_frequencies, 3, num_polarizations, num_dishes]
+    value_type: uint64
+    extents: [rfi_num_times_bar, num_frequencies, 3, num_polarizations, num_dishes]
     metadata_pool: main_pool
 host_rfi_S012bar_ringbuffer:
     kotekan_buffer: ring
@@ -59,12 +55,10 @@ host_rfi_S012bar_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_S012tilde_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_uint64 * 3 * num_frequencies * rfi_num_times
-    type: uint64
-    dimnames: ["Trfi", "F", "S"]
-    shape: [rfi_num_times, num_frequencies, 3]
+    value_type: uint64
+    extents: [rfi_num_times, num_frequencies, 3]
     metadata_pool: main_pool
 host_rfi_S012tilde_ringbuffer:
     kotekan_buffer: ring
@@ -76,12 +70,10 @@ host_rfi_S012tilde_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_SKtilde_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_float32 * 3 * num_frequencies * rfi_num_times
-    type: float32
-    dimnames: ["Trfi", "F", "S"]
-    shape: [rfi_num_times, num_frequencies, 3]
+    value_type: float32
+    extents: [rfi_num_times, num_frequencies, 3]
     metadata_pool: main_pool
 host_rfi_SKtilde_ringbuffer:
     kotekan_buffer: ring
@@ -93,12 +85,10 @@ host_rfi_SKtilde_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_RFImask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: num_frequencies * num_times / 8
-    type: uint1x8
-    dimnames: ["T8hi128", "F", "T8lo128"]
-    shape: [num_times / 8 / 128, num_frequencies, 128]
+    value_type: uint1x8
+    extents: [num_times / 8 / 128, num_frequencies, 128]
     metadata_pool: main_pool
 host_rfi_RFImask_ringbuffer:
     kotekan_buffer: ring
@@ -110,12 +100,10 @@ host_rfi_RFImask_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_SKbar_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_float32 * num_dishes * num_polarizations * 3 * num_frequencies * rfi_num_times_bar
-    type: float32
-    dimnames: ["Trfi", "F", "S", "P", "D"]
-    shape: [rfi_num_times_bar, num_frequencies, 3, num_polarizaions, num_dishes]
+    value_type: float32
+    extents: [rfi_num_times_bar, num_frequencies, 3, num_polarizations, num_dishes]
     metadata_pool: main_pool
 host_rfi_SKbar_ringbuffer:
     kotekan_buffer: ring
@@ -127,12 +115,10 @@ host_rfi_SKbar_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_SKbartilde_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_float32 * 3 * num_frequencies * rfi_num_times_bar
-    type: float32
-    dimnames: ["Trfi", "F", "S"]
-    shape: [rfi_num_times_bar, num_frequencies, 3]
+    value_type: float32
+    extents: [rfi_num_times_bar, num_frequencies, 3]
     metadata_pool: main_pool
 host_rfi_SKbartilde_ringbuffer:
     kotekan_buffer: ring

--- a/config/fengine/include/rfi_pathfinder.j2
+++ b/config/fengine/include/rfi_pathfinder.j2
@@ -25,12 +25,10 @@ rfi_num_times: 32               # 1.31072 ms cadence
 rfi_num_times_bar: 1            # 41.94304 ms cadence
 
 host_rfi_S012_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_uint64 * num_dishes * num_polarizations * 3 * num_frequencies * rfi_num_times
-    type: uint64
-    dimnames: ["Trfi", "F", "S", "P", "D"]
-    shape: [rfi_num_times, num_frequencies, 3, num_polarizations, num_dishes]
+    value_type: uint64
+    extents: [rfi_num_times, num_frequencies, 3, num_polarizations, num_dishes]
     metadata_pool: main_pool
 host_rfi_S012_ringbuffer:
     kotekan_buffer: ring
@@ -42,12 +40,10 @@ host_rfi_S012_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_S012bar_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_uint64 * num_dishes * num_polarizations * 3 * num_frequencies * rfi_num_times_bar
-    type: uint64
-    dimnames: ["Trfibar", "F", "S", "P", "D"]
-    shape: [rfi_num_times_bar, num_frequencies, 3, num_polarizations, num_dishes]
+    value_type: uint64
+    extents: [rfi_num_times_bar, num_frequencies, 3, num_polarizations, num_dishes]
     metadata_pool: main_pool
 host_rfi_S012bar_ringbuffer:
     kotekan_buffer: ring
@@ -59,12 +55,10 @@ host_rfi_S012bar_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_S012tilde_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_uint64 * 3 * num_frequencies * rfi_num_times
-    type: uint64
-    dimnames: ["Trfi", "F", "S"]
-    shape: [rfi_num_times, num_frequencies, 3]
+    value_type: uint64
+    extents: [rfi_num_times, num_frequencies, 3]
     metadata_pool: main_pool
 host_rfi_S012tilde_ringbuffer:
     kotekan_buffer: ring
@@ -76,12 +70,10 @@ host_rfi_S012tilde_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_SKtilde_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_float32 * 3 * num_frequencies * rfi_num_times
-    type: float32
-    dimnames: ["Trfi", "F", "S"]
-    shape: [rfi_num_times, num_frequencies, 3]
+    value_type: float32
+    extents: [rfi_num_times, num_frequencies, 3]
     metadata_pool: main_pool
 host_rfi_SKtilde_ringbuffer:
     kotekan_buffer: ring
@@ -93,12 +85,10 @@ host_rfi_SKtilde_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_RFImask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: num_frequencies * num_times / 8
-    type: uint1x8
-    dimnames: ["T8hi128", "F", "T8lo128"]
-    shape: [num_times / 8 / 128, num_frequencies, 128]
+    value_type: uint1x8
+    extents: [num_times / 8 / 128, num_frequencies, 128]
     metadata_pool: main_pool
 host_rfi_RFImask_ringbuffer:
     kotekan_buffer: ring
@@ -110,12 +100,10 @@ host_rfi_RFImask_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_SKbar_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_float32 * num_dishes * num_polarizations * 3 * num_frequencies * rfi_num_times_bar
-    type: float32
-    dimnames: ["Trfi", "F", "S", "P", "D"]
-    shape: [rfi_num_times_bar, num_frequencies, 3, num_polarizaions, num_dishes]
+    value_type: float32
+    extents: [rfi_num_times_bar, num_frequencies, 3, num_polarizations, num_dishes]
     metadata_pool: main_pool
 host_rfi_SKbar_ringbuffer:
     kotekan_buffer: ring
@@ -127,12 +115,10 @@ host_rfi_SKbar_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_SKbartilde_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_float32 * 3 * num_frequencies * rfi_num_times_bar
-    type: float32
-    dimnames: ["Trfi", "F", "S"]
-    shape: [rfi_num_times_bar, num_frequencies, 3]
+    value_type: float32
+    extents: [rfi_num_times_bar, num_frequencies, 3]
     metadata_pool: main_pool
 host_rfi_SKbartilde_ringbuffer:
     kotekan_buffer: ring

--- a/config/fengine/include/upchan_charts.j2
+++ b/config/fengine/include/upchan_charts.j2
@@ -83,9 +83,10 @@ upchan_all_max_output_channel: upchan_U1_max_output_channel
 # Gains
 
 host_upchan_U32_gain_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * upchan_U32_max_num_channels * 32
+    value_type: float16
+    extents: [upchan_U32_max_num_channels * 32]
     metadata_pool: main_pool
 
 # Voltages

--- a/config/fengine/include/upchan_chime.j2
+++ b/config/fengine/include/upchan_chime.j2
@@ -33,9 +33,10 @@ upchan_U16_max_num_output_channels: upchan_U16_max_output_channel - upchan_U16_m
 # Gains
 
 host_upchan_U16_gain_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * upchan_U16_max_num_channels * 16
+    value_type: float16
+    extents: [upchan_U16_max_num_channels * 16]
     metadata_pool: main_pool
 
 # Voltages

--- a/config/fengine/include/upchan_chord.j2
+++ b/config/fengine/include/upchan_chord.j2
@@ -114,39 +114,45 @@ upchan_all_max_output_channel: upchan_U1_max_output_channel
 # Gains
 
 host_upchan_U2_gain_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * upchan_U2_max_num_channels * 2
+    value_type: float16
+    extents: [upchan_U2_max_num_channels * 2]
     metadata_pool: main_pool
 
 host_upchan_U4_gain_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * upchan_U4_max_num_channels * 4
+    value_type: float16
+    extents: [upchan_U4_max_num_channels * 4]
     metadata_pool: main_pool
 
 host_upchan_U8_gain_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * upchan_U8_max_num_channels * 8
+    value_type: float16
+    extents: [upchan_U8_max_num_channels * 8]
     metadata_pool: main_pool
 
 host_upchan_U16_gain_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * upchan_U16_max_num_channels * 16
+    value_type: float16
+    extents: [upchan_U16_max_num_channels * 16]
     metadata_pool: main_pool
 
 host_upchan_U32_gain_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * upchan_U32_max_num_channels * 32
+    value_type: float16
+    extents: [upchan_U32_max_num_channels * 32]
     metadata_pool: main_pool
 
 host_upchan_U64_gain_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * upchan_U64_max_num_channels * 64
+    value_type: float16
+    extents: [upchan_U64_max_num_channels * 64]
     metadata_pool: main_pool
 
 # Voltages

--- a/config/fengine/include/upchan_hfb_chime.j2
+++ b/config/fengine/include/upchan_hfb_chime.j2
@@ -38,9 +38,10 @@ upchan_hfb_upchan_U128_max_num_output_channels: upchan_hfb_upchan_U128_max_outpu
 # Gains
 
 host_upchan_hfb_U128_gain_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * upchan_hfb_upchan_U128_max_num_channels * 128
+    value_type: float16
+    extents: [upchan_hfb_upchan_U128_max_num_channels * 128]
     metadata_pool: main_pool
 
 # Voltages

--- a/config/fengine/include/upchan_hirax.j2
+++ b/config/fengine/include/upchan_hirax.j2
@@ -95,21 +95,24 @@ upchan_all_max_output_channel: upchan_U1_max_output_channel
 # Gains
 
 host_upchan_U8_gain_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * upchan_U8_max_num_channels * 8
+    value_type: float16
+    extents: [upchan_U8_max_num_channels * 8]
     metadata_pool: main_pool
 
 host_upchan_U16_gain_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * upchan_U16_max_num_channels * 16
+    value_type: float16
+    extents: [upchan_U16_max_num_channels * 16]
     metadata_pool: main_pool
 
 host_upchan_U32_gain_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * upchan_U32_max_num_channels * 32
+    value_type: float16
+    extents: [upchan_U32_max_num_channels * 32]
     metadata_pool: main_pool
 
 # Voltages

--- a/config/fengine/include/upchan_pathfinder.j2
+++ b/config/fengine/include/upchan_pathfinder.j2
@@ -143,39 +143,45 @@ upchan_all_max_output_channel: upchan_U1_max_output_channel
 # Gains
 
 host_upchan_U2_gain_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * upchan_U2_max_num_channels * 2
+    value_type: float16
+    extents: [upchan_U2_max_num_channels * 2]
     metadata_pool: main_pool
 
 host_upchan_U4_gain_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * upchan_U4_max_num_channels * 4
+    value_type: float16
+    extents: [upchan_U4_max_num_channels * 4]
     metadata_pool: main_pool
 
 host_upchan_U8_gain_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * upchan_U8_max_num_channels * 8
+    value_type: float16
+    extents: [upchan_U8_max_num_channels * 8]
     metadata_pool: main_pool
 
 host_upchan_U16_gain_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * upchan_U16_max_num_channels * 16
+    value_type: float16
+    extents: [upchan_U16_max_num_channels * 16]
     metadata_pool: main_pool
 
 host_upchan_U32_gain_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * upchan_U32_max_num_channels * 32
+    value_type: float16
+    extents: [upchan_U32_max_num_channels * 32]
     metadata_pool: main_pool
 
 host_upchan_U64_gain_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * upchan_U64_max_num_channels * 64
+    value_type: float16
+    extents: [upchan_U64_max_num_channels * 64]
     metadata_pool: main_pool
 
 # Voltages

--- a/config/fengine/include/xpose2048_chime.j2
+++ b/config/fengine/include/xpose2048_chime.j2
@@ -143,9 +143,10 @@ scatter_indices: [
 # Buffers
 
 host_scatter_indices_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_int32 * num_dishes * num_polarizations
+    value_type: int32
+    extents: [num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 host_xposed_voltage_buffer:

--- a/config/scheduled-tests/send-recv-asdfwrite.yaml
+++ b/config/scheduled-tests/send-recv-asdfwrite.yaml
@@ -16,15 +16,17 @@ main_pool:
 
 # Buffers
 send_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: num_frame_samples
+    value_type: int4x2
+    extents: [num_frame_samples]
     metadata_pool: main_pool
 
 recv_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: num_frame_samples
+    value_type: int4x2
+    extents: [num_frame_samples]
     metadata_pool: main_pool
 
 

--- a/config/tests/chord_pathfinder_core.j2
+++ b/config/tests/chord_pathfinder_core.j2
@@ -11,73 +11,83 @@
 #########
 
 host_rfi_RFImask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: num_local_freq * samples_per_data_set / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 1024, num_local_freq, 128]
     zero_new_frames: true
     zero_value: 0xFF
     metadata_pool: main_pool
 
 host_rfi_RFImask_buffer_1:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: num_local_freq * samples_per_data_set / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 1024, num_local_freq, 128]
     zero_new_frames: true
     zero_value: 0xFF
     numa_node: 1
     metadata_pool: main_pool
 
 host_rfi_sktilde_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / rfi_downsampling_factor) * num_local_freq * 3 * sizeof_float32
+    value_type: float32
+    extents: [samples_per_data_set / rfi_downsampling_factor, num_local_freq, 3]
     metadata_pool: main_pool
 
 host_rfi_sktilde_buffer_1:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / rfi_downsampling_factor) * num_local_freq * 3 * sizeof_float32
+    value_type: float32
+    extents: [samples_per_data_set / rfi_downsampling_factor, num_local_freq, 3]
     metadata_pool: main_pool
     numa_node: 1
 
 host_rfi_RFImask_counts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * sizeof_int32
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     metadata_pool: main_pool
 
 host_rfi_RFImask_counts_buffer_1:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * sizeof_int32
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     metadata_pool: main_pool
     numa_node: 1
 
 host_pl_counts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * sizeof_int32
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     metadata_pool: main_pool
 
 host_pl_counts_buffer_1:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * sizeof_int32
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     metadata_pool: main_pool
     numa_node: 1
 
 host_rfi_RFIframemask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq
+    value_type: uint8
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     zero_new_frames: true
     zero_value: 0xFF
     metadata_pool: main_pool
 
 host_rfi_RFIframemask_buffer_1:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq
+    value_type: uint8
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     zero_new_frames: true
     zero_value: 0xFF
     metadata_pool: main_pool
@@ -87,15 +97,17 @@ vis_blocksize: 16
 vis_num_blocks_lin: num_elements / vis_blocksize
 vis_num_blocks: vis_num_blocks_lin * (vis_num_blocks_lin + 1) / 2
 host_correlation_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: num_local_freq * (samples_per_data_set / sub_integration_ntime) * 16 * 16 * vis_num_blocks * 2 * sizeof_gpu_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, vis_num_blocks, vis_blocksize, vis_blocksize, 2]
     metadata_pool: main_pool
 
 host_correlation_buffer_1:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: num_local_freq * (samples_per_data_set / sub_integration_ntime) * 16 * 16 * vis_num_blocks * 2 * sizeof_gpu_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, vis_num_blocks, vis_blocksize, vis_blocksize, 2]
     metadata_pool: main_pool
     numa_node: 1
 
@@ -104,15 +116,17 @@ counts_blocksize: 8
 counts_num_blocks_lin: (num_elements / 8) / counts_blocksize
 counts_num_blocks: (counts_num_blocks_lin * (counts_num_blocks_lin + 1)) / 2
 host_counts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * counts_num_blocks * counts_blocksize * counts_blocksize * sizeof_gpu_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, counts_num_blocks, counts_blocksize, counts_blocksize]
     metadata_pool: main_pool
 
 host_counts_buffer_1:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * counts_num_blocks * counts_blocksize * counts_blocksize * sizeof_gpu_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, counts_num_blocks, counts_blocksize, counts_blocksize]
     metadata_pool: main_pool
     numa_node: 1
 

--- a/config/tests/chord_pathfinder_dpdk.j2
+++ b/config/tests/chord_pathfinder_dpdk.j2
@@ -27,13 +27,29 @@ network_input_buffers:
         numa_node: 1
         zero_value: 0x88
         kotekan_buffer: standard
-    # Main voltage buffer after transpose
-    host_voltage_buffer_0:
-        kotekan_buffer: standard
-        numa_node: 0
-    host_voltage_buffer_1:
-        kotekan_buffer: standard
-        numa_node: 1
+
+# Main voltage buffer after transpose.
+# Produced by TransposeBasebandArray: int4x2_swapped_withoffset "E". These live outside the
+# network_input_buffers group: that group's frame_size is for the dpdk buffers, while
+# ndarray buffers derive their size from the descriptor.
+host_voltage_buffer_0:
+    kotekan_buffer: ndarray
+    log_level: info
+    num_frames: host_side_buffer_depth
+    value_type: int4x2_swapped_withoffset
+    extents: [samples_per_data_set, num_local_freq, 2, num_elements / 2]
+    metadata_pool: main_pool
+    use_hugepages: true
+    numa_node: 0
+host_voltage_buffer_1:
+    kotekan_buffer: ndarray
+    log_level: info
+    num_frames: host_side_buffer_depth
+    value_type: int4x2_swapped_withoffset
+    extents: [samples_per_data_set, num_local_freq, 2, num_elements / 2]
+    metadata_pool: main_pool
+    use_hugepages: true
+    numa_node: 1
 
 packet_receipt_bitmap_buffers:
     log_level: info
@@ -57,18 +73,21 @@ packet_receipt_bitmap_buffers:
         kotekan_buffer: standard
         numa_node: 1
 
+# Produced by ProcessPacketMask (rfi_mask_buf): uint1x8 "RFImask".
 host_rfi_RFImask_dummy_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: num_local_freq * samples_per_data_set / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 1024, num_local_freq, 128]
     zero_new_frames: true
     zero_value: 0xFF
     metadata_pool: main_pool
 
 host_rfi_RFImask_dummy_buffer_1:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: num_local_freq * samples_per_data_set / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 1024, num_local_freq, 128]
     zero_new_frames: true
     zero_value: 0xFF
     numa_node: 1
@@ -76,46 +95,52 @@ host_rfi_RFImask_dummy_buffer_1:
 
 # Note this is the expanded version of the pl_mask, which is used for correlator input
 host_pl_mask_exp_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / 64) * (num_local_freq) * (num_elements / 8) * 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 64, num_local_freq, num_polarizations, (num_elements / 8) / 2, 8]
     metadata_pool: main_pool
 
 host_pl_mask_exp_buffer_1:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / 64) * (num_local_freq) * (num_elements / 8) * 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 64, num_local_freq, num_polarizations, (num_elements / 8) / 2, 8]
     metadata_pool: main_pool
     numa_node: 1
 
 host_pl_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / 128) * (num_local_freq/4) * (num_elements / 8) * 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 128, (num_local_freq + 3) / 4, num_polarizations, (num_elements / 8) / 2, 8]
     metadata_pool: main_pool
 
 host_pl_mask_buffer_1:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / 128) * (num_local_freq/4) * (num_elements / 8) * 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 128, (num_local_freq + 3) / 4, num_polarizations, (num_elements / 8) / 2, 8]
     metadata_pool: main_pool
     numa_node: 1
 
 # Bad feed mask - marks which feeds to exclude from RFI calculations
 # Shape: [P, D] = [2, num_dishes] - all ones means all feeds are good
 host_bf_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_int8 * num_dishes * num_polarizations
+    value_type: int8
+    extents: [num_polarizations, num_dishes]
     metadata_pool: main_pool
     zero_new_frames: true
     zero_value: 0xFF
     numa_node: 0
 
 host_bf_mask_buffer_1:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_int8 * num_dishes * num_polarizations
+    value_type: int8
+    extents: [num_polarizations, num_dishes]
     metadata_pool: main_pool
     zero_new_frames: true
     zero_value: 0xFF

--- a/config/tests/chord_pathfinder_fake_input.j2
+++ b/config/tests/chord_pathfinder_fake_input.j2
@@ -6,65 +6,79 @@
 # Buffers
 
 # Main voltage buffer
+# testDataGen (gen_fake_voltage, type random_signed_offset -> int4x2_swapped_withoffset,
+# array_shape [samples_per_data_set, num_local_freq, num_polarizations, num_dishes]).
 host_voltage_buffer_0:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: samples_per_data_set * num_local_freq * num_elements
+    value_type: int4x2_swapped_withoffset
+    extents: [samples_per_data_set, num_local_freq, num_polarizations, num_dishes]
     metadata_pool: main_pool
     numa_node: 0
 host_voltage_buffer_1:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: samples_per_data_set * num_local_freq * num_elements
+    value_type: int4x2_swapped_withoffset
+    extents: [samples_per_data_set, num_local_freq, num_polarizations, num_dishes]
     metadata_pool: main_pool
     numa_node: 1
 
 
+# Produced by testRFImaskGen (gen_dummy_rfi_mask, name "RFImask", type const -> uint1x8;
+# shape [samples_per_data_set / 1024, num_local_freq, 128] is fixed in testRFImaskGen.cpp:133).
 host_rfi_RFImask_dummy_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: num_local_freq * samples_per_data_set / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 1024, num_local_freq, 128]
     zero_new_frames: true
     zero_value: 0xFF
     metadata_pool: main_pool
 
 host_rfi_RFImask_dummy_buffer_1:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: num_local_freq * samples_per_data_set / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 1024, num_local_freq, 128]
     zero_new_frames: true
     zero_value: 0xFF
     numa_node: 1
     metadata_pool: main_pool
 
+# testDataGen (gen_fake_pl_mask, type random1x8 -> uint1x8, name "pl_mask").
+# extents = [samples_per_data_set/128, (num_local_freq+3)/4, num_polarizations, num_dishes/8, 8]
 host_pl_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / 128) * (num_local_freq/4) * (num_elements / 8) * 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 128, (num_local_freq + 3) / 4, num_polarizations, num_dishes / 8, 8]
     metadata_pool: main_pool
 
 host_pl_mask_buffer_1:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / 128) * (num_local_freq/4) * (num_elements / 8) * 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 128, (num_local_freq + 3) / 4, num_polarizations, num_dishes / 8, 8]
     metadata_pool: main_pool
     numa_node: 1
 
 # Bad feed mask - marks which feeds to exclude from RFI calculations
 # Shape: [P, D] = [2, num_dishes] - all ones means all feeds are good
 host_bf_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_int8 * num_dishes * num_polarizations
+    value_type: int8
+    extents: [num_polarizations, num_dishes]
     metadata_pool: main_pool
     zero_new_frames: true
     zero_value: 0xFF
     numa_node: 0
 
 host_bf_mask_buffer_1:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_int8 * num_dishes * num_polarizations
+    value_type: int8
+    extents: [num_polarizations, num_dishes]
     metadata_pool: main_pool
     zero_new_frames: true
     zero_value: 0xFF

--- a/config/tests/thrash_n2accum_chime.yaml
+++ b/config/tests/thrash_n2accum_chime.yaml
@@ -91,33 +91,43 @@ n2_pool:
     num_metadata_objects: 16 * buffer_depth
 
 fake_correlation_buffer:
-    kotekan_buffer: standard
+    # num_elements=2048: corr_lin_blocks=num_elements/16=128, vis_num_blocks=128*129/2=8256.
+    # testN2kGen, testLostCountsGen, and N2Accumulate all use num_elements/16, so the
+    # producer and consumer agree on the block count.
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * vis_num_blocks * vis_blocksize * vis_blocksize * 2 * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, vis_num_blocks, vis_blocksize, vis_blocksize, 2]
     metadata_pool: main_pool
 
 fake_counts_buffer:
-    kotekan_buffer: standard
+    # num_elements=2048: count_lin_blocks=(num_elements/8)/8=32, counts_num_blocks=32*33/2=528.
+    # testN2kGen, testLostCountsGen (in_buf validator), and N2Accumulate all use (num_elements/8)/8.
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * counts_num_blocks * counts_blocksize * counts_blocksize * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, counts_num_blocks, counts_blocksize, counts_blocksize]
     metadata_pool: main_pool
 
 fake_rficounts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     metadata_pool: main_pool
 
 fake_plcounts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     metadata_pool: main_pool
 
 fake_rfiframemask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq
+    value_type: uint8
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     metadata_pool: main_pool
 
 n2_buffer:

--- a/config/tests/thrash_n2accum_chord.yaml
+++ b/config/tests/thrash_n2accum_chord.yaml
@@ -91,33 +91,43 @@ n2_pool:
     num_metadata_objects: 16 * buffer_depth
 
 fake_correlation_buffer:
-    kotekan_buffer: standard
+    # num_elements=1024: corr_lin_blocks=num_elements/16=64, vis_num_blocks=64*65/2=2080.
+    # testN2kGen, testLostCountsGen, and N2Accumulate all use num_elements/16, so the
+    # producer and consumer agree on the block count.
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * vis_num_blocks * vis_blocksize * vis_blocksize * 2 * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, vis_num_blocks, vis_blocksize, vis_blocksize, 2]
     metadata_pool: main_pool
 
 fake_counts_buffer:
-    kotekan_buffer: standard
+    # num_elements=1024: count_lin_blocks=(num_elements/8)/8=16, counts_num_blocks=16*17/2=136.
+    # testN2kGen, testLostCountsGen (in_buf validator), and N2Accumulate all use (num_elements/8)/8.
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * counts_num_blocks * counts_blocksize * counts_blocksize * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, counts_num_blocks, counts_blocksize, counts_blocksize]
     metadata_pool: main_pool
 
 fake_rficounts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     metadata_pool: main_pool
 
 fake_plcounts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     metadata_pool: main_pool
 
 fake_rfiframemask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq
+    value_type: uint8
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     metadata_pool: main_pool
 
 n2_buffer:

--- a/config/tests/thrash_n2accum_pathfinder.yaml
+++ b/config/tests/thrash_n2accum_pathfinder.yaml
@@ -91,33 +91,43 @@ n2_pool:
     num_metadata_objects: 16 * buffer_depth
 
 fake_correlation_buffer:
-    kotekan_buffer: standard
+    # num_elements=128: corr_lin_blocks=num_elements/16=8, vis_num_blocks=8*9/2=36.
+    # testN2kGen, testLostCountsGen, and N2Accumulate all use num_elements/16, so the
+    # producer and consumer agree on the block count.
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * vis_num_blocks * vis_blocksize * vis_blocksize * 2 * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, vis_num_blocks, vis_blocksize, vis_blocksize, 2]
     metadata_pool: main_pool
 
 fake_counts_buffer:
-    kotekan_buffer: standard
+    # num_elements=128: count_lin_blocks=(num_elements/8)/8=2, counts_num_blocks=2*3/2=3.
+    # testN2kGen, testLostCountsGen (in_buf validator), and N2Accumulate all use (num_elements/8)/8.
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * counts_num_blocks * counts_blocksize * counts_blocksize * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, counts_num_blocks, counts_blocksize, counts_blocksize]
     metadata_pool: main_pool
 
 fake_rficounts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     metadata_pool: main_pool
 
 fake_plcounts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     metadata_pool: main_pool
 
 fake_rfiframemask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq
+    value_type: uint8
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     metadata_pool: main_pool
 
 n2_buffer:

--- a/docs/sphinx/dev/dev_buffers.rst
+++ b/docs/sphinx/dev/dev_buffers.rst
@@ -69,7 +69,7 @@ Type-specific parameters are required unless marked *optional*:
        - ``quantity_name`` -- label for the stored quantity
        - ``dimnames`` -- list of axis labels, one per extent
 
-       Omitted labels are supplied by the producing stage (see below).
+       Omitted labels may be supplied by a producing stage (see below).
        ``frame_size`` is derived from the descriptor.
      - ``GenericNDArray``, built from the config block and attached at
        startup
@@ -84,8 +84,9 @@ Type-specific parameters are required unless marked *optional*:
        startup
    * - ``standard``
      - - ``frame_size`` -- frame size in bytes, set explicitly
-     - none declared; stages may attach one at runtime via
-       ``ensure_frame_desc`` / ``require_frame_desc``
+     - none declared; a stage may attach one at runtime via
+       ``ensure_frame_desc`` (``require_frame_desc`` would be fatal, as a
+       ``standard`` buffer has no declared descriptor)
    * - ``vis``
      - - ``num_elements`` -- number of correlator inputs
        - ``num_ev`` -- number of eigenvectors
@@ -128,8 +129,14 @@ therefore declare only the structure, leaving labels for the producing
 stage to supply; when both producer and consumer expect a label it must agree.
 
 The model is: **buffers carry their own description; stages validate
-against it** (and optionally complete any labels the config omitted to minimize
-repetition).
+against it.** The buffer factory guarantees the baseline at startup -- a
+declared descriptor's byte size matches ``frame_size`` and its structure
+matches the config -- so a stage never re-checks the whole shape for that
+reason. Beyond that baseline, validation lives in the stage: there is no
+shared field-validation helper, because the checks stages need (e.g. dimension
+type, buffer size divisibility, etc) are too varied to fold into one. A stage
+should read a descriptor and check any specific properties it depends on,
+completing any labels the config omitted to minimize repetition.
 
 Rationale
 ---------
@@ -149,24 +156,49 @@ Rationale
 Authoring guidance
 ------------------
 
-- Write ``extents`` as expressions over the genuinely tunable config scalars
-  (``samples_per_data_set``, ``num_dishes``, ...). Fixed algorithm geometry
-  (tile and block sizes, packing factors) has a single correct value:
-  prefer defining it in one place in the code rather than presenting it in
-  config as a tunable.
-- Stages with fixed shape requirements (GPU kernels and their CPU
-  counterparts) should validate exactly, via
-  ``Buffer::require_frame_desc(NDArray<T, D>::describe(...))`` -- a missing
-  or mismatched descriptor is fatal. Stages that adapt to their input should
-  check only the properties they require (value type, a particular axis,
-  divisibility) and size their work from the descriptor.
-- Stages that read data produced elsewhere (file readers, network receivers)
-  validate the shape they discover against the buffer's declared descriptor
-  with ``Buffer::require_frame_desc`` -- memory is allocated from the config
-  before any data arrives. ``Buffer::ensure_frame_desc`` is the right call for
-  shapes derived in code at runtime (e.g. GPU pipeline copy-out) where the
-  buffer may or may not be declared: it attaches the descriptor when the buffer
-  has none, otherwise reconciles -- validating the structure and completing any
-  unset labels. The two differ only in the undeclared case: ``require_frame_desc``
-  is fatal when no descriptor is present (config must declare it), whereas
-  ``ensure_frame_desc`` attaches one.
+Write ``extents`` as expressions over the genuinely tunable config scalars
+(``samples_per_data_set``, ``num_dishes``, ...). Fixed algorithm geometry
+(tile and block sizes, packing factors) has a single correct value: prefer
+defining it once in code rather than presenting it in config as a tunable.
+
+Choosing how a stage validates a descriptor (from the weakest assertion to the
+strongest):
+
+- **Existence only** -- ``Buffer::require_frame_desc()`` (no argument): assert
+  the buffer was declared with a descriptor, fatal otherwise. Use it for a stage
+  that adapts to whatever shape the config declares, or that depends on only a
+  subset of the descriptor; follow it with a typed read and hand-check what you
+  actually use.
+- **Typed read** -- ``Buffer::require_frame_desc<T>()``: returns the descriptor
+  as ``T``, fatal if absent or of the wrong type. It is the safe form of
+  ``get_frame_desc<T>()`` (which returns ``nullptr``); use it wherever you would
+  immediately dereference the result. This is the idiom for ``N2`` buffers --
+  read the ``N2FrameDesc`` and check ``get_num_elements()``, ``get_n2_layout()``,
+  ... against what the stage expects.
+- **Full cross-check** -- ``Buffer::require_frame_desc(NDArray<T, D>::describe(...))``:
+  declare and validate the entire expected ``value_type`` and ``extents``. Use it
+  when the stage computes that exact shape from its own config parameters (GPU
+  kernels and their CPU counterparts), so a disagreement between the stage's
+  parameters and the buffer's declaration is caught at startup.
+- **Runtime origination** -- ``Buffer::ensure_frame_desc(describe(...))``:
+  attach-or-reconcile, for buffers whose shape is known only at runtime. It
+  attaches the descriptor when the buffer has none, otherwise reconciles
+  (validating the structure and completing unset labels). It differs from
+  ``require_frame_desc`` only in the undeclared case: ``require`` is fatal,
+  ``ensure`` attaches.
+
+Whatever the form, prefer a clear ``FATAL_ERROR`` naming the stage and buffer
+and printing expected-vs-actual; that is more useful than any generic check.
+
+Avoid:
+
+- re-typing a shape in a stage when the config already declares it and nothing
+  in the stage depends on the exact extents -- use the existence-only
+  ``require_frame_desc()`` and let the buffer's producer (or another consumer)
+  validate the shape;
+- a literal ``frame_size`` next to an ``ndarray`` or ``N2`` structure -- the
+  size is derived from the descriptor;
+- ``ensure_frame_desc`` as a way to tolerate a buffer that should have been
+  declared -- that is what ``require``'s fatal is for;
+- repeating ``dimnames`` / ``quantity_name`` in config when the producing stage
+  already supplies them.

--- a/docs/sphinx/dev/dev_buffers.rst
+++ b/docs/sphinx/dev/dev_buffers.rst
@@ -4,5 +4,169 @@
 Buffers
 ************
 
-More detailed info about buffers, whatever a stage writer could need to know...
+Buffers connect stages: a stage (optionally) reads from input buffers and
+(optionally) writes to output buffers, and the buffer takes care of the
+synchronization between them, so stages never signal each other directly.
 
+The core ``Buffer`` is a fixed-size, supporting multi-producer multi-consumer
+access to a pool of frames. Each frame is a contiguous block of memory, with
+``num_frames`` frames of ``frame_size`` bytes each. A producer asks for an
+*empty* frame (``wait_for_empty_frame``), fills it, and marks it *full*
+(``mark_frame_full``); a consumer waits for a *full* frame
+(``wait_for_full_frame``), reads it, and marks it *empty*
+(``mark_frame_empty``). A frame is recycled once every registered consumer
+has marked it empty. All of these calls are thread safe and, used
+correctly, deadlock free.
+
+Points a stage writer should know:
+
+- Producers and consumers each register with the buffer by name; a buffer
+  may have several of each. Consumers must never write to frames. A buffer
+  with no registered consumer drops its frames (logging an INFO).
+- Each frame can carry a metadata object drawn from the buffer's
+  ``metadata_pool``, and -- depending on the buffer type -- the buffer
+  carries a frame descriptor (see below).
+- Frame memory is not zeroed between uses: a producer must overwrite (or
+  zero) the whole frame unless zeroing is explicitly enabled.
+- Buffers are declared in the YAML config as ``kotekan_buffer:`` blocks
+  and built by the buffer factory at startup. The buffer's name is the
+  path of its config block, and stages receive their buffers through the
+  ``bufferContainer``.
+- ``RingBuffer`` is the exception to the frame model: it coordinates
+  access to a ring of elements in memory it does not itself own (e.g. a
+  ring in GPU memory), and its producers and consumers may run at
+  different cadences.
+
+Buffer types
+============
+
+``kotekan_buffer`` selects the buffer type. Every buffer block takes
+``log_level`` (usually inherited) and optionally ``metadata_pool`` and
+``numa_node``. Frame-oriented buffers (all types except ``ring``) also
+require ``num_frames``, plus the optional allocation tunables
+``use_hugepages`` (off), ``mlock_frames`` (on), ``zero_new_frames`` (on),
+``zero_value`` (0), and ``cpu_affinity`` (unset).
+
+Type-specific parameters are required unless marked *optional*:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 12 48 40
+
+   * - Type
+     - Type-specific parameters
+     - Frame descriptor
+   * - ``ndarray``
+     - *Structural (required):*
+
+       - ``value_type`` -- kotekan ``DataType`` name (``float32``,
+         ``int4x2``, ...)
+       - ``extents`` -- list of dimension sizes; entries may be arithmetic
+         expressions over other config values
+
+       *Labels (optional):*
+
+       - ``quantity_name`` -- label for the stored quantity
+       - ``dimnames`` -- list of axis labels, one per extent
+
+       Omitted labels are supplied by the producing stage (see below).
+       ``frame_size`` is derived from the descriptor.
+     - ``GenericNDArray``, built from the config block and attached at
+       startup
+   * - ``N2``
+     - - ``num_elements`` -- number of correlator inputs
+       - ``num_ev`` -- number of eigenvectors
+       - ``n2_layout`` -- product layout (``FullUpperTri``,
+         ``Autocorrelations``, ...; see ``N2Layout``)
+
+       ``frame_size`` is derived from the descriptor.
+     - ``N2FrameDesc``, built from the config block and attached at
+       startup
+   * - ``standard``
+     - - ``frame_size`` -- frame size in bytes, set explicitly
+     - none declared; stages may attach one at runtime via
+       ``ensure_frame_desc`` / ``require_frame_desc``
+   * - ``vis``
+     - - ``num_elements`` -- number of correlator inputs
+       - ``num_ev`` -- number of eigenvectors
+       - ``num_prod`` (*optional*) -- number of products; defaults to the
+         full triangle
+
+       ``frame_size`` is computed from these.
+     - none (layout is handled by ``VisFrameView``)
+   * - ``hfb``
+     - - ``num_frb_total_beams`` -- number of FRB beams
+       - ``factor_upchan`` -- upchannelization factor (sub-frequencies)
+
+       ``frame_size`` is computed from these.
+     - none (layout is handled by ``HFBFrameView``)
+   * - ``ring``
+     - - ``ring_buffer_size`` -- ring capacity in bytes (the API speaks of
+         abstract *elements*, but all current users count bytes); the
+         buffer manages access only, the memory is owned elsewhere
+     - none
+
+For new pipelines, prefer ``ndarray`` (or ``N2`` for correlation products)
+wherever a frame is a typed array: the descriptor documents the shape in
+the config and lets stages validate it at startup. ``standard`` remains
+for opaque or byte-oriented frames.
+
+Frame descriptors
+=================
+
+Buffers may carry a *frame descriptor* describing the data in each frame: a
+``GenericNDArray`` for ``ndarray`` buffers,
+or an ``N2FrameDesc`` for ``N2`` buffers. The descriptor is declared in the
+buffer's config block, built by the buffer factory at startup, and
+``frame_size`` is derived from it (see :ref:`user_config`).
+
+For an ``ndarray`` descriptor the **structural** fields (``value_type``,
+``extents``) are required -- they fix the byte layout the factory allocates --
+while the **label** fields (``quantity_name``, ``dimnames``) are typically
+optional, although may be specified or required by a stage. A config may
+therefore declare only the structure, leaving labels for the producing
+stage to supply; when both producer and consumer expect a label it must agree.
+
+The model is: **buffers carry their own description; stages validate
+against it** (and optionally complete any labels the config omitted to minimize
+repetition).
+
+Rationale
+---------
+
+- Some stages work with arbitrary frame shapes, or move bytes without
+  interpreting them, so a buffer's description cannot always come from the
+  stages that touch it.
+- Validation is the primary safety mechanism: producer, consumer, and
+  config descriptions should be cross-checked at startup, so mismatches
+  appear at launch (with both descriptions printed) rather than downstream.
+- Shapes stay visible in the config, next to the pipeline wiring, for
+  review and debugging without consulting stage source.
+- Descriptor requirements depend on stage requirements and buffer types:
+  ``standard`` buffers carry none, ``ndarray`` buffers carry
+  partial descriptors, and ``N2`` buffers carry the full descriptor.
+
+Authoring guidance
+------------------
+
+- Write ``extents`` as expressions over the genuinely tunable config scalars
+  (``samples_per_data_set``, ``num_dishes``, ...). Fixed algorithm geometry
+  (tile and block sizes, packing factors) has a single correct value:
+  prefer defining it in one place in the code rather than presenting it in
+  config as a tunable.
+- Stages with fixed shape requirements (GPU kernels and their CPU
+  counterparts) should validate exactly, via
+  ``Buffer::require_frame_desc(NDArray<T, D>::describe(...))`` -- a missing
+  or mismatched descriptor is fatal. Stages that adapt to their input should
+  check only the properties they require (value type, a particular axis,
+  divisibility) and size their work from the descriptor.
+- Stages that read data produced elsewhere (file readers, network receivers)
+  validate the shape they discover against the buffer's declared descriptor
+  with ``Buffer::require_frame_desc`` -- memory is allocated from the config
+  before any data arrives. ``Buffer::ensure_frame_desc`` is the right call for
+  shapes derived in code at runtime (e.g. GPU pipeline copy-out) where the
+  buffer may or may not be declared: it attaches the descriptor when the buffer
+  has none, otherwise reconciles -- validating the structure and completing any
+  unset labels. The two differ only in the undeclared case: ``require_frame_desc``
+  is fatal when no descriptor is present (config must declare it), whereas
+  ``ensure_frame_desc`` attaches one.

--- a/docs/sphinx/dev/dev_stage_tutorial.rst
+++ b/docs/sphinx/dev/dev_stage_tutorial.rst
@@ -91,6 +91,10 @@ Now, let us create the header file.
 
 To let the compiler know about the stage, add it to lib/stages/CMakeLists.txt.
 
+If the buffer carries a frame descriptor (an ``ndarray`` buffer), the stage
+can validate its expected shape against it in the constructor; see
+:ref:`dev_buffers`.
+
 
 Writing a Producer/Consumer Stage
 ---------------------------------

--- a/docs/sphinx/user/user_config.rst
+++ b/docs/sphinx/user/user_config.rst
@@ -36,8 +36,8 @@ omit metadata entirely.
 
 Common keys (unless noted otherwise):
 
-- ``kotekan_buffer``: buffer type; supported values are ``standard``, ``vis``, ``N2``, ``hfb``, and
-  ``ring``.
+- ``kotekan_buffer``: buffer type; supported values are ``standard``, ``ndarray``, ``vis``, ``N2``,
+  ``hfb``, and ``ring``.
 - ``num_frames``: depth of frame-based buffers (everything except ``ring``). Pick a size that covers
   the latency of downstream stages.
 - ``metadata_pool``: optional for ``standard`` buffers; name of a :ref:`metadata pool
@@ -51,6 +51,16 @@ Common keys (unless noted otherwise):
 Type-specific notes:
 
 - ``standard`` – raw byte buffers. You must set ``frame_size`` in bytes.
+- ``ndarray`` – frames holding a single typed multi-dimensional array. The **required** structural
+  fields are ``value_type`` (a kotekan ``DataType`` name such as ``float32`` or ``int4x2``) and
+  ``extents`` (a list of dimension sizes; entries may be arithmetic expressions referencing other
+  config values, e.g. ``samples_per_data_set / upchan_factor``) -- these fix the byte layout the
+  factory allocates. The semantic labels ``quantity_name`` and ``dimnames`` (a list of axis labels,
+  one per extent) are **optional**: when omitted, the producing stage supplies them; when given,
+  the stage validates against them. ``frame_size`` is derived from the descriptor, and the frame
+  descriptor is attached to the buffer at startup, so stages can validate against it (or read
+  shapes from it) from their constructors onward. Typically paired with a ``chordMetadata`` pool.
+  See :ref:`dev_buffers` for the descriptor model and authoring guidance.
 - ``vis`` – visibility frames sized automatically from ``num_elements``, ``num_ev``, and optional
   ``num_prod`` (defaults to an upper-triangular visibility matrix). Numeric types are fixed
   (complex floats for visibilities/EVs, floats for weights/flags). The attached metadata type is

--- a/lib/core/Config.hpp
+++ b/lib/core/Config.hpp
@@ -88,30 +88,13 @@ public:
                                      T>::type* = nullptr>
     T get(const std::string& base_path, const std::string& name) const {
         nlohmann::json json_value = get_value(base_path, name);
-        T value;
         try {
-            // If the expected type is a number and the value
-            // isn't already a number then try using the configEval parser
-            if (std::is_arithmetic<T>::value && !json_value.is_number()) {
-                try {
-                    Config::configEval<T> eval(*this, base_path, name);
-                    value = eval.compute_result();
-                } catch (std::exception const& ex) {
-                    throw std::runtime_error(
-                        fmt::format(fmt("Failed to evaluate: '{:s}' with message: '{:s}' for name "
-                                        "{:s} in path {:s}"),
-                                    json_value.get<std::string>(), ex.what(), name, base_path));
-                }
-            } else {
-                value = checked_conversion<T>(json_value.get<LargeType<T>>());
-            }
+            return eval<T>(base_path, json_value);
         } catch (std::exception const& ex) {
             throw std::runtime_error(fmt::format(
                 fmt("The value {:s} in path {:s} is not of type '{:s}' or doesn't exist: {:s}"),
                 name, base_path, demangle<T>(), ex.what()));
         }
-
-        return value;
     }
 
     /**
@@ -135,6 +118,36 @@ public:
         }
 
         return value;
+    }
+
+    /**
+     * @brief Evaluate a JSON value (a number, or an arithmetic expression
+     *        string) in the config scope given by @c base_path.
+     *
+     * Like @c get() for arithmetic types, but operates on a value that is
+     * not directly addressable by a config path -- e.g. the elements of an
+     * array value, inside which @c get() cannot evaluate expressions.
+     * Variables in the expression are resolved with the usual config
+     * scoping rules, relative to @c base_path.
+     *
+     * @param base_path Config scope used to resolve variables in the expression.
+     * @param value     The JSON value to evaluate (a number or an expression string).
+     * @return  The evaluated value.
+     */
+    template<class T,
+             typename std::enable_if<std::is_arithmetic<T>::value && !std::is_same<bool, T>::value,
+                                     T>::type* = nullptr>
+    T eval(const std::string& base_path, const nlohmann::json& value) const {
+        if (value.is_number())
+            return checked_conversion<T>(value.get<LargeType<T>>());
+        try {
+            Config::configEval<T> evaluator(*this, base_path, value);
+            return evaluator.compute_result();
+        } catch (std::exception const& ex) {
+            throw std::runtime_error(
+                fmt::format(fmt("Failed to evaluate: '{:s}' with message: '{:s}' in path {:s}"),
+                            value.dump(), ex.what(), base_path));
+        }
     }
 
     /**
@@ -292,7 +305,8 @@ private:
     class configEval {
 
     public:
-        configEval(const Config& _config, const std::string& base_path, const std::string& name);
+        configEval(const Config& _config, const std::string& base_path,
+                   const nlohmann::json& value);
 
         ~configEval();
 
@@ -342,17 +356,15 @@ T Config::get_default(const std::string& base_path, const std::string& name,
 
 template<class Type>
 Config::configEval<Type>::configEval(const Config& _config, const std::string& base_path,
-                                     const std::string& name) :
+                                     const nlohmann::json& value) :
     config(_config), unique_name(base_path) {
 
-    nlohmann::json value = config.get_value(base_path, name);
-
-    if (!(value.is_string() || value.is_number())) {
-        throw std::runtime_error(fmt::format(
-            fmt("The value {:s} in path {:s} isn't a number or string to eval or does not exist."),
-            name, base_path));
+    if (!value.is_string()) {
+        throw std::runtime_error(
+            fmt::format(fmt("The value '{:s}' in path {:s} isn't a string to evaluate."),
+                        value.dump(), base_path));
     }
-    const std::string& expression = value.get<std::string>();
+    const std::string expression = value.get<std::string>();
 
     static const std::regex re(
         R"((-?(?:0|[1-9][0-9]*)(?:\.[0-9]*)?(?:[eE][+\-]?[0-9]+)?|\+|\*|\-|\/|\)|\(|[a-zA-Z][a-zA-Z0-9_]*))",

--- a/lib/core/buffer.cpp
+++ b/lib/core/buffer.cpp
@@ -767,7 +767,8 @@ void Buffer::private_copy_frame(int dest_frame_id, Buffer* src, int src_frame_id
 bool is_frame_buffer(GenericBuffer* buf) {
     // See also bufferFactory::new_buffer()
     return (buf->buffer_type == "standard") || (buf->buffer_type == "vis")
-           || (buf->buffer_type == "hfb") || (buf->buffer_type == "N2");
+           || (buf->buffer_type == "hfb") || (buf->buffer_type == "N2")
+           || (buf->buffer_type == "ndarray");
 }
 
 uint8_t* buffer_malloc(size_t len, int numa_node, bool use_hugepages, bool mlock_frames,

--- a/lib/core/buffer.hpp
+++ b/lib/core/buffer.hpp
@@ -534,10 +534,18 @@ public:
      * @brief Requires that a frame descriptor is attached to this buffer
      *        (fatal if not), then ensures it conforms to @p desc.
      *
-     * Stages should use this method to rigidly enforce that a frame descriptor
-     * is attached to the buffer and conforms to their requirements. This fatals
-     * if no descriptor has been attached -- i.e. the buffer was not declared with
-     * a described type.
+     * Stages should use this method to rigidly enforce that a frame
+     * descriptor is (already) attached to the buffer and conforms to their
+     * requirements. This fatals if no descriptor has been attached -- i.e. the
+     * buffer was not declared with a described type.
+     * 
+     * Called with no argument it performs only the existence check: the idiom
+     * for a stage that then reads the descriptor with @c get_frame_desc<T>() or
+     * @c require_frame_desc<T>() and hand-validates the specific fields it
+     * depends on. Pass @p desc to additionally cross-check a full expected
+     * descriptor, in which case this method reconciles frame descriptors as in
+     * @c ensure_frame_desc; any unset (empty) fields are filled in from the
+     * other side, and values on both sides must agree; any conflict is fatal.
      *
      * See also @c ensure_frame_desc(). The difference is that `require` fatals on a
      * missing or incompatible descriptor, whereas `ensure` attaches @p desc when
@@ -641,6 +649,41 @@ public:
     std::shared_ptr<const T> get_frame_desc() {
         buffer_lock lock(mutex);
         return std::dynamic_pointer_cast<const T>(frames_desc);
+    }
+
+    /**
+     * @brief Like @c get_frame_desc<T>(), but fatal if the buffer has no
+     *        descriptor attached or the attached descriptor is not a @c T.
+     *
+     * Use this when a stage depends on the buffer having been declared (in the
+     * config) with a described type it can read: it guarantees a non-null,
+     * correctly typed descriptor, so the caller can then hand-validate whatever
+     * specific fields it requires. Prefer it over @c get_frame_desc<T>() at
+     * sites that immediately dereference the result, to avoid a null-pointer
+     * crash when the buffer was left undeclared or declared with another type.
+     *
+     * This is the mirror of @c get_frame_desc<T>() (which returns nullptr
+     * instead of fataling) and of the non-typed @c require_frame_desc() (which
+     * only checks that a descriptor exists). It does not reconcile against an
+     * expected descriptor -- the buffer factory already validated byte size and
+     * structure against the config when it attached the descriptor.
+     *
+     * Thread-safe.
+     *
+     * @return The frame descriptor cast to @c T (never nullptr).
+     */
+    template<typename T>
+    std::shared_ptr<const T> require_frame_desc() {
+        buffer_lock lock(mutex);
+        if (!frames_desc)
+            FATAL_ERROR("Buffer {:s} has no frame descriptor; declare the buffer with a "
+                        "described buffer type (e.g. `kotekan_buffer: ndarray`) in the config",
+                        buffer_name);
+        auto typed = std::dynamic_pointer_cast<const T>(frames_desc);
+        if (!typed)
+            FATAL_ERROR("Buffer {:s} frame descriptor is not of the type required by a consumer",
+                        buffer_name);
+        return typed;
     }
 
     /**

--- a/lib/core/buffer.hpp
+++ b/lib/core/buffer.hpp
@@ -531,139 +531,149 @@ public:
     void safe_swap_frame(int src_frame_id, Buffer* dest_buf, int dest_frame_id);
 
     /**
-     * @brief Allocates a new frame description object holding a D dimensional
-     *        array of type T, or checks the given values are consistent with
-     *        the existing frame descriptor, if it exists.
-     * @param[in] extents Array extentds in the D dimensions
-     * @param[in] dimnames Array axis labels in the D dimensions
+     * @brief Requires that a frame descriptor is attached to this buffer
+     *        (fatal if not), then ensures it conforms to @p desc.
+     *
+     * Stages should use this method to rigidly enforce that a frame descriptor
+     * is attached to the buffer and conforms to their requirements. This fatals
+     * if no descriptor has been attached -- i.e. the buffer was not declared with
+     * a described type.
+     *
+     * See also @c ensure_frame_desc(). The difference is that `require` fatals on a
+     * missing or incompatible descriptor, whereas `ensure` attaches @p desc when
+     * none is present. Use `require` when a missing config declaration is an error;
+     * use `ensure` when the stage may legitimately originate the descriptor (e.g. a
+     * runtime-discovered GPU copy-out writing an undeclared buffer).
+     *
+     * Thread-safe.
      */
+    void require_frame_desc(std::shared_ptr<const kotekan::FrameDesc> desc = nullptr) {
+        buffer_lock lock(mutex);
+        if (!frames_desc)
+            FATAL_ERROR(
+                "Buffer {:s} has no frame descriptor to validate against; declare the buffer "
+                "with a described buffer type (e.g. `kotekan_buffer: ndarray`) in the config",
+                buffer_name);
+        if (desc)
+            _ensure_frame_desc_locked(std::move(desc));
+    }
+
+    /**
+     * @brief Ensures the buffer's frame descriptor conforms to @p new_desc:
+     *        attaches it if none is present, otherwise reconciles the two.
+     *
+     * If no descriptor is attached yet, @p new_desc is recorded. Otherwise the
+     * existing and given descriptors are reconciled: their structural fields
+     * (value_type, extents, and hence byte size) must match, any unset (empty)
+     * labels (quantity_name, dimnames) are filled in from the other side, and
+     * labels set on both sides must agree -- any conflict is fatal. For
+     * non-NDArray descriptors reconciliation is a strict equality check. The
+     * reconciled descriptor replaces the stored one.
+     *
+     * See also @c require_frame_desc(). The difference is that `require` fatals on a
+     * missing or incompatible descriptor, whereas `ensure` attaches @p desc when
+     * none is present. Use `require` when a missing config declaration is an error;
+     * use `ensure` when the stage may legitimately originate the descriptor (e.g. a
+     * runtime-discovered GPU copy-out writing an undeclared buffer).
+     *
+     * Thread-safe.
+     */
+    void ensure_frame_desc(std::shared_ptr<const kotekan::FrameDesc> new_desc) {
+        buffer_lock lock(mutex);
+        _ensure_frame_desc_locked(std::move(new_desc));
+    }
+
+    /**
+     * @brief Internal: attach @p new_desc, or reconcile it with the existing
+     *        descriptor, assuming the buffer @c mutex is already held.
+     *
+     * Shared, lock-free implementation of @c ensure_frame_desc() and
+     * @c require_frame_desc(). If no descriptor is attached, @p new_desc is
+     * recorded. Otherwise the two are reconciled: for NDArray descriptors the
+     * structural fields must match, unset labels are filled in and set labels
+     * validated (see @c kotekan::GenericNDArray::reconcile()), and the stored
+     * descriptor is replaced only when labels are completed; any other descriptor
+     * is compared for strict equality. A label/structural conflict, or a byte size
+     * that disagrees with @c frame_size, is fatal.
+     *
+     * The leading underscore marks this as an internal helper: it does not take
+     * the lock and is not part of the public API. Do not call it directly -- use
+     * @c ensure_frame_desc() or @c require_frame_desc().
+     *
+     * @param[in] new_desc The descriptor to attach or reconcile against.
+     */
+    void _ensure_frame_desc_locked(std::shared_ptr<const kotekan::FrameDesc> new_desc) {
+        if (new_desc->get_byte_size() != frame_size) {
+            FATAL_ERROR(
+                "Buffer {:s} frame description size ({:d}) does not match frame_size ({:d})",
+                buffer_name, new_desc->get_byte_size(), frame_size);
+        }
+        if (!frames_desc) {
+            frames_desc = std::move(new_desc);
+            return;
+        }
+        auto cur = std::dynamic_pointer_cast<const kotekan::GenericNDArray>(frames_desc);
+        auto inc = std::dynamic_pointer_cast<const kotekan::GenericNDArray>(new_desc);
+        if (cur && inc) {
+            try {
+                // reconcile() returns a completed descriptor when @p new_desc
+                // fills in labels, or nullptr when nothing changes (keep ours).
+                if (auto merged = kotekan::GenericNDArray::reconcile(*cur, *inc))
+                    frames_desc = std::move(merged);
+            } catch (const std::exception& e) {
+                FATAL_ERROR("Buffer {:s} frame description mismatch (existing vs new): {:s}",
+                            buffer_name, e.what());
+            }
+            return;
+        }
+        if (*frames_desc != *new_desc) {
+            FATAL_ERROR("Buffer {:s} frame description mismatch (existing vs new): {:s}",
+                        buffer_name, frames_desc->describe_mismatch(*new_desc));
+        }
+    }
+
+    /**
+     * @brief Legacy frame descriptor API (deprecated).
+     *
+     * These forward to @c ensure_frame_desc()/@c get_frame_desc<T>() and exist
+     * only so not-yet-migrated stages keep compiling while the codebase moves to
+     * the FrameDesc API. They are removed once every caller is migrated.
+     */
+    void set_frame_desc(std::shared_ptr<const kotekan::FrameDesc> new_desc) {
+        ensure_frame_desc(std::move(new_desc));
+    }
+
     template<typename T, std::size_t D>
     void allocate_ndarray_frame_desc(kotekan::Symbol quantity_name,
                                      const std::array<std::ptrdiff_t, D>& extents,
                                      const std::array<kotekan::Symbol, D>& dimnames) {
-        buffer_lock lock(mutex);
-        if (!frames_desc)
-            frames_desc =
-                std::make_shared<kotekan::NDArray<T, D>>(quantity_name, extents, dimnames, nullptr);
-        else {
-            auto nd_desc = std::dynamic_pointer_cast<const kotekan::GenericNDArray>(frames_desc);
-            if (!nd_desc) {
-                FATAL_ERROR("Frame desc mismatch: existing desc is not an NDArray");
-            }
-            if (D != nd_desc->get_rank())
-                FATAL_ERROR("Rank mismatch: {:d} != {:d}", D, nd_desc->get_rank());
-            if (kotekan::GetDataType_v<T> != nd_desc->get_value_datatype())
-                FATAL_ERROR("Type mismatch: {:s} != {:s}",
-                            kotekan::type_to_string(kotekan::GetDataType_v<T>),
-                            kotekan::type_to_string(nd_desc->get_value_datatype()));
-            if (quantity_name != nd_desc->get_quantity_name())
-                FATAL_ERROR("Quantity name mismatch: {:s} != {:s}", quantity_name,
-                            nd_desc->get_quantity_name());
-            if (!std::equal(extents.begin(), extents.end(), nd_desc->get_extents().begin())) {
-                // Building individual strings with move() avoids nasty constexpr/fmt::join
-                // compilation error.
-                auto ex1_j = fmt::join(extents, ", ");
-                auto ex2_j = fmt::join(nd_desc->get_extents(), ", ");
-                std::string ex1_str = fmt::format("{}", std::move(ex1_j));
-                std::string ex2_str = fmt::format("{}", std::move(ex2_j));
-                FATAL_ERROR("Extents do not match: [{:s}] != [{:s}]", ex1_str, ex2_str);
-            }
-            if (!std::equal(dimnames.begin(), dimnames.end(), nd_desc->get_dimnames().begin()))
-                FATAL_ERROR("Dimnames do not match: [{:s}] != [{:s}]", fmt::join(dimnames, ", "),
-                            fmt::join(nd_desc->get_dimnames(), ", "));
-        }
-
-        if (frames_desc->get_byte_size() != frame_size) {
-            FATAL_ERROR("Buffer {:s} ndarray_frame_desc has size {:d}, does not match buffer "
-                        "frame_size {:d}",
-                        buffer_name, frames_desc->get_byte_size(), frame_size);
-        }
+        ensure_frame_desc(kotekan::NDArray<T, D>::describe(quantity_name, extents, dimnames));
     }
 
-    /**
-     * @brief Allocates a new frame description object holding a D dimensional
-     *        array of type T, or checks the given values are consistent with
-     *        the existing frame descriptor, if it exists.
-     * @param[in] value_type the kotekan type enumerator of the values stored
-     * @param[in] rank dimensionality of the data array
-     * @param[in] extents Array extentds in the D dimensions
-     * @param[in] dimnames Array axis labels in the D dimensions
-     */
     void allocate_ndarray_frame_desc(kotekan::DataType value_type, kotekan::Symbol quantity_name,
                                      const std::vector<std::ptrdiff_t>& extents,
                                      const std::vector<kotekan::Symbol>& dimnames) {
-        buffer_lock lock(mutex);
-        if (!frames_desc) {
-            frames_desc = kotekan::GenericNDArray::create(value_type, quantity_name, extents,
-                                                          dimnames, nullptr);
-        } else {
-            auto nd_desc = std::dynamic_pointer_cast<const kotekan::GenericNDArray>(frames_desc);
-            if (!nd_desc) {
-                FATAL_ERROR("Frame desc mismatch: existing desc is not an NDArray");
-                return;
-            }
-            if (extents.size() != nd_desc->get_rank())
-                FATAL_ERROR("Rank mismatch: {:d} != {:d}", extents.size(), nd_desc->get_rank());
-            if (value_type != nd_desc->get_value_datatype())
-                FATAL_ERROR("Type mismatch: {:s} != {:s}", kotekan::type_to_string(value_type),
-                            kotekan::type_to_string(nd_desc->get_value_datatype()));
-            if (quantity_name != nd_desc->get_quantity_name())
-                FATAL_ERROR("Quantity name mismatch: {:s} != {:s}", quantity_name,
-                            nd_desc->get_quantity_name());
-            if (extents != nd_desc->get_extents())
-                FATAL_ERROR("Extents do not match: [{:s}] != [{:s}]",
-                            fmt::format("{:s}", fmt::join(extents, ", ")),
-                            fmt::format("{:s}", fmt::join(nd_desc->get_extents(), ", ")));
-            if (dimnames != nd_desc->get_dimnames())
-                FATAL_ERROR("Dimnames do not match: [{:s}] != [{:s}]",
-                            fmt::format("{:s}", fmt::join(dimnames, ", ")),
-                            fmt::format("{:s}", fmt::join(nd_desc->get_dimnames(), ", ")));
-        }
-
-        if (frames_desc->get_byte_size() != frame_size) {
-            FATAL_ERROR("Buffer {:s} ndarray_frame_desc has size {:d}, does not match buffer "
-                        "frame_size {:d}",
-                        buffer_name, frames_desc->get_byte_size(), frame_size);
-        }
+        ensure_frame_desc(
+            kotekan::GenericNDArray::describe(value_type, quantity_name, extents, dimnames));
     }
 
-    /**
-     * @brief provides read access to the array description
-     * @return The NDArray data structure describing the array. If type of frames_desc is
-     * not GenericNDArray, this will return nullptr.
-     */
     std::shared_ptr<const kotekan::GenericNDArray> get_ndarray_frame_desc() {
-        buffer_lock lock(mutex);
-        return std::dynamic_pointer_cast<const kotekan::GenericNDArray>(frames_desc);
+        return get_frame_desc<kotekan::GenericNDArray>();
+    }
+
+    std::shared_ptr<const kotekan::FrameDesc> get_frame_description() {
+        return get_frame_desc<kotekan::FrameDesc>();
     }
 
     /**
      * @brief provides read access to the frame description
-     * @return The data structure describing the frame
+     * @return The data structure describing the frame, cast to T. Returns
+     *         nullptr if no descriptor is attached or it is not a T.
      */
-    std::shared_ptr<const kotekan::FrameDesc> get_frame_description() {
+    template<typename T = kotekan::FrameDesc>
+    std::shared_ptr<const T> get_frame_desc() {
         buffer_lock lock(mutex);
-        return frames_desc;
-    }
-
-    /**
-     * @brief Sets the frame description
-     */
-    void set_frame_desc(std::shared_ptr<const kotekan::FrameDesc> new_desc) {
-        buffer_lock lock(mutex);
-
-        if (new_desc->get_byte_size() != frame_size) {
-            FATAL_ERROR("Frame description size ({:d}) is unexpected, buffer provides ({:d})",
-                        new_desc->get_byte_size(), frame_size);
-        }
-
-        if (!frames_desc) {
-            frames_desc = new_desc;
-        } else {
-            if (*frames_desc != *new_desc) {
-                ERROR("Frame description mismatch!");
-            }
-        }
+        return std::dynamic_pointer_cast<const T>(frames_desc);
     }
 
     /**

--- a/lib/core/buffer.hpp
+++ b/lib/core/buffer.hpp
@@ -633,39 +633,6 @@ public:
     }
 
     /**
-     * @brief Legacy frame descriptor API (deprecated).
-     *
-     * These forward to @c ensure_frame_desc()/@c get_frame_desc<T>() and exist
-     * only so not-yet-migrated stages keep compiling while the codebase moves to
-     * the FrameDesc API. They are removed once every caller is migrated.
-     */
-    void set_frame_desc(std::shared_ptr<const kotekan::FrameDesc> new_desc) {
-        ensure_frame_desc(std::move(new_desc));
-    }
-
-    template<typename T, std::size_t D>
-    void allocate_ndarray_frame_desc(kotekan::Symbol quantity_name,
-                                     const std::array<std::ptrdiff_t, D>& extents,
-                                     const std::array<kotekan::Symbol, D>& dimnames) {
-        ensure_frame_desc(kotekan::NDArray<T, D>::describe(quantity_name, extents, dimnames));
-    }
-
-    void allocate_ndarray_frame_desc(kotekan::DataType value_type, kotekan::Symbol quantity_name,
-                                     const std::vector<std::ptrdiff_t>& extents,
-                                     const std::vector<kotekan::Symbol>& dimnames) {
-        ensure_frame_desc(
-            kotekan::GenericNDArray::describe(value_type, quantity_name, extents, dimnames));
-    }
-
-    std::shared_ptr<const kotekan::GenericNDArray> get_ndarray_frame_desc() {
-        return get_frame_desc<kotekan::GenericNDArray>();
-    }
-
-    std::shared_ptr<const kotekan::FrameDesc> get_frame_description() {
-        return get_frame_desc<kotekan::FrameDesc>();
-    }
-
-    /**
      * @brief provides read access to the frame description
      * @return The data structure describing the frame, cast to T. Returns
      *         nullptr if no descriptor is attached or it is not a T.

--- a/lib/core/bufferFactory.cpp
+++ b/lib/core/bufferFactory.cpp
@@ -10,12 +10,13 @@
 #include "FrameDesc.hpp"       // for FrameDesc
 #include "HFBFrameView.hpp"    // for HFBFrameView
 #include "N2FrameDesc.hpp"     // for N2FrameDesc
+#include "NDArray.hpp"         // for GenericNDArray
 #include "buffer.hpp"          // for GenericBuffer, Buffer
+#include "fmt.hpp"             // for compile_string_to_view, format, fmt
 #include "kotekanLogging.hpp"  // for INFO_NON_OO
 #include "metadata.hpp"        // for metadataPool
 #include "ringbuffer.hpp"      // for RingBuffer
 #include "visBuffer.hpp"       // for VisFrameView
-#include "fmt.hpp"             // for compile_string_to_view, format, fmt
 
 using json = nlohmann::json;
 using std::map;
@@ -81,8 +82,8 @@ GenericBuffer* bufferFactory::new_buffer(const string& type_name, const string& 
         pool = metadataPools[metadataPool_name];
     }
 
-    // See also buffer::is_frame_buffer(), which looks for these three strings ("standard", "vis",
-    // "hfb")
+    // See also buffer::is_frame_buffer(), which looks for these frame-buffer type strings
+    // ("standard", "vis", "hfb", "N2", "ndarray")
     size_t frame_size = 0;
     std::shared_ptr<kotekan::FrameDesc> frame_desc = nullptr;
     if (type_name == "standard") {
@@ -91,6 +92,9 @@ GenericBuffer* bufferFactory::new_buffer(const string& type_name, const string& 
         frame_size = VisFrameView::calculate_frame_size(config, location);
     } else if (type_name == "N2") {
         frame_desc = std::make_shared<N2FrameDesc>(config, location);
+        frame_size = frame_desc->get_byte_size();
+    } else if (type_name == "ndarray") {
+        frame_desc = GenericNDArray::from_config(config, location);
         frame_size = frame_desc->get_byte_size();
     } else if (type_name == "hfb") {
         frame_size = HFBFrameView::calculate_frame_size(config, location);
@@ -113,7 +117,7 @@ GenericBuffer* bufferFactory::new_buffer(const string& type_name, const string& 
 
         // Set frame descriptor if one was created
         if (frame_desc) {
-            static_cast<Buffer*>(buf)->set_frame_desc(frame_desc);
+            static_cast<Buffer*>(buf)->ensure_frame_desc(frame_desc);
         }
 
     } else if (type_name == "ring") {

--- a/lib/cuda/cudaCopyFromRingbuffer.cpp
+++ b/lib/cuda/cudaCopyFromRingbuffer.cpp
@@ -10,6 +10,7 @@
 #include <stdexcept>           // for runtime_error
 #include <tuple>               // for tuple, make_tuple
 
+#include "NDArray.hpp"         // for GenericNDArray
 #include "Symbol.hpp"          // for Symbol
 #include "chordMetadata.hpp"   // for chordMetadata
 #include "cudaUtils.hpp"       // for CHECK_CUDA_ERROR
@@ -175,10 +176,10 @@ cudaEvent_t cudaCopyFromRingbuffer::execute(cudaPipelineState& pipestate,
             dimnames.push_back(
                 std::string(out_meta->dim_name[d],
                             strnlen(out_meta->dim_name[d], sizeof(out_meta->dim_name[d]))));
-        out_buffer->allocate_ndarray_frame_desc(out_meta->type, out_meta->get_name(), extents,
-                                                dimnames);
+        out_buffer->ensure_frame_desc(kotekan::GenericNDArray::describe(
+            out_meta->type, out_meta->get_name(), extents, dimnames));
         /* test that things are consistent */
-        out_meta->check_frame_desc(out_buffer->get_ndarray_frame_desc());
+        out_meta->check_frame_desc(out_buffer->get_frame_desc<kotekan::GenericNDArray>());
 
     } else {
         int out_id = gpu_frame_id % _gpu_buffer_depth;

--- a/lib/cuda/cudaOutputData.cpp
+++ b/lib/cuda/cudaOutputData.cpp
@@ -13,6 +13,7 @@
 #include <memory>              // for shared_ptr, __shared_ptr_access, dynamic_pointer_cast
 #include <tuple>               // for tuple, make_tuple
 
+#include "NDArray.hpp"         // for GenericNDArray
 #include "Symbol.hpp"          // for Symbol
 #include "chordMetadata.hpp"   // for chordMetadata
 #include "cudaUtils.hpp"       // for CHECK_CUDA_ERROR
@@ -138,10 +139,11 @@ cudaEvent_t cudaOutputData::execute(cudaPipelineState&,
 
                     // difficult to move to constructor since it depends on frame_desc in the
                     // signal_buffer which may not be set at contructor time
-                    output_buffer->allocate_ndarray_frame_desc(chord->type, chord->get_name(),
-                                                               dimensions, dimnames);
+                    output_buffer->ensure_frame_desc(kotekan::GenericNDArray::describe(
+                        chord->type, chord->get_name(), dimensions, dimnames));
                     /* test that things are consistent */
-                    chord->check_frame_desc(output_buffer->get_ndarray_frame_desc());
+                    chord->check_frame_desc(
+                        output_buffer->get_frame_desc<kotekan::GenericNDArray>());
                 }
             }
         }

--- a/lib/dpdk/iceBoardShuffle.hpp
+++ b/lib/dpdk/iceBoardShuffle.hpp
@@ -9,6 +9,7 @@
 #define ICE_BOARD_SHUFFLE_HPP
 
 #include "Config.hpp"
+#include "NDArray.hpp" // for GenericNDArray, NDArray
 #include "Telescope.hpp"
 #include "buffer.hpp"
 #include "bufferContainer.hpp"
@@ -274,11 +275,12 @@ iceBoardShuffle::iceBoardShuffle(kotekan::Config& config, const std::string& uni
         out_bufs[i] = buffer_container.get_buffer(buffer_names[i]);
         out_bufs[i]->register_producer(unique_name);
         /* new style array description */
-        out_bufs[i]
-            ->allocate_ndarray_frame_desc<
-                kotekan::GetType<kotekan::int4x2_swapped_withoffset>::type, 3>(
-                "E", {1, ptrdiff_t(out_bufs[i]->frame_size) / sample_size, sample_size},
-                {"F", "T", "E"});
+        out_bufs[i]->ensure_frame_desc(
+            kotekan::NDArray<kotekan::GetType<kotekan::int4x2_swapped_withoffset>::type,
+                             3>::describe("E",
+                                          {1, ptrdiff_t(out_bufs[i]->frame_size) / sample_size,
+                                           sample_size},
+                                          {"F", "T", "E"}));
     }
 
     lost_samples_buf =
@@ -490,7 +492,7 @@ inline bool iceBoardShuffle::advance_frames(uint64_t new_seq, bool first_time) {
         meta->set_strides_simple();
         // frame_desc set in constructor
         /* test that things are consistent */
-        meta->check_frame_desc(out_bufs[i]->get_ndarray_frame_desc());
+        meta->check_frame_desc(out_bufs[i]->get_frame_desc<kotekan::GenericNDArray>());
 
         // Print out the chordMetadata
         DEBUG("chordMetadata: seq: {:d} freq_id: {:d} dim[0]: {:d} dim[1]: {:d}",
@@ -542,10 +544,11 @@ inline bool iceBoardShuffle::advance_frames(uint64_t new_seq, bool first_time) {
     std::strncpy(meta->name, "lost_samples", sizeof meta->name);
     meta->set_strides_simple();
     /* new style array description */
-    lost_samples_buf->allocate_ndarray_frame_desc<kotekan::GetType<kotekan::uint8>::type, 1>(
-        "lost_samples", {ptrdiff_t(lost_samples_buf->frame_size)}, {"T"});
+    lost_samples_buf->ensure_frame_desc(
+        kotekan::NDArray<kotekan::GetType<kotekan::uint8>::type, 1>::describe(
+            "lost_samples", {ptrdiff_t(lost_samples_buf->frame_size)}, {"T"}));
     /* test that things are consistent */
-    meta->check_frame_desc(lost_samples_buf->get_ndarray_frame_desc());
+    meta->check_frame_desc(lost_samples_buf->get_frame_desc<kotekan::GenericNDArray>());
 
 
     return true;

--- a/lib/metadata/DataType.hpp
+++ b/lib/metadata/DataType.hpp
@@ -230,7 +230,7 @@ inline std::ostream& operator<<(std::ostream& os, const float16_t x) {
 
 // This enum lets us talk about the various datatypes we're using.
 enum DataType {
-    unknown_type, // keep this as first entry for GenericNDArray::create
+    unknown_type, // keep this as first entry for GenericNDArray::describe
     uint1x8,      // 8 bools (packed into a type)
     uint4x2,      // 2 unsigned 4-bit integers (packed into a byte)
     uint8,
@@ -257,7 +257,7 @@ enum DataType {
     cfloat16,
     cfloat32,
     cfloat64,
-    end_type, // keep the as the last entry for GenericNDArray::create
+    end_type, // keep the as the last entry for GenericNDArray::describe
 };
 
 // Number of bits (not bytes!) in a type. For packed types, say how

--- a/lib/metadata/FrameDesc.hpp
+++ b/lib/metadata/FrameDesc.hpp
@@ -4,6 +4,8 @@
 #include "Symbol.hpp"
 
 #include <iostream>
+#include <sstream>
+#include <string>
 
 namespace kotekan {
 
@@ -11,23 +13,33 @@ class FrameDesc {
 public:
     virtual ~FrameDesc() = default;
 
-    // A stored name for the quantity represented by this frame description
+    /// A stored name for the quantity represented by this frame description
     virtual Symbol get_quantity_name() const = 0;
 
-    // Output the frame description, useful for logging or debugging
+    /// Output the frame description, useful for logging or debugging
     virtual void output_framedesc(std::ostream& os) const = 0;
 
-    // Verify compatibility between descriptors
+    /// Describe how this descriptor differs from `other`, for error messages.
+    /// The default prints both descriptions; subclasses may return a more
+    /// targeted description.
+    virtual std::string describe_mismatch(const FrameDesc& other) const {
+        std::ostringstream this_os, other_os;
+        output_framedesc(this_os);
+        other.output_framedesc(other_os);
+        return "existing:\n" + this_os.str() + "new:\n" + other_os.str();
+    }
+
+    /// Verify compatibility between descriptors
     virtual bool operator==(const FrameDesc& other) const = 0;
 
     virtual bool operator!=(const FrameDesc& other) const {
         return !(*this == other);
     }
 
-    // Get the size of the frame in bytes
+    /// Get the size of the frame in bytes
     virtual size_t get_byte_size() const = 0;
 
-    // Strict type checking helper
+    /// Strict type checking helper
     template<typename T>
     const T* as() const {
         return dynamic_cast<const T*>(this);

--- a/lib/metadata/NDArray.cpp
+++ b/lib/metadata/NDArray.cpp
@@ -1,3 +1,7 @@
+#include "Config.hpp"   // for Config
+#include "DataType.hpp" // for operator<<
+#include "Symbol.hpp"   // for operator<<, Symbol
+
 #include <NDArray.hpp>
 #include <sys/types.h>    // for ssize_t
 #include <cassert>        // for assert
@@ -50,8 +54,7 @@ void GenericNDArray::output_framedesc(std::ostream& os) const {
 template<DataType my_datatype, size_t my_rank>
 static inline std::shared_ptr<GenericNDArray>
 make_NDArray(const DataType datatype, const Symbol quantity_name,
-             const std::vector<std::ptrdiff_t>& extents, const std::vector<Symbol>& dimnames,
-             void* data) {
+             const std::vector<std::ptrdiff_t>& extents, const std::vector<Symbol>& dimnames) {
     // recurse until datatype matches
     if constexpr (my_datatype == unknown_type) {
         assert(my_datatype != unknown_type);
@@ -64,25 +67,151 @@ make_NDArray(const DataType datatype, const Symbol quantity_name,
         } else if (int(extents.size()) == my_rank) {
             // both match
             return std::shared_ptr<GenericNDArray>(new NDArray<GetType_t<my_datatype>, my_rank>(
-                quantity_name, extents, dimnames, static_cast<GetType_t<my_datatype>*>(data)));
+                quantity_name, extents, dimnames, static_cast<GetType_t<my_datatype>*>(nullptr)));
         } else {
             return make_NDArray<my_datatype, my_rank - 1>(datatype, quantity_name, extents,
-                                                          dimnames, data);
+                                                          dimnames);
         }
     } else {
         return make_NDArray<DataType(my_datatype - 1), my_rank>(datatype, quantity_name, extents,
-                                                                dimnames, data);
+                                                                dimnames);
     }
 }
 
-std::shared_ptr<GenericNDArray> GenericNDArray::create(const DataType value_datatype,
-                                                       const Symbol quantity_name,
-                                                       const std::vector<std::ptrdiff_t>& extents,
-                                                       const std::vector<Symbol>& dimnames,
-                                                       void* data) {
+std::shared_ptr<GenericNDArray> GenericNDArray::describe(const DataType value_datatype,
+                                                         const Symbol quantity_name,
+                                                         const std::vector<std::ptrdiff_t>& extents,
+                                                         const std::vector<Symbol>& dimnames) {
     assert(extents.size() == dimnames.size() && "Sizes of extents and dimnames must aggree");
     return make_NDArray<DataType(end_type - 1), max_rank>(value_datatype, quantity_name, extents,
-                                                          dimnames, data);
+                                                          dimnames);
+}
+
+std::shared_ptr<GenericNDArray> GenericNDArray::from_config(const Config& config,
+                                                            const std::string& location) {
+    const std::string type_name = config.get<std::string>(location, "value_type");
+    const DataType value_datatype = string_to_type(type_name);
+    if (value_datatype == unknown_type)
+        throw std::runtime_error(fmt::format(
+            fmt("GenericNDArray: unknown value_type '{:s}' in path {:s}"), type_name, location));
+
+    // `quantity_name` and `dimnames` are semantic labels: they are OPTIONAL in
+    // config. When omitted, the descriptor is left with unset (empty) labels and
+    // the producing stage fills them in via Buffer::ensure_frame_desc(); when
+    // given, the stage validates against them. `value_type` and `extents` are
+    // structural (they fix the byte layout the bufferFactory allocates) and are
+    // required.
+    const Symbol quantity_name(config.get_default<std::string>(location, "quantity_name", ""));
+
+    // Extent entries may be arithmetic expressions referencing other
+    // (scoped) config values, so evaluate them individually.
+    const auto extents_json = config.get<std::vector<nlohmann::json>>(location, "extents");
+    std::vector<std::ptrdiff_t> extents;
+    extents.reserve(extents_json.size());
+    for (const auto& extent : extents_json)
+        extents.push_back(config.eval<std::ptrdiff_t>(location, extent));
+
+    if (extents.empty() || extents.size() > max_rank)
+        throw std::runtime_error(
+            fmt::format(fmt("GenericNDArray: rank {:d} is outside [1, {:d}] in path {:s}"),
+                        extents.size(), max_rank, location));
+    for (std::size_t d = 0; d < extents.size(); ++d)
+        if (extents[d] <= 0)
+            throw std::runtime_error(fmt::format(
+                fmt("GenericNDArray: extent {:d} of dimension {:d} is not positive in path {:s}"),
+                extents[d], d, location));
+
+    const auto dimname_strings =
+        config.get_default<std::vector<std::string>>(location, "dimnames", {});
+    std::vector<Symbol> dimnames;
+    if (dimname_strings.empty()) {
+        // Labels omitted: leave one unset (empty) label per axis for a stage to fill.
+        dimnames.assign(extents.size(), Symbol(""));
+    } else {
+        if (dimname_strings.size() != extents.size())
+            throw std::runtime_error(fmt::format(
+                fmt("GenericNDArray: extents size ({:d}) does not match dimnames size ({:d}) in "
+                    "path {:s}"),
+                extents.size(), dimname_strings.size(), location));
+        dimnames.reserve(dimname_strings.size());
+        for (const auto& dimname : dimname_strings)
+            dimnames.emplace_back(dimname);
+        for (std::size_t d = 0; d < dimnames.size(); ++d)
+            for (std::size_t d1 = 0; d1 < d; ++d1)
+                if (dimnames[d] == dimnames[d1])
+                    throw std::runtime_error(fmt::format(
+                        fmt("GenericNDArray: duplicate dimname '{:s}' in path {:s}"),
+                        std::string(dimnames[d]), location));
+    }
+
+    return describe(value_datatype, quantity_name, extents, dimnames);
+}
+
+std::shared_ptr<GenericNDArray> GenericNDArray::reconcile(const GenericNDArray& a,
+                                                          const GenericNDArray& b) {
+    // Structural fields must match exactly.
+    if (a.get_value_datatype() != b.get_value_datatype())
+        throw std::runtime_error(fmt::format(fmt("value type mismatch: {:s} != {:s}"),
+                                             type_to_string(a.get_value_datatype()),
+                                             type_to_string(b.get_value_datatype())));
+    if (a.get_extents() != b.get_extents())
+        throw std::runtime_error(fmt::format(fmt("extents do not match: {:s} != {:s}"),
+                                             format_vector(a.get_extents()),
+                                             format_vector(b.get_extents())));
+
+    // Labels: an unset (empty) label is filled from the other side; labels set
+    // on both sides must agree.
+    const Symbol unset("");
+    auto merge_label = [&unset](const Symbol& x, const Symbol& y, const char* what) -> Symbol {
+        if (x == unset)
+            return y;
+        if (y == unset)
+            return x;
+        if (x == y)
+            return x;
+        throw std::runtime_error(fmt::format(fmt("{:s} mismatch: {:s} != {:s}"), what,
+                                             std::string(x), std::string(y)));
+    };
+
+    const Symbol quantity_name =
+        merge_label(a.get_quantity_name(), b.get_quantity_name(), "quantity name");
+    const std::vector<Symbol> da = a.get_dimnames();
+    const std::vector<Symbol> db = b.get_dimnames();
+    std::vector<Symbol> dimnames(da.size());
+    for (std::size_t d = 0; d < da.size(); ++d)
+        dimnames[d] = merge_label(da[d], db[d], "dimname");
+
+    // `b` contributed no labels that `a` lacked: nothing to complete, so signal
+    // "no change" (the caller keeps the existing descriptor).
+    if (quantity_name == a.get_quantity_name() && dimnames == da)
+        return nullptr;
+    return describe(a.get_value_datatype(), quantity_name, a.get_extents(), dimnames);
+}
+
+std::string GenericNDArray::structure_mismatch(const GenericNDArray& other) const {
+    if (get_value_datatype() != other.get_value_datatype())
+        return fmt::format(fmt("value type mismatch: {:s} != {:s}"),
+                           type_to_string(get_value_datatype()),
+                           type_to_string(other.get_value_datatype()));
+    if (get_quantity_name() != other.get_quantity_name())
+        return fmt::format(fmt("quantity name mismatch: {:s} != {:s}"), get_quantity_name(),
+                           other.get_quantity_name());
+    if (get_rank() != other.get_rank())
+        return fmt::format(fmt("rank mismatch: {:d} != {:d}"), get_rank(), other.get_rank());
+    if (get_extents() != other.get_extents())
+        return fmt::format(fmt("extents do not match: {:s} != {:s}"), format_vector(get_extents()),
+                           format_vector(other.get_extents()));
+    if (get_dimnames() != other.get_dimnames())
+        return fmt::format(fmt("dimnames do not match: {:s} != {:s}"),
+                           format_vector(get_dimnames()), format_vector(other.get_dimnames()));
+    return std::string();
+}
+
+std::string GenericNDArray::describe_mismatch(const FrameDesc& other) const {
+    const GenericNDArray* nd = dynamic_cast<const GenericNDArray*>(&other);
+    if (!nd)
+        return FrameDesc::describe_mismatch(other);
+    return structure_mismatch(*nd);
 }
 
 bool GenericNDArray::operator==(const FrameDesc& other_desc) const {
@@ -91,15 +220,7 @@ bool GenericNDArray::operator==(const FrameDesc& other_desc) const {
         return false;
     const GenericNDArray& other = *other_ptr;
 
-    if (this->get_value_datatype() != other.get_value_datatype())
-        return false;
-    if (this->get_quantity_name() != other.get_quantity_name())
-        return false;
-    if (this->get_rank() != other.get_rank())
-        return false;
-    if (this->get_extents() != other.get_extents())
-        return false;
-    if (this->get_dimnames() != other.get_dimnames())
+    if (!structure_mismatch(other).empty())
         return false;
     if (this->get_strides() != other.get_strides())
         return false;

--- a/lib/metadata/NDArray.hpp
+++ b/lib/metadata/NDArray.hpp
@@ -77,67 +77,115 @@ make_arrays_from_pairs(std::initializer_list<std::pair<T, U>> values) {
 // - new type `NDBuffer`?
 // - add functions to allocate/deallocate buffer?
 
-// A `GenericNDArray` is similar to a numpy array. Neither the type
-// nor the rank are known at compile time. This is convenient e.g.
-// when reading data from a file, but it prevents efficient operations
-// on array elements.
+class Config;
+
+/// A `GenericNDArray` is similar to a numpy array. Neither the type
+/// nor the rank are known at compile time. This is convenient e.g.
+/// when reading data from a file, but it prevents efficient operations
+/// on array elements.
 class GenericNDArray : public FrameDesc {
 public:
-    // create an NDArray based on run-time type information
+    /// create a descriptor (an NDArray without data) based on run-time type
+    /// information, e.g. for Buffer::ensure_frame_desc / require_frame_desc. An
+    /// empty `quantity_name`, or empty `dimnames` entries, are treated as unset
+    /// labels (see reconcile()).
+    static std::shared_ptr<GenericNDArray> describe(const DataType value_datatype,
+                                                    const Symbol quantity_name,
+                                                    const std::vector<std::ptrdiff_t>& extents,
+                                                    const std::vector<Symbol>& dimnames);
+
+    /// create an NDArray frame descriptor from a config block. Reads the
+    /// structural `value_type` and `extents` (required) and the semantic labels
+    /// `quantity_name` and `dimnames` (optional -- left unset when omitted, for
+    /// the producing stage to fill in). Extent entries may be arithmetic
+    /// expressions referencing other (scoped) config values. The data pointer is
+    /// null; the result describes shape only (e.g. for Buffer::ensure_frame_desc).
+    /// Throws std::runtime_error on invalid or inconsistent config values.
+    static std::shared_ptr<GenericNDArray> from_config(const Config& config,
+                                                       const std::string& location);
+
+    /// Combine two descriptors of the same buffer. The structural fields
+    /// (value_type, extents) must match. For the label fields (quantity_name,
+    /// dimnames), an unset (empty) label on `a` is filled from `b`, and labels
+    /// set on both sides must agree. Returns the completed descriptor when `a`
+    /// gained labels from `b`, or nullptr when nothing changed (so the caller can
+    /// keep its existing descriptor). Throws std::runtime_error on any structural
+    /// or label conflict. Used by Buffer::ensure_frame_desc to merge a
+    /// config-declared descriptor with the one a stage supplies.
+    static std::shared_ptr<GenericNDArray> reconcile(const GenericNDArray& a,
+                                                     const GenericNDArray& b);
+
+    /// Deprecated alias for describe(); the data pointer is ignored. Retained so
+    /// not-yet-migrated callers compile while the codebase moves to describe();
+    /// removed once every caller is migrated.
     static std::shared_ptr<GenericNDArray> create(const DataType value_datatype,
                                                   const Symbol quantity_name,
                                                   const std::vector<std::ptrdiff_t>& extents,
-                                                  const std::vector<Symbol>& dimnames, void* data);
-    static const size_t max_rank = 10;
+                                                  const std::vector<Symbol>& dimnames, void* /*data*/) {
+        return describe(value_datatype, quantity_name, extents, dimnames);
+    }
+    /// constexpr makes this an inline variable (C++17), so odr-uses (e.g.
+    /// passing it by reference to fmt::format) link without an out-of-line
+    /// definition.
+    static constexpr size_t max_rank = 10;
     virtual ~GenericNDArray() {}
-    // The value (element) type
+    /// The value (element) type
     virtual DataType get_value_datatype() const = 0;
-    // The number of bytes for each value (element)
+    /// The number of bytes for each value (element)
     virtual std::size_t get_value_type_size() const = 0;
-    // The stored quantity_name
+    /// The stored quantity_name
     Symbol get_quantity_name() const override = 0;
-    // The rank (number of dimensions)
+    /// The rank (number of dimensions)
     virtual std::size_t get_rank() const = 0;
-    // Pointer to the array data
+    /// Pointer to the array data
     virtual const void* get_data() const = 0;
     virtual void* get_data() = 0;
-    // The array extents (array shape)
+    /// The array extents (array shape)
     virtual std::vector<std::ptrdiff_t> get_extents() const = 0;
     virtual std::ptrdiff_t get_extent(std::size_t d) const = 0;
-    // Is the array empty?
+    /// Is the array empty?
     virtual bool get_empty() const = 0;
-    // The array size. (This is the product of the extents.)
+    /// The array size. (This is the product of the extents.)
     virtual std::ptrdiff_t get_size() const = 0;
-    // The names of the array dimensions
+    /// The names of the array dimensions
     virtual std::vector<Symbol> get_dimnames() const = 0;
     virtual Symbol get_dimname(std::size_t d) const = 0;
-    // The array strides. Strides can have any value (including negative).
+    /// The array strides. Strides can have any value (including negative).
     virtual std::vector<std::ptrdiff_t> get_strides() const = 0;
     virtual std::ptrdiff_t get_stride(std::size_t d) const = 0;
 
-    // FrameDesc override
+    /// FrameDesc override
     size_t get_byte_size() const override {
         return get_size() * get_value_type_size();
     }
 
-    // Output the array description (framedesc), useful for logging or debugging
+    /// Output the array description (framedesc), useful for logging or debugging
     void output_framedesc(std::ostream& os) const override;
 
-    // Compare two NDArrays, useful to compare metadata
+    /// Describe the first structural difference (value type, quantity name,
+    /// rank, extents, dimnames) between this descriptor and `other`; returns
+    /// an empty string when they match. Strides and data are not compared.
+    std::string structure_mismatch(const GenericNDArray& other) const;
+
+    /// FrameDesc override: the structural difference when `other` is also an
+    /// NDArray, else the default both-descriptions dump.
+    std::string describe_mismatch(const FrameDesc& other) const override;
+
+    /// Compare two NDArrays, useful to compare metadata
     bool operator==(const FrameDesc& other) const override;
 };
 
-// A `NDArray<T,D>` is a `D`-dimensional array of type `T`. Different
-// from `GenericNDArray`, its elements can be accessed efficiently. If
-// you are writing C++ code that processes multi-dimensional arrays
-// then this class is a fine choice.
+/// A `NDArray<T,D>` is a `D`-dimensional array of type `T`. Different
+/// from `GenericNDArray`, its elements can be accessed efficiently. If
+/// you are writing C++ code that processes multi-dimensional arrays
+/// then this class is a fine choice.
 template<typename T, std::size_t D>
 class NDArray : public GenericNDArray {
 public:
-    // Value (element) type
+    /// Value (element) type
     using value_type = T;
     constexpr static DataType value_datatype = GetDataType_v<T>;
-    // Rank (number of dimensions)
+    /// Rank (number of dimensions)
     constexpr static std::size_t rank = D;
     constexpr static std::size_t value_type_size = sizeof(T);
 
@@ -163,18 +211,26 @@ private:
     std::array<Symbol, D> m_dimnames;
 
 public:
-    // No default constructor
+    /// No default constructor
     NDArray() = delete;
 
-    // No copy constructors
+    /// No copy constructors
     NDArray(const NDArray&) = delete;
     NDArray& operator=(const NDArray&) = delete;
 
-    // Move constructors
+    /// Move constructors
     NDArray(NDArray&&) = default;
     NDArray& operator=(NDArray&&) = default;
 
-    // Construct from extents and dimension names
+    /// Create a descriptor (an NDArray without data), e.g. for
+    /// Buffer::ensure_frame_desc / require_frame_desc
+    static std::shared_ptr<NDArray<T, D>> describe(const Symbol quantity_name,
+                                                   const std::array<std::ptrdiff_t, D>& extents,
+                                                   const std::array<Symbol, D>& dimnames) {
+        return std::make_shared<NDArray<T, D>>(quantity_name, extents, dimnames, nullptr);
+    }
+
+    /// Construct from extents and dimension names
     NDArray(const Symbol quantity_name, const std::vector<std::ptrdiff_t>& extents,
             const std::vector<Symbol>& dimnames, T* data) {
         assert(extents.size() == D && "extents size must match dimensionality D");
@@ -226,7 +282,7 @@ public:
     //     m_data = data;
     // }
 
-    // Get a pointer to the first element
+    /// Get a pointer to the first element
     const T* data() const {
         return m_data;
     }
@@ -234,12 +290,12 @@ public:
         return m_data;
     }
 
-    // The (physical) quantity_name
+    /// The (physical) quantity_name
     Symbol quantity_name() const {
         return m_quantity_name;
     }
 
-    // The array extents (array shape)
+    /// The array extents (array shape)
     std::array<std::ptrdiff_t, D> extents() const {
         return m_extents;
     }
@@ -248,17 +304,17 @@ public:
         return m_extents[d];
     }
 
-    // Is the array empty?
+    /// Is the array empty?
     bool empty() const {
         return size() == 0;
     }
 
-    // The array size. (This is the product of the extents.)
+    /// The array size. (This is the product of the extents.)
     std::ptrdiff_t size() const {
         return m_size;
     }
 
-    // The names of the array dimensions
+    /// The names of the array dimensions
     std::array<Symbol, D> dimnames() const {
         return m_dimnames;
     }
@@ -267,7 +323,7 @@ public:
         return m_dimnames[d];
     }
 
-    // The array strides. Strides can have any value (including negative).
+    /// The array strides. Strides can have any value (including negative).
     std::array<std::ptrdiff_t, D> strides() const {
         return m_strides;
     }
@@ -276,7 +332,7 @@ public:
         return m_strides[d];
     }
 
-    // Convert an array index to an offset, using the strides
+    /// Convert an array index to an offset, using the strides
     template<typename I = std::ptrdiff_t>
     std::ptrdiff_t index2offset(const std::array<I, D>& ind) const {
         for (std::size_t d = 0; d < D; ++d)
@@ -287,7 +343,7 @@ public:
         return off;
     }
 
-    // Access an array element by index
+    /// Access an array element by index
     template<typename I = std::ptrdiff_t>
     const T& operator()(const std::array<I, D>& ind) const {
         return m_data[index2offset(ind)];
@@ -305,7 +361,7 @@ public:
         return (*this)(std::array<std::ptrdiff_t, sizeof...(Inds)>{inds...});
     }
 
-    // A const iterator
+    /// A const iterator
     class ConstIterator {
         const NDArray<T, D>* m_parent;
         std::array<std::ptrdiff_t, D> m_indices;
@@ -421,9 +477,12 @@ private:
 
         for (std::size_t d = 0; d < D; ++d)
             m_dimnames.at(d) = dimnames.at(d);
+        // Unset (empty) labels are permitted on multiple axes; only set labels
+        // must be unique.
         for (std::size_t d = 0; d < D; ++d)
             for (std::size_t d1 = 0; d1 < d; ++d1)
-                assert(m_dimnames.at(d) != m_dimnames.at(d1));
+                assert(m_dimnames.at(d) == Symbol("")
+                       || m_dimnames.at(d) != m_dimnames.at(d1));
 
         m_size = 1;
         for (std::size_t d = D; d > 0; --d) {

--- a/lib/metadata/NDArray.hpp
+++ b/lib/metadata/NDArray.hpp
@@ -94,24 +94,18 @@ public:
                                                     const std::vector<std::ptrdiff_t>& extents,
                                                     const std::vector<Symbol>& dimnames);
 
-    /// create an NDArray frame descriptor from a config block. Reads the
-    /// structural `value_type` and `extents` (required) and the semantic labels
-    /// `quantity_name` and `dimnames` (optional -- left unset when omitted, for
-    /// the producing stage to fill in). Extent entries may be arithmetic
-    /// expressions referencing other (scoped) config values. The data pointer is
-    /// null; the result describes shape only (e.g. for Buffer::ensure_frame_desc).
-    /// Throws std::runtime_error on invalid or inconsistent config values.
+    /// Build a frame descriptor from a config block. `value_type` and `extents`
+    /// are required; the optional labels `quantity_name` and `dimnames` are left
+    /// unset when omitted. Extents may be arithmetic expressions over other
+    /// config values. Throws on invalid or inconsistent config.
     static std::shared_ptr<GenericNDArray> from_config(const Config& config,
                                                        const std::string& location);
 
-    /// Combine two descriptors of the same buffer. The structural fields
-    /// (value_type, extents) must match. For the label fields (quantity_name,
-    /// dimnames), an unset (empty) label on `a` is filled from `b`, and labels
-    /// set on both sides must agree. Returns the completed descriptor when `a`
-    /// gained labels from `b`, or nullptr when nothing changed (so the caller can
-    /// keep its existing descriptor). Throws std::runtime_error on any structural
-    /// or label conflict. Used by Buffer::ensure_frame_desc to merge a
-    /// config-declared descriptor with the one a stage supplies.
+    /// Merge two descriptors for the same buffer. The structural fields
+    /// (value_type, extents) must match; an unset label (quantity_name,
+    /// dimnames) on `a` is filled from `b`, and labels set on both sides must
+    /// agree. Returns the merged descriptor if `a` gained labels, or nullptr if
+    /// nothing changed. Throws on any structural or label conflict.
     static std::shared_ptr<GenericNDArray> reconcile(const GenericNDArray& a,
                                                      const GenericNDArray& b);
     /// constexpr makes this an inline variable (C++17), so odr-uses (e.g.

--- a/lib/metadata/NDArray.hpp
+++ b/lib/metadata/NDArray.hpp
@@ -114,16 +114,6 @@ public:
     /// config-declared descriptor with the one a stage supplies.
     static std::shared_ptr<GenericNDArray> reconcile(const GenericNDArray& a,
                                                      const GenericNDArray& b);
-
-    /// Deprecated alias for describe(); the data pointer is ignored. Retained so
-    /// not-yet-migrated callers compile while the codebase moves to describe();
-    /// removed once every caller is migrated.
-    static std::shared_ptr<GenericNDArray> create(const DataType value_datatype,
-                                                  const Symbol quantity_name,
-                                                  const std::vector<std::ptrdiff_t>& extents,
-                                                  const std::vector<Symbol>& dimnames, void* /*data*/) {
-        return describe(value_datatype, quantity_name, extents, dimnames);
-    }
     /// constexpr makes this an inline variable (C++17), so odr-uses (e.g.
     /// passing it by reference to fmt::format) link without an out-of-line
     /// definition.

--- a/lib/stages/AirspyAlign.cpp
+++ b/lib/stages/AirspyAlign.cpp
@@ -37,10 +37,10 @@ AirspyAlign::AirspyAlign(Config& config, const std::string& unique_name,
     buf_inB = get_buffer("in_bufB");
     buf_inB->register_consumer(unique_name);
 
-    // Both inputs are int16 1-D airspy sample streams; set_frame_desc
+    // Both inputs are int16 1-D airspy sample streams; ensure_frame_desc
     // records or cross-checks against airspyInput's earlier assertion.
-    buf_inA->set_frame_desc(kotekan_airspy::make_input_desc(buf_inA->frame_size / sizeof(short)));
-    buf_inB->set_frame_desc(kotekan_airspy::make_input_desc(buf_inB->frame_size / sizeof(short)));
+    buf_inA->ensure_frame_desc(kotekan_airspy::make_input_desc(buf_inA->frame_size / sizeof(short)));
+    buf_inB->ensure_frame_desc(kotekan_airspy::make_input_desc(buf_inB->frame_size / sizeof(short)));
 
     _lag_window = config.get_default<uint32_t>(unique_name, "lag_window",
                                                buf_inA->frame_size / sizeof(short));

--- a/lib/stages/AirspyAlign.cpp
+++ b/lib/stages/AirspyAlign.cpp
@@ -37,10 +37,11 @@ AirspyAlign::AirspyAlign(Config& config, const std::string& unique_name,
     buf_inB = get_buffer("in_bufB");
     buf_inB->register_consumer(unique_name);
 
-    // Both inputs are int16 1-D airspy sample streams; ensure_frame_desc
-    // records or cross-checks against airspyInput's earlier assertion.
-    buf_inA->ensure_frame_desc(kotekan_airspy::make_input_desc(buf_inA->frame_size / sizeof(short)));
-    buf_inB->ensure_frame_desc(kotekan_airspy::make_input_desc(buf_inB->frame_size / sizeof(short)));
+    // Both inputs are int16 1-D airspy sample streams whose descriptors are
+    // declared in config (kotekan_buffer: ndarray). require_frame_desc confirms
+    // the config declaration is present; this stage reads only the byte length.
+    buf_inA->require_frame_desc();
+    buf_inB->require_frame_desc();
 
     _lag_window = config.get_default<uint32_t>(unique_name, "lag_window",
                                                buf_inA->frame_size / sizeof(short));

--- a/lib/stages/CountLostPLSamplesScalar.cpp
+++ b/lib/stages/CountLostPLSamplesScalar.cpp
@@ -8,6 +8,7 @@
 #include "Config.hpp"           // for Config
 #include "DataType.hpp"         // for uint1x8_t
 #include "N2Util.hpp"           // for frameID, modulo
+#include "NDArray.hpp"          // for NDArray, GenericNDArray, Config
 #include "StageFactory.hpp"     // for REGISTER_KOTEKAN_STAGE
 #include "buffer.hpp"           // for Buffer
 #include "bufferContainer.hpp"  // for bufferContainer
@@ -137,13 +138,13 @@ CountLostPLSamplesScalar::CountLostPLSamplesScalar(Config& config, const std::st
     }
 
     // Make frame desc for produced buffer (this also checks the size)
-    in_buf->allocate_ndarray_frame_desc<kotekan::uint1x8_t, 5>(
+    in_buf->require_frame_desc(kotekan::NDArray<kotekan::uint1x8_t, 5>::describe(
         "pl_mask",
         {div_noremainder(_samples_per_data_set, 128), (_num_local_freq + 3) / 4, _num_polarizations,
          div_noremainder(_num_dishes, 8), 64 / 8},
-        {"T2hi64", "F4", "P", "D8", "T2lo64"});
-    out_buf->allocate_ndarray_frame_desc<int32_t, 2>(
-        "pl_lost_counts_scalar", {_num_integrations, _num_local_freq}, {"Tc", "F"});
+        {"T2hi64", "F4", "P", "D8", "T2lo64"}));
+    out_buf->require_frame_desc(kotekan::NDArray<int32_t, 2>::describe(
+        "pl_lost_counts_scalar", {_num_integrations, _num_local_freq}, {"Tc", "F"}));
 }
 
 CountLostPLSamplesScalar::~CountLostPLSamplesScalar() {}
@@ -276,14 +277,14 @@ void CountLostPLSamplesScalar::main_thread() {
         meta_out->deepCopy(meta_in);
 
         // Set NDArray fields
-        meta_out->set_from_frame_desc(out_buf->get_ndarray_frame_desc());
+        meta_out->set_from_frame_desc(out_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // Set non-NDArray things.
         meta_out->set_time_downsampling_fpga(
             div_noremainder(meta_in->get_time_downsampling_fpga(), 128) * _sub_integration_ntime);
 
         // test that things are consistent
-        meta_out->check_frame_desc(out_buf->get_ndarray_frame_desc());
+        meta_out->check_frame_desc(out_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         in_buf->mark_frame_empty(unique_name, in_frame_id++);
         out_buf->mark_frame_full(unique_name, out_frame_id++);

--- a/lib/stages/CountLostPLSamplesScalar.cpp
+++ b/lib/stages/CountLostPLSamplesScalar.cpp
@@ -137,14 +137,12 @@ CountLostPLSamplesScalar::CountLostPLSamplesScalar(Config& config, const std::st
                     "scalar in elements.");
     }
 
-    // Make frame desc for produced buffer (this also checks the size)
-    in_buf->require_frame_desc(kotekan::NDArray<kotekan::uint1x8_t, 5>::describe(
-        "pl_mask",
-        {div_noremainder(_samples_per_data_set, 128), (_num_local_freq + 3) / 4, _num_polarizations,
-         div_noremainder(_num_dishes, 8), 64 / 8},
-        {"T2hi64", "F4", "P", "D8", "T2lo64"}));
-    out_buf->require_frame_desc(kotekan::NDArray<int32_t, 2>::describe(
-        "pl_lost_counts_scalar", {_num_integrations, _num_local_freq}, {"Tc", "F"}));
+    // in_buf (pl_mask) and out_buf (pl_lost_counts_scalar) shapes are validated
+    // by the pl_mask producer and the N2Accumulate consumer respectively; this
+    // stage reads/writes them as flat arrays (indices computed from config, not
+    // the declared extents), so it only requires that descriptors were declared.
+    in_buf->require_frame_desc();
+    out_buf->require_frame_desc();
 }
 
 CountLostPLSamplesScalar::~CountLostPLSamplesScalar() {}

--- a/lib/stages/EigenN2Iter.cpp
+++ b/lib/stages/EigenN2Iter.cpp
@@ -83,10 +83,8 @@ EigenN2Iter::EigenN2Iter(Config& config, const std::string& unique_name,
         FATAL_ERROR("EigenN2Iter stage requires an 'N2' buffer type for in_buf and out_buf.");
 
     // Validate that input and output buffers have N2 frame descriptors set
-    auto in_desc =
-        std::dynamic_pointer_cast<const kotekan::N2FrameDesc>(in_buf->get_frame_description());
-    auto out_desc =
-        std::dynamic_pointer_cast<const kotekan::N2FrameDesc>(out_buf->get_frame_description());
+    auto in_desc = in_buf->get_frame_desc<kotekan::N2FrameDesc>();
+    auto out_desc = out_buf->get_frame_desc<kotekan::N2FrameDesc>();
     if (!in_desc || !out_desc) {
         FATAL_ERROR("EigenN2Iter: Input and output buffers must have N2FrameDesc set");
     }
@@ -110,8 +108,7 @@ EigenN2Iter::EigenN2Iter(Config& config, const std::string& unique_name,
             FATAL_ERROR("EigenN2Iter stage requires 'N2' buffer type for failed_buf.");
 
         // Validate that input and failed buffers have N2 frame descriptors set
-        auto failed_desc = std::dynamic_pointer_cast<const kotekan::N2FrameDesc>(
-            failed_buf->get_frame_description());
+        auto failed_desc = failed_buf->get_frame_desc<kotekan::N2FrameDesc>();
         if (!failed_desc) {
             FATAL_ERROR("EigenN2Iter: failed_buf buffer must have N2FrameDesc set");
         }

--- a/lib/stages/EigenN2Iter.cpp
+++ b/lib/stages/EigenN2Iter.cpp
@@ -83,11 +83,8 @@ EigenN2Iter::EigenN2Iter(Config& config, const std::string& unique_name,
         FATAL_ERROR("EigenN2Iter stage requires an 'N2' buffer type for in_buf and out_buf.");
 
     // Validate that input and output buffers have N2 frame descriptors set
-    auto in_desc = in_buf->get_frame_desc<kotekan::N2FrameDesc>();
-    auto out_desc = out_buf->get_frame_desc<kotekan::N2FrameDesc>();
-    if (!in_desc || !out_desc) {
-        FATAL_ERROR("EigenN2Iter: Input and output buffers must have N2FrameDesc set");
-    }
+    auto in_desc = in_buf->require_frame_desc<kotekan::N2FrameDesc>();
+    auto out_desc = out_buf->require_frame_desc<kotekan::N2FrameDesc>();
     // Validate num_elements and layout match
     if (in_desc->get_num_elements() != out_desc->get_num_elements()) {
         FATAL_ERROR("EigenN2Iter: Input and output buffer num_elements must match");
@@ -108,10 +105,7 @@ EigenN2Iter::EigenN2Iter(Config& config, const std::string& unique_name,
             FATAL_ERROR("EigenN2Iter stage requires 'N2' buffer type for failed_buf.");
 
         // Validate that input and failed buffers have N2 frame descriptors set
-        auto failed_desc = failed_buf->get_frame_desc<kotekan::N2FrameDesc>();
-        if (!failed_desc) {
-            FATAL_ERROR("EigenN2Iter: failed_buf buffer must have N2FrameDesc set");
-        }
+        auto failed_desc = failed_buf->require_frame_desc<kotekan::N2FrameDesc>();
         // Validate num_elements and layout match
         if (in_desc->get_num_elements() != failed_desc->get_num_elements()) {
             FATAL_ERROR("EigenN2Iter: Input and failed buffer num_elements must match");

--- a/lib/stages/N2Accumulate.cpp
+++ b/lib/stages/N2Accumulate.cpp
@@ -231,16 +231,7 @@ N2Accumulate::N2Accumulate(Config& config, const std::string& unique_name,
     // Validate that the output buffer's frame descriptor (set by bufferFactory) matches
     // what this stage will produce
     {
-        auto out_frame_desc = out_buf->get_frame_desc();
-        if (!out_frame_desc) {
-            FATAL_ERROR("N2Accumulate: Output buffer {:s} does not have a frame descriptor set",
-                        out_buf->buffer_name);
-        }
-        auto n2_desc = std::dynamic_pointer_cast<const kotekan::N2FrameDesc>(out_frame_desc);
-        if (!n2_desc) {
-            FATAL_ERROR("N2Accumulate: Output buffer {:s} does not have an N2FrameDesc",
-                        out_buf->buffer_name);
-        }
+        auto n2_desc = out_buf->require_frame_desc<kotekan::N2FrameDesc>();
         // Validate the descriptor matches what we expect to produce
         if (n2_desc->get_num_elements() != (uint32_t)_num_elements) {
             FATAL_ERROR(

--- a/lib/stages/N2Accumulate.cpp
+++ b/lib/stages/N2Accumulate.cpp
@@ -28,6 +28,7 @@
 #include "Hash.hpp"               // for operator!=
 #include "N2FrameDesc.hpp"        // for N2FrameDesc
 #include "N2Layout.hpp"           // for N2Layout
+#include "NDArray.hpp"            // for GenericNDArray
 #include "dataset.hpp"            // for dset_id_t
 #include "div.hpp"                // for div_ceil, num_triangle_blocks
 #include "jsonMetadata.hpp"       // for MAX_NUM_RFI_THRESHOLDS
@@ -202,35 +203,35 @@ N2Accumulate::N2Accumulate(Config& config, const std::string& unique_name,
     _accum_bin_idx = -1;
 
     // Ensure incoming buffer shapes and type are correct
-    in_buf->allocate_ndarray_frame_desc(kotekan::int32, "n2k_correlation",
-                                        {_n_integrations_per_n2k_frame, _num_freq_per_n2k_frame,
-                                         _n2k_correlation_num_blocks, _n2k_correlation_blocksize,
-                                         _n2k_correlation_blocksize, 2},
-                                        {"Tc", "F", "DPhi", "DPlo1", "DPlo2", "C"});
+    in_buf->require_frame_desc(kotekan::GenericNDArray::describe(
+        kotekan::int32, "n2k_correlation",
+        {_n_integrations_per_n2k_frame, _num_freq_per_n2k_frame, _n2k_correlation_num_blocks,
+         _n2k_correlation_blocksize, _n2k_correlation_blocksize, 2},
+        {"Tc", "F", "DPhi", "DPlo1", "DPlo2", "C"}));
 
-    in_counts_buf->allocate_ndarray_frame_desc(kotekan::int32, "n2k_counts",
-                                               {_n_integrations_per_n2k_frame,
-                                                _num_freq_per_n2k_frame, _n2k_counts_num_blocks,
-                                                _n2k_counts_blocksize, _n2k_counts_blocksize},
-                                               {"Tc", "F", "D8Phi", "D8Plo1", "D8Plo2"});
+    in_counts_buf->require_frame_desc(kotekan::GenericNDArray::describe(
+        kotekan::int32, "n2k_counts",
+        {_n_integrations_per_n2k_frame, _num_freq_per_n2k_frame, _n2k_counts_num_blocks,
+         _n2k_counts_blocksize, _n2k_counts_blocksize},
+        {"Tc", "F", "D8Phi", "D8Plo1", "D8Plo2"}));
 
-    in_rficounts_buf->allocate_ndarray_frame_desc(
+    in_rficounts_buf->require_frame_desc(kotekan::GenericNDArray::describe(
         kotekan::int32, "RFImask_counts", {_n_integrations_per_n2k_frame, _num_freq_per_n2k_frame},
-        {"Tc", "F"});
+        {"Tc", "F"}));
 
-    in_plcounts_buf->allocate_ndarray_frame_desc(
+    in_plcounts_buf->require_frame_desc(kotekan::GenericNDArray::describe(
         kotekan::int32, "pl_lost_counts_scalar",
-        {_n_integrations_per_n2k_frame, _num_freq_per_n2k_frame}, {"Tc", "F"});
+        {_n_integrations_per_n2k_frame, _num_freq_per_n2k_frame}, {"Tc", "F"}));
 
-    in_rfiframemask_buf->allocate_ndarray_frame_desc(
+    in_rfiframemask_buf->require_frame_desc(kotekan::GenericNDArray::describe(
         kotekan::uint8, "RFIFrameMask", {_n_integrations_per_n2k_frame, _num_freq_per_n2k_frame},
-        {"Tc", "F"});
+        {"Tc", "F"}));
 
 
     // Validate that the output buffer's frame descriptor (set by bufferFactory) matches
     // what this stage will produce
     {
-        auto out_frame_desc = out_buf->get_frame_description();
+        auto out_frame_desc = out_buf->get_frame_desc();
         if (!out_frame_desc) {
             FATAL_ERROR("N2Accumulate: Output buffer {:s} does not have a frame descriptor set",
                         out_buf->buffer_name);

--- a/lib/stages/N2FrameToVisFrame.cpp
+++ b/lib/stages/N2FrameToVisFrame.cpp
@@ -50,7 +50,7 @@ n2FrameToVisFrame::n2FrameToVisFrame(Config& config, const std::string& unique_n
     // N2FrameDesc's are constructed on buffer creation (before stages) so this object will
     // exist with the correct data.
     const std::shared_ptr<const kotekan::N2FrameDesc> n2_frame_desc =
-        std::dynamic_pointer_cast<const kotekan::N2FrameDesc>(n2_buf->get_frame_description());
+        n2_buf->get_frame_desc<kotekan::N2FrameDesc>();
     if (!n2_frame_desc) {
         FATAL_ERROR("n2_buf does not have N2 Frame Descriptor");
     }

--- a/lib/stages/N2FrameToVisFrame.cpp
+++ b/lib/stages/N2FrameToVisFrame.cpp
@@ -50,10 +50,7 @@ n2FrameToVisFrame::n2FrameToVisFrame(Config& config, const std::string& unique_n
     // N2FrameDesc's are constructed on buffer creation (before stages) so this object will
     // exist with the correct data.
     const std::shared_ptr<const kotekan::N2FrameDesc> n2_frame_desc =
-        n2_buf->get_frame_desc<kotekan::N2FrameDesc>();
-    if (!n2_frame_desc) {
-        FATAL_ERROR("n2_buf does not have N2 Frame Descriptor");
-    }
+        n2_buf->require_frame_desc<kotekan::N2FrameDesc>();
     uint32_t n2_ne = n2_frame_desc->get_num_elements();
     uint32_t n2_np = n2_frame_desc->get_num_products();
     uint32_t n2_nev = n2_frame_desc->get_num_ev();

--- a/lib/stages/N2Subset.cpp
+++ b/lib/stages/N2Subset.cpp
@@ -48,23 +48,8 @@ N2Subset::N2Subset(Config& config, const std::string& unique_name,
     }
 
     // Get and validate frame descriptors
-    auto in_frame_desc = in_buf->get_frame_desc();
-    if (!in_frame_desc) {
-        FATAL_ERROR("N2Subset: in_buf does not have a frame descriptor set");
-    }
-    in_desc = std::dynamic_pointer_cast<const N2FrameDesc>(in_frame_desc);
-    if (!in_desc) {
-        FATAL_ERROR("N2Subset: in_buf does not have an N2FrameDesc");
-    }
-
-    auto out_frame_desc = out_buf->get_frame_desc();
-    if (!out_frame_desc) {
-        FATAL_ERROR("N2Subset: out_buf does not have a frame descriptor set");
-    }
-    out_desc = std::dynamic_pointer_cast<const N2FrameDesc>(out_frame_desc);
-    if (!out_desc) {
-        FATAL_ERROR("N2Subset: out_buf does not have an N2FrameDesc");
-    }
+    in_desc = in_buf->require_frame_desc<N2FrameDesc>();
+    out_desc = out_buf->require_frame_desc<N2FrameDesc>();
 
     // Store num_elements from descriptors
     _in_num_elements = in_desc->get_num_elements();

--- a/lib/stages/N2Subset.cpp
+++ b/lib/stages/N2Subset.cpp
@@ -48,7 +48,7 @@ N2Subset::N2Subset(Config& config, const std::string& unique_name,
     }
 
     // Get and validate frame descriptors
-    auto in_frame_desc = in_buf->get_frame_description();
+    auto in_frame_desc = in_buf->get_frame_desc();
     if (!in_frame_desc) {
         FATAL_ERROR("N2Subset: in_buf does not have a frame descriptor set");
     }
@@ -57,7 +57,7 @@ N2Subset::N2Subset(Config& config, const std::string& unique_name,
         FATAL_ERROR("N2Subset: in_buf does not have an N2FrameDesc");
     }
 
-    auto out_frame_desc = out_buf->get_frame_description();
+    auto out_frame_desc = out_buf->get_frame_desc();
     if (!out_frame_desc) {
         FATAL_ERROR("N2Subset: out_buf does not have a frame descriptor set");
     }

--- a/lib/stages/N2TimeDownsample.cpp
+++ b/lib/stages/N2TimeDownsample.cpp
@@ -45,8 +45,8 @@ N2TimeDownsample::N2TimeDownsample(Config& config, const std::string& unique_nam
     out_buf->register_producer(unique_name);
 
     // Validate that input and output buffers have compatible N2 frame descriptors
-    auto in_desc = in_buf->get_frame_description();
-    auto out_desc = out_buf->get_frame_description();
+    auto in_desc = in_buf->get_frame_desc();
+    auto out_desc = out_buf->get_frame_desc();
     if (!in_desc || !out_desc) {
         FATAL_ERROR("N2TimeDownsample: Input and output buffers must have frame descriptors set");
     }

--- a/lib/stages/PLMaskExpandedToCompact.cpp
+++ b/lib/stages/PLMaskExpandedToCompact.cpp
@@ -14,6 +14,7 @@
 #include "kotekanLogging.hpp"   // for FATAL_ERROR, INFO
 #include "fmt.hpp"              // for compile_string_to_view
 #include "DataType.hpp"         // for DataType
+#include "NDArray.hpp"
 
 using kotekan::bufferContainer;
 using kotekan::Config;
@@ -64,14 +65,14 @@ STAGE_CONSTRUCTOR(PLMaskExpandedToCompact) {
     }
 
     // Set up ndarray frame descriptor for the input and output
-    in_buf->allocate_ndarray_frame_desc(
+    in_buf->require_frame_desc(kotekan::GenericNDArray::describe(
         kotekan::uint1x8, "pl_mask_exp",
         {(ptrdiff_t)(T / 64), (ptrdiff_t)F, 2, (ptrdiff_t)(E_div_8 / 2), 8},
-        {"Thi64", "F", "P", "D8", "Tlo64"});
-    out_buf->allocate_ndarray_frame_desc(
+        {"Thi64", "F", "P", "D8", "Tlo64"}));
+    out_buf->require_frame_desc(kotekan::GenericNDArray::describe(
         kotekan::uint1x8, "pl_mask",
         {(ptrdiff_t)(T / 128), (ptrdiff_t)F_compact, 2, (ptrdiff_t)(E_div_8 / 2), 8},
-        {"T2hi64", "F4", "P", "D8", "T2lo64"});
+        {"T2hi64", "F4", "P", "D8", "T2lo64"}));
 
     INFO("PLMaskExpandedToCompact: Expanded [T/64={:d}][F={:d}][E/8={:d}] -> "
          "Compact [T/128={:d}][F4={:d}][E/8={:d}]",
@@ -174,7 +175,7 @@ void PLMaskExpandedToCompact::main_thread() {
         out_meta->deepCopy(in_meta);
 
         // Set NDArray meta from the frame descriptor
-        out_meta->set_from_frame_desc(out_buf->get_ndarray_frame_desc());
+        out_meta->set_from_frame_desc(out_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // Other updates from in_meta
         // Compact mask covers 128 baseband samples per uint64 (vs 64 for expanded)

--- a/lib/stages/ProcessPacketMask.cpp
+++ b/lib/stages/ProcessPacketMask.cpp
@@ -14,6 +14,7 @@
 #include "kotekanLogging.hpp"   // for INFO, DEBUG2
 #include "fmt.hpp"              // for compile_string_to_view, format, fmt
 #include "DataType.hpp"         // for DataType
+#include "NDArray.hpp"
 
 using kotekan::bufferContainer;
 using kotekan::Config;
@@ -130,10 +131,10 @@ STAGE_CONSTRUCTOR(ProcessPacketMask) {
             pl_mask_buf->frame_size, expected_pl_mask_size, T / 64, num_frequency, E / 8));
     }
 
-    pl_mask_buf->allocate_ndarray_frame_desc(
+    pl_mask_buf->require_frame_desc(kotekan::GenericNDArray::describe(
         kotekan::uint1x8, "pl_mask_exp",
         {time_long * time_short / 64, num_frequency, 2, element_long * element_short / 8 / 2, 8},
-        {"Thi64", "F", "P", "D8", "Tlo64"});
+        {"Thi64", "F", "P", "D8", "Tlo64"}));
 
     // Validate rfi_mask buffer size
     // rfi_mask shape: uint8_t [T/1024][F][128] where T = time_long * time_short
@@ -145,9 +146,9 @@ STAGE_CONSTRUCTOR(ProcessPacketMask) {
                         rfi_mask_buf->frame_size, expected_rfi_mask_size, T / 1024, num_frequency));
     }
 
-    rfi_mask_buf->allocate_ndarray_frame_desc(kotekan::uint1x8, "RFImask",
-                                              {time_long * time_short / 1024, num_frequency, 128},
-                                              {"T8hi128", "F", "T8lo128"});
+    rfi_mask_buf->require_frame_desc(kotekan::GenericNDArray::describe(
+        kotekan::uint1x8, "RFImask", {time_long * time_short / 1024, num_frequency, 128},
+        {"T8hi128", "F", "T8lo128"}));
 
     INFO("ProcessPacketMask: Initialized with {:d} receipt bitmap buffers",
          receipt_bitmap_bufs.size());

--- a/lib/stages/RfiFrameMask.cpp
+++ b/lib/stages/RfiFrameMask.cpp
@@ -25,6 +25,7 @@
 #include "restServer.hpp"       // for restServer, connectionInstance
 #include "fmt.hpp"              // for compile_string_to_view, format, format_string
 #include "DataType.hpp"         // for DataType
+#include "NDArray.hpp"          // for GenericNDArray, Config
 #include "Stage.hpp"            // for Stage
 #include "jsonMetadata.hpp"     // for MAX_NUM_RFI_THRESHOLDS
 
@@ -174,9 +175,11 @@ RfiFrameMask::RfiFrameMask(Config& config, const std::string& unique_name,
     out_buf = get_buffer("out_buf");
     out_buf->register_producer(unique_name);
 
-    // Ensure outgoing buffer is standard type
-    if (out_buf->buffer_type != "standard")
-        FATAL_ERROR("RfiFrameMask out_buf ({:s}) is not of type standard.", out_buf->buffer_name);
+    // The output buffer must carry an NDArray frame descriptor (declared with
+    // `kotekan_buffer: ndarray` in the config); require_frame_desc below validates
+    // its shape/type.
+    if (out_buf->buffer_type != "ndarray")
+        FATAL_ERROR("RfiFrameMask out_buf ({:s}) is not of type ndarray.", out_buf->buffer_name);
 
     // Sanity checks on initialization
     {
@@ -208,10 +211,10 @@ RfiFrameMask::RfiFrameMask(Config& config, const std::string& unique_name,
 
     // Set up frame descriptors. This also checks their shape, type, and size is consistent with
     // other stages in the pipeline.
-    in_buf->allocate_ndarray_frame_desc(kotekan::float32, "SKtilde",
-                                        {_rfi_num_times, _num_local_freq, 3}, {"Trfi", "F", "SK"});
-    out_buf->allocate_ndarray_frame_desc(kotekan::uint8, "RFIFrameMask",
-                                         {_num_integrations, _num_local_freq}, {"Tc", "F"});
+    in_buf->require_frame_desc(kotekan::GenericNDArray::describe(
+        kotekan::float32, "SKtilde", {_rfi_num_times, _num_local_freq, 3}, {"Trfi", "F", "SK"}));
+    out_buf->require_frame_desc(kotekan::GenericNDArray::describe(
+        kotekan::uint8, "RFIFrameMask", {_num_integrations, _num_local_freq}, {"Tc", "F"}));
 
     // Initialize current RFI excision status, the "next" values are taken care of by the
     // configUpdater)
@@ -335,7 +338,7 @@ void RfiFrameMask::main_thread() {
         // Start with a copy
         out_meta->deepCopy(in_meta);
         // Set the array shape stuff from the frame descriptor.
-        out_meta->set_from_frame_desc(out_buf->get_ndarray_frame_desc());
+        out_meta->set_from_frame_desc(out_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // Set other metadata we changed or added.
         out_meta->set_time_downsampling_fpga(
@@ -350,7 +353,7 @@ void RfiFrameMask::main_thread() {
         out_meta->set_rfi_frame_excision_thresholds(meta_thresholds);
 
         // Check we're consistent with the frame desc, just in case!
-        out_meta->check_frame_desc(out_buf->get_ndarray_frame_desc());
+        out_meta->check_frame_desc(out_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // Advance to the next frame
         in_buf->mark_frame_empty(unique_name, in_frame_id++);

--- a/lib/stages/RfiMaskSum.cpp
+++ b/lib/stages/RfiMaskSum.cpp
@@ -15,6 +15,7 @@
 #include "kotekanLogging.hpp"   // for FATAL_ERROR, DEBUG, INFO
 #include "fmt.hpp"              // for compile_string_to_view
 #include "DataType.hpp"         // for DataType
+#include "NDArray.hpp"          // for GenericNDArray, Config
 #include "Stage.hpp"            // for Stage
 
 
@@ -102,9 +103,11 @@ RfiMaskSum::RfiMaskSum(Config& config, const std::string& unique_name,
     out_buf = get_buffer("out_buf");
     out_buf->register_producer(unique_name);
 
-    // Ensure outgoing buffer is of type N2
-    if (out_buf->buffer_type != "standard")
-        FATAL_ERROR("RfiMaskSum out_buf ({:s}) is not of type standard.", out_buf->buffer_name);
+    // The output buffer must carry an NDArray frame descriptor (declared with
+    // `kotekan_buffer: ndarray` in the config); require_frame_desc below validates
+    // its shape/type.
+    if (out_buf->buffer_type != "ndarray")
+        FATAL_ERROR("RfiMaskSum out_buf ({:s}) is not of type ndarray.", out_buf->buffer_name);
 
     // Sanity checks on initialization
     {
@@ -142,12 +145,12 @@ RfiMaskSum::RfiMaskSum(Config& config, const std::string& unique_name,
         FATAL_ERROR("RfiMaskSum in_buf ({:s}) has frame size {:d}. Expected {:d}.",
                     in_buf->buffer_name, in_buf->frame_size, in_rfimask_frame_size);
 
-    in_buf->allocate_ndarray_frame_desc(
+    in_buf->require_frame_desc(kotekan::GenericNDArray::describe(
         kotekan::uint1x8, "RFImask",
         {div_noremainder(_samples_per_data_set, 1024), _num_local_freq, 1024 / 8},
-        {"T8hi128", "F", "T8lo128"});
-    out_buf->allocate_ndarray_frame_desc(kotekan::int32, "RFImask_counts",
-                                         {_num_integrations, _num_local_freq}, {"Tc", "F"});
+        {"T8hi128", "F", "T8lo128"}));
+    out_buf->require_frame_desc(kotekan::GenericNDArray::describe(
+        kotekan::int32, "RFImask_counts", {_num_integrations, _num_local_freq}, {"Tc", "F"}));
 }
 
 void RfiMaskSum::main_thread() {
@@ -187,11 +190,11 @@ void RfiMaskSum::main_thread() {
         const std::shared_ptr<chordMetadata> out_meta = get_chord_metadata(out_buf, out_frame_id);
 
         out_meta->deepCopy(in_meta);
-        out_meta->set_from_frame_desc(out_buf->get_ndarray_frame_desc());
+        out_meta->set_from_frame_desc(out_buf->get_frame_desc<kotekan::GenericNDArray>());
         out_meta->set_time_downsampling_fpga(
             div_noremainder(in_meta->get_time_downsampling_fpga(), 1024) * _sub_integration_ntime);
 
-        out_meta->check_frame_desc(out_buf->get_ndarray_frame_desc());
+        out_meta->check_frame_desc(out_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // Advance to the next frame
         in_buf->mark_frame_empty(unique_name, in_frame_id++);

--- a/lib/stages/SampleAutocorr.cpp
+++ b/lib/stages/SampleAutocorr.cpp
@@ -32,7 +32,7 @@ SampleAutocorr::SampleAutocorr(Config& config, const std::string& unique_name,
     buf_in->register_consumer(unique_name);
 
     // Input: cfloat32 1-D fengine spectra (consumer-only; no out_buf).
-    buf_in->set_frame_desc(
+    buf_in->ensure_frame_desc(
         kotekan_airspy::make_fengine_desc(buf_in->frame_size / (2 * sizeof(float))));
 
     _spectrum_length = config.get_default<int>(unique_name, "spectrum_length", 1024);

--- a/lib/stages/SimpleCrosscorr.cpp
+++ b/lib/stages/SimpleCrosscorr.cpp
@@ -43,9 +43,9 @@ SimpleCrosscorr::SimpleCrosscorr(Config& config, const std::string& unique_name,
     // crosscorr unit test captures buf_out via rawFileWrite. networkPowerStream
     // asserts the expected power_corr layout on its consumer side, so the
     // contract is still documented in code.
-    buf_inA->set_frame_desc(
+    buf_inA->ensure_frame_desc(
         kotekan_airspy::make_fengine_desc(buf_inA->frame_size / (2 * sizeof(float))));
-    buf_inB->set_frame_desc(
+    buf_inB->ensure_frame_desc(
         kotekan_airspy::make_fengine_desc(buf_inB->frame_size / (2 * sizeof(float))));
 }
 

--- a/lib/stages/TransposeBasebandArray.cpp
+++ b/lib/stages/TransposeBasebandArray.cpp
@@ -15,6 +15,7 @@
 #include "kotekanLogging.hpp"   // for INFO, DEBUG, ERROR
 #include "fmt.hpp"              // for compile_string_to_view, format, fmt
 #include "DataType.hpp"         // for DataType
+#include "NDArray.hpp"
 
 #ifdef __AVX512F__
 #include <immintrin.h>          // for __m512i, _mm512_stream_si512, _mm512_set1_epi8, _mm512_se...
@@ -152,9 +153,9 @@ STAGE_CONSTRUCTOR(TransposeBasebandArray) {
     // Set the output buffer frame ndarray shape
 
     // Confusingly the array name is "E" for electric field
-    out_buf->allocate_ndarray_frame_desc(
+    out_buf->require_frame_desc(kotekan::GenericNDArray::describe(
         kotekan::int4x2_swapped_withoffset, "E",
-        {timesamples_per_frame, NUM_LOCAL_FREQ, 2, NUM_ELEMENTS / 2}, {"T", "F", "P", "D"});
+        {timesamples_per_frame, NUM_LOCAL_FREQ, 2, NUM_ELEMENTS / 2}, {"T", "F", "P", "D"}));
 
     INFO("TransposeBasebandArray: Input shape: [{:d}][{:d}][{:d}][{:d}][{:d}]", time_long,
          NUM_LOCAL_FREQ, ELEMENT_LONG, TIME_SHORT, ELEMENT_SHORT);

--- a/lib/stages/airspyFrameDesc.hpp
+++ b/lib/stages/airspyFrameDesc.hpp
@@ -11,10 +11,10 @@
  * @file
  * @brief Frame-descriptor builders for the airspy autocorr / crosscorr pipelines.
  *
- * Uses the *buffer-level* FrameDesc mechanism (Buffer::set_frame_desc /
- * get_frame_description) -- independent of the metadata pool, which these
+ * Uses the *buffer-level* FrameDesc mechanism (Buffer::ensure_frame_desc /
+ * get_frame_desc) -- independent of the metadata pool, which these
  * pipelines run with set to "none". The convention: every airspy
- * producer/consumer stage calls @c buf->set_frame_desc on each buffer it
+ * producer/consumer stage calls @c buf->ensure_frame_desc on each buffer it
  * touches via one of these helpers. The first call records the descriptor;
  * subsequent calls compare via @c FrameDesc::operator== and ERROR on
  * mismatch -- so producer/consumer construction order is irrelevant, and a
@@ -34,8 +34,8 @@ namespace kotekan_airspy {
 
 /// Raw airspy samples: int16 1-D buffer of length @p n_samples.
 inline std::shared_ptr<kotekan::GenericNDArray> make_input_desc(std::ptrdiff_t n_samples) {
-    return kotekan::GenericNDArray::create(kotekan::DataType::int16, "airspy_samples", {n_samples},
-                                           {"sample"}, nullptr);
+    return kotekan::GenericNDArray::describe(kotekan::DataType::int16, "airspy_samples",
+                                             {n_samples}, {"sample"});
 }
 
 /// fftwEngine output spectra: cfloat32 1-D buffer of length @p n_complex.
@@ -43,8 +43,8 @@ inline std::shared_ptr<kotekan::GenericNDArray> make_input_desc(std::ptrdiff_t n
 /// descriptor records total complex elements, the consumers' indexing
 /// arithmetic comes from their own config.
 inline std::shared_ptr<kotekan::GenericNDArray> make_fengine_desc(std::ptrdiff_t n_complex) {
-    return kotekan::GenericNDArray::create(kotekan::DataType::cfloat32, "fengine_spectra",
-                                           {n_complex}, {"bin"}, nullptr);
+    return kotekan::GenericNDArray::describe(kotekan::DataType::cfloat32, "fengine_spectra",
+                                             {n_complex}, {"bin"});
 }
 
 /// SimpleCrosscorr / simpleAutocorr -> networkPowerStream layout. Per
@@ -54,7 +54,7 @@ inline std::shared_ptr<kotekan::GenericNDArray> make_fengine_desc(std::ptrdiff_t
 /// for multi-element (crosscorr), to match what the producers actually
 /// emit and what networkPowerStream walks for each element/time index.
 ///
-/// @note Only networkPowerStream (the consumer) calls set_frame_desc with
+/// @note Only networkPowerStream (the consumer) calls ensure_frame_desc with
 /// this; the producers (simpleAutocorr / SimpleCrosscorr) deliberately
 /// leave their out_buf untagged so the corr-buffer round-trip tests that
 /// use rawFileWrite still work (rawFileWrite refuses NDArray-tagged
@@ -64,12 +64,11 @@ inline std::shared_ptr<kotekan::GenericNDArray> make_fengine_desc(std::ptrdiff_t
 inline std::shared_ptr<kotekan::GenericNDArray>
 make_power_corr_desc(std::ptrdiff_t num_elements, std::ptrdiff_t spectrum_length) {
     if (num_elements == 1) {
-        return kotekan::GenericNDArray::create(kotekan::DataType::float32, "power_corr",
-                                               {spectrum_length + 1}, {"bin"}, nullptr);
+        return kotekan::GenericNDArray::describe(kotekan::DataType::float32, "power_corr",
+                                                 {spectrum_length + 1}, {"bin"});
     }
-    return kotekan::GenericNDArray::create(kotekan::DataType::float32, "power_corr",
-                                           {num_elements, spectrum_length + 1}, {"elem", "bin"},
-                                           nullptr);
+    return kotekan::GenericNDArray::describe(kotekan::DataType::float32, "power_corr",
+                                             {num_elements, spectrum_length + 1}, {"elem", "bin"});
 }
 
 } // namespace kotekan_airspy

--- a/lib/stages/airspyInput.cpp
+++ b/lib/stages/airspyInput.cpp
@@ -47,10 +47,12 @@ airspyInput::airspyInput(Config& config, const std::string& unique_name,
         return;
     }
 
-    // Buffer carries int16 1-D samples. ensure_frame_desc validates byte size
-    // against buf->frame_size and either records the descriptor or compares
-    // against an earlier assertion -- see airspyFrameDesc.hpp.
-    buf->ensure_frame_desc(kotekan_airspy::make_input_desc(buf->frame_size / BYTES_PER_SAMPLE));
+    // Buffer carries int16 1-D samples; its descriptor is declared in config
+    // (kotekan_buffer: ndarray) and attached by the buffer factory at startup,
+    // which already checks the descriptor's byte size against frame_size.
+    // require_frame_desc just confirms config declared it. The even-sample-count
+    // constraint above is enforced separately: the descriptor cannot express it.
+    buf->require_frame_desc();
 
     freq = config.get_default<float>(unique_name, "freq", 1420) * 1e6;             // MHz
     _sample_rate = config.get_default<float>(unique_name, "sample_bw", 2.5) * 1e6; // MSPS

--- a/lib/stages/airspyInput.cpp
+++ b/lib/stages/airspyInput.cpp
@@ -47,10 +47,10 @@ airspyInput::airspyInput(Config& config, const std::string& unique_name,
         return;
     }
 
-    // Buffer carries int16 1-D samples. set_frame_desc validates byte size
+    // Buffer carries int16 1-D samples. ensure_frame_desc validates byte size
     // against buf->frame_size and either records the descriptor or compares
     // against an earlier assertion -- see airspyFrameDesc.hpp.
-    buf->set_frame_desc(kotekan_airspy::make_input_desc(buf->frame_size / BYTES_PER_SAMPLE));
+    buf->ensure_frame_desc(kotekan_airspy::make_input_desc(buf->frame_size / BYTES_PER_SAMPLE));
 
     freq = config.get_default<float>(unique_name, "freq", 1420) * 1e6;             // MHz
     _sample_rate = config.get_default<float>(unique_name, "sample_bw", 2.5) * 1e6; // MSPS

--- a/lib/stages/asdfFileRead.cpp
+++ b/lib/stages/asdfFileRead.cpp
@@ -1,5 +1,6 @@
 #include <Config.hpp>             // for Config
 #include <DataType.hpp>           // for string_to_type, type_to_string, DataType
+#include <NDArray.hpp>            // for GenericNDArray
 #include <Stage.hpp>              // for Stage
 #include <StageFactory.hpp>       // for REGISTER_KOTEKAN_STAGE
 #include <Symbol.hpp>             // for Symbol
@@ -224,9 +225,10 @@ public:
                         const std::string dim_name = dim_names->at(d)->get_maybe_string().value();
                         dimnames.push_back(dim_name);
                     }
-                    buffer->allocate_ndarray_frame_desc(value_type, name, dimensions, dimnames);
+                    buffer->require_frame_desc(
+                        kotekan::GenericNDArray::describe(value_type, name, dimensions, dimnames));
                     /* test that things are consistent */
-                    meta->check_frame_desc(buffer->get_ndarray_frame_desc());
+                    meta->check_frame_desc(buffer->get_frame_desc<kotekan::GenericNDArray>());
                 }
 
 

--- a/lib/stages/asdfFileWrite.cpp
+++ b/lib/stages/asdfFileWrite.cpp
@@ -140,8 +140,11 @@ public:
             assert(metadata_is_chord(mc) || metadata_is_N2(mc));
             const std::shared_ptr<const chordMetadata> meta = get_chord_metadata(mc);
             const std::shared_ptr<const kotekan::GenericNDArray> frame_desc =
-                buffer->get_ndarray_frame_desc();
-            assert(frame_desc);
+                buffer->get_frame_desc<kotekan::GenericNDArray>();
+            if (!frame_desc)
+                FATAL_ERROR("Buffer \"{:s}\" has no NDArray frame descriptor; asdfFileWrite "
+                            "needs one to describe the written array",
+                            buffer->buffer_name);
 
             const double this_time = current_time();
             const double elapsed_time = this_time - start_time;

--- a/lib/stages/bufferDelay.cpp
+++ b/lib/stages/bufferDelay.cpp
@@ -94,11 +94,11 @@ void bufferDelay::main_thread() {
                 in_buf->pass_metadata(in_frame_release_id, out_buf, out_frame_id);
                 in_buf->swap_frames(in_frame_release_id, out_buf, out_frame_id);
             }
-            const auto in_frame_desc = in_buf->get_frame_description();
+            const auto in_frame_desc = in_buf->get_frame_desc();
             if (in_frame_desc) {
-                out_buf->set_frame_desc(in_frame_desc);
+                out_buf->require_frame_desc(in_frame_desc);
             } else {
-                assert(!out_buf->get_frame_description());
+                assert(!out_buf->get_frame_desc());
             }
 
             DEBUG("Reached maximum no. of frames to hold. Releasing oldest frame... in_frame_id: "

--- a/lib/stages/bufferMerge.cpp
+++ b/lib/stages/bufferMerge.cpp
@@ -116,11 +116,11 @@ void bufferMerge::main_thread() {
                 in_buf->pass_metadata(in_frame_id, out_buf, out_frame_id);
 
                 // Link frame description
-                const auto in_frame_desc = in_buf->get_frame_description();
+                const auto in_frame_desc = in_buf->get_frame_desc();
                 if (in_frame_desc) {
-                    out_buf->set_frame_desc(in_frame_desc);
+                    out_buf->require_frame_desc(in_frame_desc);
                 } else {
-                    assert(!out_buf->get_frame_description());
+                    assert(!out_buf->get_frame_desc());
                 }
 
                 // Copy or swap the frame.

--- a/lib/stages/bufferQuiet.cpp
+++ b/lib/stages/bufferQuiet.cpp
@@ -135,11 +135,11 @@ void bufferQuiet::main_thread() {
                 // this just copies the shared pointer, and is only valid since
                 // a frame description must never change
             }
-            const auto in_frame_desc = in_buf->get_frame_description();
+            const auto in_frame_desc = in_buf->get_frame_desc();
             if (in_frame_desc) {
-                out_buf->set_frame_desc(in_frame_desc);
+                out_buf->require_frame_desc(in_frame_desc);
             } else {
-                assert(!out_buf->get_frame_description());
+                assert(!out_buf->get_frame_desc());
             }
 
             DEBUG("Releasing frame... in_frame_id: {:d}, in_frame_hold_ctr: {:d}, "

--- a/lib/stages/bufferRecv.cpp
+++ b/lib/stages/bufferRecv.cpp
@@ -20,6 +20,7 @@
 #include <utility>                // for pair
 
 #include "Config.hpp"             // for Config
+#include "NDArray.hpp"            // for GenericNDArray, Config
 #include "StageFactory.hpp"       // for REGISTER_KOTEKAN_STAGE
 #include "Symbol.hpp"             // for Symbol
 #include "buffer.hpp"             // for Buffer, buffer_free, buffer_malloc
@@ -550,7 +551,6 @@ void connInstance::internal_read_callback() {
                 if (metadata)
                     metadata->set_from_bytes((char*)metadata_space, buf_frame_header.metadata_size);
 
-                // TODO: actuall transfer the NDArray information
                 auto chord = std::dynamic_pointer_cast<chordMetadata>(metadata);
                 if (chord) {
                     /* new style array description */
@@ -562,10 +562,14 @@ void connInstance::internal_read_callback() {
                                         strnlen(chord->dim_name[d], sizeof(chord->dim_name[d])));
                     }
 
-                    buf->allocate_ndarray_frame_desc(chord->type, chord->get_name(), dimensions,
-                                                     dimnames);
+                    // The frame descriptor is discovered from the received frame,
+                    // so ensure_frame_desc: attach it when the receive buffer is
+                    // undeclared (e.g. `standard`), or validate the received shape
+                    // against the buffer's declared descriptor when it has one.
+                    buf->ensure_frame_desc(kotekan::GenericNDArray::describe(
+                        chord->type, chord->get_name(), dimensions, dimnames));
                     /* test that things are consistent */
-                    chord->check_frame_desc(buf->get_ndarray_frame_desc());
+                    chord->check_frame_desc(buf->get_frame_desc<kotekan::GenericNDArray>());
                 }
 
                 buf->mark_frame_full(producer_name, frame_id);

--- a/lib/stages/bufferRecv.cpp
+++ b/lib/stages/bufferRecv.cpp
@@ -551,6 +551,10 @@ void connInstance::internal_read_callback() {
                 if (metadata)
                     metadata->set_from_bytes((char*)metadata_space, buf_frame_header.metadata_size);
 
+                // TODO: instead of reconstructing the descriptor from chordMetadata
+                // here, the sender should transmit the buffer's frame descriptor over
+                // the wire and the receiver should validate its config-declared
+                // descriptor against it.
                 auto chord = std::dynamic_pointer_cast<chordMetadata>(metadata);
                 if (chord) {
                     /* new style array description */

--- a/lib/stages/calcBBPhase.cpp
+++ b/lib/stages/calcBBPhase.cpp
@@ -70,15 +70,15 @@ public:
         A_buffer->register_producer(unique_name);
         s_buffer->register_producer(unique_name);
 
-        bb_beam_positions_buffer->allocate_ndarray_frame_desc<float, 2>(
-            "bb_beam_positions", {bb_num_beams, 2}, {"B", "X/Y"});
-        
-        A_buffer->allocate_ndarray_frame_desc<std::int8_t, 5>(
-            "A", {num_frequencies, num_polarizations, bb_num_beams, num_dishes, num_components},
-            {"F", "P", "B", "D", "C"});
+        bb_beam_positions_buffer->require_frame_desc(kotekan::NDArray<float, 2>::describe(
+            "bb_beam_positions", {bb_num_beams, 2}, {"B", "X/Y"}));
 
-        s_buffer->allocate_ndarray_frame_desc<std::int32_t, 3>(
-            "s", {num_frequencies, num_polarizations, bb_num_beams}, {"F", "P", "B"});
+        A_buffer->require_frame_desc(kotekan::NDArray<std::int8_t, 5>::describe(
+            "A", {num_frequencies, num_polarizations, bb_num_beams, num_dishes, num_components},
+            {"F", "P", "B", "D", "C"}));
+
+        s_buffer->require_frame_desc(kotekan::NDArray<std::int32_t, 3>::describe(
+            "s", {num_frequencies, num_polarizations, bb_num_beams}, {"F", "P", "B"}));
     }
 
     virtual ~calcBBPhase() {}
@@ -135,14 +135,15 @@ public:
 
 
         // Get timing info from beam positions buffer.
-        const auto& bb_beam_positions_meta = get_chord_metadata(bb_beam_positions_buffer->get_metadata(frame_id));
+        const auto& bb_beam_positions_meta =
+            get_chord_metadata(bb_beam_positions_buffer->get_metadata(frame_id));
         uint64_t seq_num = bb_beam_positions_meta->get_fpga_seq_num();
         uint64_t time_downsampling = bb_beam_positions_meta->get_time_downsampling_fpga();
 
         // Set metadata
         A_buffer->allocate_new_metadata_object(frame_id);
         const auto& A_meta = get_chord_metadata(A_buffer->get_metadata(frame_id));
-        A_meta->set_from_frame_desc(A_buffer->get_ndarray_frame_desc());
+        A_meta->set_from_frame_desc(A_buffer->get_frame_desc<kotekan::GenericNDArray>());
         A_meta->set_fpga_seq_num(seq_num);
         A_meta->set_time_downsampling_fpga(time_downsampling);
         A_meta->set_coarse_freq(frequency_channels);
@@ -151,7 +152,7 @@ public:
 
         s_buffer->allocate_new_metadata_object(frame_id);
         const auto& s_meta = get_chord_metadata(s_buffer->get_metadata(frame_id));
-        s_meta->set_from_frame_desc(s_buffer->get_ndarray_frame_desc());
+        s_meta->set_from_frame_desc(s_buffer->get_frame_desc<kotekan::GenericNDArray>());
         s_meta->set_fpga_seq_num(seq_num);
         s_meta->set_time_downsampling_fpga(time_downsampling);
         s_meta->set_coarse_freq(frequency_channels);

--- a/lib/stages/calcFRB2Weights.cpp
+++ b/lib/stages/calcFRB2Weights.cpp
@@ -1,5 +1,6 @@
 #include "Config.hpp"                   // for Config
 #include "DataType.hpp"                 // for float16_t
+#include "NDArray.hpp"                  // for GenericNDArray
 #include "Stage.hpp"                    // for Stage
 #include "StageFactory.hpp"             // for REGISTER_KOTEKAN_STAGE
 #include "Telescope.hpp"                // for Telescope, freq_id_t
@@ -101,11 +102,11 @@ public:
         frb2_beam_positions_buffer->register_consumer(unique_name);
         W2_buffer->register_producer(unique_name);
 
-        frb2_beam_positions_buffer->allocate_ndarray_frame_desc<float, 2>(
-            "frb2_beam_positions", {frb2_num_beams, 2}, {"R", "X/Y"});
-        W2_buffer->allocate_ndarray_frame_desc<float16_t, 4>(
+        frb2_beam_positions_buffer->require_frame_desc(kotekan::NDArray<float, 2>::describe(
+            "frb2_beam_positions", {frb2_num_beams, 2}, {"R", "X/Y"}));
+        W2_buffer->require_frame_desc(kotekan::NDArray<float16_t, 4>::describe(
             "W2", {frb2_num_frequencies, frb2_num_beams, frb1_num_beams_Q, frb1_num_beams_P},
-            {"Fbar", "R", "beamQ", "beamP"});
+            {"Fbar", "R", "beamQ", "beamP"}));
     }
 
     virtual ~calcFRB2Weights() {}
@@ -179,10 +180,9 @@ public:
         assert(std::ptrdiff_t(W2_buffer->frame_size) == W2_frame_size);
 
         // Set metadata
-
         W2_buffer->allocate_new_metadata_object(frame_id);
         const auto& W2_meta = get_chord_metadata(W2_buffer->get_metadata(frame_id));
-        W2_meta->set_from_frame_desc(W2_buffer->get_ndarray_frame_desc());
+        W2_meta->set_from_frame_desc(W2_buffer->get_frame_desc<kotekan::GenericNDArray>());
         W2_meta->set_fpga_seq_num(0);           // ???
         W2_meta->set_time_downsampling_fpga(1); // ???
         W2_meta->set_coarse_freq(coarse_freq);

--- a/lib/stages/fftwEngine.cpp
+++ b/lib/stages/fftwEngine.cpp
@@ -32,11 +32,11 @@ fftwEngine::fftwEngine(Config& config, const std::string& unique_name,
     out_buf = get_buffer("out_buf");
     out_buf->register_producer(unique_name);
 
-    // Output is cfloat32 1-D regardless of input_type (we accept either
-    // int16 reals or cint16 IQ pairs upstream, so in_buf's descriptor is
-    // intentionally left for the upstream producer to assert).
-    out_buf->ensure_frame_desc(
-        kotekan_airspy::make_fengine_desc(out_buf->frame_size / sizeof(fftwf_complex)));
+    // Output is cfloat32 1-D regardless of input_type (we accept either int16
+    // reals or cint16 IQ pairs upstream, so in_buf's descriptor is intentionally
+    // left for the upstream producer to assert). out_buf's descriptor is declared
+    // in config (kotekan_buffer: ndarray); require_frame_desc confirms it.
+    out_buf->require_frame_desc();
 
     _spectrum_length = config.get_default<int>(unique_name, "spectrum_length", 128);
 

--- a/lib/stages/fftwEngine.cpp
+++ b/lib/stages/fftwEngine.cpp
@@ -35,7 +35,7 @@ fftwEngine::fftwEngine(Config& config, const std::string& unique_name,
     // Output is cfloat32 1-D regardless of input_type (we accept either
     // int16 reals or cint16 IQ pairs upstream, so in_buf's descriptor is
     // intentionally left for the upstream producer to assert).
-    out_buf->set_frame_desc(
+    out_buf->ensure_frame_desc(
         kotekan_airspy::make_fengine_desc(out_buf->frame_size / sizeof(fftwf_complex)));
 
     _spectrum_length = config.get_default<int>(unique_name, "spectrum_length", 128);

--- a/lib/stages/givenDataGen.cpp
+++ b/lib/stages/givenDataGen.cpp
@@ -12,6 +12,7 @@
 #include <stdexcept>            // for invalid_argument, runtime_error
 
 #include "DataType.hpp"         // for type_total_bytes, string_to_type, DataType
+#include "NDArray.hpp"          // for GenericNDArray, Config
 #include "StageFactory.hpp"     // for REGISTER_KOTEKAN_STAGE
 #include "bufferContainer.hpp"  // for bufferContainer
 #include "chordMetadata.hpp"    // for chordMetadata, get_chord_metadata, CHORD_META_MAX_DIM
@@ -111,9 +112,10 @@ void givenDataGen::main_thread() {
         }
         chordmeta->set_strides_simple();
 
-        _out_buf->allocate_ndarray_frame_desc(chordmeta->type, _name, _array_shape, _dim_name);
+        _out_buf->require_frame_desc(
+            kotekan::GenericNDArray::describe(chordmeta->type, _name, _array_shape, _dim_name));
         /* test that things are consistent */
-        chordmeta->check_frame_desc(_out_buf->get_ndarray_frame_desc());
+        chordmeta->check_frame_desc(_out_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         _out_buf->mark_frame_full(unique_name, frame_id);
 

--- a/lib/stages/hdf5FileRead.cpp
+++ b/lib/stages/hdf5FileRead.cpp
@@ -2,6 +2,7 @@
 
 #include <Config.hpp>          // for Config
 #include <DataType.hpp>        // for string_to_type, DataType
+#include <NDArray.hpp>         // for GenericNDArray
 #include <Stage.hpp>           // for Stage
 #include <StageFactory.hpp>    // for REGISTER_KOTEKAN_STAGE
 #include <Symbol.hpp>          // for Symbol
@@ -294,9 +295,10 @@ public:
                     std::vector<ptrdiff_t> dimensions(dims.begin(), dims.end());
                     std::vector<kotekan::Symbol> dimnames(dim_names.begin(), dim_names.end());
 
-                    buffer->allocate_ndarray_frame_desc(value_type, name, dimensions, dimnames);
+                    buffer->require_frame_desc(
+                        kotekan::GenericNDArray::describe(value_type, name, dimensions, dimnames));
                     /* test that things are consistent */
-                    meta->check_frame_desc(buffer->get_ndarray_frame_desc());
+                    meta->check_frame_desc(buffer->get_frame_desc<kotekan::GenericNDArray>());
                 }
 
                 // Read buffer

--- a/lib/stages/hdf5FileReadSingleFile.cpp
+++ b/lib/stages/hdf5FileReadSingleFile.cpp
@@ -20,6 +20,7 @@
 
 #include "Config.hpp"                          // for Config
 #include "DataType.hpp"                        // for string_to_type, DataType
+#include "NDArray.hpp"                         // for GenericNDArray
 #include "Stage.hpp"                           // for Stage
 #include "StageFactory.hpp"                    // for REGISTER_KOTEKAN_STAGE
 #include "Symbol.hpp"                          // for Symbol
@@ -185,11 +186,11 @@ public:
                     break;
 
                 // Set metadata
-                buffer->allocate_ndarray_frame_desc(type, kotekan::Symbol(name), new_dims,
-                                                    new_dim_names);
+                buffer->require_frame_desc(kotekan::GenericNDArray::describe(
+                    type, kotekan::Symbol(name), new_dims, new_dim_names));
                 buffer->allocate_new_metadata_object(frame_id);
                 const auto& meta = get_chord_metadata(buffer->get_metadata(frame_id));
-                meta->set_from_frame_desc(buffer->get_ndarray_frame_desc());
+                meta->set_from_frame_desc(buffer->get_frame_desc<kotekan::GenericNDArray>());
 
                 meta->set_coarse_freq(frequency_channels);
                 meta->set_freq_upchan_factor(new_freq_upchan_factor);

--- a/lib/stages/hdf5FileWrite.cpp
+++ b/lib/stages/hdf5FileWrite.cpp
@@ -591,8 +591,12 @@ public:
                     assert(metadata_is_chord(mc));
                     const std::shared_ptr<const chordMetadata> meta = get_chord_metadata(mc);
                     const std::shared_ptr<const kotekan::GenericNDArray> frame_desc =
-                        buffer->get_ndarray_frame_desc();
-                    assert(frame_desc);
+                        buffer->get_frame_desc<kotekan::GenericNDArray>();
+                    if (!frame_desc)
+                        FATAL_ERROR(
+                            "Buffer \"{:s}\" has no NDArray frame descriptor; hdf5FileWrite "
+                            "needs one to write CHORD-metadata frames",
+                            buffer->buffer_name);
                     write_chord(frame, meta, frame_desc, frame_counter);
                 } else if (metadata_is_N2(mc)) {
                     assert(metadata_is_N2(mc));

--- a/lib/stages/loadFeedGains.cpp
+++ b/lib/stages/loadFeedGains.cpp
@@ -85,11 +85,11 @@ loadFeedGains::loadFeedGains(Config& config, const std::string& unique_name,
                         num_local_freq * num_elements * 2 * sizeof(float), buf->frame_size);
         }
         // Set frame description
-        buf->allocate_ndarray_frame_desc<kotekan::GetType_t<kotekan::float32>, 3>(
+        buf->ensure_frame_desc(kotekan::NDArray<kotekan::GetType_t<kotekan::float32>, 3>::describe(
             "gain",
             {static_cast<ptrdiff_t>(num_local_freq), static_cast<ptrdiff_t>(num_elements),
              (ptrdiff_t)2},
-            {"F", "E", "ReIm"});
+            {"F", "E", "ReIm"}));
     }
 
     // Set up callbacks for each beam_id
@@ -272,10 +272,10 @@ void loadFeedGains::main_thread() {
         // Set metadata from the frame desc, and other metadata
         buf->allocate_new_metadata_object(frame_id);
         auto meta = get_chord_metadata(buf, frame_id);
-        meta->set_from_frame_desc(buf->get_ndarray_frame_desc());
+        meta->set_from_frame_desc(buf->get_frame_desc<kotekan::GenericNDArray>());
         meta->set_name("gain");
         // Verify that frame desc and metadata match
-        meta->check_frame_desc(buf->get_ndarray_frame_desc());
+        meta->check_frame_desc(buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // load gains into the buffer, returning in the received frame
         // is invalid

--- a/lib/stages/lostSamplesToN2Counts.cpp
+++ b/lib/stages/lostSamplesToN2Counts.cpp
@@ -92,10 +92,10 @@ lostSamplesToN2Counts::lostSamplesToN2Counts(Config& config, const std::string& 
             "Number of lost_samples buffers ({:d}) does not evenly divide total frequencies ({:d})",
             _nbufs, num_n2k_freq);
 
-    // Check the rfi mask shape against expectation
-    rfi_mask_buf->require_frame_desc(kotekan::NDArray<kotekan::uint1x8_t, 3>::describe(
-        "RFImask", {std::ptrdiff_t(samples_per_data_set / 1024), std::ptrdiff_t(num_n2k_freq), 128},
-        {"T8hi128", "F", "T8lo128"}));
+    // rfi_mask's shape is established and validated by its producer; this stage
+    // works from frame_size and config (checked above), so it only requires that
+    // a descriptor was declared rather than re-asserting the full shape.
+    rfi_mask_buf->require_frame_desc();
 
     // This is a bit of a misnomer - the lost_samples buffer does not _include_
     // multiple frequencies, but information may be shared by multiple frequencies

--- a/lib/stages/lostSamplesToN2Counts.cpp
+++ b/lib/stages/lostSamplesToN2Counts.cpp
@@ -8,6 +8,7 @@
 #include "Config.hpp"           // for Config
 #include "DataType.hpp"         // for DataType, GetType_t
 #include "N2Util.hpp"           // for frameID, modulo
+#include "NDArray.hpp"          // for NDArray, GenericNDArray, Config
 #include "StageFactory.hpp"     // for REGISTER_KOTEKAN_STAGE
 #include "buffer.hpp"           // for Buffer
 #include "bufferContainer.hpp"  // for bufferContainer
@@ -91,11 +92,10 @@ lostSamplesToN2Counts::lostSamplesToN2Counts(Config& config, const std::string& 
             "Number of lost_samples buffers ({:d}) does not evenly divide total frequencies ({:d})",
             _nbufs, num_n2k_freq);
 
-    // Check rfi make frame size against expectation
-    size_t _expected_rfi_frame_size = num_n2k_freq * samples_per_data_set / BITS_PER_BYTE;
-    if (rfi_mask_buf->frame_size != _expected_rfi_frame_size)
-        FATAL_ERROR("Unexpected frame size for rfi_mask {:d} - expected {:d}",
-                    rfi_mask_buf->frame_size, _expected_rfi_frame_size);
+    // Check the rfi mask shape against expectation
+    rfi_mask_buf->require_frame_desc(kotekan::NDArray<kotekan::uint1x8_t, 3>::describe(
+        "RFImask", {std::ptrdiff_t(samples_per_data_set / 1024), std::ptrdiff_t(num_n2k_freq), 128},
+        {"T8hi128", "F", "T8lo128"}));
 
     // This is a bit of a misnomer - the lost_samples buffer does not _include_
     // multiple frequencies, but information may be shared by multiple frequencies
@@ -120,11 +120,12 @@ lostSamplesToN2Counts::lostSamplesToN2Counts(Config& config, const std::string& 
     // Set the frame description
     // The buffer name and axis names are the same as those set in
     // cudaPL1butCorrelator
-    n2k_counts_buf->allocate_ndarray_frame_desc<kotekan::GetType_t<kotekan::int32>, 5>(
-        "n2k_counts",
-        {static_cast<long>(_num_subintegrations), static_cast<long>(num_n2k_freq),
-         static_cast<long>(_counts_ntiles), COUNTS_BLOCK_SIZE, COUNTS_BLOCK_SIZE},
-        {"Tc", "F", "D8Phi", "D8Plo1", "D8Plo2"});
+    n2k_counts_buf->require_frame_desc(
+        kotekan::NDArray<kotekan::GetType_t<kotekan::int32>, 5>::describe(
+            "n2k_counts",
+            {static_cast<long>(_num_subintegrations), static_cast<long>(num_n2k_freq),
+             static_cast<long>(_counts_ntiles), COUNTS_BLOCK_SIZE, COUNTS_BLOCK_SIZE},
+            {"Tc", "F", "D8Phi", "D8Plo1", "D8Plo2"}));
 }
 
 lostSamplesToN2Counts::~lostSamplesToN2Counts() {}
@@ -256,7 +257,7 @@ void lostSamplesToN2Counts::main_thread() {
         // Update metadata from the frame description
         std::shared_ptr<chordMetadata> meta =
             get_chord_metadata(n2k_counts_buf, n2k_counts_buf_frame_id);
-        meta->set_from_frame_desc(n2k_counts_buf->get_ndarray_frame_desc());
+        meta->set_from_frame_desc(n2k_counts_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // Set additional metadata not handled by the helper, including
         // the name and FPGA time-sample downsampling
@@ -264,7 +265,7 @@ void lostSamplesToN2Counts::main_thread() {
         meta->set_time_downsampling_fpga(sub_integration_ntime);
 
         // Check that frame desc and metadata match
-        meta->check_frame_desc(n2k_counts_buf->get_ndarray_frame_desc());
+        meta->check_frame_desc(n2k_counts_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // Release the current frames and increment to the next frame ID
         n2k_counts_buf->mark_frame_full(unique_name, n2k_counts_buf_frame_id);

--- a/lib/stages/lostSamplesToPLMask.cpp
+++ b/lib/stages/lostSamplesToPLMask.cpp
@@ -65,14 +65,15 @@ lostSamplesToPLMask::lostSamplesToPLMask(Config& config, const std::string& uniq
         FATAL_ERROR("Unexpected frames sizes for pl_mask {:d} and lost_samples {:d}",
                     pl_mask_buf->frame_size, lost_samples_bufs.at(0)->frame_size);
 
-    pl_mask_buf->allocate_ndarray_frame_desc<kotekan::GetType_t<kotekan::uint1x8>, 5>(
-        "pl_mask",
-        {ptrdiff_t(lost_samples_bufs.at(0)->frame_size / PL_MASK_DOWNSAMPLING_FACTOR
-                   / PL_MASK_HILO_SPLIT),
-         ptrdiff_t(lost_samples_bufs.size()), num_polarizations,
-         num_dishes / PL_MASK_DISHES_PER_BIN,
-         PL_MASK_HILO_SPLIT / BITS_PER_BYTE /* because we count uint1x8, not uint1 */},
-        {"T2hi64", "F4", "P", "D8", "T2lo64"});
+    pl_mask_buf->require_frame_desc(
+        kotekan::NDArray<kotekan::GetType_t<kotekan::uint1x8>, 5>::describe(
+            "pl_mask",
+            {ptrdiff_t(lost_samples_bufs.at(0)->frame_size / PL_MASK_DOWNSAMPLING_FACTOR
+                       / PL_MASK_HILO_SPLIT),
+             ptrdiff_t(lost_samples_bufs.size()), num_polarizations,
+             num_dishes / PL_MASK_DISHES_PER_BIN,
+             PL_MASK_HILO_SPLIT / BITS_PER_BYTE /* because we count uint1x8, not uint1 */},
+            {"T2hi64", "F4", "P", "D8", "T2lo64"}));
 }
 
 lostSamplesToPLMask::~lostSamplesToPLMask() {}
@@ -100,10 +101,10 @@ void lostSamplesToPLMask::main_thread() {
             // constant for all iterations but only set by the producer before
             // it marks the frame as full, so cannot be checked before the first
             // wait_for_full_frame()
-            auto const expected_lost_samples_frame_desc = kotekan::GenericNDArray::create(
-                kotekan::DataType::uint8, "lost_samples", {ptrdiff_t(lost_samples_buf->frame_size)},
-                {"T"}, nullptr);
-            assert(*lost_samples_buf->get_ndarray_frame_desc()
+            auto const expected_lost_samples_frame_desc =
+                kotekan::GenericNDArray::describe(kotekan::DataType::uint8, "lost_samples",
+                                                  {ptrdiff_t(lost_samples_buf->frame_size)}, {"T"});
+            assert(*lost_samples_buf->get_frame_desc<kotekan::GenericNDArray>()
                    == *expected_lost_samples_frame_desc);
 
             // pl_mask buffer_format [time / 2 % 64][dish / 8][polr][freq / 4][time / 2 / 64]
@@ -146,7 +147,8 @@ void lostSamplesToPLMask::main_thread() {
                 pl_mask_meta->deepCopy(lost_samples_meta);
 
                 // update array description
-                pl_mask_meta->set_from_frame_desc(pl_mask_buf->get_ndarray_frame_desc());
+                pl_mask_meta->set_from_frame_desc(
+                    pl_mask_buf->get_frame_desc<kotekan::GenericNDArray>());
 
                 // update metadata
                 pl_mask_meta->set_time_downsampling_fpga(pl_mask_meta->get_time_downsampling_fpga()
@@ -185,7 +187,7 @@ void lostSamplesToPLMask::main_thread() {
         lost_samples_buf_frame_id =
             (lost_samples_buf_frame_id + 1) % lost_samples_bufs.at(0)->num_frames;
 
-        pl_mask_meta->check_frame_desc(pl_mask_buf->get_ndarray_frame_desc());
+        pl_mask_meta->check_frame_desc(pl_mask_buf->get_frame_desc<kotekan::GenericNDArray>());
         pl_mask_buf->mark_frame_full(unique_name, pl_mask_buf_frame_id);
         pl_mask_buf_frame_id = (pl_mask_buf_frame_id + 1) % pl_mask_buf->num_frames;
     }

--- a/lib/stages/networkPowerStream.cpp
+++ b/lib/stages/networkPowerStream.cpp
@@ -50,11 +50,11 @@ networkPowerStream::networkPowerStream(Config& config, const std::string& unique
     // Per integration the upstream emits [freqs float32 bins, 1 uint32 count]
     // per element; we expect ``times`` integrations packed into one frame.
     // The descriptor folds the count word into the float32 array (see
-    // airspyFrameDesc.hpp). When set_frame_desc has already been called by
+    // airspyFrameDesc.hpp). When ensure_frame_desc has already been called by
     // the producer (simpleAutocorr / SimpleCrosscorr), this becomes a
     // cross-check via FrameDesc::operator==; otherwise it just records
     // the expected layout for any later consumer/producer.
-    in_buf->set_frame_desc(kotekan_airspy::make_power_corr_desc(elems * times, freqs));
+    in_buf->ensure_frame_desc(kotekan_airspy::make_power_corr_desc(elems * times, freqs));
 
     freq0 = config.get_default<float>(unique_name, "freq", 600.) * 1e6;
     sample_bw = config.get_default<float>(unique_name, "sample_bw", 200.) * 1e6;

--- a/lib/stages/parseReorderDefault.cpp
+++ b/lib/stages/parseReorderDefault.cpp
@@ -13,6 +13,7 @@
 #include <tuple>                // for get
 
 #include "DataType.hpp"         // for DataType
+#include "NDArray.hpp"          // for GenericNDArray
 #include "StageFactory.hpp"     // for REGISTER_KOTEKAN_STAGE
 #include "Telescope.hpp"        // for Telescope, ElementOrder
 #include "bufferContainer.hpp"  // for bufferContainer
@@ -63,21 +64,21 @@ parseReorderDefault::parseReorderDefault(Config& config, const std::string& uniq
 
 #if 0 // this is what it should be
     if(_input_order == ElementOrder::CHIMECorrelator) {
-          _out_buf->allocate_ndarray_frame_desc(kotekan::int32, _name, {_num_polarizations*_num_dishes},
-                                                {"E"});
+          _out_buf->require_frame_desc(kotekan::GenericNDArray::describe(kotekan::int32, _name, {_num_polarizations*_num_dishes},
+                                                {"E"}));
     } else if(_input_order == ElementOrder::CHIMECylinder) {
-          _out_buf->allocate_ndarray_frame_desc(kotekan::int32, _name, {_num_chime_cylinders, _num_polarizations, _num_dishes/_num_chime_cylinders},
-                                                {"C", "P", "D"});
+          _out_buf->require_frame_desc(kotekan::GenericNDArray::describe(kotekan::int32, _name, {_num_chime_cylinders, _num_polarizations, _num_dishes/_num_chime_cylinders},
+                                                {"C", "P", "D"}));
     } else if(_input_order == ElementOrder::CHIMEBeamformer) {
-          _out_buf->allocate_ndarray_frame_desc(kotekan::int32, _name, {_num_polarizations, _num_dishes},
-                                                {"P", "D"});
+          _out_buf->require_frame_desc(kotekan::GenericNDArray::describe(kotekan::int32, _name, {_num_polarizations, _num_dishes},
+                                                {"P", "D"}));
     } else {
         FATAL_ERROR("Unexpected input_order {:s}", _input_order);
     }
 #else
     // this is what xpose2048 expects
-    _out_buf->allocate_ndarray_frame_desc(kotekan::int32, _name, {_num_polarizations, _num_dishes},
-                                          {"P", "D"});
+    _out_buf->require_frame_desc(kotekan::GenericNDArray::describe(
+        kotekan::int32, _name, {_num_polarizations, _num_dishes}, {"P", "D"}));
 #endif
 }
     
@@ -129,8 +130,8 @@ void parseReorderDefault::main_thread() {
 
         chordmeta->set_frame_counter(0); // these do not actually change with time
 
-        chordmeta->set_from_frame_desc(_out_buf->get_ndarray_frame_desc());
-        chordmeta->check_frame_desc(_out_buf->get_ndarray_frame_desc());
+        chordmeta->set_from_frame_desc(_out_buf->get_frame_desc<kotekan::GenericNDArray>());
+        chordmeta->check_frame_desc(_out_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         _out_buf->mark_frame_full(unique_name, frame_id);
 

--- a/lib/stages/processFeedGains.cpp
+++ b/lib/stages/processFeedGains.cpp
@@ -80,8 +80,13 @@ processFeedGains::processFeedGains(Config& config, const std::string& unique_nam
                     out_buf_size, out_buf->frame_size);
     }
 
-    // set the output buffer frame description
-    set_frame_desc(out_buf);
+    // Set (originate) the output buffer frame description. out_buf is declared
+    // `standard` here: this gains subsystem (chime_upgrade_test_gains, DPDK-only)
+    // hasn't been migrated to ndarray, so the stage attaches the descriptor itself
+    // via ensure_frame_desc. This works equally if out_buf is later declared
+    // ndarray, in which case ensure_frame_desc validates against the config
+    // descriptor instead of attaching one.
+    ensure_frame_desc(out_buf);
 
     // Allocate permanent buffers to hold the loaded gains in memory. These will only
     // be updated whenever the gains are updated, and get repeatedly copied
@@ -92,12 +97,12 @@ processFeedGains::processFeedGains(Config& config, const std::string& unique_nam
 
 processFeedGains::~processFeedGains() {}
 
-void processFeedGains::set_frame_desc(Buffer* buf) {
-    buf->allocate_ndarray_frame_desc<kotekan::GetType_t<kotekan::float32>, 5>(
+void processFeedGains::ensure_frame_desc(Buffer* buf) {
+    buf->ensure_frame_desc(kotekan::NDArray<kotekan::GetType_t<kotekan::float32>, 5>::describe(
         "processed_gain",
         {static_cast<ptrdiff_t>(num_beams), static_cast<ptrdiff_t>(num_local_freq),
          static_cast<ptrdiff_t>(upchan_factor), static_cast<ptrdiff_t>(num_elements), (ptrdiff_t)2},
-        {"R", "F", "U", "E", "ReIm"});
+        {"R", "F", "U", "E", "ReIm"}));
 }
 
 void processFeedGains::copy_upchannelize_f(const float* src_f, float* dst_f, size_t fid) {
@@ -188,10 +193,10 @@ void processFeedGains::main_thread() {
         // Set metadata from the frame desc, and other metadata
         out_buf->allocate_new_metadata_object(out_buf_frame_id);
         auto meta = get_chord_metadata(out_buf, out_buf_frame_id);
-        meta->set_from_frame_desc(out_buf->get_ndarray_frame_desc());
+        meta->set_from_frame_desc(out_buf->get_frame_desc<kotekan::GenericNDArray>());
         meta->set_name("processed_gain");
         // Verify that frame desc and metadata match
-        meta->check_frame_desc(out_buf->get_ndarray_frame_desc());
+        meta->check_frame_desc(out_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // copy from permanent buffer to output buffer
         // NB: this needs to happen every time, since the mask and gain buffers

--- a/lib/stages/processFeedGains.hpp
+++ b/lib/stages/processFeedGains.hpp
@@ -74,7 +74,7 @@ private:
 
     /// Create a frame desc for the output buffer. Default creates a frame desc
     /// containing [beam, freq, subfreq, element, ReIm] axes.
-    virtual void set_frame_desc(Buffer* buf);
+    virtual void ensure_frame_desc(Buffer* buf);
 
     std::vector<Buffer*> gain_buffers;
     Buffer* in_mask_buf;

--- a/lib/stages/rawFileWrite.cpp
+++ b/lib/stages/rawFileWrite.cpp
@@ -11,6 +11,7 @@
 #include <memory>                   // for shared_ptr, __shared_ptr_access
 
 #include "Config.hpp"               // for Config
+#include "NDArray.hpp"              // for GenericNDArray, Config
 #include "StageFactory.hpp"         // for REGISTER_KOTEKAN_STAGE
 #include "buffer.hpp"               // for Buffer
 #include "bufferContainer.hpp"      // for bufferContainer
@@ -74,7 +75,7 @@ void rawFileWrite::main_thread() {
             break;
 
         // Check for NDArray on first frame (after producer may have set the descriptor)
-        if (buf->get_ndarray_frame_desc()) {
+        if (buf->get_frame_desc<kotekan::GenericNDArray>()) {
             FATAL_ERROR(
                 "rawFileWrite does not support NDArray buffers. The NDArray frame descriptor "
                 "is set dynamically and will not be written to the file.");

--- a/lib/stages/rfiBroadcast.cpp
+++ b/lib/stages/rfiBroadcast.cpp
@@ -126,7 +126,12 @@ void rfiBroadcast::main_thread() {
     const size_t FSE = FS * num_elements;
 
     // Sort out the rfi mask buffer time stride
-    auto rfi_frame_desc = rfi_mask_buf->get_ndarray_frame_desc();
+    auto rfi_frame_desc = rfi_mask_buf->get_frame_desc<kotekan::GenericNDArray>();
+    if (!rfi_frame_desc)
+        FATAL_ERROR("rfi_mask_buf ({:s}) has no NDArray frame descriptor; rfiBroadcast needs the "
+                    "mask shape, so declare the buffer with `kotekan_buffer: ndarray` in the "
+                    "config",
+                    rfi_mask_buf->buffer_name);
     auto _rfi_frame_rank = rfi_frame_desc->get_rank();
     auto _rfi_frame_dims = rfi_frame_desc->get_extents();
     size_t _rfi_t_hi = _rfi_frame_dims[_rfi_frame_rank - 1];

--- a/lib/stages/setBBBeams.cpp
+++ b/lib/stages/setBBBeams.cpp
@@ -170,8 +170,8 @@ setBBBeams::setBBBeams(Config& config, const std::string& unique_name,
     rest_server.register_get_callback(unique_name + "/beams",
                                       std::bind(&setBBBeams::send_beams, this, _1));
 
-    out_pos_buf->allocate_ndarray_frame_desc<float, 2>("bb_beam_positions", {static_cast<ptrdiff_t>(num_beams), 2}, {"B", "X/Y"});
-    out_id_buf->allocate_ndarray_frame_desc<uint64_t, 1>("bb_beam_ids", {static_cast<ptrdiff_t>(num_beams)}, {"B"});
+    out_pos_buf->require_frame_desc(kotekan::NDArray<float, 2>::describe("bb_beam_positions", {static_cast<ptrdiff_t>(num_beams), 2}, {"B", "X/Y"}));
+    out_id_buf->require_frame_desc(kotekan::NDArray<uint64_t, 1>::describe("bb_beam_ids", {static_cast<ptrdiff_t>(num_beams)}, {"B"}));
 }
 
 setBBBeams::~setBBBeams() {
@@ -304,24 +304,24 @@ void setBBBeams::main_thread() {
         const std::shared_ptr<chordMetadata> pos_meta = get_chord_metadata(out_pos_buf, pos_frame_id);
 
         // Set ndarray sizes and timing
-        pos_meta->set_from_frame_desc(out_pos_buf->get_ndarray_frame_desc());
+        pos_meta->set_from_frame_desc(out_pos_buf->get_frame_desc<kotekan::GenericNDArray>());
         pos_meta->set_fpga_seq_num(seq_num);
         pos_meta->set_time_downsampling_fpga(time_downsampling_fpga);
 
         // Check consistency just in case
-        pos_meta->check_frame_desc(out_pos_buf->get_ndarray_frame_desc());
+        pos_meta->check_frame_desc(out_pos_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // Set id metadata
         out_id_buf->allocate_new_metadata_object(id_frame_id);
         const std::shared_ptr<chordMetadata> id_meta = get_chord_metadata(out_id_buf, id_frame_id);
 
         // Check consistency just in case
-        id_meta->set_from_frame_desc(out_id_buf->get_ndarray_frame_desc());
+        id_meta->set_from_frame_desc(out_id_buf->get_frame_desc<kotekan::GenericNDArray>());
         id_meta->set_fpga_seq_num(seq_num);
         id_meta->set_time_downsampling_fpga(time_downsampling_fpga);
 
         // Check consistency just in case
-        id_meta->check_frame_desc(out_id_buf->get_ndarray_frame_desc());
+        id_meta->check_frame_desc(out_id_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // Increment frames so next loop gets a new seq_num
         num_frames++;

--- a/lib/stages/setFRB1Phase.cpp
+++ b/lib/stages/setFRB1Phase.cpp
@@ -1,5 +1,6 @@
 #include "Config.hpp"          // for Config
 #include "DataType.hpp"        // for float16_t
+#include "NDArray.hpp"
 #include "Stage.hpp"           // for Stage
 #include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
 #include "buffer.hpp"          // for Buffer
@@ -81,14 +82,15 @@ public:
                       * num_dishes_N * num_dishes_M * num_components);
 
         // Set metadata
-        frb1_phase_buffer->allocate_ndarray_frame_desc<float16_t, 5>(
+        frb1_phase_buffer->require_frame_desc(kotekan::NDArray<float16_t, 5>::describe(
             "W",
             {upchan_max_num_channels * upchan_factor, num_polarizations, num_dishes_N, num_dishes_M,
              num_components},
-            {"F", "P", "dishN", "dishM", "C"});
+            {"F", "P", "dishN", "dishM", "C"}));
         frb1_phase_buffer->allocate_new_metadata_object(frame_id);
         const auto& frb1_phase_meta = get_chord_metadata(frb1_phase_buffer->get_metadata(frame_id));
-        frb1_phase_meta->set_from_frame_desc(frb1_phase_buffer->get_ndarray_frame_desc());
+        frb1_phase_meta->set_from_frame_desc(
+            frb1_phase_buffer->get_frame_desc<kotekan::GenericNDArray>());
         frb1_phase_meta->set_fpga_seq_num(0);           // ???
         frb1_phase_meta->set_time_downsampling_fpga(1); // ???
         std::vector<int> coarse_freq(upchan_num_channels * upchan_factor);

--- a/lib/stages/setFRBBeams.cpp
+++ b/lib/stages/setFRBBeams.cpp
@@ -150,8 +150,8 @@ setFRBBeams::setFRBBeams(Config& config, const std::string& unique_name,
     rest_server.register_get_callback(unique_name + "/beams",
                                       std::bind(&setFRBBeams::send_beams, this, _1));
 
-    out_pos_buf->allocate_ndarray_frame_desc<float, 2>("frb2_beam_positions", {static_cast<ptrdiff_t>(num_beams), 2}, {"R", "X/Y"});
-    out_id_buf->allocate_ndarray_frame_desc<uint64_t, 1>("frb2_beam_ids", {static_cast<ptrdiff_t>(num_beams)}, {"R"});
+    out_pos_buf->require_frame_desc(kotekan::NDArray<float, 2>::describe("frb2_beam_positions", {static_cast<ptrdiff_t>(num_beams), 2}, {"R", "X/Y"}));
+    out_id_buf->require_frame_desc(kotekan::NDArray<uint64_t, 1>::describe("frb2_beam_ids", {static_cast<ptrdiff_t>(num_beams)}, {"R"}));
 }
 
 setFRBBeams::~setFRBBeams() {
@@ -238,20 +238,20 @@ void setFRBBeams::main_thread() {
         out_pos_buf->allocate_new_metadata_object(pos_frame_id);
         const std::shared_ptr<chordMetadata> pos_meta = get_chord_metadata(out_pos_buf, pos_frame_id);
 
-        pos_meta->set_from_frame_desc(out_pos_buf->get_ndarray_frame_desc());
+        pos_meta->set_from_frame_desc(out_pos_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // If this gets made time-dependent, set fpga_seq_num, and fpga_time_downsampling here.
 
-        pos_meta->check_frame_desc(out_pos_buf->get_ndarray_frame_desc());
+        pos_meta->check_frame_desc(out_pos_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         out_id_buf->allocate_new_metadata_object(id_frame_id);
         const std::shared_ptr<chordMetadata> id_meta = get_chord_metadata(out_id_buf, id_frame_id);
 
-        id_meta->set_from_frame_desc(out_id_buf->get_ndarray_frame_desc());
+        id_meta->set_from_frame_desc(out_id_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // If this gets made time-dependent, set fpga_seq_num, and fpga_time_downsampling here.
 
-        id_meta->check_frame_desc(out_id_buf->get_ndarray_frame_desc());
+        id_meta->check_frame_desc(out_id_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         out_pos_buf->mark_frame_full(unique_name, pos_frame_id++);
         out_id_buf->mark_frame_full(unique_name, id_frame_id++);

--- a/lib/stages/setScatterIndices.cpp
+++ b/lib/stages/setScatterIndices.cpp
@@ -8,6 +8,7 @@
 #include <memory>               // for allocator, __shared_ptr_access, shared_ptr
 
 #include "Config.hpp"           // for Config
+#include "NDArray.hpp"
 #include "Stage.hpp"            // for Stage
 #include "StageFactory.hpp"     // for REGISTER_KOTEKAN_STAGE
 #include "buffer.hpp"           // for Buffer
@@ -63,12 +64,13 @@ public:
                == sizeof(std::int32_t) * num_polarizations * num_dishes);
 
         // Set metadata
-        scatter_indices_buffer->allocate_ndarray_frame_desc<std::int32_t, 2>(
-            "scatter_indices", {num_polarizations, num_dishes}, {"P", "D"});
+        scatter_indices_buffer->require_frame_desc(kotekan::NDArray<std::int32_t, 2>::describe(
+            "scatter_indices", {num_polarizations, num_dishes}, {"P", "D"}));
         scatter_indices_buffer->allocate_new_metadata_object(frame_id);
         const auto& scatter_indices_meta =
             get_chord_metadata(scatter_indices_buffer->get_metadata(frame_id));
-        scatter_indices_meta->set_from_frame_desc(scatter_indices_buffer->get_ndarray_frame_desc());
+        scatter_indices_meta->set_from_frame_desc(
+            scatter_indices_buffer->get_frame_desc<kotekan::GenericNDArray>());
         // scatter_indices_meta->set_fpga_seq_num(0);           // ???
         // scatter_indices_meta->set_time_downsampling_fpga(1); // ???
 

--- a/lib/stages/setUpchanGain.cpp
+++ b/lib/stages/setUpchanGain.cpp
@@ -16,6 +16,7 @@
 #include "chordMetadata.hpp"             // for chordMetadata, get_chord_metadata
 #include "kotekanLogging.hpp"            // for DEBUG
 #include "DataType.hpp"                  // for float16_t
+#include "NDArray.hpp"
 #include "fmt.hpp"                       // for compile_string_to_view, format
 
 class setUpchanGain : public kotekan::Stage {
@@ -71,12 +72,13 @@ public:
             return;
 
         // Set metadata
-        upchan_gain_buffer->allocate_ndarray_frame_desc<float16_t, 1>(
-            "G", {upchan_max_num_channels * upchan_factor}, {"Fbar"});
+        upchan_gain_buffer->require_frame_desc(kotekan::NDArray<float16_t, 1>::describe(
+            "G", {upchan_max_num_channels * upchan_factor}, {"Fbar"}));
         upchan_gain_buffer->allocate_new_metadata_object(frame_id);
         const auto& upchan_gain_meta =
             get_chord_metadata(upchan_gain_buffer->get_metadata(frame_id));
-        upchan_gain_meta->set_from_frame_desc(upchan_gain_buffer->get_ndarray_frame_desc());
+        upchan_gain_meta->set_from_frame_desc(
+            upchan_gain_buffer->get_frame_desc<kotekan::GenericNDArray>());
         upchan_gain_meta->set_fpga_seq_num(0);           // ???
         upchan_gain_meta->set_time_downsampling_fpga(1); // ???
         const auto& upchan_channels_set = upchan_schedule.get_upchan_channels(upchan_factor);

--- a/lib/stages/simpleAutocorr.cpp
+++ b/lib/stages/simpleAutocorr.cpp
@@ -42,7 +42,7 @@ simpleAutocorr::simpleAutocorr(Config& config, const std::string& unique_name,
     // test pipeline captures buf_out through rawFileWrite. networkPowerStream
     // asserts the expected power_corr layout on its consumer side, so the
     // contract is still documented in code.
-    buf_in->set_frame_desc(
+    buf_in->ensure_frame_desc(
         kotekan_airspy::make_fengine_desc(buf_in->frame_size / (2 * sizeof(float))));
 }
 

--- a/lib/stages/testDataGen.cpp
+++ b/lib/stages/testDataGen.cpp
@@ -18,6 +18,7 @@
 #include "CHORDTelescope.hpp"   // for CHORDTelescope
 #include "Config.hpp"           // for Config
 #include "DataType.hpp"         // for DataType, KOTEKAN_FLOAT16, float16_t
+#include "NDArray.hpp"          // for GenericNDArray, Config
 #include "StageFactory.hpp"     // for REGISTER_KOTEKAN_STAGE
 #include "Symbol.hpp"           // for Symbol
 #include "Telescope.hpp"        // for Telescope, stream_t
@@ -358,9 +359,10 @@ void testDataGen::main_thread() {
         const std::vector<ptrdiff_t> extents(_array_shape.begin(), _array_shape.end());
         const std::vector<kotekan::Symbol> dimnames(_dim_name.begin(), _dim_name.end());
 
-        buf->allocate_ndarray_frame_desc(chordmeta->type, _name, extents, dimnames);
+        buf->ensure_frame_desc(
+            kotekan::GenericNDArray::describe(chordmeta->type, _name, extents, dimnames));
         /* test that things are consistent */
-        chordmeta->check_frame_desc(buf->get_ndarray_frame_desc());
+        chordmeta->check_frame_desc(buf->get_frame_desc<kotekan::GenericNDArray>());
 
         if (type == "onehot") {
             int val = value;

--- a/lib/testing/FakeN2.cpp
+++ b/lib/testing/FakeN2.cpp
@@ -55,7 +55,7 @@ FakeN2::FakeN2(Config& config, const std::string& unique_name, bufferContainer& 
     out_buf->register_producer(unique_name);
 
     // Get N2 parameters from the buffer's frame descriptor (set by bufferFactory)
-    auto frame_desc = out_buf->get_frame_description();
+    auto frame_desc = out_buf->get_frame_desc();
     if (!frame_desc) {
         FATAL_ERROR("Buffer {:s} does not have a frame descriptor set", out_buf->buffer_name);
     }
@@ -322,8 +322,8 @@ ReplaceN2::ReplaceN2(Config& config, const std::string& unique_name,
     out_buf->register_producer(unique_name);
 
     // Validate that input and output buffers have compatible N2 frame descriptors
-    auto in_desc = in_buf->get_frame_description();
-    auto out_desc = out_buf->get_frame_description();
+    auto in_desc = in_buf->get_frame_desc();
+    auto out_desc = out_buf->get_frame_desc();
     if (!in_desc || !out_desc) {
         FATAL_ERROR("ReplaceN2: Input and output buffers must have frame descriptors set");
     }

--- a/lib/testing/FakeN2.cpp
+++ b/lib/testing/FakeN2.cpp
@@ -55,14 +55,7 @@ FakeN2::FakeN2(Config& config, const std::string& unique_name, bufferContainer& 
     out_buf->register_producer(unique_name);
 
     // Get N2 parameters from the buffer's frame descriptor (set by bufferFactory)
-    auto frame_desc = out_buf->get_frame_desc();
-    if (!frame_desc) {
-        FATAL_ERROR("Buffer {:s} does not have a frame descriptor set", out_buf->buffer_name);
-    }
-    auto n2_desc = std::dynamic_pointer_cast<const kotekan::N2FrameDesc>(frame_desc);
-    if (!n2_desc) {
-        FATAL_ERROR("Buffer {:s} does not have an N2FrameDesc", out_buf->buffer_name);
-    }
+    auto n2_desc = out_buf->require_frame_desc<kotekan::N2FrameDesc>();
     num_elements = n2_desc->get_num_elements();
     num_eigenvectors = n2_desc->get_num_ev();
     n2_layout = n2_desc->get_n2_layout();

--- a/lib/testing/N2FringeStop.cpp
+++ b/lib/testing/N2FringeStop.cpp
@@ -42,8 +42,8 @@ N2FringeStop::N2FringeStop(Config& config, const std::string& unique_name,
     out_buf->register_producer(unique_name);
 
     // Validate that input and output buffers have compatible N2 frame descriptors
-    auto in_desc = in_buf->get_frame_description();
-    auto out_desc = out_buf->get_frame_description();
+    auto in_desc = in_buf->get_frame_desc();
+    auto out_desc = out_buf->get_frame_desc();
     if (!in_desc || !out_desc) {
         FATAL_ERROR("N2FringeStop: Input and output buffers must have frame descriptors set");
     }

--- a/lib/testing/applyGenPL.cpp
+++ b/lib/testing/applyGenPL.cpp
@@ -1,6 +1,7 @@
 #include "applyGenPL.hpp"
 
 #include "Config.hpp"          // for Config
+#include "NDArray.hpp"         // for GenericNDArray, Config
 #include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
 #include "buffer.hpp"          // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
@@ -60,30 +61,16 @@ applyGenPL::applyGenPL(Config& config, const std::string& unique_name,
     output_buf = get_buffer("voltage_out_buf");
     output_buf->register_producer(unique_name);
 
-    size_t voltage_frame_size =
-        _samples_per_data_set * _num_local_freq * _num_elements * sizeof(char);
-    size_t pl_frame_size =
-        (_samples_per_data_set / 2) * (_num_local_freq / 4) * (_num_elements / 8) / 8;
-
-    if (input_buf->frame_size != voltage_frame_size) {
-        FATAL_ERROR("applyGenPL voltage_in_buf ({:s}) has frame size {:d}, expected {:d}.",
-                    input_buf->buffer_name, input_buf->frame_size, voltage_frame_size);
-        std::abort();
-    }
-    if (plmask_buf->frame_size != pl_frame_size) {
-        FATAL_ERROR("applyGenPL plmask_in_buf ({:s}) has frame size {:d}, expected {:d}.",
-                    plmask_buf->buffer_name, plmask_buf->frame_size, voltage_frame_size);
-        std::abort();
-    }
-    if (output_buf->frame_size != voltage_frame_size) {
-        FATAL_ERROR("applyGenPL voltage_out_buf ({:s}) has frame size {:d}, expected {:d}.",
-                    output_buf->buffer_name, output_buf->frame_size, voltage_frame_size);
-        std::abort();
-    }
-
-    output_buf->allocate_ndarray_frame_desc(
+    input_buf->require_frame_desc(kotekan::GenericNDArray::describe(
         kotekan::int4x2_swapped_withoffset, "E",
-        {_samples_per_data_set, _num_local_freq, 2, _num_elements / 2}, {"T", "F", "P", "D"});
+        {_samples_per_data_set, _num_local_freq, 2, _num_elements / 2}, {"T", "F", "P", "D"}));
+    plmask_buf->require_frame_desc(kotekan::GenericNDArray::describe(
+        kotekan::uint1x8, "pl_mask",
+        {_samples_per_data_set / 128, _num_local_freq / 4, 2, (_num_elements / 8) / 2, 8},
+        {"T2hi64", "F4", "P", "D8", "T2lo64"}));
+    output_buf->require_frame_desc(kotekan::GenericNDArray::describe(
+        kotekan::int4x2_swapped_withoffset, "E",
+        {_samples_per_data_set, _num_local_freq, 2, _num_elements / 2}, {"T", "F", "P", "D"}));
 }
 
 applyGenPL::~applyGenPL() {}

--- a/lib/testing/gpuSimulateN2kCorr.cpp
+++ b/lib/testing/gpuSimulateN2kCorr.cpp
@@ -2,6 +2,7 @@
 
 #include "Config.hpp"          // for Config
 #include "DataType.hpp"        // for DataType, GetType
+#include "NDArray.hpp"         // for NDArray, GenericNDArray, Config
 #include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
 #include "buffer.hpp"          // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
@@ -79,41 +80,24 @@ gpuSimulateN2kCorr::gpuSimulateN2kCorr(Config& config, const std::string& unique
     output_buf = get_buffer("corr_out_buf");
     output_buf->register_producer(unique_name);
 
-    // Check buffer frame sizes
-    size_t input_voltage_frame_size =
-        sizeof(char) * _num_elements * _num_local_freq * _samples_per_data_set;
-    size_t rfimask_frame_size = _num_local_freq * _samples_per_data_set / 8;
-
-    size_t num_blocks = num_triangle_blocks(_num_elements, _corr_blocksize);
-    size_t num_correlations = _samples_per_data_set / _sub_integration_ntime;
-
-    size_t corr_frame_size = 2 * sizeof(int) * _corr_blocksize * _corr_blocksize * num_blocks
-                             * _num_local_freq * num_correlations;
-
-    if (input_buf->frame_size != input_voltage_frame_size) {
-        FATAL_ERROR("network_in_buf ({:s}) has frame size {:d}, expected {:d}",
-                    input_buf->buffer_name, input_buf->frame_size, input_voltage_frame_size);
-        std::abort();
-    }
-    if (rfimask_buf->frame_size != rfimask_frame_size) {
-        FATAL_ERROR("rfimask_in_buf ({:s}) has frame size {:d}, expected {:d}",
-                    rfimask_buf->buffer_name, rfimask_buf->frame_size, rfimask_frame_size);
-        std::abort();
-    }
-    if (output_buf->frame_size != corr_frame_size) {
-        FATAL_ERROR("corr_out_buf ({:s}) has frame size {:d}, expected {:d}",
-                    output_buf->buffer_name, output_buf->frame_size, corr_frame_size);
-        std::abort();
-    }
-
     /* new style array description */
     // number of elements = number of dishes * polarizations
     int nt_inner = _sub_integration_ntime;
     int nt_outer = _samples_per_data_set / nt_inner;
-    output_buf->allocate_ndarray_frame_desc<kotekan::GetType<kotekan::int32>::type, 6>(
-        "n2k_correlation",
-        {nt_outer, _num_local_freq, num_triangle_blocks(_num_elements, _corr_blocksize), 16, 16, 2},
-        {"Tc", "F", "DPhi", "DPlo1", "DPlo2", "C"});
+    input_buf->require_frame_desc(
+        kotekan::NDArray<kotekan::int4x2_swapped_withoffset_t, 4>::describe(
+            "E", {_samples_per_data_set, _num_local_freq, 2, _num_elements / 2},
+            {"T", "F", "P", "D"}));
+    rfimask_buf->require_frame_desc(
+        kotekan::NDArray<kotekan::GetType<kotekan::uint1x8>::type, 3>::describe(
+            "RFImask", {_samples_per_data_set / 1024, _num_local_freq, 128},
+            {"T8hi128", "F", "T8lo128"}));
+    output_buf->require_frame_desc(
+        kotekan::NDArray<kotekan::GetType<kotekan::int32>::type, 6>::describe(
+            "n2k_correlation",
+            {nt_outer, _num_local_freq, num_triangle_blocks(_num_elements, _corr_blocksize), 16, 16,
+             2},
+            {"Tc", "F", "DPhi", "DPlo1", "DPlo2", "C"}));
 }
 
 gpuSimulateN2kCorr::~gpuSimulateN2kCorr() {}
@@ -285,7 +269,7 @@ void gpuSimulateN2kCorr::main_thread() {
 
         // frame_desc set in constructor
         /* test that things are consistent */
-        meta_out->check_frame_desc(output_buf->get_ndarray_frame_desc());
+        meta_out->check_frame_desc(output_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         meta_out->set_fpga_seq_num(meta_in->get_fpga_seq_num());
         meta_out->set_time_downsampling_fpga(meta_in->get_time_downsampling_fpga()

--- a/lib/testing/gpuSimulateN2kPL1bitCorr.cpp
+++ b/lib/testing/gpuSimulateN2kPL1bitCorr.cpp
@@ -2,6 +2,7 @@
 
 #include "Config.hpp"          // for Config
 #include "DataType.hpp"        // for DataType, GetType
+#include "NDArray.hpp"         // for NDArray, GenericNDArray, Config
 #include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
 #include "buffer.hpp"          // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
@@ -87,9 +88,17 @@ gpuSimulateN2kPL1bitCorr::gpuSimulateN2kPL1bitCorr(Config& config, const std::st
     int nf = _num_local_freq;
     int ne = _num_elements / 8;
     int n_blocks = num_triangle_blocks(ne, _blocksize);
-    output_buf->allocate_ndarray_frame_desc<kotekan::GetType<kotekan::int32>::type, 5>(
-        "n2k_counts", {n_integrations, nf, n_blocks, _blocksize, _blocksize},
-        {"Tc", "F", "D8Phi", "D8Plo1", "D8Plo2"});
+    input_plmask_buf->require_frame_desc(
+        kotekan::NDArray<kotekan::GetType<kotekan::uint1x8>::type, 5>::describe(
+            "pl_mask_exp", {_samples_per_data_set / 64, nf, 2, ne / 2, 8},
+            {"Thi64", "F", "P", "D8", "Tlo64"}));
+    input_rfimask_buf->require_frame_desc(
+        kotekan::NDArray<kotekan::GetType<kotekan::uint1x8>::type, 3>::describe(
+            "RFImask", {_samples_per_data_set / 1024, nf, 128}, {"T8hi128", "F", "T8lo128"}));
+    output_buf->require_frame_desc(
+        kotekan::NDArray<kotekan::GetType<kotekan::int32>::type, 5>::describe(
+            "n2k_counts", {n_integrations, nf, n_blocks, _blocksize, _blocksize},
+            {"Tc", "F", "D8Phi", "D8Plo1", "D8Plo2"}));
 }
 
 gpuSimulateN2kPL1bitCorr::~gpuSimulateN2kPL1bitCorr() {}
@@ -254,7 +263,7 @@ void gpuSimulateN2kPL1bitCorr::main_thread() {
         meta_out->set_strides_simple();
         // frame_desc set in constructor
         /* test that things are consistent */
-        meta_out->check_frame_desc(output_buf->get_ndarray_frame_desc());
+        meta_out->check_frame_desc(output_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         meta_out->set_fpga_seq_num(meta_in->get_fpga_seq_num());
         meta_out->set_time_downsampling_fpga(

--- a/lib/testing/gpuSimulateN2kPLExpand.cpp
+++ b/lib/testing/gpuSimulateN2kPLExpand.cpp
@@ -2,6 +2,7 @@
 
 #include "Config.hpp"          // for Config
 #include "DataType.hpp"        // for DataType, GetType
+#include "NDArray.hpp"         // for NDArray, GenericNDArray, Config
 #include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
 #include "buffer.hpp"          // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
@@ -45,8 +46,13 @@ gpuSimulateN2kPLExpand::gpuSimulateN2kPLExpand(Config& config, const std::string
     int nt = _samples_per_data_set / 64;
     int nf = _num_local_freq;
     int ne = _num_elements / 8;
-    output_buf->allocate_ndarray_frame_desc<kotekan::GetType<kotekan::uint1x8>::type, 5>(
-        "pl_mask_exp", {nt, nf, 2, ne / 2, 8}, {"Thi64", "F", "P", "D8", "Tlo64"});
+    input_buf->require_frame_desc(
+        kotekan::NDArray<kotekan::GetType<kotekan::uint1x8>::type, 5>::describe(
+            "pl_mask", {nt / 2, (nf + 3) / 4, 2, ne / 2, 8},
+            {"T2hi64", "F4", "P", "D8", "T2lo64"}));
+    output_buf->require_frame_desc(
+        kotekan::NDArray<kotekan::GetType<kotekan::uint1x8>::type, 5>::describe(
+            "pl_mask_exp", {nt, nf, 2, ne / 2, 8}, {"Thi64", "F", "P", "D8", "Tlo64"}));
 }
 
 gpuSimulateN2kPLExpand::~gpuSimulateN2kPLExpand() {}
@@ -172,7 +178,7 @@ void gpuSimulateN2kPLExpand::main_thread() {
         meta_out->deepCopy(meta_in);
 
         // frame_desc set in constructor
-        meta_out->set_from_frame_desc(output_buf->get_ndarray_frame_desc());
+        meta_out->set_from_frame_desc(output_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // Update changes
         meta_out->set_fpga_seq_num(meta_in->get_fpga_seq_num());
@@ -198,7 +204,7 @@ void gpuSimulateN2kPLExpand::main_thread() {
         assert(meta_out->get_nfreq() <= CHORD_META_MAX_FREQ);
 
         /* test that things are consistent */
-        meta_out->check_frame_desc(output_buf->get_ndarray_frame_desc());
+        meta_out->check_frame_desc(output_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         input_buf->mark_frame_empty(unique_name, input_frame_id);
         output_buf->mark_frame_full(unique_name, output_frame_id);

--- a/lib/testing/gpuSimulatePLMaskAccumulator.cpp
+++ b/lib/testing/gpuSimulatePLMaskAccumulator.cpp
@@ -1,6 +1,7 @@
 #include "Config.hpp"          // for Config
 #include "DataType.hpp"        // for DataType, GetType
 #include "N2Util.hpp"          // for frameID
+#include "NDArray.hpp"         // for NDArray, GenericNDArray, Config
 #include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
 #include "buffer.hpp"          // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
@@ -130,14 +131,14 @@ gpuSimulatePLMaskAccumulator::gpuSimulatePLMaskAccumulator(Config& config,
     }
 
     // Make frame desc for produced buffer (this also checks the size)
-    in_buf->allocate_ndarray_frame_desc<kotekan::uint1x8_t, 5>(
+    in_buf->require_frame_desc(kotekan::NDArray<kotekan::uint1x8_t, 5>::describe(
         "pl_mask",
         {div_noremainder(_samples_per_data_set, 128), div_noremainder(_num_local_freq, 4),
          _num_polarizations, div_noremainder(_num_dishes, 8), 64 / 8},
-        {"T2hi64", "F4", "P", "D8", "T2lo64"});
-    out_buf->allocate_ndarray_frame_desc<uint64_t, 4>(
+        {"T2hi64", "F4", "P", "D8", "T2lo64"}));
+    out_buf->require_frame_desc(kotekan::NDArray<uint64_t, 4>::describe(
         "pl_counts", {_num_integrations, _num_local_freq, _num_polarizations, _num_dishes},
-        {"Tc", "F", "P", "D"});
+        {"Tc", "F", "P", "D"}));
 }
 
 gpuSimulatePLMaskAccumulator::~gpuSimulatePLMaskAccumulator() {}
@@ -244,7 +245,7 @@ void gpuSimulatePLMaskAccumulator::main_thread() {
         // Start with a copy
         meta_out->deepCopy(meta_in);
 
-        meta_out->set_from_frame_desc(out_buf->get_ndarray_frame_desc());
+        meta_out->set_from_frame_desc(out_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // Set non-NDArray things.
         meta_out->set_fpga_seq_num(meta_in->get_fpga_seq_num());
@@ -252,7 +253,7 @@ void gpuSimulatePLMaskAccumulator::main_thread() {
             div_noremainder(meta_in->get_time_downsampling_fpga(), 128) * _sub_integration_ntime);
 
         // test that things are consistent
-        meta_out->check_frame_desc(out_buf->get_ndarray_frame_desc());
+        meta_out->check_frame_desc(out_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         INFO("Simulating GPU RFI S012 done for {:s}[{:d}] result is in {:s}[{:d}]",
              in_buf->buffer_name, in_frame_id, out_buf->buffer_name, out_frame_id);

--- a/lib/testing/gpuSimulateRFIS012.cpp
+++ b/lib/testing/gpuSimulateRFIS012.cpp
@@ -3,6 +3,7 @@
 #include "Config.hpp"          // for Config
 #include "DataType.hpp"        // for DataType, GetType
 #include "N2Util.hpp"          // for frameID
+#include "NDArray.hpp"         // for NDArray, GenericNDArray, Config
 #include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
 #include "buffer.hpp"          // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
@@ -47,10 +48,6 @@ gpuSimulateRFIS012::gpuSimulateRFIS012(Config& config, const std::string& unique
     out_rfis012_buf->register_producer(unique_name);
 
 
-    size_t voltage_size = _samples_per_data_set * _num_local_freq * _num_elements;
-    size_t plmask_size =
-        ((_samples_per_data_set / 2) * (_num_local_freq / 4) * (_num_elements / 8)) / 8;
-
     // Check input sizes and buffer compatibility
     if (_samples_per_data_set % _rfi_downsampling_factor != 0) {
         FATAL_ERROR("samples_per_data_set must be a multiple of rfi_downsampling_factor");
@@ -60,25 +57,21 @@ gpuSimulateRFIS012::gpuSimulateRFIS012(Config& config, const std::string& unique
     if (_num_elements % 8 != 0) {
         FATAL_ERROR("num_elements (num_polarizations x num_dishes) must be a multiple of 8");
     }
-    assert(_samples_per_data_set % _rfi_downsampling_factor == 0);
 
-    if (in_voltage_buf->frame_size != voltage_size) {
-        FATAL_ERROR("in_voltage_buf ({:s}) has frame size: {:d}, expected: {:d}",
-                    in_voltage_buf->buffer_name, in_voltage_buf->frame_size, voltage_size);
-    }
-    assert(in_voltage_buf->frame_size == voltage_size);
-
-    if (in_plmask_buf->frame_size != plmask_size) {
-        FATAL_ERROR("in_plmask_buf ({:s}) has frame size: {:d}, expected: {:d}",
-                    in_plmask_buf->buffer_name, in_plmask_buf->frame_size, plmask_size);
-    }
-    assert(in_plmask_buf->frame_size == plmask_size);
+    in_voltage_buf->require_frame_desc(
+        kotekan::NDArray<kotekan::int4x2_swapped_withoffset_t, 4>::describe(
+            "E", {_samples_per_data_set, _num_local_freq, _num_polarizations, _num_dishes},
+            {"T", "F", "P", "D"}));
+    in_plmask_buf->require_frame_desc(kotekan::NDArray<kotekan::uint1x8_t, 5>::describe(
+        "pl_mask",
+        {_samples_per_data_set / 128, _num_local_freq / 4, _num_polarizations, _num_dishes / 8, 8},
+        {"T2hi64", "F4", "P", "D8", "T2lo64"}));
 
     // Make frame desc for produced buffer
     int64_t nt = _samples_per_data_set / _rfi_downsampling_factor;
-    out_rfis012_buf->allocate_ndarray_frame_desc<uint64_t, 5>(
+    out_rfis012_buf->require_frame_desc(kotekan::NDArray<uint64_t, 5>::describe(
         "S012", {nt, _num_local_freq, 3, _num_polarizations, _num_dishes},
-        {"Trfi", "F", "S", "P", "D"});
+        {"Trfi", "F", "S", "P", "D"}));
 }
 
 gpuSimulateRFIS012::~gpuSimulateRFIS012() {}
@@ -213,10 +206,10 @@ void gpuSimulateRFIS012::main_thread() {
         // Start with a copy
         meta_out->deepCopy(meta_in);
 
-        meta_out->set_from_frame_desc(out_rfis012_buf->get_ndarray_frame_desc());
+        meta_out->set_from_frame_desc(out_rfis012_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // test that things are consistent
-        meta_out->check_frame_desc(out_rfis012_buf->get_ndarray_frame_desc());
+        meta_out->check_frame_desc(out_rfis012_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // Set non-NDArray things.
         meta_out->set_fpga_seq_num(meta_in->get_fpga_seq_num());

--- a/lib/testing/gpuSimulateRFIS012bar.cpp
+++ b/lib/testing/gpuSimulateRFIS012bar.cpp
@@ -3,6 +3,7 @@
 #include "Config.hpp"          // for Config
 #include "DataType.hpp"        // for DataType, GetType
 #include "N2Util.hpp"          // for frameID
+#include "NDArray.hpp"         // for NDArray, GenericNDArray, Config
 #include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
 #include "buffer.hpp"          // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
@@ -60,19 +61,16 @@ gpuSimulateRFIS012bar::gpuSimulateRFIS012bar(Config& config, const std::string& 
     assert((_samples_per_data_set / _rfi_downsampling_factor) % _rfi_second_downsampling_factor
            == 0);
 
-    size_t rfi_s012_size = (_samples_per_data_set / _rfi_downsampling_factor) * _num_local_freq * 3
-                           * _num_elements * sizeof(uint64_t);
-
-    if (in_buf->frame_size != rfi_s012_size) {
-        FATAL_ERROR("in_buf ({:s}) has frame size: {:d}, expected {:d}", in_buf->buffer_name,
-                    in_buf->frame_size, rfi_s012_size);
-    }
-    assert(in_buf->frame_size == rfi_s012_size);
+    in_buf->require_frame_desc(kotekan::NDArray<uint64_t, 5>::describe(
+        "S012",
+        {_samples_per_data_set / _rfi_downsampling_factor, _num_local_freq, 3, _num_polarizations,
+         _num_dishes},
+        {"Trfi", "F", "S", "P", "D"}));
 
     int64_t nt = _samples_per_data_set / _rfi_downsampling_factor / _rfi_second_downsampling_factor;
-    out_buf->allocate_ndarray_frame_desc<uint64_t, 5>(
+    out_buf->require_frame_desc(kotekan::NDArray<uint64_t, 5>::describe(
         "S012bar", {nt, _num_local_freq, 3, _num_polarizations, _num_dishes},
-        {"Trfibar", "F", "S", "P", "D"});
+        {"Trfibar", "F", "S", "P", "D"}));
 }
 
 gpuSimulateRFIS012bar::~gpuSimulateRFIS012bar() {}
@@ -125,10 +123,10 @@ void gpuSimulateRFIS012bar::main_thread() {
 
         // Start with a copy
         meta_out->deepCopy(meta_in);
-        meta_out->set_from_frame_desc(out_buf->get_ndarray_frame_desc());
+        meta_out->set_from_frame_desc(out_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // test that things are consistent
-        meta_out->check_frame_desc(out_buf->get_ndarray_frame_desc());
+        meta_out->check_frame_desc(out_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // Set non-NDArray things.
         meta_out->set_fpga_seq_num(meta_in->get_fpga_seq_num());

--- a/lib/testing/gpuSimulateRFIS012tilde.cpp
+++ b/lib/testing/gpuSimulateRFIS012tilde.cpp
@@ -3,6 +3,7 @@
 #include "Config.hpp"          // for Config
 #include "DataType.hpp"        // for DataType, GetType
 #include "N2Util.hpp"          // for frameID
+#include "NDArray.hpp"         // for NDArray, GenericNDArray, Config
 #include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
 #include "buffer.hpp"          // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
@@ -52,26 +53,14 @@ gpuSimulateRFIS012tilde::gpuSimulateRFIS012tilde(Config& config, const std::stri
     }
     assert(_samples_per_data_set % _rfi_downsampling_factor == 0);
 
-    size_t bf_mask_size = _num_elements;
-    size_t rfi_s012_size = (_samples_per_data_set / _rfi_downsampling_factor) * _num_local_freq * 3
-                           * _num_elements * sizeof(uint64_t);
-
-    if (in_rfi_s012_buf->frame_size != rfi_s012_size) {
-        FATAL_ERROR("in_rfi_s012_buf ({:s}) has frame size: {:d}, expected {:d}",
-                    in_rfi_s012_buf->buffer_name, in_rfi_s012_buf->frame_size, rfi_s012_size);
-    }
-    assert(in_rfi_s012_buf->frame_size == rfi_s012_size);
-
-    if (in_bf_mask_buf->frame_size != bf_mask_size) {
-        FATAL_ERROR("in_bf_mask_buf ({:s}) has frame size: {:d}, expected {:d}",
-                    in_bf_mask_buf->buffer_name, in_bf_mask_buf->frame_size, bf_mask_size);
-    }
-    assert(in_bf_mask_buf->frame_size == bf_mask_size);
-
     int64_t nt = _samples_per_data_set / _rfi_downsampling_factor;
     int64_t nf = _num_local_freq;
-    out_rfi_s012tilde_buf->allocate_ndarray_frame_desc<uint64_t, 3>("S012tilde", {nt, nf, 3},
-                                                                    {"Trfi", "F", "S"});
+    in_rfi_s012_buf->require_frame_desc(kotekan::NDArray<uint64_t, 5>::describe(
+        "S012", {nt, nf, 3, _num_polarizations, _num_dishes}, {"Trfi", "F", "S", "P", "D"}));
+    in_bf_mask_buf->require_frame_desc(kotekan::NDArray<std::int8_t, 2>::describe(
+        "bf_mask", {_num_polarizations, _num_dishes}, {"P", "D"}));
+    out_rfi_s012tilde_buf->require_frame_desc(
+        kotekan::NDArray<uint64_t, 3>::describe("S012tilde", {nt, nf, 3}, {"Trfi", "F", "S"}));
 }
 
 gpuSimulateRFIS012tilde::~gpuSimulateRFIS012tilde() {}
@@ -160,10 +149,12 @@ void gpuSimulateRFIS012tilde::main_thread() {
         // Start with a copy
         meta_out->deepCopy(meta_in);
 
-        meta_out->set_from_frame_desc(out_rfi_s012tilde_buf->get_ndarray_frame_desc());
+        meta_out->set_from_frame_desc(
+            out_rfi_s012tilde_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // test that things are consistent
-        meta_out->check_frame_desc(out_rfi_s012tilde_buf->get_ndarray_frame_desc());
+        meta_out->check_frame_desc(
+            out_rfi_s012tilde_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // Set non-NDArray things.
         meta_out->set_fpga_seq_num(meta_in->get_fpga_seq_num());

--- a/lib/testing/gpuSimulateRFISK.cpp
+++ b/lib/testing/gpuSimulateRFISK.cpp
@@ -1,6 +1,7 @@
 #include "Config.hpp"          // for Config
 #include "DataType.hpp"        // for DataType, GetType
 #include "N2Util.hpp"          // for frameID
+#include "NDArray.hpp"         // for NDArray, GenericNDArray, Config
 #include "Stage.hpp"           // for Stage
 #include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
 #include "buffer.hpp"          // for Buffer
@@ -206,46 +207,37 @@ gpuSimulateRFISK::gpuSimulateRFISK(Config& config, const std::string& unique_nam
     out_rfi_mask_buf->register_producer(unique_name);
 
     int64_t nt = _samples_per_data_set / _rfi_downsampling_factor;
-    size_t bf_mask_size = _num_elements;
-    size_t rfi_s012_size = nt * _num_local_freq * 3 * _num_elements * sizeof(uint64_t);
-
     // Check input sizes and buffer compatibility
     if (_samples_per_data_set % _rfi_downsampling_factor != 0) {
         FATAL_ERROR("samples_per_data_set must be a multiple of rfi_downsampling_factor");
     }
     assert(_samples_per_data_set % _rfi_downsampling_factor == 0);
 
-    if (in_rfi_s012_buf->frame_size != rfi_s012_size) {
-        FATAL_ERROR("in_rfi_s012_buf ({:s}) has frame size: {:d}, expected: {:d}",
-                    in_rfi_s012_buf->buffer_name, in_rfi_s012_buf->frame_size, rfi_s012_size);
-    }
-    assert(in_rfi_s012_buf->frame_size == rfi_s012_size);
-
-    if (in_bf_mask_buf->frame_size != bf_mask_size) {
-        FATAL_ERROR("in_bf_mask_buf ({:s}) has frame size: {:d}, expected: {:d}",
-                    in_bf_mask_buf->buffer_name, in_bf_mask_buf->frame_size, bf_mask_size);
-    }
-    assert(in_bf_mask_buf->frame_size == bf_mask_size);
+    in_rfi_s012_buf->require_frame_desc(kotekan::NDArray<uint64_t, 5>::describe(
+        _bar_mode ? "S012bar" : "S012", {nt, _num_local_freq, 3, _num_polarizations, _num_dishes},
+        {_bar_mode ? "Trfibar" : "Trfi", "F", "S", "P", "D"}));
+    in_bf_mask_buf->require_frame_desc(kotekan::NDArray<std::int8_t, 2>::describe(
+        "bf_mask", {_num_polarizations, _num_dishes}, {"P", "D"}));
 
     // Make frame desc for produced buffers
     if (_bar_mode) {
-        out_rfi_sk_buf->allocate_ndarray_frame_desc<float, 5>(
+        out_rfi_sk_buf->require_frame_desc(kotekan::NDArray<float, 5>::describe(
             "SKbar", {nt, _num_local_freq, 3, _num_polarizations, _num_dishes},
-            {"Trfibar", "F", "SK", "P", "D"});
-        out_rfi_sktilde_buf->allocate_ndarray_frame_desc<float, 3>(
-            "SKbartilde", {nt, _num_local_freq, 3}, {"Trfibar", "F", "SK"});
-        out_rfi_mask_buf->allocate_ndarray_frame_desc<kotekan::uint1x8_t, 3>(
+            {"Trfibar", "F", "SK", "P", "D"}));
+        out_rfi_sktilde_buf->require_frame_desc(kotekan::NDArray<float, 3>::describe(
+            "SKbartilde", {nt, _num_local_freq, 3}, {"Trfibar", "F", "SK"}));
+        out_rfi_mask_buf->require_frame_desc(kotekan::NDArray<kotekan::uint1x8_t, 3>::describe(
             "RFImask", {_samples_per_data_set / 1024, _num_local_freq, 128},
-            {"T8hi128", "F", "T8lo128"});
+            {"T8hi128", "F", "T8lo128"}));
     } else {
-        out_rfi_sk_buf->allocate_ndarray_frame_desc<float, 5>(
+        out_rfi_sk_buf->require_frame_desc(kotekan::NDArray<float, 5>::describe(
             "SK", {nt, _num_local_freq, 3, _num_polarizations, _num_dishes},
-            {"Trfi", "F", "SK", "P", "D"});
-        out_rfi_sktilde_buf->allocate_ndarray_frame_desc<float, 3>(
-            "SKtilde", {nt, _num_local_freq, 3}, {"Trfi", "F", "SK"});
-        out_rfi_mask_buf->allocate_ndarray_frame_desc<kotekan::uint1x8_t, 3>(
+            {"Trfi", "F", "SK", "P", "D"}));
+        out_rfi_sktilde_buf->require_frame_desc(kotekan::NDArray<float, 3>::describe(
+            "SKtilde", {nt, _num_local_freq, 3}, {"Trfi", "F", "SK"}));
+        out_rfi_mask_buf->require_frame_desc(kotekan::NDArray<kotekan::uint1x8_t, 3>::describe(
             "RFImask", {_samples_per_data_set / 1024, _num_local_freq, 128},
-            {"T8hi128", "F", "T8lo128"});
+            {"T8hi128", "F", "T8lo128"}));
     }
 
     // Check the size of the interpolation tables
@@ -552,14 +544,18 @@ void gpuSimulateRFISK::main_thread() {
         meta_sktilde->deepCopy(meta_in);
         meta_rfi_mask->deepCopy(meta_in);
 
-        meta_sk->set_from_frame_desc(out_rfi_sk_buf->get_ndarray_frame_desc());
-        meta_sktilde->set_from_frame_desc(out_rfi_sktilde_buf->get_ndarray_frame_desc());
-        meta_rfi_mask->set_from_frame_desc(out_rfi_mask_buf->get_ndarray_frame_desc());
+        meta_sk->set_from_frame_desc(out_rfi_sk_buf->get_frame_desc<kotekan::GenericNDArray>());
+        meta_sktilde->set_from_frame_desc(
+            out_rfi_sktilde_buf->get_frame_desc<kotekan::GenericNDArray>());
+        meta_rfi_mask->set_from_frame_desc(
+            out_rfi_mask_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // test that things are consistent
-        meta_sk->check_frame_desc(out_rfi_sk_buf->get_ndarray_frame_desc());
-        meta_sktilde->check_frame_desc(out_rfi_sktilde_buf->get_ndarray_frame_desc());
-        meta_rfi_mask->check_frame_desc(out_rfi_mask_buf->get_ndarray_frame_desc());
+        meta_sk->check_frame_desc(out_rfi_sk_buf->get_frame_desc<kotekan::GenericNDArray>());
+        meta_sktilde->check_frame_desc(
+            out_rfi_sktilde_buf->get_frame_desc<kotekan::GenericNDArray>());
+        meta_rfi_mask->check_frame_desc(
+            out_rfi_mask_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // Set non-NDArray things.
         meta_rfi_mask->set_time_downsampling_fpga(1024 * meta_in->get_time_downsampling_fpga()

--- a/lib/testing/inventBFMask.cpp
+++ b/lib/testing/inventBFMask.cpp
@@ -1,5 +1,6 @@
 #include "Config.hpp"            // for Config
 #include "DataType.hpp"          // for string_to_type, DataType
+#include "NDArray.hpp"           // for NDArray, GenericNDArray
 #include "Stage.hpp"             // for Stage
 #include "StageFactory.hpp"      // for REGISTER_KOTEKAN_STAGE
 #include "Symbol.hpp"            // for Symbol
@@ -31,9 +32,9 @@ class inventBFMask : public kotekan::Stage {
     const int num_dishes = config.get<int>(unique_name, "num_dishes");
     const int num_polarizations = config.get<int>(unique_name, "num_polarizations");
     const int num_times = config.get<int>(unique_name, "num_times");
-    const std::string mode = config.get_default<std::string>(unique_name, "mode",
-            "all_good");
-    const std::vector<int> manual_bad_feeds = config.get_default<std::vector<int>>(unique_name, "manual_bad_feeds", {});
+    const std::string mode = config.get_default<std::string>(unique_name, "mode", "all_good");
+    const std::vector<int> manual_bad_feeds =
+        config.get_default<std::vector<int>>(unique_name, "manual_bad_feeds", {});
 
     Buffer* const buffer;
 
@@ -71,11 +72,11 @@ public:
             return;
 
         // Set metadata
-        buffer->allocate_ndarray_frame_desc<std::int8_t, 2>(
-            "bf_mask", {num_polarizations, num_dishes}, {"P", "D"});
+        buffer->require_frame_desc(kotekan::NDArray<std::int8_t, 2>::describe(
+            "bf_mask", {num_polarizations, num_dishes}, {"P", "D"}));
         buffer->allocate_new_metadata_object(frame_id);
         const auto& meta = get_chord_metadata(buffer->get_metadata(frame_id));
-        meta->set_from_frame_desc(buffer->get_ndarray_frame_desc());
+        meta->set_from_frame_desc(buffer->get_frame_desc<kotekan::GenericNDArray>());
         meta->set_fpga_seq_num(frame_index * num_times);
         meta->set_time_downsampling_fpga(1);
 
@@ -92,12 +93,12 @@ public:
                 else if (mode == "all_bad")
                     frame[idx] = 0; // dish is not active
                 else if (mode == "auto") {
-                    if (tel.cast<CHORDTelescope>().get_dish_at_idx(dish).type == DishType::ArrayDish)
+                    if (tel.cast<CHORDTelescope>().get_dish_at_idx(dish).type
+                        == DishType::ArrayDish)
                         frame[idx] = 1;
                     else
                         frame[idx] = 0;
-                }
-                else 
+                } else
                     frame[idx] = 1;
             }
 

--- a/lib/testing/inventPLMask.cpp
+++ b/lib/testing/inventPLMask.cpp
@@ -1,5 +1,6 @@
 #include "Config.hpp"            // for Config
 #include "DataType.hpp"          // for string_to_type, DataType
+#include "NDArray.hpp"           // for NDArray, GenericNDArray
 #include "Stage.hpp"             // for Stage
 #include "StageFactory.hpp"      // for REGISTER_KOTEKAN_STAGE
 #include "Symbol.hpp"            // for Symbol
@@ -65,14 +66,14 @@ public:
                 return;
 
             // Set metadata
-            buffer->allocate_ndarray_frame_desc<kotekan::uint1x8_t, 5>(
+            buffer->require_frame_desc(kotekan::NDArray<kotekan::uint1x8_t, 5>::describe(
                 "pl_mask",
                 {div_noremainder(num_times, 2 * 64), div_noremainder(num_frequencies, 4),
                  num_polarizations, div_noremainder(num_dishes, 8), 64 / 8},
-                {"T2hi64", "F4", "P", "D8", "T2lo64"});
+                {"T2hi64", "F4", "P", "D8", "T2lo64"}));
             buffer->allocate_new_metadata_object(frame_id);
             const auto& meta = get_chord_metadata(buffer->get_metadata(frame_id));
-            meta->set_from_frame_desc(buffer->get_ndarray_frame_desc());
+            meta->set_from_frame_desc(buffer->get_frame_desc<kotekan::GenericNDArray>());
             meta->set_fpga_seq_num(frame_index * num_times);
             meta->set_time_downsampling_fpga(2 * 64);
 

--- a/lib/testing/inventVoltage.cpp
+++ b/lib/testing/inventVoltage.cpp
@@ -1,5 +1,6 @@
 #include "Config.hpp"            // for Config
 #include "DataType.hpp"          // for string_to_type, DataType
+#include "NDArray.hpp"           // for NDArray, GenericNDArray
 #include "Stage.hpp"             // for Stage
 #include "StageFactory.hpp"      // for REGISTER_KOTEKAN_STAGE
 #include "Symbol.hpp"            // for Symbol
@@ -80,8 +81,10 @@ public:
         buffer->register_producer(unique_name);
 
         // Set metadata
-        buffer->allocate_ndarray_frame_desc<kotekan::int4x2_swapped_withoffset_t, 4>(
-            "E", {num_times, num_frequencies, num_polarizations, num_dishes}, {"T", "F", "P", "D"});
+        buffer->require_frame_desc(
+            kotekan::NDArray<kotekan::int4x2_swapped_withoffset_t, 4>::describe(
+                "E", {num_times, num_frequencies, num_polarizations, num_dishes},
+                {"T", "F", "P", "D"}));
     }
 
     virtual ~inventVoltage() {}
@@ -154,7 +157,7 @@ public:
             buffer->allocate_new_metadata_object(frame_id);
             const auto& meta = get_chord_metadata(buffer->get_metadata(frame_id));
             meta->set_fpga_seq_num(frame_index * num_times);
-            meta->set_from_frame_desc(buffer->get_ndarray_frame_desc());
+            meta->set_from_frame_desc(buffer->get_frame_desc<kotekan::GenericNDArray>());
             meta->set_time_downsampling_fpga(1);
 
             // Set frequency information

--- a/lib/testing/inventVoltageCHIME.cpp
+++ b/lib/testing/inventVoltageCHIME.cpp
@@ -1,5 +1,6 @@
 #include "Config.hpp"            // for Config
 #include "DataType.hpp"          // for string_to_type, DataType
+#include "NDArray.hpp"           // for NDArray, GenericNDArray
 #include "Stage.hpp"             // for Stage
 #include "StageFactory.hpp"      // for REGISTER_KOTEKAN_STAGE
 #include "Symbol.hpp"            // for Symbol
@@ -79,8 +80,9 @@ public:
             buffer->register_producer(unique_name);
 
             // Set metadata
-            buffer->allocate_ndarray_frame_desc<kotekan::int4x2_swapped_withoffset_t, 3>(
-                "E", {1, num_times, num_polarizations * num_dishes}, {"F", "T", "E"});
+            buffer->require_frame_desc(
+                kotekan::NDArray<kotekan::int4x2_swapped_withoffset_t, 3>::describe(
+                    "E", {1, num_times, num_polarizations * num_dishes}, {"F", "T", "E"}));
         }
     }
 
@@ -160,7 +162,7 @@ public:
                 buffer->allocate_new_metadata_object(frame_id);
                 const auto& meta = get_chord_metadata(buffer->get_metadata(frame_id));
                 meta->set_fpga_seq_num(frame_index * num_times);
-                meta->set_from_frame_desc(buffer->get_ndarray_frame_desc());
+                meta->set_from_frame_desc(buffer->get_frame_desc<kotekan::GenericNDArray>());
                 meta->set_time_downsampling_fpga(1);
 
                 // Set frequency information

--- a/lib/testing/testLostCountsGen.cpp
+++ b/lib/testing/testLostCountsGen.cpp
@@ -1,6 +1,7 @@
 #include "Config.hpp"          // for Config
 #include "DataType.hpp"        // for DataType
 #include "N2Util.hpp"          // for frameID
+#include "NDArray.hpp"         // for NDArray, GenericNDArray, Config
 #include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
 #include "buffer.hpp"          // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
@@ -159,14 +160,14 @@ testLostCountsGen::testLostCountsGen(Config& config, const std::string& unique_n
             FATAL_ERROR("num_elements {:d} is not a multiple of {:d}", num_elements,
                         8 * n2k_counts_blocksize);
 
-        in_buf->allocate_ndarray_frame_desc<int32_t, 5>(
+        in_buf->require_frame_desc(kotekan::NDArray<int32_t, 5>::describe(
             "n2k_counts",
             {num_integrations, num_local_freq, n2k_counts_num_blocks, n2k_counts_blocksize,
              n2k_counts_blocksize},
-            {"Tc", "F", "D8Phi", "D8Plo1", "D8Plo2"});
+            {"Tc", "F", "D8Phi", "D8Plo1", "D8Plo2"}));
     }
-    out_buf->allocate_ndarray_frame_desc<int32_t, 2>(name, {num_integrations, num_local_freq},
-                                                     {"Tc", "F"});
+    out_buf->require_frame_desc(kotekan::NDArray<int32_t, 2>::describe(
+        name, {num_integrations, num_local_freq}, {"Tc", "F"}));
 }
 
 std::shared_ptr<chordMetadata> testLostCountsGen::get_new_metadata(Buffer* buf, frameID frame_id) {
@@ -189,7 +190,7 @@ std::shared_ptr<chordMetadata> testLostCountsGen::get_new_metadata(Buffer* buf, 
 }
 
 void testLostCountsGen::set_metadata(const std::shared_ptr<chordMetadata>& meta, uint64_t seq_num) {
-    meta->set_from_frame_desc(out_buf->get_ndarray_frame_desc());
+    meta->set_from_frame_desc(out_buf->get_frame_desc<kotekan::GenericNDArray>());
 
     meta->set_fpga_seq_num(seq_num);
     meta->set_time_downsampling_fpga(sub_integration_ntime);
@@ -257,7 +258,7 @@ void testLostCountsGen::main_thread() {
         set_metadata(meta, seq_num);
 
         // check frame descriptors match metadata
-        meta->check_frame_desc(out_buf->get_ndarray_frame_desc());
+        meta->check_frame_desc(out_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // If we're not repeating, or we're in the first num_frames, generate data
         if (repeat_count <= 0 || (num_frames > 0 && num_frames_generated < num_frames)) {

--- a/lib/testing/testLostSamplesToPLMask.cpp
+++ b/lib/testing/testLostSamplesToPLMask.cpp
@@ -3,6 +3,7 @@
 #include "Config.hpp" // for Config
 #include "Hash.hpp"
 #include "Metadata.hpp"        // for GenericNDArray
+#include "NDArray.hpp"         // for NDArray, GenericNDArray, Config
 #include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
 #include "buffer.hpp"          // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
@@ -64,19 +65,21 @@ testLostSamplesToPLMask::testLostSamplesToPLMask(Config& config, const std::stri
         FATAL_ERROR("Unexpected frames sizes for pl_mask {:d} and lost_samples {:d}",
                     pl_mask_buf->frame_size, lost_samples_bufs.at(0)->frame_size);
 
-    pl_mask_buf->allocate_ndarray_frame_desc<kotekan::GetType_t<kotekan::uint1x8>, 5>(
-        "pl_mask",
-        {ptrdiff_t(lost_samples_bufs.at(0)->frame_size / PL_MASK_DOWNSAMPLING_FACTOR
-                   / PL_MASK_HILO_SPLIT),
-         ptrdiff_t(lost_samples_bufs.size()), num_polarizations,
-         num_dishes / PL_MASK_DISHES_PER_BIN,
-         PL_MASK_HILO_SPLIT / BITS_PER_BYTE /* because we count uint1x8, not uint1 */},
-        {"T2hi64", "F4", "P", "D8", "T2lo64"});
+    pl_mask_buf->require_frame_desc(
+        kotekan::NDArray<kotekan::GetType_t<kotekan::uint1x8>, 5>::describe(
+            "pl_mask",
+            {ptrdiff_t(lost_samples_bufs.at(0)->frame_size / PL_MASK_DOWNSAMPLING_FACTOR
+                       / PL_MASK_HILO_SPLIT),
+             ptrdiff_t(lost_samples_bufs.size()), num_polarizations,
+             num_dishes / PL_MASK_DISHES_PER_BIN,
+             PL_MASK_HILO_SPLIT / BITS_PER_BYTE /* because we count uint1x8, not uint1 */},
+            {"T2hi64", "F4", "P", "D8", "T2lo64"}));
 
     for (int fbin = 0; fbin < num_freq_bins; ++fbin) {
         auto lost_samples_buf = lost_samples_bufs.at(fbin);
-        lost_samples_buf->allocate_ndarray_frame_desc<kotekan::GetType_t<kotekan::uint8>, 1>(
-            "lost_samples", {ptrdiff_t(lost_samples_bufs.at(0)->frame_size)}, {"T"});
+        lost_samples_buf->require_frame_desc(
+            kotekan::NDArray<kotekan::GetType_t<kotekan::uint8>, 1>::describe(
+                "lost_samples", {ptrdiff_t(lost_samples_bufs.at(0)->frame_size)}, {"T"}));
     }
 }
 
@@ -137,7 +140,7 @@ void testLostSamplesToPLMask::main_thread() {
         pl_mask_buf->allocate_new_metadata_object(frame_id);
         auto pl_mask_meta = get_chord_metadata(pl_mask_buf, frame_id);
 
-        pl_mask_meta->set_from_frame_desc(pl_mask_buf->get_ndarray_frame_desc());
+        pl_mask_meta->set_from_frame_desc(pl_mask_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // physics metadata
         // TODO: add more that dpdk adds
@@ -155,7 +158,7 @@ void testLostSamplesToPLMask::main_thread() {
         pl_mask_meta->set_freq_upchan_factor(freq_upchan_factor);
         pl_mask_meta->set_freq_upchan_index(freq_upchan_index);
 
-        pl_mask_meta->check_frame_desc(pl_mask_buf->get_ndarray_frame_desc());
+        pl_mask_meta->check_frame_desc(pl_mask_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // done
         pl_mask_buf->mark_frame_full(unique_name, frame_id);
@@ -173,7 +176,8 @@ void testLostSamplesToPLMask::main_thread() {
 
             lost_samples_buf->allocate_new_metadata_object(frame_id);
             auto lost_samples_meta = get_chord_metadata(lost_samples_buf, frame_id);
-            lost_samples_meta->set_from_frame_desc(lost_samples_buf->get_ndarray_frame_desc());
+            lost_samples_meta->set_from_frame_desc(
+                lost_samples_buf->get_frame_desc<kotekan::GenericNDArray>());
 
             // physics metadata
             // TODO: add more that dpdk adds
@@ -186,7 +190,8 @@ void testLostSamplesToPLMask::main_thread() {
                 std::vector<int>(&coarse_freq[fbin * PL_MASK_FREQS_PER_BIN],
                                  &coarse_freq[(fbin + 1) * PL_MASK_FREQS_PER_BIN]));
 
-            lost_samples_meta->check_frame_desc(lost_samples_buf->get_ndarray_frame_desc());
+            lost_samples_meta->check_frame_desc(
+                lost_samples_buf->get_frame_desc<kotekan::GenericNDArray>());
 
             // done
             lost_samples_buf->mark_frame_full(unique_name, frame_id);

--- a/lib/testing/testN2kGen.cpp
+++ b/lib/testing/testN2kGen.cpp
@@ -2,6 +2,7 @@
 
 #include "Config.hpp"          // for Config
 #include "DataType.hpp"        // for DataType
+#include "NDArray.hpp"         // for GenericNDArray
 #include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
 #include "buffer.hpp"          // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
@@ -149,14 +150,14 @@ testN2kGen::testN2kGen(Config& config, const std::string& unique_name,
         count_blocksize * count_blocksize * count_num_blocks * num_local_freq * num_integrations;
 
     // allocate frame descriptors
-    corr_buf->allocate_ndarray_frame_desc(
+    corr_buf->require_frame_desc(kotekan::GenericNDArray::describe(
         kotekan::int32, "n2k_correlation",
         {num_integrations, num_local_freq, corr_num_blocks, corr_blocksize, corr_blocksize, 2},
-        {"Tc", "F", "DPhi", "DPlo1", "DPlo2", "C"});
-    count_buf->allocate_ndarray_frame_desc(
+        {"Tc", "F", "DPhi", "DPlo1", "DPlo2", "C"}));
+    count_buf->require_frame_desc(kotekan::GenericNDArray::describe(
         kotekan::int32, "n2k_counts",
         {num_integrations, num_local_freq, count_num_blocks, count_blocksize, count_blocksize},
-        {"Tc", "F", "D8Phi", "D8Plo1", "D8Plo2"});
+        {"Tc", "F", "D8Phi", "D8Plo1", "D8Plo2"}));
 }
 
 std::shared_ptr<chordMetadata> testN2kGen::get_new_metadata(Buffer* buf, frameID frame_id) {
@@ -289,14 +290,14 @@ void testN2kGen::main_thread() {
             get_new_metadata(count_buf, count_frame_id);
 
         // fill metadata
-        corr_meta->set_from_frame_desc(corr_buf->get_ndarray_frame_desc());
-        count_meta->set_from_frame_desc(count_buf->get_ndarray_frame_desc());
+        corr_meta->set_from_frame_desc(corr_buf->get_frame_desc<kotekan::GenericNDArray>());
+        count_meta->set_from_frame_desc(count_buf->get_frame_desc<kotekan::GenericNDArray>());
         set_shared_metadata(corr_meta, seq_num);
         set_shared_metadata(count_meta, seq_num);
 
         // check frame descriptors match metadata
-        corr_meta->check_frame_desc(corr_buf->get_ndarray_frame_desc());
-        count_meta->check_frame_desc(count_buf->get_ndarray_frame_desc());
+        corr_meta->check_frame_desc(corr_buf->get_frame_desc<kotekan::GenericNDArray>());
+        count_meta->check_frame_desc(count_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // If we're not repeating, or we're in the first num_frames, generate data
         if (repeat_count <= 0 || (num_frames > 0 && num_frames_generated < num_frames)) {

--- a/lib/testing/testRFIFrameMaskGen.cpp
+++ b/lib/testing/testRFIFrameMaskGen.cpp
@@ -1,6 +1,7 @@
 #include "Config.hpp"          // for Config
 #include "DataType.hpp"        // for DataType
 #include "N2Util.hpp"          // for frameID
+#include "NDArray.hpp"         // for GenericNDArray
 #include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
 #include "buffer.hpp"          // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
@@ -139,8 +140,8 @@ testRFIFrameMaskGen::testRFIFrameMaskGen(Config& config, const std::string& uniq
     }
 
     // allocate frame descriptors
-    out_buf->allocate_ndarray_frame_desc(kotekan::uint8, name, {num_integrations, num_local_freq},
-                                         {"Tc", "F"});
+    out_buf->require_frame_desc(kotekan::GenericNDArray::describe(
+        kotekan::uint8, name, {num_integrations, num_local_freq}, {"Tc", "F"}));
 }
 
 std::shared_ptr<chordMetadata> testRFIFrameMaskGen::get_new_metadata(Buffer* buf,
@@ -165,7 +166,7 @@ std::shared_ptr<chordMetadata> testRFIFrameMaskGen::get_new_metadata(Buffer* buf
 
 void testRFIFrameMaskGen::set_metadata(const std::shared_ptr<chordMetadata>& meta,
                                        uint64_t seq_num) {
-    meta->set_from_frame_desc(out_buf->get_ndarray_frame_desc());
+    meta->set_from_frame_desc(out_buf->get_frame_desc<kotekan::GenericNDArray>());
 
     meta->set_fpga_seq_num(seq_num);
     meta->set_time_downsampling_fpga(sub_integration_ntime);
@@ -243,7 +244,7 @@ void testRFIFrameMaskGen::main_thread() {
         set_metadata(meta, seq_num);
 
         // check frame descriptors match metadata
-        meta->check_frame_desc(out_buf->get_ndarray_frame_desc());
+        meta->check_frame_desc(out_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // If we're not repeating, or we're in the first num_frames, generate data
         if (repeat_count <= 0 || (num_frames > 0 && num_frames_generated < num_frames)) {

--- a/lib/testing/testRFIS012Gen.cpp
+++ b/lib/testing/testRFIS012Gen.cpp
@@ -1,5 +1,6 @@
 #include "Config.hpp"          // for Config
 #include "DataType.hpp"        // for DataType
+#include "NDArray.hpp"         // for NDArray, GenericNDArray, Config
 #include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
 #include "buffer.hpp"          // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
@@ -164,13 +165,13 @@ testRFIS012Gen::testRFIS012Gen(Config& config, const std::string& unique_name,
 
     // allocate frame descriptor
     if (bar_mode) {
-        out_buf->allocate_ndarray_frame_desc<uint64_t, 5>(
+        out_buf->require_frame_desc(kotekan::NDArray<uint64_t, 5>::describe(
             "S012bar", {num_rfi_samples, num_local_freq, 3, num_polarizations, num_dishes},
-            {"Trfibar", "F", "S", "P", "D"});
+            {"Trfibar", "F", "S", "P", "D"}));
     } else {
-        out_buf->allocate_ndarray_frame_desc<uint64_t, 5>(
+        out_buf->require_frame_desc(kotekan::NDArray<uint64_t, 5>::describe(
             "S012", {num_rfi_samples, num_local_freq, 3, num_polarizations, num_dishes},
-            {"Trfi", "F", "S", "P", "D"});
+            {"Trfi", "F", "S", "P", "D"}));
     }
 }
 
@@ -195,7 +196,7 @@ std::shared_ptr<chordMetadata> testRFIS012Gen::get_new_metadata(frameID frame_id
 }
 
 void testRFIS012Gen::set_metadata(const std::shared_ptr<chordMetadata>& meta, uint64_t seq_num) {
-    meta->set_from_frame_desc(out_buf->get_ndarray_frame_desc());
+    meta->set_from_frame_desc(out_buf->get_frame_desc<kotekan::GenericNDArray>());
 
     meta->set_fpga_seq_num(seq_num);
     meta->set_time_downsampling_fpga(downsampling_factor);
@@ -242,7 +243,7 @@ void testRFIS012Gen::main_thread() {
         set_metadata(meta, seq_num);
 
         // check frame descriptors match metadata
-        meta->check_frame_desc(out_buf->get_ndarray_frame_desc());
+        meta->check_frame_desc(out_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // Access Strides into s012
         int64_t ds = num_elements;

--- a/lib/testing/testRFImaskGen.cpp
+++ b/lib/testing/testRFImaskGen.cpp
@@ -1,5 +1,6 @@
 #include "Config.hpp"          // for Config
 #include "DataType.hpp"        // for DataType
+#include "NDArray.hpp"         // for GenericNDArray
 #include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
 #include "buffer.hpp"          // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
@@ -130,9 +131,9 @@ testRFImaskGen::testRFImaskGen(Config& config, const std::string& unique_name,
     }
 
     // allocate frame descriptors
-    out_buf->allocate_ndarray_frame_desc(kotekan::uint1x8, name,
-                                         {samples_per_data_set / 1024, num_local_freq, 128},
-                                         {"T8hi128", "F", "T8lo128"});
+    out_buf->require_frame_desc(kotekan::GenericNDArray::describe(
+        kotekan::uint1x8, name, {samples_per_data_set / 1024, num_local_freq, 128},
+        {"T8hi128", "F", "T8lo128"}));
 
     if (out_buf->frame_size != out_buf->frames_desc->get_byte_size())
         FATAL_ERROR("out_but {:s} has frame size {:d}, expected {:d}.", out_buf->buffer_name,
@@ -159,7 +160,7 @@ std::shared_ptr<chordMetadata> testRFImaskGen::get_new_metadata(Buffer* buf, fra
 }
 
 void testRFImaskGen::set_metadata(const std::shared_ptr<chordMetadata>& meta, uint64_t seq_num) {
-    meta->set_from_frame_desc(out_buf->get_ndarray_frame_desc());
+    meta->set_from_frame_desc(out_buf->get_frame_desc<kotekan::GenericNDArray>());
 
     meta->set_fpga_seq_num(seq_num);
     meta->set_time_downsampling_fpga(1024);
@@ -226,7 +227,7 @@ void testRFImaskGen::main_thread() {
         set_metadata(meta, seq_num);
 
         // check frame descriptors match metadata
-        meta->check_frame_desc(out_buf->get_ndarray_frame_desc());
+        meta->check_frame_desc(out_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // If we're not repeating, or we're in the first num_frames, generate data
         if (repeat_count <= 0 || (num_frames > 0 && num_frames_generated < num_frames)) {

--- a/lib/testing/testXpose.cpp
+++ b/lib/testing/testXpose.cpp
@@ -2,6 +2,7 @@
 
 #include "Config.hpp"          // for Config
 #include "Metadata.hpp"        // for GenericNDArray
+#include "NDArray.hpp"         // for GenericNDArray, Config
 #include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
 #include "buffer.hpp"          // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
@@ -53,9 +54,9 @@ testXpose::testXpose(Config& config, const std::string& unique_name,
                     out_xposed_buf->frame_size,
                     num_times * num_xposed_frequencies * num_polarizations * num_dishes
                         * sizeof(uint8_t));
-    out_xposed_buf->allocate_ndarray_frame_desc(
+    out_xposed_buf->require_frame_desc(kotekan::GenericNDArray::describe(
         kotekan::int4x2_swapped_withoffset, "E",
-        {num_times, num_xposed_frequencies, num_polarizations, num_dishes}, {"T", "F", "P", "D"});
+        {num_times, num_xposed_frequencies, num_polarizations, num_dishes}, {"T", "F", "P", "D"}));
 
     scatter_indices_buf = get_buffer("scatter_indices_buf");
     scatter_indices_buf->register_producer(unique_name);
@@ -65,8 +66,8 @@ testXpose::testXpose(Config& config, const std::string& unique_name,
                     num_polarizations * num_dishes * sizeof(int32_t));
     // TODO: this is not quite correct. Really if going to cylinder order
     // the array is {4,2,256} {"C", "P", "D"}
-    scatter_indices_buf->allocate_ndarray_frame_desc(kotekan::int32, "scatter_indices",
-                                                     {num_polarizations, num_dishes}, {"P", "D"});
+    scatter_indices_buf->require_frame_desc(kotekan::GenericNDArray::describe(
+        kotekan::int32, "scatter_indices", {num_polarizations, num_dishes}, {"P", "D"}));
 
     // Register as producer for all xpose2048 input buffers
     json bufs = config.get_value(unique_name, "out_bufs");
@@ -74,9 +75,9 @@ testXpose::testXpose(Config& config, const std::string& unique_name,
         Buffer* buf = buffer_container.get_buffer(it.value().get<std::string>());
         out_bufs.push_back(buf);
         buf->register_producer(unique_name);
-        buf->allocate_ndarray_frame_desc(
+        buf->require_frame_desc(kotekan::GenericNDArray::describe(
             kotekan::int4x2_swapped_withoffset, "E",
-            {num_frequencies, num_times, num_polarizations * num_dishes}, {"F", "T", "E"});
+            {num_frequencies, num_times, num_polarizations * num_dishes}, {"F", "T", "E"}));
         if (buf->frame_size
             != num_polarizations * num_dishes * num_times * num_frequencies * sizeof(uint8_t))
             FATAL_ERROR("Input samples bufferer {:s} has unexpected size {:d} instead of {:d}",
@@ -119,8 +120,10 @@ void testXpose::main_thread() {
     scatter_indices_buf->allocate_new_metadata_object(scatter_indices_id);
     auto scatter_indices_meta = get_chord_metadata(scatter_indices_buf, scatter_indices_id);
     scatter_indices_meta->set_fpga_seq_num(0);
-    scatter_indices_meta->set_from_frame_desc(scatter_indices_buf->get_ndarray_frame_desc());
-    scatter_indices_meta->check_frame_desc(scatter_indices_buf->get_ndarray_frame_desc());
+    scatter_indices_meta->set_from_frame_desc(
+        scatter_indices_buf->get_frame_desc<kotekan::GenericNDArray>());
+    scatter_indices_meta->check_frame_desc(
+        scatter_indices_buf->get_frame_desc<kotekan::GenericNDArray>());
     scatter_indices_buf->mark_frame_full(unique_name, scatter_indices_id);
 
     // for each time
@@ -188,8 +191,10 @@ void testXpose::main_thread() {
             std::vector<int> coarse_freq(num_frequencies);
             std::iota(coarse_freq.begin(), coarse_freq.end(), buf_num * num_frequencies);
             out_meta->set_coarse_freq(coarse_freq);
-            out_meta->set_from_frame_desc(out_bufs.at(buf_num)->get_ndarray_frame_desc());
-            out_meta->check_frame_desc(out_bufs.at(buf_num)->get_ndarray_frame_desc());
+            out_meta->set_from_frame_desc(
+                out_bufs.at(buf_num)->get_frame_desc<kotekan::GenericNDArray>());
+            out_meta->check_frame_desc(
+                out_bufs.at(buf_num)->get_frame_desc<kotekan::GenericNDArray>());
             out_bufs.at(buf_num)->mark_frame_full(unique_name, out_id);
         }
 
@@ -202,8 +207,10 @@ void testXpose::main_thread() {
         std::vector<int> coarse_freq(num_xposed_frequencies);
         std::iota(coarse_freq.begin(), coarse_freq.end(), 0);
         out_xposed_meta->set_coarse_freq(coarse_freq);
-        out_xposed_meta->set_from_frame_desc(out_xposed_buf->get_ndarray_frame_desc());
-        out_xposed_meta->check_frame_desc(out_xposed_buf->get_ndarray_frame_desc());
+        out_xposed_meta->set_from_frame_desc(
+            out_xposed_buf->get_frame_desc<kotekan::GenericNDArray>());
+        out_xposed_meta->check_frame_desc(
+            out_xposed_buf->get_frame_desc<kotekan::GenericNDArray>());
         out_xposed_buf->mark_frame_full(unique_name, out_xposed_id);
 
         out_xposed_id += 1;

--- a/lib/utils/N2FrameView.cpp
+++ b/lib/utils/N2FrameView.cpp
@@ -14,24 +14,12 @@
 #include "fmt.hpp"             // for compile_string_to_view
 #include "kotekanLogging.hpp"  // for FATAL_ERROR_NON_OO
 
-namespace {
-
-// Helper to ensure that the given FrameDesc is actually an N2FrameDesc
-std::shared_ptr<const kotekan::N2FrameDesc>
-validate_desc_type(std::shared_ptr<const kotekan::FrameDesc> desc) {
-    auto n2_desc = std::dynamic_pointer_cast<const kotekan::N2FrameDesc>(desc);
-    if (!n2_desc) {
-        FATAL_ERROR_NON_OO("N2FrameView: Buffer does not have a valid N2FrameDesc");
-    }
-    return n2_desc;
-}
-} // namespace
 
 N2FrameView::N2FrameView(Buffer* buf, int frame_id) :
 
     FrameView(buf, frame_id),
     _metadata(std::static_pointer_cast<N2Metadata>(buf->metadata[frame_id])),
-    _desc(validate_desc_type(buf->get_frame_desc())),
+    _desc(buf->require_frame_desc<kotekan::N2FrameDesc>()),
 
     // Set the const refs to the structural metadata
     n2_layout(_desc->get_n2_layout()), num_elements(_desc->get_num_elements()),

--- a/lib/utils/N2FrameView.cpp
+++ b/lib/utils/N2FrameView.cpp
@@ -31,7 +31,7 @@ N2FrameView::N2FrameView(Buffer* buf, int frame_id) :
 
     FrameView(buf, frame_id),
     _metadata(std::static_pointer_cast<N2Metadata>(buf->metadata[frame_id])),
-    _desc(validate_desc_type(buf->get_frame_description())),
+    _desc(validate_desc_type(buf->get_frame_desc())),
 
     // Set the const refs to the structural metadata
     n2_layout(_desc->get_n2_layout()), num_elements(_desc->get_num_elements()),

--- a/python/kotekan/runner.py
+++ b/python/kotekan/runner.py
@@ -827,7 +827,13 @@ class DumpVisBuffer(OutputBuffer):
 
 
 class ReadChordBuffer(InputBuffer):
-    """Write down a ChordBuffer and reads it with hdf5FileRead."""
+    """Write down a ChordBuffer and reads it with hdf5FileRead.
+
+    When the first buffer's metadata carries name/type/dim_names, the
+    kotekan buffer is declared as `kotekan_buffer: ndarray` so the frame
+    descriptor is attached at startup (and hdf5FileRead validates against
+    it); otherwise it falls back to a plain standard buffer.
+    """
 
     _buf_ind = 0
 
@@ -840,14 +846,28 @@ class ReadChordBuffer(InputBuffer):
         self.input_dir = input_dir
         self.buffer_list = buffer_list
 
-        self.buffer_block = {
-            self.name: {
-                "kotekan_buffer": "standard",
-                "metadata_pool": "main_pool",
-                "num_frames": "buffer_depth",
-                "frame_size": buffer_list[0].data.nbytes,
+        meta = buffer_list[0].metadata
+        if all(key in meta for key in ("name", "type", "dim_names")):
+            self.buffer_block = {
+                self.name: {
+                    "kotekan_buffer": "ndarray",
+                    "metadata_pool": "main_pool",
+                    "num_frames": "buffer_depth",
+                    "value_type": str(meta["type"]),
+                    "quantity_name": str(meta["name"]),
+                    "extents": [int(n) for n in buffer_list[0].data.shape],
+                    "dimnames": [str(d) for d in meta["dim_names"]],
+                }
             }
-        }
+        else:
+            self.buffer_block = {
+                self.name: {
+                    "kotekan_buffer": "standard",
+                    "metadata_pool": "main_pool",
+                    "num_frames": "buffer_depth",
+                    "frame_size": buffer_list[0].data.nbytes,
+                }
+            }
 
         stage_config = {
             "kotekan_stage": "hdf5FileRead",
@@ -874,6 +894,17 @@ class DumpChordBuffer(OutputBuffer):
     ----------
     output_dir : str
         Temp. directory to output to. Dumped files are not removed.
+    quantity_name : str, optional
+        Together with `dimnames`, declare the buffer as `kotekan_buffer:
+        ndarray`, attaching the frame descriptor at startup (the stage under
+        test then validates against it instead of allocating it). Must match
+        the descriptor the producing stage declares exactly.
+    dimnames : list of str, optional
+        Axis labels, one per entry of `shape`. See `quantity_name`.
+    value_type : str, optional
+        kotekan DataType name for the ndarray declaration. Defaults to the
+        numpy name of `dtype`, which is correct for plain types; packed
+        types (e.g. "uint1x8", "int4x2") must be given explicitly.
     """
 
     _buf_ind = 0
@@ -881,7 +912,15 @@ class DumpChordBuffer(OutputBuffer):
     name = None
 
     def __init__(
-        self, output_dir, shape, dtype, max_frames=-1, input_order="CHORDBeamformer"
+        self,
+        output_dir,
+        shape,
+        dtype,
+        max_frames=-1,
+        input_order="CHORDBeamformer",
+        quantity_name=None,
+        dimnames=None,
+        value_type=None,
     ):
         self.name = f"dumpchord_buf{self._buf_ind}"
         stage_name = f"dump{self._buf_ind}"
@@ -893,14 +932,31 @@ class DumpChordBuffer(OutputBuffer):
         self.max_frames = max_frames
         self.dtype = dtype
 
-        self.buffer_block = {
-            self.name: {
-                "kotekan_buffer": "standard",
-                "metadata_pool": "main_pool",
-                "num_frames": "buffer_depth",
-                "frame_size": self.num_entries * np.dtype(self.dtype).itemsize,
+        if quantity_name is not None:
+            if dimnames is None or len(dimnames) != len(shape):
+                raise ValueError(
+                    "dimnames must be given with quantity_name, one per axis"
+                )
+            self.buffer_block = {
+                self.name: {
+                    "kotekan_buffer": "ndarray",
+                    "metadata_pool": "main_pool",
+                    "num_frames": "buffer_depth",
+                    "value_type": value_type or np.dtype(self.dtype).name,
+                    "quantity_name": quantity_name,
+                    "extents": [int(n) for n in shape],
+                    "dimnames": list(dimnames),
+                }
             }
-        }
+        else:
+            self.buffer_block = {
+                self.name: {
+                    "kotekan_buffer": "standard",
+                    "metadata_pool": "main_pool",
+                    "num_frames": "buffer_depth",
+                    "frame_size": self.num_entries * np.dtype(self.dtype).itemsize,
+                }
+            }
 
         self.stage_block = {
             stage_name: {

--- a/tests/boost/CMakeLists.txt
+++ b/tests/boost/CMakeLists.txt
@@ -182,6 +182,19 @@ target_link_libraries(test_CHORDTelescope PRIVATE kotekan_utils)
 add_executable(test_N2FrameDesc test_N2FrameDesc.cpp)
 target_link_libraries(test_N2FrameDesc PRIVATE kotekan_metadata kotekan_utils libexternal)
 
+# test_NDArrayBufferConfig - config-driven NDArray frame descriptors and the `ndarray` buffer type
+# in bufferFactory
+add_executable(test_NDArrayBufferConfig test_NDArrayBufferConfig.cpp)
+target_link_libraries(
+    test_NDArrayBufferConfig
+    PRIVATE libexternal
+            kotekan_libs
+            kotekan_utils
+            kotekan_core
+            -Wl,--whole-archive
+            kotekan_metadata
+            -Wl,--no-whole-archive)
+
 # test_N2Subset - tests for N2Subset stage
 add_executable(test_N2Subset test_N2Subset.cpp)
 target_link_libraries(

--- a/tests/boost/test_N2Subset.cpp
+++ b/tests/boost/test_N2Subset.cpp
@@ -106,7 +106,7 @@ BOOST_AUTO_TEST_CASE(test_fulluppertri_to_autocorrelations) {
     size_t in_frame_size = N2FrameDesc::calculate_frame_size(num_elements, num_ev, in_num_prod);
     Buffer in_buf(num_frames, in_frame_size, pool, in_buf_name, "N2", 0, false, false,
                   std::vector<int>{}, true);
-    in_buf.set_frame_desc(
+    in_buf.ensure_frame_desc(
         std::make_shared<N2FrameDesc>(num_elements, num_ev, in_num_prod, N2Layout::FullUpperTri));
     in_buf.register_producer("test_producer");
 
@@ -115,7 +115,7 @@ BOOST_AUTO_TEST_CASE(test_fulluppertri_to_autocorrelations) {
     size_t out_frame_size = N2FrameDesc::calculate_frame_size(num_elements, num_ev, out_num_prod);
     Buffer out_buf(num_frames, out_frame_size, pool, out_buf_name, "N2", 0, false, false,
                    std::vector<int>{}, true);
-    out_buf.set_frame_desc(std::make_shared<N2FrameDesc>(num_elements, num_ev, out_num_prod,
+    out_buf.ensure_frame_desc(std::make_shared<N2FrameDesc>(num_elements, num_ev, out_num_prod,
                                                          N2Layout::Autocorrelations));
 
     // Create buffer container
@@ -206,7 +206,7 @@ BOOST_AUTO_TEST_CASE(test_fulluppertri_to_general_subset) {
     size_t in_frame_size = N2FrameDesc::calculate_frame_size(num_elements, num_ev, in_num_prod);
     Buffer in_buf(num_frames, in_frame_size, pool, in_buf_name, "N2", 0, false, false,
                   std::vector<int>{}, true);
-    in_buf.set_frame_desc(
+    in_buf.ensure_frame_desc(
         std::make_shared<N2FrameDesc>(num_elements, num_ev, in_num_prod, N2Layout::FullUpperTri));
     in_buf.register_producer("test_producer");
 
@@ -215,7 +215,7 @@ BOOST_AUTO_TEST_CASE(test_fulluppertri_to_general_subset) {
         N2FrameDesc::calculate_frame_size(num_elements, num_ev, product_list.size());
     Buffer out_buf(num_frames, out_frame_size, pool, out_buf_name, "N2", 0, false, false,
                    std::vector<int>{}, true);
-    out_buf.set_frame_desc(std::make_shared<N2FrameDesc>(num_elements, num_ev, product_list.size(),
+    out_buf.ensure_frame_desc(std::make_shared<N2FrameDesc>(num_elements, num_ev, product_list.size(),
                                                          N2Layout::GeneralSubset, product_list));
 
     // Create buffer container
@@ -287,13 +287,13 @@ BOOST_AUTO_TEST_CASE(test_autocorrelations_to_autocorrelations) {
 
     Buffer in_buf(num_frames, frame_size, pool, in_buf_name, "N2", 0, false, false,
                   std::vector<int>{}, true);
-    in_buf.set_frame_desc(
+    in_buf.ensure_frame_desc(
         std::make_shared<N2FrameDesc>(num_elements, num_ev, num_prod, N2Layout::Autocorrelations));
     in_buf.register_producer("test_producer");
 
     Buffer out_buf(num_frames, frame_size, pool, out_buf_name, "N2", 0, false, false,
                    std::vector<int>{}, true);
-    out_buf.set_frame_desc(
+    out_buf.ensure_frame_desc(
         std::make_shared<N2FrameDesc>(num_elements, num_ev, num_prod, N2Layout::Autocorrelations));
 
     // Create buffer container
@@ -368,7 +368,7 @@ BOOST_AUTO_TEST_CASE(test_have_inputs_subset) {
     size_t in_frame_size = N2FrameDesc::calculate_frame_size(num_elements, num_ev, in_num_prod);
     Buffer in_buf(num_frames, in_frame_size, pool, in_buf_name, "N2", 0, false, false,
                   std::vector<int>{}, true);
-    in_buf.set_frame_desc(
+    in_buf.ensure_frame_desc(
         std::make_shared<N2FrameDesc>(num_elements, num_ev, in_num_prod, N2Layout::FullUpperTri));
     in_buf.register_producer("test_producer");
 
@@ -377,7 +377,7 @@ BOOST_AUTO_TEST_CASE(test_have_inputs_subset) {
         N2FrameDesc::calculate_frame_size(num_elements, num_ev, product_list.size());
     Buffer out_buf(num_frames, out_frame_size, pool, out_buf_name, "N2", 0, false, false,
                    std::vector<int>{}, true);
-    out_buf.set_frame_desc(std::make_shared<N2FrameDesc>(num_elements, num_ev, product_list.size(),
+    out_buf.ensure_frame_desc(std::make_shared<N2FrameDesc>(num_elements, num_ev, product_list.size(),
                                                          N2Layout::InputORMasked, product_list));
 
     // Create buffer container
@@ -450,7 +450,7 @@ BOOST_AUTO_TEST_CASE(test_only_inputs_subset) {
     size_t in_frame_size = N2FrameDesc::calculate_frame_size(num_elements, num_ev, in_num_prod);
     Buffer in_buf(num_frames, in_frame_size, pool, in_buf_name, "N2", 0, false, false,
                   std::vector<int>{}, true);
-    in_buf.set_frame_desc(
+    in_buf.ensure_frame_desc(
         std::make_shared<N2FrameDesc>(num_elements, num_ev, in_num_prod, N2Layout::FullUpperTri));
     in_buf.register_producer("test_producer");
 
@@ -459,7 +459,7 @@ BOOST_AUTO_TEST_CASE(test_only_inputs_subset) {
         N2FrameDesc::calculate_frame_size(num_elements, num_ev, product_list.size());
     Buffer out_buf(num_frames, out_frame_size, pool, out_buf_name, "N2", 0, false, false,
                    std::vector<int>{}, true);
-    out_buf.set_frame_desc(std::make_shared<N2FrameDesc>(num_elements, num_ev, product_list.size(),
+    out_buf.ensure_frame_desc(std::make_shared<N2FrameDesc>(num_elements, num_ev, product_list.size(),
                                                          N2Layout::InputANDMasked, product_list));
 
     // Create buffer container

--- a/tests/boost/test_NDArrayBufferConfig.cpp
+++ b/tests/boost/test_NDArrayBufferConfig.cpp
@@ -1,0 +1,243 @@
+#define BOOST_TEST_MODULE "test_NDArrayBufferConfig"
+
+#include <boost/test/included/unit_test.hpp>
+#include <cstddef>   // for ptrdiff_t, size_t
+#include <map>       // for map
+#include <memory>    // for shared_ptr
+#include <stdexcept> // for runtime_error
+#include <string>    // for string
+#include <vector>    // for vector
+
+// the code to test:
+#include "Config.hpp"        // for Config
+#include "NDArray.hpp"       // for GenericNDArray
+#include "Symbol.hpp"        // for Symbol
+#include "buffer.hpp"        // for Buffer, is_frame_buffer
+#include "bufferFactory.hpp" // for bufferFactory
+#include "metadata.hpp"      // for metadataPool
+
+#include "json.hpp" // for json
+
+using kotekan::Config;
+using kotekan::GenericNDArray;
+using kotekan::Symbol;
+
+using json = nlohmann::json;
+
+// Config::eval evaluates numbers and expression strings in a config scope.
+BOOST_AUTO_TEST_CASE(config_eval) {
+    json json_config = {{"num_local_freq", 16}, {"samples_per_data_set", 1024}};
+    Config config;
+    config.update_config(json_config);
+
+    BOOST_CHECK_EQUAL(config.eval<std::ptrdiff_t>("/", json(42)), 42);
+    BOOST_CHECK_EQUAL(config.eval<std::ptrdiff_t>("/", json("num_local_freq")), 16);
+    BOOST_CHECK_EQUAL(config.eval<std::ptrdiff_t>("/", json("num_local_freq * 2")), 32);
+    BOOST_CHECK_EQUAL(
+        config.eval<std::ptrdiff_t>("/", json("samples_per_data_set / num_local_freq + 1")), 65);
+
+    // Unknown variables, malformed expressions, and non-evaluable json fail
+    BOOST_CHECK_THROW(config.eval<std::ptrdiff_t>("/", json("not_defined + 1")),
+                      std::runtime_error);
+    BOOST_CHECK_THROW(config.eval<std::ptrdiff_t>("/", json("5 +")), std::runtime_error);
+    BOOST_CHECK_THROW(config.eval<std::ptrdiff_t>("/", json::object()), std::runtime_error);
+}
+
+// GenericNDArray::from_config builds a frame descriptor from a config block,
+// with extent entries evaluated as (scoped) arithmetic expressions.
+BOOST_AUTO_TEST_CASE(from_config) {
+    json json_config = {{"num_local_freq", 16},
+                        {"samples_per_data_set", 1024},
+                        {"my_buf",
+                         {{"value_type", "uint8"},
+                          {"quantity_name", "voltage"},
+                          {"extents", {"num_local_freq", "samples_per_data_set / 2", 4}},
+                          {"dimnames", {"F", "T", "D"}}}}};
+    Config config;
+    config.update_config(json_config);
+
+    auto desc = GenericNDArray::from_config(config, "/my_buf");
+    BOOST_REQUIRE(desc);
+    BOOST_CHECK(desc->get_value_datatype() == kotekan::uint8);
+    BOOST_CHECK(desc->get_quantity_name() == Symbol("voltage"));
+    BOOST_CHECK_EQUAL(desc->get_rank(), 3);
+    BOOST_CHECK_EQUAL(desc->get_extent(0), 16);
+    BOOST_CHECK_EQUAL(desc->get_extent(1), 512);
+    BOOST_CHECK_EQUAL(desc->get_extent(2), 4);
+    BOOST_CHECK(desc->get_dimname(0) == Symbol("F"));
+    BOOST_CHECK(desc->get_dimname(1) == Symbol("T"));
+    BOOST_CHECK(desc->get_dimname(2) == Symbol("D"));
+    BOOST_CHECK_EQUAL(desc->get_byte_size(), 16 * 512 * 4);
+}
+
+// Build a Config holding a single buffer block at /my_buf.
+static Config make_config(json block) {
+    json json_config = {{"my_buf", std::move(block)}};
+    Config config;
+    config.update_config(json_config);
+    return config;
+}
+
+// Invalid config blocks fail loudly at construction.
+BOOST_AUTO_TEST_CASE(from_config_errors) {
+    // unknown value_type
+    {
+        Config config = make_config({{"value_type", "complex128"},
+                                     {"quantity_name", "q"},
+                                     {"extents", {4}},
+                                     {"dimnames", {"X"}}});
+        BOOST_CHECK_THROW(GenericNDArray::from_config(config, "/my_buf"), std::runtime_error);
+    }
+    // missing required structural key (value_type)
+    {
+        Config config = make_config({{"extents", {4}}, {"dimnames", {"X"}}});
+        BOOST_CHECK_THROW(GenericNDArray::from_config(config, "/my_buf"), std::runtime_error);
+    }
+    // extents / dimnames size mismatch
+    {
+        Config config = make_config({{"value_type", "float32"},
+                                     {"quantity_name", "q"},
+                                     {"extents", {4, 2}},
+                                     {"dimnames", {"X"}}});
+        BOOST_CHECK_THROW(GenericNDArray::from_config(config, "/my_buf"), std::runtime_error);
+    }
+    // non-positive extent
+    {
+        Config config = make_config({{"value_type", "float32"},
+                                     {"quantity_name", "q"},
+                                     {"extents", {4, 0}},
+                                     {"dimnames", {"X", "Y"}}});
+        BOOST_CHECK_THROW(GenericNDArray::from_config(config, "/my_buf"), std::runtime_error);
+    }
+    // empty extents (rank 0)
+    {
+        Config config = make_config({{"value_type", "float32"},
+                                     {"quantity_name", "q"},
+                                     {"extents", json::array()},
+                                     {"dimnames", json::array()}});
+        BOOST_CHECK_THROW(GenericNDArray::from_config(config, "/my_buf"), std::runtime_error);
+    }
+    // duplicate dimnames
+    {
+        Config config = make_config({{"value_type", "float32"},
+                                     {"quantity_name", "q"},
+                                     {"extents", {4, 2}},
+                                     {"dimnames", {"X", "X"}}});
+        BOOST_CHECK_THROW(GenericNDArray::from_config(config, "/my_buf"), std::runtime_error);
+    }
+}
+
+// quantity_name and dimnames are optional labels: omitting them leaves the
+// descriptor with unset (empty) labels for a stage to fill in via reconcile().
+BOOST_AUTO_TEST_CASE(optional_labels_and_reconcile) {
+    // from_config with only the structural fields succeeds; labels are unset.
+    Config config = make_config({{"value_type", "float32"}, {"extents", {4, 2}}});
+    auto partial = GenericNDArray::from_config(config, "/my_buf");
+    BOOST_REQUIRE(partial);
+    BOOST_CHECK(partial->get_quantity_name() == Symbol(""));
+    BOOST_CHECK(partial->get_dimname(0) == Symbol(""));
+    BOOST_CHECK(partial->get_dimname(1) == Symbol(""));
+
+    // a fully-labelled descriptor of the same structure
+    auto full = GenericNDArray::describe(kotekan::float32, Symbol("gain"), {4, 2},
+                                         {Symbol("F"), Symbol("E")});
+
+    // reconcile fills the unset labels from the labelled side
+    auto merged = GenericNDArray::reconcile(*partial, *full);
+    BOOST_REQUIRE(merged);
+    BOOST_CHECK(merged->get_quantity_name() == Symbol("gain"));
+    BOOST_CHECK(merged->get_dimname(0) == Symbol("F"));
+    BOOST_CHECK(merged->get_dimname(1) == Symbol("E"));
+    // the reverse adds nothing (`full` already has all labels) -> nullptr
+    BOOST_CHECK(!GenericNDArray::reconcile(*full, *partial));
+
+    // structural mismatch (extents) throws
+    auto other_extents = GenericNDArray::describe(kotekan::float32, Symbol("gain"), {2, 4},
+                                                  {Symbol("F"), Symbol("E")});
+    BOOST_CHECK_THROW(GenericNDArray::reconcile(*full, *other_extents), std::runtime_error);
+
+    // conflicting set labels throw
+    auto other_label = GenericNDArray::describe(kotekan::float32, Symbol("other"), {4, 2},
+                                                {Symbol("F"), Symbol("E")});
+    BOOST_CHECK_THROW(GenericNDArray::reconcile(*full, *other_label), std::runtime_error);
+}
+
+// The bufferFactory creates `ndarray` buffers with the frame descriptor
+// attached at startup and frame_size derived from it -- and stage-style
+// ensure_frame_desc calls then act as pure validators.
+BOOST_AUTO_TEST_CASE(buffer_factory_ndarray) {
+    json json_config = {{"log_level", "off"},
+                        {"num_local_freq", 16},
+                        {"gain_buffer",
+                         {{"kotekan_buffer", "ndarray"},
+                          {"value_type", "float32"},
+                          {"quantity_name", "gains"},
+                          {"extents", {"num_local_freq", 4}},
+                          {"dimnames", {"F", "G"}},
+                          {"num_frames", 2},
+                          {"metadata_pool", "none"}}}};
+    Config config;
+    config.update_config(json_config);
+
+    std::map<std::string, std::shared_ptr<metadataPool>> pools;
+    kotekan::bufferFactory factory(config, pools);
+    auto buffers = factory.build_buffers();
+    BOOST_REQUIRE_EQUAL(buffers.size(), 1);
+
+    auto* buf = dynamic_cast<Buffer*>(buffers.at("gain_buffer"));
+    BOOST_REQUIRE(buf);
+    BOOST_CHECK(is_frame_buffer(buf));
+    BOOST_CHECK_EQUAL(buf->frame_size, 16 * 4 * sizeof(float));
+
+    // The descriptor is present before any stage would run
+    auto desc = buf->get_frame_desc<kotekan::GenericNDArray>();
+    BOOST_REQUIRE(desc);
+    BOOST_CHECK(desc->get_value_datatype() == kotekan::float32);
+    BOOST_CHECK(desc->get_quantity_name() == Symbol("gains"));
+    BOOST_CHECK_EQUAL(desc->get_rank(), 2);
+    BOOST_CHECK_EQUAL(desc->get_extent(0), 16);
+    BOOST_CHECK_EQUAL(desc->get_extent(1), 4);
+
+    // A stage-style declare call now validates against the factory-set
+    // descriptor instead of allocating (the migration "auto-degrade"
+    // property); a matching call passes through silently.
+    buf->ensure_frame_desc(
+        kotekan::NDArray<float, 2>::describe(Symbol("gains"), {16, 4}, {Symbol("F"), Symbol("G")}));
+    BOOST_CHECK(buf->get_frame_desc<kotekan::GenericNDArray>() == desc);
+
+    // ... and a MISMATCHING declare call is fatal. (Under the boost test
+    // build, FATAL_ERROR throws std::runtime_error via KTK_BOOST_ERR before
+    // raising SIGTERM, so the fatal paths are testable with CHECK_THROW.)
+    // Same byte size, swapped extents/dimnames -- reaches the field checks:
+    BOOST_CHECK_THROW((buf->ensure_frame_desc(kotekan::NDArray<float, 2>::describe(
+                          Symbol("gains"), {4, 16}, {Symbol("G"), Symbol("F")}))),
+                      std::runtime_error);
+    // Same byte size and shape, wrong value type:
+    BOOST_CHECK_THROW((buf->ensure_frame_desc(kotekan::NDArray<int32_t, 2>::describe(
+                          Symbol("gains"), {16, 4}, {Symbol("F"), Symbol("G")}))),
+                      std::runtime_error);
+    // Same byte size and shape, wrong quantity name:
+    BOOST_CHECK_THROW((buf->ensure_frame_desc(kotekan::NDArray<float, 2>::describe(
+                          Symbol("not_gains"), {16, 4}, {Symbol("F"), Symbol("G")}))),
+                      std::runtime_error);
+
+    // ensure_frame_desc with a mismatching descriptor of equal byte size is
+    // fatal (previously only a soft ERROR):
+    BOOST_CHECK_THROW(buf->ensure_frame_desc(GenericNDArray::describe(
+                          kotekan::float32, Symbol("gains"), {4, 16}, {Symbol("G"), Symbol("F")})),
+                      std::runtime_error);
+    // ... as is one with the wrong byte size:
+    BOOST_CHECK_THROW(buf->ensure_frame_desc(GenericNDArray::describe(
+                          kotekan::float32, Symbol("gains"), {16, 8}, {Symbol("F"), Symbol("G")})),
+                      std::runtime_error);
+    // The recorded descriptor is unchanged by any of the rejected calls
+    BOOST_CHECK(buf->get_frame_desc<kotekan::GenericNDArray>() == desc);
+
+    // Setting an equal descriptor again is accepted
+    buf->ensure_frame_desc(GenericNDArray::describe(kotekan::float32, Symbol("gains"), {16, 4},
+                                                 {Symbol("F"), Symbol("G")}));
+    BOOST_CHECK(buf->get_frame_desc<kotekan::GenericNDArray>() == desc);
+
+    for (auto& [name, b] : buffers)
+        delete b;
+}

--- a/tests/boost/test_eigenStages.cpp
+++ b/tests/boost/test_eigenStages.cpp
@@ -183,8 +183,8 @@ static EigenResults run_pipeline(const EigenStageTestParams& p, const string& st
 
     // Set frame descriptors for N2 buffers (required by stages)
     if (n2_desc) {
-        in_buf.set_frame_desc(n2_desc);
-        out_buf.set_frame_desc(n2_desc);
+        in_buf.ensure_frame_desc(n2_desc);
+        out_buf.ensure_frame_desc(n2_desc);
     }
 
     kotekan::bufferContainer bc;
@@ -446,8 +446,8 @@ run_n2_pipeline_pair(const EigenStageTestParams& params_a,
         s.out_buf = std::make_unique<Buffer>(
             s.params.total_frames, frame_size, pool, s.out_buf_name, "N2", 0,
             false, false, std::vector<int>{}, true);
-        s.in_buf->set_frame_desc(n2_desc);
-        s.out_buf->set_frame_desc(n2_desc);
+        s.in_buf->ensure_frame_desc(n2_desc);
+        s.out_buf->ensure_frame_desc(n2_desc);
         bc.add_buffer(s.in_buf_name, s.in_buf.get());
         bc.add_buffer(s.out_buf_name, s.out_buf.get());
         // Hold the output frames so we can inspect them after the stage exits.

--- a/tests/boost/test_hdf5N2Write.cpp
+++ b/tests/boost/test_hdf5N2Write.cpp
@@ -282,7 +282,7 @@ BOOST_AUTO_TEST_CASE(test_visfiledata_add_frame_single_slot) {
     const size_t frame_size = N2FrameDesc::calculate_frame_size(num_input, num_ev, num_prod);
     auto pool = metadataPool::create(1, sizeof(N2Metadata), "test_pool", "N2Metadata");
     Buffer buf(1, frame_size, pool, "n2buf", "N2", 1, false, false, std::vector<int>{}, true);
-    buf.set_frame_desc(std::make_shared<kotekan::N2FrameDesc>(num_input, num_ev, num_prod,
+    buf.ensure_frame_desc(std::make_shared<kotekan::N2FrameDesc>(num_input, num_ev, num_prod,
                                                               N2Layout::FullUpperTri));
 
     buf.allocate_new_metadata_object(0);
@@ -360,7 +360,7 @@ BOOST_AUTO_TEST_CASE(test_visfiledata_era_and_fraction_guards) {
     const size_t frame_size = N2FrameDesc::calculate_frame_size(num_input, num_ev, num_prod);
     auto pool = metadataPool::create(2, sizeof(N2Metadata), "pool_guard", "N2Metadata");
     Buffer buf(2, frame_size, pool, "n2buf_guard", "N2", 1, false, false, std::vector<int>{}, true);
-    buf.set_frame_desc(std::make_shared<kotekan::N2FrameDesc>(num_input, num_ev, num_prod,
+    buf.ensure_frame_desc(std::make_shared<kotekan::N2FrameDesc>(num_input, num_ev, num_prod,
                                                               N2Layout::FullUpperTri));
 
     // Prepare frame view and two metadata instances for the same (f,t)
@@ -493,7 +493,7 @@ BOOST_AUTO_TEST_CASE(test_writer_base_dir_conflict_detection) {
     auto pool = metadataPool::create(2, sizeof(N2Metadata), "pool_conflict", "N2Metadata");
     Buffer buf(2, frame_size, pool, in_buf_name, "N2", /*numa*/ 0, /*huge*/ false,
                /*mlock*/ false, /*producers*/ std::vector<int>{}, /*zero_new_frames*/ true);
-    buf.set_frame_desc(
+    buf.ensure_frame_desc(
         std::make_shared<N2FrameDesc>(num_input, num_ev, num_prod, N2Layout::FullUpperTri));
     buf.register_producer("test-producer");
     kotekan::bufferContainer bc;
@@ -540,7 +540,7 @@ BOOST_AUTO_TEST_CASE(test_writer_full_block_transpose) {
     auto pool = metadataPool::create(2, sizeof(N2Metadata), "pool_full", "N2Metadata");
     Buffer buf(2, frame_size, pool, in_buf_name, "N2", /*numa*/ 0, /*huge*/ false,
                /*mlock*/ false, /*producers*/ std::vector<int>{}, /*zero_new_frames*/ true);
-    buf.set_frame_desc(
+    buf.ensure_frame_desc(
         std::make_shared<N2FrameDesc>(num_input, num_ev, num_prod, N2Layout::FullUpperTri));
     buf.register_producer("test-producer");
     kotekan::bufferContainer bc;
@@ -631,7 +631,7 @@ BOOST_AUTO_TEST_CASE(test_writer_partial_flush_on_exit) {
     auto pool = metadataPool::create(2, sizeof(N2Metadata), "pool_partial", "N2Metadata");
     Buffer buf(2, frame_size, pool, in_buf_name, "N2", /*numa*/ 0, /*huge*/ false,
                /*mlock*/ false, /*producers*/ std::vector<int>{}, /*zero_new_frames*/ true);
-    buf.set_frame_desc(
+    buf.ensure_frame_desc(
         std::make_shared<N2FrameDesc>(num_input, num_ev, num_prod, N2Layout::FullUpperTri));
     buf.register_producer("test-producer");
     kotekan::bufferContainer bc;
@@ -712,7 +712,7 @@ BOOST_AUTO_TEST_CASE(test_writer_multi_file_rollover) {
         num_input, num_ev, N2FrameDesc::get_num_prod(num_input, N2Layout::FullUpperTri));
     auto pool = metadataPool::create(2, sizeof(N2Metadata), "pool_roll", "N2Metadata");
     Buffer buf(2, frame_size, pool, in_buf_name, "N2", 0, false, false, std::vector<int>{}, true);
-    buf.set_frame_desc(std::make_shared<N2FrameDesc>(
+    buf.ensure_frame_desc(std::make_shared<N2FrameDesc>(
         num_input, num_ev, N2FrameDesc::get_num_prod(num_input, N2Layout::FullUpperTri),
         N2Layout::FullUpperTri));
     buf.register_producer("test-producer");
@@ -795,7 +795,7 @@ BOOST_AUTO_TEST_CASE(test_writer_distinct_window_names) {
         num_input, num_ev, N2FrameDesc::get_num_prod(num_input, N2Layout::FullUpperTri));
     auto pool = metadataPool::create(2, sizeof(N2Metadata), "pool_subsec", "N2Metadata");
     Buffer buf(2, frame_size, pool, in_buf_name, "N2", 0, false, false, std::vector<int>{}, true);
-    buf.set_frame_desc(std::make_shared<N2FrameDesc>(
+    buf.ensure_frame_desc(std::make_shared<N2FrameDesc>(
         num_input, num_ev, N2FrameDesc::get_num_prod(num_input, N2Layout::FullUpperTri),
         N2Layout::FullUpperTri));
     buf.register_producer("test-producer");
@@ -869,7 +869,7 @@ BOOST_AUTO_TEST_CASE(test_writer_timeout_finalize_zero_threshold) {
         num_input, num_ev, N2FrameDesc::get_num_prod(num_input, N2Layout::FullUpperTri));
     auto pool = metadataPool::create(8, sizeof(N2Metadata), "pool_timeout", "N2Metadata");
     Buffer buf(8, frame_size, pool, in_buf_name, "N2", 0, false, false, std::vector<int>{}, true);
-    buf.set_frame_desc(std::make_shared<N2FrameDesc>(
+    buf.ensure_frame_desc(std::make_shared<N2FrameDesc>(
         num_input, num_ev, N2FrameDesc::get_num_prod(num_input, N2Layout::FullUpperTri),
         N2Layout::FullUpperTri));
     buf.register_producer("test-producer");
@@ -945,7 +945,7 @@ BOOST_AUTO_TEST_CASE(test_writer_drop_if_final_exists) {
         num_input, num_ev, N2FrameDesc::get_num_prod(num_input, N2Layout::FullUpperTri));
     auto pool = metadataPool::create(2, sizeof(N2Metadata), "pool_drop", "N2Metadata");
     Buffer buf(2, frame_size, pool, in_buf_name, "N2", 0, false, false, std::vector<int>{}, true);
-    buf.set_frame_desc(std::make_shared<N2FrameDesc>(
+    buf.ensure_frame_desc(std::make_shared<N2FrameDesc>(
         num_input, num_ev, N2FrameDesc::get_num_prod(num_input, N2Layout::FullUpperTri),
         N2Layout::FullUpperTri));
     buf.register_producer("test-producer");
@@ -1037,7 +1037,7 @@ BOOST_AUTO_TEST_CASE(test_writer_geometry_basic) {
         num_input, num_ev, N2FrameDesc::get_num_prod(num_input, N2Layout::FullUpperTri));
     auto pool = metadataPool::create(4, sizeof(N2Metadata), "pool_geom", "N2Metadata");
     Buffer buf(4, frame_size, pool, in_buf_name, "N2", 0, false, false, std::vector<int>{}, true);
-    buf.set_frame_desc(std::make_shared<N2FrameDesc>(
+    buf.ensure_frame_desc(std::make_shared<N2FrameDesc>(
         num_input, num_ev, N2FrameDesc::get_num_prod(num_input, N2Layout::FullUpperTri),
         N2Layout::FullUpperTri));
     buf.register_producer("test-producer");

--- a/tests/test_lostsamples_to_n2counts.py
+++ b/tests/test_lostsamples_to_n2counts.py
@@ -45,10 +45,13 @@ class FakeRFIBuffer(runner.InputBuffer):
 
         self.buffer_block = {
             self.name: {
-                "kotekan_buffer": "standard",
+                "kotekan_buffer": "ndarray",
                 "metadata_pool": "main_pool",
                 "num_frames": "buffer_depth",
-                "frame_size": "(samples_per_data_set * num_local_freq) / 8",
+                "value_type": "uint1x8",
+                "quantity_name": "RFImask",
+                "extents": [samples_per_data_set // 1024, num_local_freq, 128],
+                "dimnames": ["T8hi128", "F", "T8lo128"],
             }
         }
 
@@ -57,7 +60,7 @@ class FakeRFIBuffer(runner.InputBuffer):
             "out_buf": self.name,
             "type": "const1x8",
             "value": 85,  # alternating 10101010...
-            "name": stage_name,
+            "name": "RFImask",
             "array_shape": [samples_per_data_set // 1024, num_local_freq, 128],
             "dim_name": ["T8hi128", "F", "T8lo128"],
         }
@@ -137,10 +140,19 @@ class DumpCountsBuffer(runner.OutputBuffer):
 
         self.buffer_block = {
             self.name: {
-                "kotekan_buffer": "standard",
+                "kotekan_buffer": "ndarray",
                 "metadata_pool": "main_pool",
                 "num_frames": "buffer_depth",
-                "frame_size": "sizeof_int * num_local_freq * counts_ntiles * 8 * 8 * samples_per_data_set / sub_integration_ntime",
+                "value_type": "int32",
+                "quantity_name": "n2k_counts",
+                "extents": [
+                    "samples_per_data_set / sub_integration_ntime",
+                    "num_local_freq",
+                    "counts_ntiles",
+                    8,
+                    8,
+                ],
+                "dimnames": ["Tc", "F", "D8Phi", "D8Plo1", "D8Plo2"],
             }
         }
 

--- a/tests/test_parseReorderDefault.py
+++ b/tests/test_parseReorderDefault.py
@@ -26,9 +26,12 @@ global_params = {
     # KotekanStageTester adds a "main_pool" section
     # Buffers
     "reorder_buffer": {
-        "kotekan_buffer": "standard",
+        "kotekan_buffer": "ndarray",
         "num_frames": 1,
-        "frame_size": 2048 * 4,
+        "value_type": "int32",
+        "quantity_name": "scatter_indices",
+        "extents": ["num_polarizations", "num_dishes"],
+        "dimnames": ["P", "D"],
         "metadata_pool": "main_pool",
     },
     # dump to disk to inspect manually

--- a/tests/test_pl_count_lost_scalar.py
+++ b/tests/test_pl_count_lost_scalar.py
@@ -194,6 +194,8 @@ def pllostcounts_data(tmpdir_factory, setup, plmask_data):
         dtype=np.int32,
         max_frames=num_frames,
         input_order="CHIMEBeamformer",
+        quantity_name="pl_lost_counts_scalar",
+        dimnames=["Tc", "F"],
     )
 
     # The test stage!

--- a/tests/test_rfi_framemask.py
+++ b/tests/test_rfi_framemask.py
@@ -187,6 +187,8 @@ def rfiframemask_data(tmpdir_factory, setup, sktilde_data):
         dtype=np.uint8,
         max_frames=num_frames,
         input_order="CHIMEBeamformer",
+        quantity_name="RFIFrameMask",
+        dimnames=["Tc", "F"],
     )
 
     # The test stage!

--- a/tests/test_rfi_masksum.py
+++ b/tests/test_rfi_masksum.py
@@ -161,6 +161,8 @@ def rfimasksum_data(tmpdir_factory, setup):
         dtype=np.int32,
         max_frames=num_frames,
         input_order="CHIMEBeamformer",
+        quantity_name="RFImask_counts",
+        dimnames=["Tc", "F"],
     )
 
     test = runner.KotekanStageTester(

--- a/tests/test_setScatterIndices.py
+++ b/tests/test_setScatterIndices.py
@@ -1,0 +1,77 @@
+"""Validate setScatterIndices against a config-declared ndarray buffer.
+
+Covers the framedesc conversion: the stage no longer *sets* its output
+descriptor but *requires* (validates) the one the bufferFactory attaches from
+an `kotekan_buffer: ndarray` declaration. The negative case confirms
+require_frame_desc actually rejects a structurally-wrong declaration (a
+transposed shape that has the same byte size) -- the property the
+order-sensitive fengine conversions rely on.
+"""
+import pytest
+import numpy as np
+import h5py
+
+from kotekan import runner
+
+if not runner.has_hdf5():
+    pytest.fail("HDF5 support not available; unable to run tests!")
+
+NUM_DISHES = 8
+NUM_POL = 2
+
+stage_params = {
+    "scatter_indices_name": "scatter_buffer",
+    "num_dishes": NUM_DISHES,
+    "num_polarizations": NUM_POL,
+    "scatter_indices": list(range(NUM_POL * NUM_DISHES)),
+}
+
+
+def _global(extents, dimnames, tmpdir):
+    return {
+        "type": "config",
+        "log_level": "INFO",
+        "num_dishes": NUM_DISHES,
+        "num_polarizations": NUM_POL,
+        "scatter_buffer": {
+            "kotekan_buffer": "ndarray",
+            "num_frames": 1,
+            "value_type": "int32",
+            "quantity_name": "scatter_indices",
+            "extents": extents,
+            "dimnames": dimnames,
+            "metadata_pool": "main_pool",
+        },
+        "write_scatter": {
+            "kotekan_stage": "hdf5FileWrite",
+            "base_dir": str(tmpdir),
+            "prefix_hostname": False,
+            "max_frames": "1",
+            "file_name": "scatter_buffer",
+            "in_buf": "scatter_buffer",
+            "input_order": "CHIMEBeamformer",
+        },
+    }
+
+
+def test_setScatterIndices_validates_matching_ndarray(tmpdir_factory):
+    """Correct ndarray declaration: require_frame_desc passes, payload is written."""
+    tmpdir = tmpdir_factory.mktemp("setScatterIndices_ok")
+    g = _global(["num_polarizations", "num_dishes"], ["P", "D"], tmpdir)
+    runner.KotekanStageTester("setScatterIndices", stage_params, None, None, g).run()
+
+    buf = h5py.File(str(tmpdir) + "/scatter_buffer.00000000.h5", "r")["scatter_buffer"]
+    assert buf.attrs["name"] == "scatter_indices"
+    assert tuple(buf.shape) == (NUM_POL, NUM_DISHES)
+    assert tuple(buf.attrs["dim_names"]) == ("P", "D")
+    assert buf.attrs["type"] == "int32"
+    assert np.all(np.asarray(buf).flatten() == np.arange(NUM_POL * NUM_DISHES))
+
+
+def test_setScatterIndices_rejects_transposed_ndarray(tmpdir_factory):
+    """Same byte size, transposed shape -> require_frame_desc must fatal."""
+    tmpdir = tmpdir_factory.mktemp("setScatterIndices_bad")
+    g = _global(["num_dishes", "num_polarizations"], ["D", "P"], tmpdir)
+    runner.KotekanStageTester(
+        "setScatterIndices", stage_params, None, None, g, expect_failure=True
+    ).run()


### PR DESCRIPTION
Converges ndarray frame_descs with other buffer types: buffers own descriptions, stages validate.

  - adds ndarray buffer type
  - buffer factory allocates based on ndarray value_type and extents
  - Buffer::require_frame_desc/ensure_frame_desc for validation
  - Many stages migrated from standard to ndarray buffers, configs updated appropriately
  - Does not address ringbuffer types.
  - Does not address some producers (dpdk, cudacopy stages)