### PR TITLE
Correct x/y vs. M/N directions in FRB beamformers

### DIFF
--- a/config/fengine/include/frb_charts.j2
+++ b/config/fengine/include/frb_charts.j2
@@ -6,9 +6,8 @@
 
 # cudaQuantize requires `frb_num_output_times` to be a multiple of 256
 frb_num_output_times: 256
-# TODO: remove
-frb_num_beams_P: 2 * num_dishes_x
-frb_num_beams_Q: 2 * num_dishes_y
+frb1_num_beams_P: 2 * num_dishes_x
+frb1_num_beams_Q: 2 * num_dishes_y
 frb1_input_scale: 1.0 / 16
 
 frb_rad2deg: 57.29577951308232  # 180/pi
@@ -56,12 +55,12 @@ host_frb2_weights_buffer:
 host_frb1_beams_buffer:
     kotekan_buffer: standard
     num_frames: buffer_depth
-    frame_size: sizeof_float16 * frb_num_beams_P * frb_num_beams_Q * upchan_all_max_num_output_channels * frb_num_output_times
+    frame_size: sizeof_float16 * frb1_num_beams_P * frb1_num_beams_Q * upchan_all_max_num_output_channels * frb_num_output_times
     metadata_pool: main_pool
 host_frb1_beams_ringbuffer:
     kotekan_buffer: ring
     num_frames: buffer_depth
-    ring_buffer_size: buffer_depth * sizeof_float16 * frb_num_beams_P * frb_num_beams_Q * upchan_all_max_num_output_channels * frb_num_output_times
+    ring_buffer_size: buffer_depth * sizeof_float16 * frb1_num_beams_P * frb1_num_beams_Q * upchan_all_max_num_output_channels * frb_num_output_times
     metadata_pool: main_pool
 
 host_frb2_beams_buffer:
@@ -165,9 +164,6 @@ run_frb23:
           frb1_max_num_frequencies: upchan_all_max_num_output_channels
           frb1_max_num_times: buffer_depth * frb_num_output_times
           frb2_num_frequencies: upchan_all_max_output_channel - upchan_all_min_output_channel
-          frb1_num_beams_P: frb_num_beams_P
-          frb1_num_beams_Q: frb_num_beams_Q
-          # frb2_num_beams: frb2_num_beams
           frb2_num_times: frb_num_output_times
           in_signal: host_frb1_beams_ringbuffer
           frb1_beams_name: frb1_beams

--- a/config/fengine/include/frb_chime.j2
+++ b/config/fengine/include/frb_chime.j2
@@ -6,16 +6,15 @@
 
 # cudaQuantize requires `frb_num_output_times` to be a multiple of 256
 frb_num_output_times: 256
-# TODO: remove
-frb_num_beams_P: 2 * num_dishes_y
-frb_num_beams_Q: 2 * num_dishes_x
-frb1_swap_xy: true
+frb1_swap_MN: true
+frb1_num_beams_P: 2 * num_dishes_y
+frb1_num_beams_Q: 2 * num_dishes_x
 frb1_input_scale: 1.0 / 64
 
 frb_rad2deg: 57.29577951308232  # 180/pi
 
-frb2_num_beams_x: 8
-frb2_num_beams_y: 512
+frb2_num_beams_x: 4
+frb2_num_beams_y: 256
 frb2_num_beams: frb2_num_beams_x * frb2_num_beams_y
 frb2_beam_separation_x: 0.0010 * frb_rad2deg
 frb2_beam_separation_y: 0.0001 * frb_rad2deg
@@ -57,12 +56,12 @@ host_frb2_weights_buffer:
 host_frb1_beams_buffer:
     kotekan_buffer: standard
     num_frames: buffer_depth
-    frame_size: sizeof_float16 * frb_num_beams_P * frb_num_beams_Q * upchan_U16_max_num_output_channels * frb_num_output_times
+    frame_size: sizeof_float16 * frb1_num_beams_P * frb1_num_beams_Q * upchan_U16_max_num_output_channels * frb_num_output_times
     metadata_pool: main_pool
 host_frb1_beams_ringbuffer:
     kotekan_buffer: ring
     num_frames: buffer_depth
-    ring_buffer_size: buffer_depth * sizeof_float16 * frb_num_beams_P * frb_num_beams_Q * upchan_U16_max_num_output_channels * frb_num_output_times
+    ring_buffer_size: buffer_depth * sizeof_float16 * frb1_num_beams_P * frb1_num_beams_Q * upchan_U16_max_num_output_channels * frb_num_output_times
     metadata_pool: main_pool
 
 host_frb2_beams_buffer:
@@ -163,9 +162,6 @@ run_frb23:
           frb1_max_num_frequencies: upchan_U16_max_num_output_channels
           frb1_max_num_times: buffer_depth * frb_num_output_times
           frb2_num_frequencies: upchan_U16_max_num_output_channels
-          frb1_num_beams_P: frb_num_beams_P
-          frb1_num_beams_Q: frb_num_beams_Q
-          # frb2_num_beams: frb2_num_beams
           frb2_num_times: frb_num_output_times
           in_signal: host_frb1_beams_ringbuffer
           frb1_beams_name: frb1_beams

--- a/config/fengine/include/frb_chord.j2
+++ b/config/fengine/include/frb_chord.j2
@@ -6,9 +6,8 @@
 
 # cudaQuantize requires `frb_num_output_times` to be a multiple of 256
 frb_num_output_times: 256
-# TODO: remove
-frb_num_beams_P: 2 * num_dishes_x
-frb_num_beams_Q: 2 * num_dishes_y
+frb1_num_beams_P: 2 * num_dishes_x
+frb1_num_beams_Q: 2 * num_dishes_y
 frb1_input_scale: 1.0 / 32
 
 frb_rad2deg: 57.29577951308232  # 180/pi
@@ -92,12 +91,12 @@ host_frb2_weights_buffer:
 host_frb1_beams_buffer:
     kotekan_buffer: standard
     num_frames: buffer_depth
-    frame_size: sizeof_float16 * frb_num_beams_P * frb_num_beams_Q * upchan_all_max_num_output_channels * frb_num_output_times
+    frame_size: sizeof_float16 * frb1_num_beams_P * frb1_num_beams_Q * upchan_all_max_num_output_channels * frb_num_output_times
     metadata_pool: main_pool
 host_frb1_beams_ringbuffer:
     kotekan_buffer: ring
     num_frames: buffer_depth
-    ring_buffer_size: buffer_depth * sizeof_float16 * frb_num_beams_P * frb_num_beams_Q * upchan_all_max_num_output_channels * frb_num_output_times
+    ring_buffer_size: buffer_depth * sizeof_float16 * frb1_num_beams_P * frb1_num_beams_Q * upchan_all_max_num_output_channels * frb_num_output_times
     metadata_pool: main_pool
 
 host_frb2_beams_buffer:
@@ -393,9 +392,6 @@ run_frb23:
           frb1_max_num_frequencies: upchan_all_max_num_output_channels
           frb1_max_num_times: buffer_depth * frb_num_output_times
           frb2_num_frequencies: upchan_all_max_output_channel - upchan_all_min_output_channel
-          frb1_num_beams_P: frb_num_beams_P
-          frb1_num_beams_Q: frb_num_beams_Q
-          # frb2_num_beams: frb2_num_beams
           frb2_num_times: frb_num_output_times
           in_signal: host_frb1_beams_ringbuffer
           frb1_beams_name: frb1_beams

--- a/config/fengine/include/frb_hirax.j2
+++ b/config/fengine/include/frb_hirax.j2
@@ -6,9 +6,8 @@
 
 # cudaQuantize requires `frb_num_output_times` to be a multiple of 256
 frb_num_output_times: 256
-# TODO: remove
-frb_num_beams_P: 2 * num_dishes_x
-frb_num_beams_Q: 2 * num_dishes_y
+frb1_num_beams_P: 2 * num_dishes_x
+frb1_num_beams_Q: 2 * num_dishes_y
 frb1_input_scale: 1.0 / 32
 
 frb_rad2deg: 57.29577951308232  # 180/pi
@@ -68,12 +67,12 @@ host_frb2_weights_buffer:
 host_frb1_beams_buffer:
     kotekan_buffer: standard
     num_frames: buffer_depth
-    frame_size: sizeof_float16 * frb_num_beams_P * frb_num_beams_Q * upchan_all_max_num_output_channels * frb_num_output_times
+    frame_size: sizeof_float16 * frb1_num_beams_P * frb1_num_beams_Q * upchan_all_max_num_output_channels * frb_num_output_times
     metadata_pool: main_pool
 host_frb1_beams_ringbuffer:
     kotekan_buffer: ring
     num_frames: buffer_depth
-    ring_buffer_size: buffer_depth * sizeof_float16 * frb_num_beams_P * frb_num_beams_Q * upchan_all_max_num_output_channels * frb_num_output_times
+    ring_buffer_size: buffer_depth * sizeof_float16 * frb1_num_beams_P * frb1_num_beams_Q * upchan_all_max_num_output_channels * frb_num_output_times
     metadata_pool: main_pool
 
 host_frb2_beams_buffer:
@@ -241,9 +240,6 @@ run_frb23:
           frb1_max_num_frequencies: upchan_all_max_num_output_channels
           frb1_max_num_times: buffer_depth * frb_num_output_times
           frb2_num_frequencies: upchan_all_max_output_channel - upchan_all_min_output_channel
-          frb1_num_beams_P: frb_num_beams_P
-          frb1_num_beams_Q: frb_num_beams_Q
-          # frb2_num_beams: frb2_num_beams
           frb2_num_times: frb_num_output_times
           in_signal: host_frb1_beams_ringbuffer
           frb1_beams_name: frb1_beams

--- a/config/fengine/include/frb_pathfinder.j2
+++ b/config/fengine/include/frb_pathfinder.j2
@@ -6,9 +6,8 @@
 
 # cudaQuantize requires `frb_num_output_times` to be a multiple of 256
 frb_num_output_times: 256
-# TODO: remove
-frb_num_beams_P: 2 * num_dishes_x
-frb_num_beams_Q: 2 * num_dishes_y
+frb1_num_beams_P: 2 * num_dishes_x
+frb1_num_beams_Q: 2 * num_dishes_y
 frb1_input_scale: 1.0 / 16
 
 frb_rad2deg: 57.29577951308232  # 180/pi
@@ -92,12 +91,12 @@ host_frb2_weights_buffer:
 host_frb1_beams_buffer:
     kotekan_buffer: standard
     num_frames: buffer_depth
-    frame_size: sizeof_float16 * frb_num_beams_P * frb_num_beams_Q * upchan_all_max_num_output_channels * frb_num_output_times
+    frame_size: sizeof_float16 * frb1_num_beams_P * frb1_num_beams_Q * upchan_all_max_num_output_channels * frb_num_output_times
     metadata_pool: main_pool
 host_frb1_beams_ringbuffer:
     kotekan_buffer: ring
     num_frames: buffer_depth
-    ring_buffer_size: buffer_depth * sizeof_float16 * frb_num_beams_P * frb_num_beams_Q * upchan_all_max_num_output_channels * frb_num_output_times
+    ring_buffer_size: buffer_depth * sizeof_float16 * frb1_num_beams_P * frb1_num_beams_Q * upchan_all_max_num_output_channels * frb_num_output_times
     metadata_pool: main_pool
 
 host_frb2_beams_buffer:
@@ -393,9 +392,6 @@ run_frb23:
           frb1_max_num_frequencies: upchan_all_max_num_output_channels
           frb1_max_num_times: buffer_depth * frb_num_output_times
           frb2_num_frequencies: upchan_all_max_output_channel - upchan_all_min_output_channel
-          frb1_num_beams_P: frb_num_beams_P
-          frb1_num_beams_Q: frb_num_beams_Q
-          # frb2_num_beams: frb2_num_beams
           frb2_num_times: frb_num_output_times
           in_signal: host_frb1_beams_ringbuffer
           frb1_beams_name: frb1_beams

--- a/config/fengine/include/hfb_chime.j2
+++ b/config/fengine/include/hfb_chime.j2
@@ -43,12 +43,12 @@ host_hfb2_weights_buffer:
 host_hfb1_beams_buffer:
     kotekan_buffer: standard
     num_frames: buffer_depth
-    frame_size: sizeof_float16 * frb_num_beams_P * frb_num_beams_Q * upchan_hfb_upchan_U128_max_num_output_channels * hfb_num_output_times
+    frame_size: sizeof_float16 * frb1_num_beams_P * frb1_num_beams_Q * upchan_hfb_upchan_U128_max_num_output_channels * hfb_num_output_times
     metadata_pool: main_pool
 host_hfb1_beams_ringbuffer:
     kotekan_buffer: ring
     num_frames: buffer_depth
-    ring_buffer_size: buffer_depth * sizeof_float16 * frb_num_beams_P * frb_num_beams_Q * upchan_hfb_upchan_U128_max_num_output_channels * hfb_num_output_times
+    ring_buffer_size: buffer_depth * sizeof_float16 * frb1_num_beams_P * frb1_num_beams_Q * upchan_hfb_upchan_U128_max_num_output_channels * hfb_num_output_times
     metadata_pool: main_pool
 
 host_hfb2_beams_buffer:
@@ -141,8 +141,6 @@ run_hfb23:
           frb1_max_num_frequencies: upchan_hfb_upchan_U128_max_num_output_channels
           frb1_max_num_times: buffer_depth * hfb_num_output_times
           frb2_num_frequencies: upchan_hfb_upchan_U128_max_num_output_channels
-          frb1_num_beams_P: frb_num_beams_P
-          frb1_num_beams_Q: frb_num_beams_Q
           frb2_num_frequencies: upchan_hfb_upchan_U128_max_num_output_channels
           frb2_num_beams: hfb2_num_beams
           frb2_num_times: hfb_num_output_times

--- a/config/fengine/include/output_charts.j2
+++ b/config/fengine/include/output_charts.j2
@@ -162,7 +162,7 @@ run_recv_frb1_beams:
         - name: cudaCopyFromRingbuffer
           host_signal: host_frb1_beams_ringbuffer
           gpu_mem_input: frb1_beams_buffer
-          output_size: sizeof_float16 * frb_num_beams_P * frb_num_beams_Q * upchan_all_max_num_output_channels * frb_num_output_times
+          output_size: sizeof_float16 * frb1_num_beams_P * frb1_num_beams_Q * upchan_all_max_num_output_channels * frb_num_output_times
           ring_buffer_size: buffer_depth * output_size
           out_buf: host_frb1_beams_buffer
 

--- a/config/fengine/include/output_chime.j2
+++ b/config/fengine/include/output_chime.j2
@@ -194,7 +194,7 @@ run_recv_frb1_beams:
         - name: cudaCopyFromRingbuffer
           host_signal: host_frb1_beams_ringbuffer
           gpu_mem_input: frb1_beams_buffer
-          output_size: sizeof_float16 * frb_num_beams_P * frb_num_beams_Q * upchan_U16_max_num_output_channels * frb_num_output_times
+          output_size: sizeof_float16 * frb1_num_beams_P * frb1_num_beams_Q * upchan_U16_max_num_output_channels * frb_num_output_times
           ring_buffer_size: buffer_depth * output_size
           out_buf: host_frb1_beams_buffer
 
@@ -210,7 +210,7 @@ run_recv_hfb1_beams:
         - name: cudaCopyFromRingbuffer
           host_signal: host_hfb1_beams_ringbuffer
           gpu_mem_input: hfb1_beams_buffer
-          output_size: sizeof_float16 * frb_num_beams_P * frb_num_beams_Q * upchan_hfb_upchan_U128_max_num_output_channels * hfb_num_output_times
+          output_size: sizeof_float16 * frb1_num_beams_P * frb1_num_beams_Q * upchan_hfb_upchan_U128_max_num_output_channels * hfb_num_output_times
           ring_buffer_size: buffer_depth * output_size
           out_buf: host_hfb1_beams_buffer
 

--- a/config/fengine/include/output_chord.j2
+++ b/config/fengine/include/output_chord.j2
@@ -242,7 +242,7 @@ run_recv_frb1_beams:
         - name: cudaCopyFromRingbuffer
           host_signal: host_frb1_beams_ringbuffer
           gpu_mem_input: frb1_beams_buffer
-          output_size: sizeof_float16 * frb_num_beams_P * frb_num_beams_Q * upchan_all_max_num_output_channels * frb_num_output_times
+          output_size: sizeof_float16 * frb1_num_beams_P * frb1_num_beams_Q * upchan_all_max_num_output_channels * frb_num_output_times
           ring_buffer_size: buffer_depth * output_size
           out_buf: host_frb1_beams_buffer
 

--- a/config/fengine/include/output_hirax.j2
+++ b/config/fengine/include/output_hirax.j2
@@ -194,7 +194,7 @@ run_recv_frb1_beams:
         - name: cudaCopyFromRingbuffer
           host_signal: host_frb1_beams_ringbuffer
           gpu_mem_input: frb1_beams_buffer
-          output_size: sizeof_float16 * frb_num_beams_P * frb_num_beams_Q * upchan_all_max_num_output_channels * frb_num_output_times
+          output_size: sizeof_float16 * frb1_num_beams_P * frb1_num_beams_Q * upchan_all_max_num_output_channels * frb_num_output_times
           ring_buffer_size: buffer_depth * output_size
           out_buf: host_frb1_beams_buffer
 

--- a/config/fengine/include/output_pathfinder.j2
+++ b/config/fengine/include/output_pathfinder.j2
@@ -242,7 +242,7 @@ run_recv_frb1_beams:
         - name: cudaCopyFromRingbuffer
           host_signal: host_frb1_beams_ringbuffer
           gpu_mem_input: frb1_beams_buffer
-          output_size: sizeof_float16 * frb_num_beams_P * frb_num_beams_Q * upchan_all_max_num_output_channels * frb_num_output_times
+          output_size: sizeof_float16 * frb1_num_beams_P * frb1_num_beams_Q * upchan_all_max_num_output_channels * frb_num_output_times
           ring_buffer_size: buffer_depth * output_size
           out_buf: host_frb1_beams_buffer
 

--- a/julia/kernels/chimefrb_template.cxx
+++ b/julia/kernels/chimefrb_template.cxx
@@ -367,8 +367,8 @@ cudaEvent_t cuda{{{kernel_name}}}::execute(cudaPipelineState& /*pipestate*/, con
         {{/kernel_arguments}}
 
         const auto Ebar_meta = Ebar_buffer.get_metadata();
-        assert(Telescope::instance().get_grid_size_x() <= cuda_dish_layout_M);
-        assert(Telescope::instance().get_grid_size_y() <= cuda_dish_layout_N);
+        assert(Telescope::instance().get_grid_size_x() <= cuda_dish_layout_N);
+        assert(Telescope::instance().get_grid_size_y() <= cuda_dish_layout_M);
 
         // Allocate metadata of I buffer only once
         const bool I_has_metadata = I_buffer.has_metadata();

--- a/julia/output/chimefrb_chime_U128.cxx
+++ b/julia/output/chimefrb_chime_U128.cxx
@@ -450,8 +450,8 @@ cudaCHIMEFRBBeamformer_chime_U128::execute(cudaPipelineState& /*pipestate*/,
             I_buffer.set_metadata(Ebar_buffer.get_metadata());
 
         const auto Ebar_meta = Ebar_buffer.get_metadata();
-        assert(Telescope::instance().get_grid_size_x() <= cuda_dish_layout_M);
-        assert(Telescope::instance().get_grid_size_y() <= cuda_dish_layout_N);
+        assert(Telescope::instance().get_grid_size_x() <= cuda_dish_layout_N);
+        assert(Telescope::instance().get_grid_size_y() <= cuda_dish_layout_M);
 
         // Allocate metadata of I buffer only once
         const bool I_has_metadata = I_buffer.has_metadata();

--- a/julia/output/chimefrb_chime_U128.ptx
+++ b/julia/output/chimefrb_chime_U128.ptx
@@ -13,18 +13,18 @@
 .address_size 64
 
 	// .globl	_Z8chimefrb5Int32S_S_S_13CuDeviceArrayI9Float16x2Li1ELi1EES0_I6Int4x8Li1ELi1EES2_S0_IS_Li1ELi1EE // -- Begin function _Z8chimefrb5Int32S_S_S_13CuDeviceArrayI9Float16x2Li1ELi1EES0_I6Int4x8Li1ELi1EES2_S0_IS_Li1ELi1EE
-.func gpu_signal_exception
+.func gpu_report_exception
 (
-	.param .align 8 .b8 gpu_signal_exception_param_0[16]
+	.param .align 8 .b8 gpu_report_exception_param_0[16],
+	.param .b64 gpu_report_exception_param_1
 )
 .noreturn
 {
 	trap;
 }
-.func gpu_report_exception
+.func gpu_signal_exception
 (
-	.param .align 8 .b8 gpu_report_exception_param_0[16],
-	.param .b64 gpu_report_exception_param_1
+	.param .align 8 .b8 gpu_signal_exception_param_0[16]
 )
 .noreturn
 {

--- a/julia/output/chimefrb_chime_U16.cxx
+++ b/julia/output/chimefrb_chime_U16.cxx
@@ -450,8 +450,8 @@ cudaCHIMEFRBBeamformer_chime_U16::execute(cudaPipelineState& /*pipestate*/,
             I_buffer.set_metadata(Ebar_buffer.get_metadata());
 
         const auto Ebar_meta = Ebar_buffer.get_metadata();
-        assert(Telescope::instance().get_grid_size_x() <= cuda_dish_layout_M);
-        assert(Telescope::instance().get_grid_size_y() <= cuda_dish_layout_N);
+        assert(Telescope::instance().get_grid_size_x() <= cuda_dish_layout_N);
+        assert(Telescope::instance().get_grid_size_y() <= cuda_dish_layout_M);
 
         // Allocate metadata of I buffer only once
         const bool I_has_metadata = I_buffer.has_metadata();

--- a/lib/cuda/generated/CHIMEFRBBeamformer_chime_U128.ptx
+++ b/lib/cuda/generated/CHIMEFRBBeamformer_chime_U128.ptx
@@ -13,18 +13,18 @@
 .address_size 64
 
 	// .globl	_Z8chimefrb5Int32S_S_S_13CuDeviceArrayI9Float16x2Li1ELi1EES0_I6Int4x8Li1ELi1EES2_S0_IS_Li1ELi1EE // -- Begin function _Z8chimefrb5Int32S_S_S_13CuDeviceArrayI9Float16x2Li1ELi1EES0_I6Int4x8Li1ELi1EES2_S0_IS_Li1ELi1EE
-.func gpu_signal_exception
+.func gpu_report_exception
 (
-	.param .align 8 .b8 gpu_signal_exception_param_0[16]
+	.param .align 8 .b8 gpu_report_exception_param_0[16],
+	.param .b64 gpu_report_exception_param_1
 )
 .noreturn
 {
 	trap;
 }
-.func gpu_report_exception
+.func gpu_signal_exception
 (
-	.param .align 8 .b8 gpu_report_exception_param_0[16],
-	.param .b64 gpu_report_exception_param_1
+	.param .align 8 .b8 gpu_signal_exception_param_0[16]
 )
 .noreturn
 {

--- a/lib/cuda/generated/cudaCHIMEFRBBeamformer_chime_U128.cpp
+++ b/lib/cuda/generated/cudaCHIMEFRBBeamformer_chime_U128.cpp
@@ -450,8 +450,8 @@ cudaCHIMEFRBBeamformer_chime_U128::execute(cudaPipelineState& /*pipestate*/,
             I_buffer.set_metadata(Ebar_buffer.get_metadata());
 
         const auto Ebar_meta = Ebar_buffer.get_metadata();
-        assert(Telescope::instance().get_grid_size_x() <= cuda_dish_layout_M);
-        assert(Telescope::instance().get_grid_size_y() <= cuda_dish_layout_N);
+        assert(Telescope::instance().get_grid_size_x() <= cuda_dish_layout_N);
+        assert(Telescope::instance().get_grid_size_y() <= cuda_dish_layout_M);
 
         // Allocate metadata of I buffer only once
         const bool I_has_metadata = I_buffer.has_metadata();

--- a/lib/cuda/generated/cudaCHIMEFRBBeamformer_chime_U16.cpp
+++ b/lib/cuda/generated/cudaCHIMEFRBBeamformer_chime_U16.cpp
@@ -450,8 +450,8 @@ cudaCHIMEFRBBeamformer_chime_U16::execute(cudaPipelineState& /*pipestate*/,
             I_buffer.set_metadata(Ebar_buffer.get_metadata());
 
         const auto Ebar_meta = Ebar_buffer.get_metadata();
-        assert(Telescope::instance().get_grid_size_x() <= cuda_dish_layout_M);
-        assert(Telescope::instance().get_grid_size_y() <= cuda_dish_layout_N);
+        assert(Telescope::instance().get_grid_size_x() <= cuda_dish_layout_N);
+        assert(Telescope::instance().get_grid_size_y() <= cuda_dish_layout_M);
 
         // Allocate metadata of I buffer only once
         const bool I_has_metadata = I_buffer.has_metadata();

--- a/lib/stages/calcFRB2Weights.cpp
+++ b/lib/stages/calcFRB2Weights.cpp
@@ -40,12 +40,14 @@ class calcFRB2Weights : public kotekan::Stage {
 
     // FRB1 beamformer setup
 
-    // The directions we call "x" and "y" are really just describing
-    // the in-memory layout of the dishes (antennae) in the dish
-    // array. For CHORD, the physical x-direction (east-west) runs
-    // fastest, but for CHIME, the y-direction (north-south) runs
-    // fastest. This is necessary to get an efficient FRB1 beamformer
-    // given the different shapes of the dish (antenna) layouts.
+    // The directions "x" and "y" are the geographic direction
+    // east-west and north-south. The directions we call "M" and "N"
+    // are really just describing the in-memory layout of the dishes
+    // (antennae) in the dish array. For CHORD, the physical
+    // x-direction (east-west) runs fastest, but for CHIME, the
+    // y-direction (north-south) runs fastest. This is necessary to
+    // get an efficient FRB1 beamformer given the different shapes of
+    // the dish (antenna) layouts.
     //
     // Internally (in the FRB1 kernels) we call the dish (antenna)
     // directions M and N, where M runs fastest, and the respective
@@ -54,31 +56,29 @@ class calcFRB2Weights : public kotekan::Stage {
     // converse, M=P=y=north/south and N=Q=x=east/west.
     //
     // We need to take this into account when creating the FRB2
-    // beamforming weights. For CHORD we have `frb1_swap_xy=false`,
-    // and for CHIME we have `frb1_swap_xy=true`.
-    const bool frb1_swap_xy = config.get_default<bool>(unique_name, "frb1_swap_xy", false);
-    const int num_dishes_x = frb1_swap_xy ? Telescope::instance().get_grid_size_y() 
-                                          : Telescope::instance().get_grid_size_x();
-    const int num_dishes_y = frb1_swap_xy ? Telescope::instance().get_grid_size_x()
-                                          : Telescope::instance().get_grid_size_y();
-    const int frb1_num_beams_x = 2 * num_dishes_x;
-    const int frb1_num_beams_y = 2 * num_dishes_y;
-    const int frb1_num_beams = frb1_num_beams_x * frb1_num_beams_y;
+    // beamforming weights. For CHORD we have `frb1_swap_MN=false`,
+    // and for CHIME we have `frb1_swap_MN=true`.
+    const int num_dishes_x = Telescope::instance().get_grid_size_x();
+    const int num_dishes_y = Telescope::instance().get_grid_size_y();
+    const bool frb1_swap_MN = config.get_default<bool>(unique_name, "frb1_swap_MN", false);
+    const int num_dishes_M = frb1_swap_MN ? num_dishes_y : num_dishes_x;
+    const int num_dishes_N = frb1_swap_MN ? num_dishes_x : num_dishes_y;
+    const int frb1_num_beams_P = 2 * num_dishes_M;
+    const int frb1_num_beams_Q = 2 * num_dishes_N;
 
     // FRB2 beamformer setup
     const int frb2_num_beams_x = config.get<int>(unique_name, "frb2_num_beams_x");
     const int frb2_num_beams_y = config.get<int>(unique_name, "frb2_num_beams_y");
     const int frb2_num_beams = frb2_num_beams_x * frb2_num_beams_y;
-    const float frb2_beam_separation_x = config.get<float>(unique_name, "frb2_beam_separation_x");
-    const float frb2_beam_separation_y = config.get<float>(unique_name, "frb2_beam_separation_y");
     const int frb2_num_frequencies = config.get<int>(unique_name, "frb2_num_frequencies");
 
     const int num_threads = config.get_default<int>(unique_name, "num_threads", 1);
 
     const std::ptrdiff_t frb2_beam_positions_frame_size [[maybe_unused]] =
         sizeof(float) * 2 * frb2_num_beams;
-    const std::ptrdiff_t W2_frame_size [[maybe_unused]] =
-        sizeof(float16_t) * frb1_num_beams * frb2_num_beams * frb2_num_frequencies;
+    const std::ptrdiff_t W2_frame_size [[maybe_unused]] = sizeof(float16_t) * frb1_num_beams_P
+                                                          * frb1_num_beams_Q * frb2_num_beams
+                                                          * frb2_num_frequencies;
 
     Buffer* const frb2_beam_positions_buffer;
     Buffer* const W2_buffer;
@@ -100,14 +100,12 @@ public:
             FATAL_ERROR("num_threads %d must be positive", num_threads);
         frb2_beam_positions_buffer->register_consumer(unique_name);
         W2_buffer->register_producer(unique_name);
-        
+
         frb2_beam_positions_buffer->allocate_ndarray_frame_desc<float, 2>(
             "frb2_beam_positions", {frb2_num_beams, 2}, {"R", "X/Y"});
-        W2_buffer->allocate_ndarray_frame_desc<float16_t, 4>("W2",
-                                                             {frb2_num_frequencies,
-                                                              frb2_num_beams_y * frb2_num_beams_x,
-                                                              frb1_num_beams_y, frb1_num_beams_x},
-                                                             {"Fbar", "R", "beamQ", "beamP"});
+        W2_buffer->allocate_ndarray_frame_desc<float16_t, 4>(
+            "W2", {frb2_num_frequencies, frb2_num_beams, frb1_num_beams_Q, frb1_num_beams_P},
+            {"Fbar", "R", "beamQ", "beamP"});
     }
 
     virtual ~calcFRB2Weights() {}
@@ -213,8 +211,8 @@ public:
             };
 
             const std::ptrdiff_t str_beamP = 1;
-            const std::ptrdiff_t str_beamQ = str_beamP * frb1_num_beams_x;
-            const std::ptrdiff_t str_beamR = str_beamQ * frb1_num_beams_y;
+            const std::ptrdiff_t str_beamQ = str_beamP * frb1_num_beams_P;
+            const std::ptrdiff_t str_beamR = str_beamQ * frb1_num_beams_Q;
             const std::ptrdiff_t str_freq = str_beamR * frb2_num_beams;
 
             // Vectors giving the feed separation in each axis direction in meters.
@@ -236,8 +234,8 @@ public:
 #pragma omp parallel num_threads(num_threads)
 #endif
             {
-                std::vector<float> Up(frb1_num_beams_x);
-                std::vector<float> Uq(frb1_num_beams_y);
+                std::vector<float> Up(frb1_num_beams_P);
+                std::vector<float> Uq(frb1_num_beams_Q);
 
 #ifdef WITH_OMP
 #pragma omp for
@@ -263,14 +261,16 @@ public:
                         const float theta_y = num_dishes_y
                                               * (nx * sigmay_x + ny * sigmay_y + nz * sigmay_z)
                                               / wavelength;
+                        const float theta_M = frb1_swap_MN ? theta_y : theta_x;
+                        const float theta_N = frb1_swap_MN ? theta_x : theta_y;
 
-                        for (int i = 0; i < frb1_num_beams_x; ++i)
-                            Up[i] = Ufunc(i, num_dishes_x, theta_x);
-                        for (int j = 0; j < frb1_num_beams_y; ++j)
-                            Uq[j] = Ufunc(j, num_dishes_y, theta_y);
+                        for (int i = 0; i < frb1_num_beams_P; ++i)
+                            Up[i] = Ufunc(i, num_dishes_M, theta_M);
+                        for (int j = 0; j < frb1_num_beams_Q; ++j)
+                            Uq[j] = Ufunc(j, num_dishes_N, theta_N);
 
-                        for (int beamQ = 0; beamQ < frb1_num_beams_y; ++beamQ) {
-                            for (int beamP = 0; beamP < frb1_num_beams_x; ++beamP) {
+                        for (int beamQ = 0; beamQ < frb1_num_beams_Q; ++beamQ) {
+                            for (int beamP = 0; beamP < frb1_num_beams_P; ++beamP) {
                                 const std::ptrdiff_t idx = str_beamP * beamP + str_beamQ * beamQ
                                                            + str_beamR * beamR + str_freq * freq;
                                 assert(idx >= 0

--- a/lib/stages/setFRB1Phase.cpp
+++ b/lib/stages/setFRB1Phase.cpp
@@ -1,27 +1,32 @@
-#include <unistd.h>             // for sleep
-#include <cassert>              // for assert
-#include <string>               // for basic_string, string
-#include <vector>               // for vector
-#include <complex>              // for complex
-#include <cstddef>              // for ptrdiff_t
-#include <functional>           // for function
-#include <memory>               // for allocator, __shared_ptr_access, shared_ptr
+#include "Config.hpp"          // for Config
+#include "DataType.hpp"        // for float16_t
+#include "Stage.hpp"           // for Stage
+#include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
+#include "buffer.hpp"          // for Buffer
+#include "bufferContainer.hpp" // for bufferContainer
+#include "chordMetadata.hpp"   // for chordMetadata, get_chord_metadata
+#include "kotekanLogging.hpp"  // for DEBUG
 
-#include "Config.hpp"           // for Config
-#include "Stage.hpp"            // for Stage
-#include "StageFactory.hpp"     // for REGISTER_KOTEKAN_STAGE
-#include "buffer.hpp"           // for Buffer
-#include "bufferContainer.hpp"  // for bufferContainer
-#include "chordMetadata.hpp"    // for chordMetadata, get_chord_metadata
-#include "kotekanLogging.hpp"   // for DEBUG
-#include "DataType.hpp"         // for float16_t
-#include "fmt.hpp"              // for compile_string_to_view, format
+#include "fmt.hpp" // for compile_string_to_view, format
+
+#include <cassert>    // for assert
+#include <complex>    // for complex
+#include <cstddef>    // for ptrdiff_t
+#include <functional> // for function
+#include <memory>     // for allocator, __shared_ptr_access, shared_ptr
+#include <string>     // for basic_string, string
+#include <unistd.h>   // for sleep
+#include <vector>     // for vector
 
 class setFRB1Phase : public kotekan::Stage {
     // Telescope layout
     const int num_components = config.get<int>(unique_name, "num_components");
     const int num_dishes_x = Telescope::instance().get_grid_size_x();
     const int num_dishes_y = Telescope::instance().get_grid_size_y();
+    // See calcFRB2Weights.cpp
+    const bool frb1_swap_MN = config.get_default<bool>(unique_name, "frb1_swap_MN", false);
+    const int num_dishes_M = frb1_swap_MN ? num_dishes_y : num_dishes_x;
+    const int num_dishes_N = frb1_swap_MN ? num_dishes_x : num_dishes_y;
     const int num_polarizations = config.get<int>(unique_name, "num_polarizations");
 
     const std::vector<int> frequency_channels =
@@ -73,12 +78,12 @@ public:
         // Check buffer size
         assert(frb1_phase_buffer->frame_size
                == sizeof(float16_t) * upchan_max_num_channels * upchan_factor * num_polarizations
-                      * num_dishes_y * num_dishes_x * num_components);
+                      * num_dishes_N * num_dishes_M * num_components);
 
         // Set metadata
         frb1_phase_buffer->allocate_ndarray_frame_desc<float16_t, 5>(
             "W",
-            {upchan_max_num_channels * upchan_factor, num_polarizations, num_dishes_y, num_dishes_x,
+            {upchan_max_num_channels * upchan_factor, num_polarizations, num_dishes_N, num_dishes_M,
              num_components},
             {"F", "P", "dishN", "dishM", "C"});
         frb1_phase_buffer->allocate_new_metadata_object(frame_id);
@@ -102,15 +107,15 @@ public:
         frb1_phase_meta->set_freq_upchan_index(freq_upchan_index);
 
         // Set buffer
-        const std::ptrdiff_t str_dish_x = 1;
-        const std::ptrdiff_t str_dish_y = str_dish_x * num_dishes_x;
-        const std::ptrdiff_t str_polr = str_dish_y * num_dishes_y;
+        const std::ptrdiff_t str_dish_M = 1;
+        const std::ptrdiff_t str_dish_N = str_dish_M * num_dishes_M;
+        const std::ptrdiff_t str_polr = str_dish_N * num_dishes_N;
         const std::ptrdiff_t str_freq = str_polr * num_polarizations;
         for (int freq = 0; freq < upchan_max_num_channels * upchan_factor; ++freq) {
             for (int polr = 0; polr < num_polarizations; ++polr) {
-                for (int dish_y = 0; dish_y < num_dishes_y; ++dish_y) {
-                    for (int dish_x = 0; dish_x < num_dishes_x; ++dish_x) {
-                        const std::ptrdiff_t idx = str_dish_x * dish_x + str_dish_y * dish_y
+                for (int dish_N = 0; dish_N < num_dishes_N; ++dish_N) {
+                    for (int dish_M = 0; dish_M < num_dishes_M; ++dish_M) {
+                        const std::ptrdiff_t idx = str_dish_M * dish_M + str_dish_N * dish_N
                                                    + str_polr * polr + str_freq * freq;
                         assert(idx >= 0
                                && idx < std::ptrdiff_t(frb1_phase_buffer->frame_size


### PR DESCRIPTION
CHARTS, CHORD, and Hirax arrange dishes and beams differently from CHIME in the FRB beamformer. Clean this up, add comments, and correct errors. (Probably.)