### PR TITLE
Telescope metadata cleanup

### DIFF
--- a/lib/stages/hdf5FileRead.cpp
+++ b/lib/stages/hdf5FileRead.cpp
@@ -1,36 +1,37 @@
-#include <Config.hpp>                             // for Config
-#include <DataType.hpp>                           // for string_to_type, DataType
-#include <Stage.hpp>                              // for Stage
-#include <StageFactory.hpp>                       // for REGISTER_KOTEKAN_STAGE
-#include <Symbol.hpp>                             // for Symbol
-#include <buffer.hpp>                             // for Buffer
-#include <bufferContainer.hpp>                    // for bufferContainer
-#include <chordMetadata.hpp>                      // for chordMetadata, metadata_is_chord, get_c...
-#include <hdf5Files.hpp>                          // for chord_metadata_version
-#include <highfive/H5Attribute.hpp>               // for Attribute, Attribute::read
-#include <highfive/H5DataSet.hpp>                 // for DataSet, AnnotateTraits::getAttribute
-#include <highfive/H5DataSpace.hpp>               // for DataSpace, DataSpace::getDimensions
-#include <highfive/H5Exception.hpp>               // for FileException
-#include <highfive/H5File.hpp>                    // for File, File::File, NodeTraits::getDataSet
-#include <highfive/bits/H5Slice_traits_misc.hpp>  // for SliceTraits::read_raw
-#include <kotekanLogging.hpp>                     // for DEBUG, FATAL_ERROR, ERROR
-#include <metadata.hpp>                           // for metadataObject
-#include <prometheusMetrics.hpp>                  // for Metrics, Gauge
-#include <unistd.h>                               // for gethostname, sleep
-#include <visUtil.hpp>                            // for current_time
-#include <algorithm>                              // for copy
-#include <array>                                  // for array
-#include <cassert>                                // for assert
-#include <cstddef>                                // for ptrdiff_t
-#include <cstdint>                                // for int64_t, uint8_t
-#include <functional>                             // for function
-#include <iomanip>                                // for operator<<, setfill, setw
-#include <memory>                                 // for allocator, shared_ptr, __shared_ptr_access
-#include <sstream>                                // for basic_ostream, operator<<, basic_ostrin...
-#include <string>                                 // for basic_string, char_traits, string, oper...
-#include <vector>                                 // for vector
+#include "fmt.hpp" // for compile_string_to_view
 
-#include "fmt.hpp"                                // for compile_string_to_view
+#include <Config.hpp>          // for Config
+#include <DataType.hpp>        // for string_to_type, DataType
+#include <Stage.hpp>           // for Stage
+#include <StageFactory.hpp>    // for REGISTER_KOTEKAN_STAGE
+#include <Symbol.hpp>          // for Symbol
+#include <algorithm>           // for copy
+#include <array>               // for array
+#include <buffer.hpp>          // for Buffer
+#include <bufferContainer.hpp> // for bufferContainer
+#include <cassert>             // for assert
+#include <chordMetadata.hpp>   // for chordMetadata, metadata_is_chord, get_c...
+#include <cstddef>             // for ptrdiff_t
+#include <cstdint>             // for int64_t, uint8_t
+#include <fmt/ranges.h>
+#include <functional>                            // for function
+#include <hdf5Files.hpp>                         // for chord_metadata_version
+#include <highfive/H5Attribute.hpp>              // for Attribute, Attribute::read
+#include <highfive/H5DataSet.hpp>                // for DataSet, AnnotateTraits::getAttribute
+#include <highfive/H5DataSpace.hpp>              // for DataSpace, DataSpace::getDimensions
+#include <highfive/H5Exception.hpp>              // for FileException
+#include <highfive/H5File.hpp>                   // for File, File::File, NodeTraits::getDataSet
+#include <highfive/bits/H5Slice_traits_misc.hpp> // for SliceTraits::read_raw
+#include <iomanip>                               // for operator<<, setfill, setw
+#include <kotekanLogging.hpp>                    // for DEBUG, FATAL_ERROR, ERROR
+#include <memory>                                // for allocator, shared_ptr, __shared_ptr_access
+#include <metadata.hpp>                          // for metadataObject
+#include <prometheusMetrics.hpp>                 // for Metrics, Gauge
+#include <sstream>                               // for basic_ostream, operator<<, basic_ostrin...
+#include <string>                                // for basic_string, char_traits, string, oper...
+#include <unistd.h>                              // for gethostname, sleep
+#include <vector>                                // for vector
+#include <visUtil.hpp>                           // for current_time
 
 using namespace hdf5;
 using namespace HighFive;
@@ -43,6 +44,9 @@ class hdf5FileRead : public kotekan::Stage {
     const int host_pool_rank = config.get_default<int>(unique_name, "frequency_pool_rank", 0);
     const int host_pool_size = config.get_default<int>(unique_name, "frequency_pool_size", 1);
     const bool do_once = config.get_default<bool>(unique_name, "do_once", false);
+
+    const uint64_t num_polarizations = config.get<uint64_t>(unique_name, "num_polarizations");
+    const uint64_t num_dishes = config.get<uint64_t>(unique_name, "num_dishes");
 
     Buffer* const buffer;
 
@@ -59,6 +63,103 @@ public:
     }
 
     virtual ~hdf5FileRead() {}
+
+    /**
+     * @brief Read and check the telescope metadata
+     *
+     * @param node   The HDF5 object (file, group, dataset, etc.) where the metadata should be
+     *               read from
+     */
+    template<typename Node>
+    void check_telescope_metadata(Node& node) {
+        const auto& telescope = Telescope::instance();
+
+        const auto check_string_attr = [&](const std::string& key,
+                                           const std::string& expected_value) {
+            if (node.hasAttribute(key)) {
+                const auto value = node.getAttribute(key).template read<std::string>();
+                if (value != expected_value)
+                    FATAL_ERROR("Attribute {:s} is \"{}\", expected \"{}\"", key, value,
+                                expected_value);
+            }
+        };
+
+        const auto check_float_attr = [&](const std::string& key, const double expected_value) {
+            if (node.hasAttribute(key)) {
+                const auto value = node.getAttribute(key).template read<double>();
+                if (value != expected_value)
+                    FATAL_ERROR("Attribute {:s} is {}, expected {}", key, value, expected_value);
+            }
+        };
+
+        const auto check_int_attr = [&](const std::string& key, const std::int64_t expected_value) {
+            if (node.hasAttribute(key)) {
+                const auto value = node.getAttribute(key).template read<std::int64_t>();
+                if (value != expected_value)
+                    FATAL_ERROR("Attribute {:s} is {}, expected {}", key, value, expected_value);
+            }
+        };
+
+        const auto check_uint_attr = [&](const std::string& key,
+                                         const std::uint64_t expected_value) {
+            if (node.hasAttribute(key)) {
+                const auto value = node.getAttribute(key).template read<std::uint64_t>();
+                if (value != expected_value)
+                    FATAL_ERROR("Attribute {:s} is {}, expected {}", key, value, expected_value);
+            }
+        };
+
+        const auto check_bool_attr = [&](const std::string& key, const bool expected_value) {
+            if (node.hasAttribute(key)) {
+                const auto value = node.getAttribute(key).template read<bool>();
+                if (value != expected_value)
+                    FATAL_ERROR("Attribute {:s} is {}, expected {}", key, value, expected_value);
+            }
+        };
+
+        check_string_attr("telescope_name", telescope.get_name());
+        check_uint_attr("seq_length_nsec", telescope.seq_length_nsec());
+        check_bool_attr("gps_time_enabled", telescope.gps_time_enabled());
+        check_int_attr("num_polarizations", num_polarizations);
+        check_int_attr("num_dishes", num_dishes);
+        check_float_attr("itrs_lat_deg", telescope.get_itrs_lat_deg());
+        check_float_attr("itrs_lon_deg", telescope.get_itrs_lon_deg());
+        // node.getAttribute("grid_orientation", telescope.get_grid_orientation());
+        check_uint_attr("grid_size_x", telescope.get_grid_size_x());
+        check_uint_attr("grid_size_y", telescope.get_grid_size_y());
+        check_float_attr("feed_separation_x_m", telescope.get_feed_separation_x_m());
+        check_float_attr("feed_separation_y_m", telescope.get_feed_separation_y_m());
+
+        if (node.hasAttribute("dish_grid_indices")) {
+            auto attr = node.getAttribute("dish_grid_indices");
+            auto space = attr.getSpace();
+            auto dims = space.getDimensions(); // {N, 2}
+            assert(dims.size() == 2);
+            assert(dims.at(1) == 2);
+            std::vector<std::array<std::int64_t, 2>> dish_grid_indices(dims.at(0));
+            attr.read_raw(reinterpret_cast<std::int64_t*>(dish_grid_indices.data()));
+            const auto& expected_dish_grid_indices =
+                telescope.get_main_array_grid_indices(num_dishes, ElementOrder::CHORDBeamformer);
+            if (dish_grid_indices != expected_dish_grid_indices)
+                FATAL_ERROR("Attribute dish_grid_indices is {}, expected {}", dish_grid_indices,
+                            expected_dish_grid_indices);
+        }
+
+        if (node.hasAttribute("feed_positions_m")) {
+            auto attr = node.getAttribute("feed_positions_m");
+            auto space = attr.getSpace();
+            auto dims = space.getDimensions(); // {N, 3}
+            assert(dims.size() == 3);
+            assert(dims.at(1) == 3);
+            std::vector<std::array<double, 3>> feed_positions_m(dims.at(0));
+            attr.read_raw(reinterpret_cast<double*>(feed_positions_m.data()));
+            const auto& expected_feed_positions_m =
+                telescope.get_feed_positions_m(num_dishes, ElementOrder::CHORDBeamformer);
+            if (feed_positions_m != expected_feed_positions_m)
+                FATAL_ERROR("Attribute feed_positions_m is {}, expected {}", feed_positions_m,
+                            expected_feed_positions_m);
+        }
+    }
 
     void main_thread() override {
         auto& read_time_metric = kotekan::prometheus::Metrics::instance().add_gauge(
@@ -180,7 +281,8 @@ public:
                         dataset.getAttribute("rfi_frame_excision_thresholds")
                             .read<std::vector<std::array<float, 2>>>());
 
-                // TODO: Read telescope fields and WARN if they don't match?
+                // Read telescope fields and abort if they don't match
+                check_telescope_metadata(dataset);
 
                 {
                     /* new style array description */

--- a/lib/stages/hdf5FileWrite.cpp
+++ b/lib/stages/hdf5FileWrite.cpp
@@ -1,5 +1,7 @@
+#include "CHORDTelescope.hpp"      // for CHORDTelescope
 #include "Config.hpp"              // for Config
 #include "DataType.hpp"            // for DataType, type_to_string
+#include "ICETelescope.hpp"        // for ICETelescope
 #include "N2FrameView.hpp"         // for N2FrameView
 #include "N2Metadata.hpp"          // for metadata_is_N2
 #include "NDArray.hpp"             // for GenericNDArray
@@ -201,12 +203,12 @@ public:
 
         // Flatten to proper HDF5 multi-dimensional arrays
         const auto& dish_grid_indices =
-            telescope.get_main_array_grid_indices(num_dishes, ElementOrder::CHORDBeamformer);
+            telescope.get_main_array_grid_indices(num_dishes, telescope.fiducial_element_order());
         node.createAttribute("dish_grid_indices", DataSpace({dish_grid_indices.size(), 2}),
                              create_datatype<std::int64_t>())
             .write_raw(reinterpret_cast<const std::int64_t*>(dish_grid_indices.data()));
         const auto& feed_positions_m =
-            telescope.get_feed_positions_m(num_dishes, ElementOrder::CHORDBeamformer);
+            telescope.get_feed_positions_m(num_dishes, telescope.fiducial_element_order());
         node.createAttribute("feed_positions_m", DataSpace({feed_positions_m.size(), 3}),
                              create_datatype<double>())
             .write_raw(reinterpret_cast<const double*>(feed_positions_m.data()));

--- a/lib/stages/hdf5FileWrite.cpp
+++ b/lib/stages/hdf5FileWrite.cpp
@@ -1,51 +1,52 @@
-#include <errno.h>                                // for errno, EEXIST, EISDIR
-#include <gsl-lite.hpp>                           // for span
-#include <string.h>                               // for strerror
-#include <sys/stat.h>                             // for mkdir
-#include <unistd.h>                               // for gethostname
-#include <highfive/H5DataSet.hpp>                 // for DataSet, AnnotateTraits::createAttribute
-#include <highfive/H5DataSpace.hpp>               // for DataSpace, DataSpace::DataSpace, DataSp...
-#include <highfive/H5DataType.hpp>                // for DataType
-#include <highfive/H5File.hpp>                    // for File, NodeTraits::createDataSet, File::...
-#include <highfive/H5Object.hpp>                  // for hsize_t, H5Z_FLAG_MANDATORY
-#include <highfive/H5PropertyList.hpp>            // for PropertyType, RawPropertyList, Chunking
-#include <highfive/H5Selection.hpp>               // for SliceTraits::write_raw, Selection, Slic...
-#include <highfive/bits/H5PropertyList_misc.hpp>  // for PropertyList::_initializeIfNeeded, Prop...
-#include <highfive/bits/H5Selection_misc.hpp>     // for Selection::getSpace
-#include <algorithm>                              // for max, min
-#include <array>                                  // for array
-#include <atomic>                                 // for __atomic_base, atomic
-#include <cassert>                                // for assert
-#include <cstddef>                                // for size_t
-#include <cstdint>                                // for int64_t, uint8_t, uint32_t
-#include <functional>                             // for function
-#include <iomanip>                                // for operator<<, setfill, setw
-#include <memory>                                 // for allocator, shared_ptr, __shared_ptr_access
-#include <sstream>                                // for basic_ostream, operator<<, basic_ostrin...
-#include <string>                                 // for basic_string, char_traits, string, oper...
-#include <vector>                                 // for vector
+#include "Config.hpp"              // for Config
+#include "DataType.hpp"            // for DataType, type_to_string
+#include "N2FrameView.hpp"         // for N2FrameView
+#include "N2Metadata.hpp"          // for metadata_is_N2
+#include "NDArray.hpp"             // for GenericNDArray
+#include "Stage.hpp"               // for Stage
+#include "StageFactory.hpp"        // for REGISTER_KOTEKAN_STAGE
+#include "Symbol.hpp"              // for Symbol
+#include "Telescope.hpp"           // for Telescope
+#include "buffer.hpp"              // for Buffer
+#include "bufferContainer.hpp"     // for bufferContainer
+#include "chordMetadata.hpp"       // for chordMetadata, metadata_is_chord, get_c...
+#include "errors.h"                // for exit_kotekan, ReturnCode
+#include "hdf5Files.hpp"           // for chord2hdf5, BITSHUFFLE_BLOCKSIZE_AUTO
+#include "kotekanLogging.hpp"      // for DEBUG, FATAL_ERROR, WARN, INFO
+#include "metadata.hpp"            // for metadataObject
+#include "prometheusMetrics.hpp"   // for Metrics, Gauge
+#include "timeUtil.hpp"            // for EOP
+#include "visUtil.hpp"             // for current_time
+#include "waitingForMaxFrames.hpp" // for waiting_for_max_frames
 
-#include "Config.hpp"                             // for Config
-#include "DataType.hpp"                           // for DataType, type_to_string
-#include "N2FrameView.hpp"                        // for N2FrameView
-#include "N2Metadata.hpp"                         // for metadata_is_N2
-#include "NDArray.hpp"                            // for GenericNDArray
-#include "Stage.hpp"                              // for Stage
-#include "StageFactory.hpp"                       // for REGISTER_KOTEKAN_STAGE
-#include "Symbol.hpp"                             // for Symbol
-#include "Telescope.hpp"                          // for Telescope
-#include "buffer.hpp"                             // for Buffer
-#include "bufferContainer.hpp"                    // for bufferContainer
-#include "chordMetadata.hpp"                      // for chordMetadata, metadata_is_chord, get_c...
-#include "errors.h"                               // for exit_kotekan, ReturnCode
-#include "hdf5Files.hpp"                          // for chord2hdf5, BITSHUFFLE_BLOCKSIZE_AUTO
-#include "kotekanLogging.hpp"                     // for DEBUG, FATAL_ERROR, WARN, INFO
-#include "metadata.hpp"                           // for metadataObject
-#include "prometheusMetrics.hpp"                  // for Metrics, Gauge
-#include "timeUtil.hpp"                           // for EOP
-#include "visUtil.hpp"                            // for current_time
-#include "waitingForMaxFrames.hpp"                // for waiting_for_max_frames
-#include "fmt.hpp"                                // for compile_string_to_view
+#include "fmt.hpp" // for compile_string_to_view
+
+#include <algorithm>                             // for max, min
+#include <array>                                 // for array
+#include <atomic>                                // for __atomic_base, atomic
+#include <cassert>                               // for assert
+#include <cstddef>                               // for size_t
+#include <cstdint>                               // for int64_t, uint8_t, uint32_t
+#include <errno.h>                               // for errno, EEXIST, EISDIR
+#include <functional>                            // for function
+#include <gsl-lite.hpp>                          // for span
+#include <highfive/H5DataSet.hpp>                // for DataSet, AnnotateTraits::createAttribute
+#include <highfive/H5DataSpace.hpp>              // for DataSpace, DataSpace::DataSpace, DataSp...
+#include <highfive/H5DataType.hpp>               // for DataType
+#include <highfive/H5File.hpp>                   // for File, NodeTraits::createDataSet, File::...
+#include <highfive/H5Object.hpp>                 // for hsize_t, H5Z_FLAG_MANDATORY
+#include <highfive/H5PropertyList.hpp>           // for PropertyType, RawPropertyList, Chunking
+#include <highfive/H5Selection.hpp>              // for SliceTraits::write_raw, Selection, Slic...
+#include <highfive/bits/H5PropertyList_misc.hpp> // for PropertyList::_initializeIfNeeded, Prop...
+#include <highfive/bits/H5Selection_misc.hpp>    // for Selection::getSpace
+#include <iomanip>                               // for operator<<, setfill, setw
+#include <memory>                                // for allocator, shared_ptr, __shared_ptr_access
+#include <sstream>                               // for basic_ostream, operator<<, basic_ostrin...
+#include <string.h>                              // for strerror
+#include <string>                                // for basic_string, char_traits, string, oper...
+#include <sys/stat.h>                            // for mkdir
+#include <unistd.h>                              // for gethostname
+#include <vector>                                // for vector
 
 
 using namespace hdf5;
@@ -101,8 +102,6 @@ class hdf5FileWrite : public kotekan::Stage {
 
     const uint64_t num_polarizations = config.get<uint64_t>(unique_name, "num_polarizations");
     const uint64_t num_dishes = config.get<uint64_t>(unique_name, "num_dishes");
-    const uint64_t num_elements = num_polarizations * num_dishes;
-    const ElementOrder input_order = config.get<ElementOrder>(unique_name, "input_order");
 
     Buffer* const buffer;
 
@@ -175,6 +174,42 @@ public:
         // You may have to use `h5clear -s FILENAME.h5` to "tell" the file that the writer does not
         // exist any more.
         return std::make_unique<File>(full_path, File::Truncate | File::WriteSWMR, fprops, fapl);
+    }
+
+    /**
+     * @brief Write the telescope metadata
+     *
+     * @param node   The HDF5 object (file, group, dataset, etc.) where the metadata should be
+     *               attached
+     */
+    template<typename Node>
+    void write_telescope_metadata(Node& node) {
+        const auto& telescope = Telescope::instance();
+
+        node.createAttribute("telescope_name", telescope.get_name());
+        node.createAttribute("seq_length_nsec", telescope.seq_length_nsec());
+        node.createAttribute("gps_time_enabled", telescope.gps_time_enabled());
+        node.createAttribute("num_polarizations", num_polarizations);
+        node.createAttribute("num_dishes", num_dishes);
+        node.createAttribute("itrs_lat_deg", telescope.get_itrs_lat_deg());
+        node.createAttribute("itrs_lon_deg", telescope.get_itrs_lon_deg());
+        node.createAttribute("grid_orientation", telescope.get_grid_orientation());
+        node.createAttribute("grid_size_x", telescope.get_grid_size_x());
+        node.createAttribute("grid_size_y", telescope.get_grid_size_y());
+        node.createAttribute("feed_separation_x_m", telescope.get_feed_separation_x_m());
+        node.createAttribute("feed_separation_y_m", telescope.get_feed_separation_y_m());
+
+        // Flatten to proper HDF5 multi-dimensional arrays
+        const auto& dish_grid_indices =
+            telescope.get_main_array_grid_indices(num_dishes, ElementOrder::CHORDBeamformer);
+        node.createAttribute("dish_grid_indices", DataSpace({dish_grid_indices.size(), 2}),
+                             create_datatype<std::int64_t>())
+            .write_raw(reinterpret_cast<const std::int64_t*>(dish_grid_indices.data()));
+        const auto& feed_positions_m =
+            telescope.get_feed_positions_m(num_dishes, ElementOrder::CHORDBeamformer);
+        node.createAttribute("feed_positions_m", DataSpace({feed_positions_m.size(), 3}),
+                             create_datatype<double>())
+            .write_raw(reinterpret_cast<const double*>(feed_positions_m.data()));
     }
 
     /**
@@ -261,10 +296,6 @@ public:
 
             // Write metadata (attributes)
 
-            dataset.createAttribute("telescope_name", telescope.get_name());
-            dataset.createAttribute("seq_length_nsec", telescope.seq_length_nsec());
-            dataset.createAttribute("gps_time_enabled", telescope.gps_time_enabled());
-
             dataset.createAttribute("chord_metadata_version", chord_metadata_version);
             dataset.createAttribute("name", meta->get_name());
             dataset.createAttribute("type",
@@ -300,22 +331,7 @@ public:
                 dataset.createAttribute("rfi_frame_excision_thresholds",
                                         meta->get_rfi_frame_excision_thresholds());
 
-            {
-                // Telescope data
-                dataset.createAttribute("num_polarizations", num_polarizations);
-                dataset.createAttribute("num_dishes", num_dishes);
-                dataset.createAttribute("num_elements", num_elements);
-                dataset.createAttribute("input_order", ElementOrder_to_string(input_order));
-                dataset.createAttribute("itrs_lat_deg", telescope.get_itrs_lat_deg());
-                dataset.createAttribute("itrs_lon_deg", telescope.get_itrs_lon_deg());
-                dataset.createAttribute("grid_orientation", telescope.get_grid_orientation());
-                dataset.createAttribute("grid_size_x", telescope.get_grid_size_x());
-                dataset.createAttribute("grid_size_y", telescope.get_grid_size_y());
-                dataset.createAttribute("feed_separation_x_m", telescope.get_feed_separation_x_m());
-                dataset.createAttribute("feed_separation_y_m", telescope.get_feed_separation_y_m());
-                dataset.createAttribute("main_array_grid_indices", telescope.get_main_array_grid_indices(num_elements, input_order));
-                dataset.createAttribute("feed_positions_m", telescope.get_feed_positions_m(num_elements, input_order));
-            }
+            write_telescope_metadata(dataset);
 
             if (create_single_file) {
                 // Start SWMR mode
@@ -380,7 +396,6 @@ public:
         const std::vector<size_t> gain_dims({frame.num_elements, 2});
         const std::vector<size_t> radiometer_chi2_dims({3}); // 3 pol pairs XX, XY, YY
 
-
         // Create dataspaces
         const DataSpace vis_space(vis_dims);
         const DataSpace weight_space(weight_dims);
@@ -430,12 +445,9 @@ public:
         radiometer_chi2_dset.write_raw(frame.radiometer_chi2.data(), float_type);
 
         // Set metadata as file-level attributes
-        file.createAttribute("num_polarizations", num_polarizations);
-        file.createAttribute("num_dishes", num_dishes);
-        file.createAttribute("num_elements", frame.num_elements);
         file.createAttribute("num_prod", frame.num_prod);
         file.createAttribute("num_ev", frame.num_ev);
-        file.createAttribute("input_order", ElementOrder_to_string(input_order));
+        // file.createAttribute("input_order", ElementOrder_to_string(input_order));
         file.createAttribute("freq_id", frame.freq_id);
         file.createAttribute("freq_MHz", frame.freq_MHz);
         file.createAttribute("abs_time_idx", frame.abs_time_idx);
@@ -468,19 +480,7 @@ public:
         file.createAttribute("rfi_frame_excision_threshold", frame.rfi_frame_excision_threshold);
         file.createAttribute("rfi_frame_excision_fraction", frame.rfi_frame_excision_fraction);
 
-        {
-            // Telescope data
-            const Telescope &tel = Telescope::instance();
-            file.createAttribute("itrs_lat_deg", tel.get_itrs_lat_deg());
-            file.createAttribute("itrs_lon_deg", tel.get_itrs_lon_deg());
-            file.createAttribute("grid_orientation", tel.get_grid_orientation());
-            file.createAttribute("grid_size_x", tel.get_grid_size_x());
-            file.createAttribute("grid_size_y", tel.get_grid_size_y());
-            file.createAttribute("feed_separation_x_m", tel.get_feed_separation_x_m());
-            file.createAttribute("feed_separation_y_m", tel.get_feed_separation_y_m());
-            file.createAttribute("main_array_grid_indices", tel.get_main_array_grid_indices(num_elements, input_order));
-            file.createAttribute("feed_positions_m", tel.get_feed_positions_m(num_elements, input_order));
-        }
+        write_telescope_metadata(file);
     }
 
     /**

--- a/lib/stages/hdf5Files.hpp
+++ b/lib/stages/hdf5Files.hpp
@@ -12,7 +12,7 @@ namespace hdf5 {
 // The version number of the CHORD metadata format in HDF5 files.
 // This uses semver: A file with version X.Y can be read by software
 // that understands X.Z even when Y > Z.
-constexpr std::array<int, 2> chord_metadata_version{1, 0};
+constexpr std::array<int, 2> chord_metadata_version{2, 0};
 
 // Bitshuffle flags
 constexpr unsigned int H5Z_BLOSC = 32001;      // blosc filter id

--- a/lib/testing/fakeGpu.cpp
+++ b/lib/testing/fakeGpu.cpp
@@ -235,15 +235,22 @@ bool FakeTelescope::gps_time_enabled() const {
     return true;
 }
 
-station_id_t FakeTelescope::element_index_to_station_id(uint64_t el_idx, [[maybe_unused]] ElementOrder ord) const {
+ElementOrder FakeTelescope::fiducial_element_order() const {
+    return ElementOrder::CHIMEBeamformer;
+}
+
+station_id_t FakeTelescope::element_index_to_station_id(uint64_t el_idx,
+                                                        [[maybe_unused]] ElementOrder ord) const {
     return el_idx;
 }
 
-uint64_t FakeTelescope::station_id_to_element_index(station_id_t st_id, [[maybe_unused]] ElementOrder ord) const {
+uint64_t FakeTelescope::station_id_to_element_index(station_id_t st_id,
+                                                    [[maybe_unused]] ElementOrder ord) const {
     return st_id;
 }
 
-grid_idx_2d_t FakeTelescope::station_id_to_main_array_grid_indices([[maybe_unused]] station_id_t st_id) const {
+grid_idx_2d_t
+FakeTelescope::station_id_to_main_array_grid_indices([[maybe_unused]] station_id_t st_id) const {
     return grid_idx_2d_t{-1, -1};
 }
 

--- a/lib/testing/fakeGpu.hpp
+++ b/lib/testing/fakeGpu.hpp
@@ -115,15 +115,17 @@ public:
     uint64_t to_seq(timespec time) const override;
     uint64_t seq_length_nsec() const override;
     bool gps_time_enabled() const override;
+    ElementOrder fiducial_element_order() const override;
     station_id_t element_index_to_station_id(uint64_t el_idx, ElementOrder ord) const override;
     uint64_t station_id_to_element_index(station_id_t st_id, ElementOrder ord) const override;
-    grid_idx_2d_t station_id_to_main_array_grid_indices(station_id_t st_id) const override; 
+    grid_idx_2d_t station_id_to_main_array_grid_indices(station_id_t st_id) const override;
     vec3d_t station_id_to_feed_position_m(station_id_t st_id) const override;
     double get_feed_separation_x_m() const override;
     double get_feed_separation_y_m() const override;
     uint64_t get_grid_size_x() const override;
     uint64_t get_grid_size_y() const override;
     vec3d_t get_phase_center_in_grid_frame() const override;
+
 private:
     size_t _num_local_freq;
 };

--- a/lib/utils/CHORDTelescope.cpp
+++ b/lib/utils/CHORDTelescope.cpp
@@ -1,20 +1,21 @@
 #include "CHORDTelescope.hpp"
 
-#include <assert.h>            // for assert
-#include <algorithm>           // for max, min
-#include <stdexcept>           // for runtime_error
-#include <vector>              // for vector
-#include <cmath>               // for sin, cos, floor, ceil, M_PI, abs
-#include <chrono>              // for duration_cast, duration, nanoseconds, system_clock
-#include <limits>              // for numeric_limits
+#include "Telescope.hpp"      // for freq_id_t, Telescope, nyquist_zone_t, stream_t, REGISTER_T...
+#include "geoUtil.hpp"        // for GeoFrame
+#include "kotekanLogging.hpp" // for FATAL_ERROR_NON_OO, WARN_NON_OO, INFO_NON_OO, DEBUG, FATAL...
+#include "restClient.hpp"     // for restClient
+#include "timeUtil.hpp"       // for EOP, nanosec_i64_to_timespec
 
-#include "Telescope.hpp"       // for freq_id_t, Telescope, nyquist_zone_t, stream_t, REGISTER_T...
-#include "geoUtil.hpp"         // for GeoFrame
-#include "kotekanLogging.hpp"  // for FATAL_ERROR_NON_OO, WARN_NON_OO, INFO_NON_OO, DEBUG, FATAL...
-#include "restClient.hpp"      // for restClient
-#include "timeUtil.hpp"        // for EOP, nanosec_i64_to_timespec
-#include "fmt.hpp"             // for compile_string_to_view, format, format_string
-#include "json.hpp"            // for basic_json, operator==, json, input_adapter
+#include "fmt.hpp"  // for compile_string_to_view, format, format_string
+#include "json.hpp" // for basic_json, operator==, json, input_adapter
+
+#include <algorithm> // for max, min
+#include <assert.h>  // for assert
+#include <chrono>    // for duration_cast, duration, nanoseconds, system_clock
+#include <cmath>     // for sin, cos, floor, ceil, M_PI, abs
+#include <limits>    // for numeric_limits
+#include <stdexcept> // for runtime_error
+#include <vector>    // for vector
 
 
 REGISTER_TELESCOPE(CHORDTelescope, "CHORDTelescope");
@@ -38,13 +39,10 @@ static constexpr double deg2rad = M_PI / 180.0;
 
 // Dish parameters calculation/initialization
 
-DishParams DishParams::from_config(const kotekan::Config& config,
-                                               const std::string& path,
-                                               uint64_t num_dishes,
-                                               uint64_t dish_grid_size_x,
-                                               uint64_t dish_grid_size_y,
-                                               double dish_separation_x_m,
-                                               double dish_separation_y_m) {
+DishParams DishParams::from_config(const kotekan::Config& config, const std::string& path,
+                                   uint64_t num_dishes, uint64_t dish_grid_size_x,
+                                   uint64_t dish_grid_size_y, double dish_separation_x_m,
+                                   double dish_separation_y_m) {
     DishParams dish_params;
 
     // Dish pointing co-elevation
@@ -80,7 +78,8 @@ DishParams DishParams::from_config(const kotekan::Config& config,
 
     std::vector<bool> occupied_loc(dish_grid_size_x * dish_grid_size_y, false);
 
-    // Load the dishes from the config into the table. Make sure dish indices are consistent and, optionally, the ArrayDish grid locations are unique.
+    // Load the dishes from the config into the table. Make sure dish indices are consistent and,
+    // optionally, the ArrayDish grid locations are unique.
     for (const dishInfo& dish : cfg_tab) {
         dish_index_t idx = dish.idx;
         if (idx < 0) {
@@ -105,7 +104,9 @@ DishParams DishParams::from_config(const kotekan::Config& config,
                 int64_t occ_idx = dish.grid_x_idx + dish.grid_y_idx * dish_grid_size_x;
 
                 if (occupied_loc.at(occ_idx))
-                    FATAL_ERROR_NON_OO("Array dish {:s} has grid_idx = ({:d}, {:d}) which is already occupied.", dish.label, dish.grid_x_idx, dish.grid_y_idx);
+                    FATAL_ERROR_NON_OO(
+                        "Array dish {:s} has grid_idx = ({:d}, {:d}) which is already occupied.",
+                        dish.label, dish.grid_x_idx, dish.grid_y_idx);
 
                 occupied_loc.at(occ_idx) = true;
             }
@@ -411,7 +412,7 @@ CHORDTelescope::CHORDTelescope(const kotekan::Config& config, const std::string&
     _freq_params(FreqParams::from_config(config, path)),
     // GPS time configuration parameters
     _gps_time_params(GPSTimeParams::from_config(config, path)),
-    // Instrument geographic coordinates    
+    // Instrument geographic coordinates
     _dish_frame(dish_frame_from_config(config, path)),
     _num_polarizations(config.get<uint64_t>(path, "num_polarizations")),
     _num_dishes(config.get<uint64_t>(path, "num_dishes")),
@@ -420,7 +421,9 @@ CHORDTelescope::CHORDTelescope(const kotekan::Config& config, const std::string&
     _dish_grid_size_y(config.get<uint64_t>(path, "dish_grid_size_y")),
     _dish_separation_grid_x_m(config.get_default<double>(path, "dish_separation_x_m", 6.3)),
     _dish_separation_grid_y_m(config.get_default<double>(path, "dish_separation_y_m", 8.5)),
-    _dish_params(DishParams::from_config(config, path, _num_dishes, _dish_grid_size_x, _dish_grid_size_y, _dish_separation_grid_x_m, _dish_separation_grid_y_m)) {
+    _dish_params(DishParams::from_config(config, path, _num_dishes, _dish_grid_size_x,
+                                         _dish_grid_size_y, _dish_separation_grid_x_m,
+                                         _dish_separation_grid_y_m)) {
 
     DEBUG("Building CHORDTelescope");
 }
@@ -619,9 +622,13 @@ freq_id_t CHORDTelescope::to_freq_id(stream_t stream_id, uint32_t index) const {
 size_t CHORDTelescope::num_freq_per_stream() const {
     return 48;
 }
-    
+
+ElementOrder CHORDTelescope::fiducial_element_order() const {
+    return ElementOrder::CHORDBeamformer;
+}
+
 station_id_t CHORDTelescope::element_index_to_station_id(uint64_t el_idx, ElementOrder ord) const {
-    if (el_idx >= _num_elements) 
+    if (el_idx >= _num_elements)
         FATAL_ERROR("Element idx {:d} >= num_elements {:d}", el_idx, _num_elements);
 
     if (ord == ElementOrder::CHORDEarly) {
@@ -635,7 +642,7 @@ station_id_t CHORDTelescope::element_index_to_station_id(uint64_t el_idx, Elemen
 }
 
 uint64_t CHORDTelescope::station_id_to_element_index(station_id_t st_id, ElementOrder ord) const {
-    if (st_id >= _num_elements) 
+    if (st_id >= _num_elements)
         FATAL_ERROR("Element idx {:d} >= num_elements {:d}", st_id, _num_elements);
 
     uint64_t el_idx = std::numeric_limits<uint64_t>::max();
@@ -650,8 +657,9 @@ uint64_t CHORDTelescope::station_id_to_element_index(station_id_t st_id, Element
     }
     FATAL_ERROR("Cannot handle element order {}.", ord);
 
-    if (el_idx >= _num_elements) 
-        FATAL_ERROR("station_id {:d} order {}: Element idx {:d} >= num_elements {:d}", st_id, ord, el_idx, _num_elements);
+    if (el_idx >= _num_elements)
+        FATAL_ERROR("station_id {:d} order {}: Element idx {:d} >= num_elements {:d}", st_id, ord,
+                    el_idx, _num_elements);
 
     return el_idx;
 }
@@ -666,9 +674,9 @@ grid_idx_2d_t CHORDTelescope::station_id_to_main_array_grid_indices(station_id_t
 
     if (d.type != DishType::ArrayDish)
         return {-1, -1};
-    
+
     return {d.grid_x_idx, d.grid_y_idx};
-} 
+}
 
 vec3d_t CHORDTelescope::station_id_to_feed_position_m(station_id_t st_id) const {
     uint64_t pol;
@@ -676,11 +684,12 @@ vec3d_t CHORDTelescope::station_id_to_feed_position_m(station_id_t st_id) const 
     decode_station_id(st_id, dish, pol);
     if (dish >= _num_dishes)
         FATAL_ERROR("station_id {:d}: dish {:d} >= num_dishes {:d}", st_id, dish, _num_dishes);
-    
+
     return _dish_params.dish_positions.at(dish);
 }
 
-void CHORDTelescope::decode_station_id(station_id_t st_id, uint64_t& dish, uint64_t& polarization) const {
+void CHORDTelescope::decode_station_id(station_id_t st_id, uint64_t& dish,
+                                       uint64_t& polarization) const {
     dish = st_id % _num_dishes;
     polarization = st_id / _num_dishes;
 }
@@ -688,7 +697,7 @@ void CHORDTelescope::decode_station_id(station_id_t st_id, uint64_t& dish, uint6
 station_id_t CHORDTelescope::encode_station_id(uint64_t dish, uint64_t polarization) const {
     return dish + polarization * _num_dishes;
 }
-    
+
 double CHORDTelescope::get_feed_separation_x_m() const {
     return _dish_separation_grid_x_m;
 }
@@ -704,7 +713,7 @@ uint64_t CHORDTelescope::get_grid_size_x() const {
 uint64_t CHORDTelescope::get_grid_size_y() const {
     return _dish_grid_size_y;
 }
-    
+
 vec3d_t CHORDTelescope::get_phase_center_in_grid_frame() const {
 
     // Get the pointing vector (phase center) for the telescope in dish coordinates. This is

--- a/lib/utils/CHORDTelescope.hpp
+++ b/lib/utils/CHORDTelescope.hpp
@@ -1,20 +1,21 @@
 #ifndef CHORD_TELESCOPE_HPP
 #define CHORD_TELESCOPE_HPP
 
-#include <stdint.h>       // for uint64_t, int64_t, uint32_t, int32_t
-#include <time.h>         // for size_t, timespec
-#include <array>          // for array
-#include <complex>        // for complex
-#include <string>         // for basic_string, string, allocator, operator==
-#include <utility>        // for move, forward
-#include <vector>         // for vector
-#include <stdexcept>      // for runtime_error
+#include "Config.hpp"    // for Config
+#include "Telescope.hpp" // for freq_id_t, nyquist_zone_t, Telescope, stream_t
+#include "geoUtil.hpp"   // for GeoFrame
+#include "timeUtil.hpp"  // for EOP
 
-#include "Config.hpp"     // for Config
-#include "Telescope.hpp"  // for freq_id_t, nyquist_zone_t, Telescope, stream_t
-#include "geoUtil.hpp"    // for GeoFrame
-#include "timeUtil.hpp"   // for EOP
-#include "json.hpp"       // for json
+#include "json.hpp" // for json
+
+#include <array>     // for array
+#include <complex>   // for complex
+#include <stdexcept> // for runtime_error
+#include <stdint.h>  // for uint64_t, int64_t, uint32_t, int32_t
+#include <string>    // for basic_string, string, allocator, operator==
+#include <time.h>    // for size_t, timespec
+#include <utility>   // for move, forward
+#include <vector>    // for vector
 
 // Types for frequency and dish indexing
 // (Not necessarily logical IDs)
@@ -171,8 +172,9 @@ struct DishParams {
      * @return  The built DishParams.
      **/
     static DishParams from_config(const kotekan::Config& config, const std::string& path,
-                                        uint64_t num_dishes, uint64_t dish_grid_size_x, uint64_t dish_grid_size_y,
-                                        double dish_separation_x_m, double dish_separation_y_m);
+                                  uint64_t num_dishes, uint64_t dish_grid_size_x,
+                                  uint64_t dish_grid_size_y, double dish_separation_x_m,
+                                  double dish_separation_y_m);
 
     /**
      * @brief   Set dish information about dish inputs from the config.
@@ -181,8 +183,7 @@ struct DishParams {
      * @param   config  The config.
      * @param   path    This telescope's path in the config.
      **/
-    void set_dish_info(const kotekan::Config& config, const std::string& path,
-                       uint64_t num_dishes,
+    void set_dish_info(const kotekan::Config& config, const std::string& path, uint64_t num_dishes,
                        uint64_t dish_grid_size_x, uint64_t dish_grid_size_y,
                        double dish_separation_x_m, double dish_separation_y_m);
 };
@@ -350,7 +351,8 @@ private:
  * 2025/12/04: Factor telescope members into logical groups: frequency parameters,
  *              gps time parameters, geographic/dish parameters. JM (PR #1373)
  * 2026/01/28:  Remove EOP functionality and move to Telescope.
- * 2026/06/01:  Move much geographic, coordinates, and vector logic into Telescope and GeoFrame. Add new functions for element ordering and dish position access. Clean up.
+ * 2026/06/01:  Move much geographic, coordinates, and vector logic into Telescope and GeoFrame. Add
+ * new functions for element ordering and dish position access. Clean up.
  */
 
 class CHORDTelescope : public Telescope {
@@ -401,10 +403,11 @@ public:
      *          Uses the epoch of time0_ns.
      */
     int64_t to_time_ns(uint64_t seq) const override;
-    
+
+    ElementOrder fiducial_element_order() const override;
     station_id_t element_index_to_station_id(uint64_t el_idx, ElementOrder ord) const override;
     uint64_t station_id_to_element_index(station_id_t st_id, ElementOrder ord) const override;
-    grid_idx_2d_t station_id_to_main_array_grid_indices(station_id_t st_id) const override; 
+    grid_idx_2d_t station_id_to_main_array_grid_indices(station_id_t st_id) const override;
     vec3d_t station_id_to_feed_position_m(station_id_t st_id) const override;
     double get_feed_separation_x_m() const override;
     double get_feed_separation_y_m() const override;
@@ -413,7 +416,7 @@ public:
 
     void decode_station_id(station_id_t st_id, uint64_t& dish, uint64_t& polarization) const;
     station_id_t encode_station_id(uint64_t dish, uint64_t polarization) const;
-    
+
     vec3d_t get_phase_center_in_grid_frame() const override;
 
     /**
@@ -441,7 +444,7 @@ public:
      * @param   j   First index, int, 0 <= j < 3, col
      **/
     double get_dish_orientation_el(int i, int j) const;
-    
+
     /**
      * @brief   Return the full Topo -> Dish frame rotation matrix.
      **/

--- a/lib/utils/ICETelescope.cpp
+++ b/lib/utils/ICETelescope.cpp
@@ -1,15 +1,16 @@
 #include "ICETelescope.hpp"
 
-#include <cmath>               // for abs
-#include <stdexcept>           // for invalid_argument, runtime_error
+#include "Telescope.hpp"      // for Telescope, stream_t, freq_id_t, REGISTER_TELESCOPE, _facto...
+#include "geoUtil.hpp"        // for GeoFrame
+#include "kotekanLogging.hpp" // for WARN, INFO, FATAL_ERROR, FATAL_ERROR_NON_OO
+#include "restClient.hpp"     // for restClient
+#include "visUtil.hpp"        // for input_ctype
 
-#include "Telescope.hpp"       // for Telescope, stream_t, freq_id_t, REGISTER_TELESCOPE, _facto...
-#include "geoUtil.hpp"         // for GeoFrame
-#include "kotekanLogging.hpp"  // for WARN, INFO, FATAL_ERROR, FATAL_ERROR_NON_OO
-#include "restClient.hpp"      // for restClient
-#include "visUtil.hpp"         // for input_ctype
-#include "fmt.hpp"             // for compile_string_to_view, format, format_string
-#include "json.hpp"            // for basic_json, input_adapter, json
+#include "fmt.hpp"  // for compile_string_to_view, format, format_string
+#include "json.hpp" // for basic_json, input_adapter, json
+
+#include <cmath>     // for abs
+#include <stdexcept> // for invalid_argument, runtime_error
 
 
 REGISTER_TELESCOPE(ICETelescope, "ICETelescope");
@@ -28,7 +29,7 @@ ICETelescope::ICETelescope(const kotekan::Config& config, const std::string& pat
     _num_dishes_per_cylinder(_num_dishes / _num_cylinders),
     _feed_separation_x_m(config.get_default<double>(path, "feed_sep_EW", 0.0)),
     _feed_separation_y_m(config.get_default<double>(path, "feed_sep_NS", 0.0)) {
-    
+
     INFO("Building ICETelescope");
 
     // TODO: rename this parameter to `num_freq_per_stream` in the config
@@ -64,18 +65,19 @@ ICETelescope::ICETelescope(const kotekan::Config& config, const std::string& pat
     }
 
     if (_num_dishes % _num_cylinders != 0)
-        FATAL_ERROR("num_cylinders {:d} does not divide num_dishes {:d}", _num_cylinders, _num_dishes);
+        FATAL_ERROR("num_cylinders {:d} does not divide num_dishes {:d}", _num_cylinders,
+                    _num_dishes);
 
     const auto input_tuple = ICETelescope::parse_reorder_default(config, path, _num_elements);
     _input_reorder = std::get<0>(input_tuple);
     _input_map = std::get<1>(input_tuple);
     if (_input_reorder.size() != _num_elements) {
         FATAL_ERROR("input_reorder has size {:d}, should be num_elements = {:d}",
-                _input_reorder.size(), _num_elements);
+                    _input_reorder.size(), _num_elements);
     }
     if (_input_reorder.size() != _num_elements) {
         FATAL_ERROR("input_map (from input_reorder) has size {:d}, should be num_elements = {:d}",
-                _input_map.size(), _num_elements);
+                    _input_map.size(), _num_elements);
     }
 
     _correlator_stations = invert_reorder_table(_input_reorder);
@@ -83,7 +85,8 @@ ICETelescope::ICETelescope(const kotekan::Config& config, const std::string& pat
     _feed_positions_2d = config.get_default<std::vector<vec2d_t>>(path, "feed_positions", {});
 
     if (_feed_positions_2d.size() > 0 && _feed_positions_2d.size() != _num_dishes)
-        FATAL_ERROR("feed_positions has size {:d}, should be num_dishes {:d}", _feed_positions_2d.size(), _num_dishes);
+        FATAL_ERROR("feed_positions has size {:d}, should be num_dishes {:d}",
+                    _feed_positions_2d.size(), _num_dishes);
 }
 
 
@@ -255,8 +258,12 @@ GeoFrame ICETelescope::grid_frame_from_config(const kotekan::Config& config,
     return grid_frame;
 }
 
+ElementOrder ICETelescope::fiducial_element_order() const {
+    return ElementOrder::CHIMEBeamformer;
+}
+
 station_id_t ICETelescope::element_index_to_station_id(uint64_t el_idx, ElementOrder ord) const {
-    if (el_idx >= _num_elements) 
+    if (el_idx >= _num_elements)
         FATAL_ERROR("Element idx {:d} >= num_elements {:d}", el_idx, _num_elements);
 
     if (ord == ElementOrder::CHIMECorrelator) {
@@ -274,7 +281,7 @@ station_id_t ICETelescope::element_index_to_station_id(uint64_t el_idx, ElementO
 }
 
 uint64_t ICETelescope::station_id_to_element_index(station_id_t st_id, ElementOrder ord) const {
-    if (st_id >= _num_elements) 
+    if (st_id >= _num_elements)
         FATAL_ERROR("Station ID {:d} >= num_elements {:d}", st_id, _num_elements);
 
     if (ord == ElementOrder::CHIMECorrelator) {
@@ -291,35 +298,35 @@ uint64_t ICETelescope::station_id_to_element_index(station_id_t st_id, ElementOr
 }
 
 grid_idx_2d_t ICETelescope::station_id_to_main_array_grid_indices(station_id_t st_id) const {
-    if (st_id >= _num_elements) 
+    if (st_id >= _num_elements)
         FATAL_ERROR("Station ID {:d} >= num_elements {:d}", st_id, _num_elements);
-    
+
     uint64_t cylinder, polarization, dish_in_cyl;
     decode_station_id(st_id, cylinder, polarization, dish_in_cyl);
 
     return grid_idx_2d_t{static_cast<int32_t>(cylinder), static_cast<int32_t>(dish_in_cyl)};
-} 
+}
 
 vec3d_t ICETelescope::station_id_to_feed_position_m(station_id_t st_id) const {
-    if (st_id >= _num_elements) 
+    if (st_id >= _num_elements)
         FATAL_ERROR("Station ID {:d} >= num_elements {:d}", st_id, _num_elements);
 
     uint64_t cylinder, polarization, dish_in_cyl;
     decode_station_id(st_id, cylinder, polarization, dish_in_cyl);
 
     if (_feed_positions_2d.size() == 0) {
-        double x_idx = cylinder - 0.5*(_num_cylinders - 1);
-        double y_idx = dish_in_cyl - 0.5*(_num_dishes_per_cylinder - 1);
+        double x_idx = cylinder - 0.5 * (_num_cylinders - 1);
+        double y_idx = dish_in_cyl - 0.5 * (_num_dishes_per_cylinder - 1);
         return vec3d_t{x_idx * _feed_separation_x_m, y_idx * _feed_separation_y_m, 0.0};
     }
-    
+
     uint64_t dish = dish_in_cyl + cylinder * _num_dishes_per_cylinder;
 
     vec2d_t pos_2d = _feed_positions_2d.at(dish);
 
     return vec3d_t{pos_2d[0], pos_2d[1], 0.0};
 }
-    
+
 double ICETelescope::get_feed_separation_x_m() const {
     return _feed_separation_x_m;
 }
@@ -327,17 +334,17 @@ double ICETelescope::get_feed_separation_x_m() const {
 double ICETelescope::get_feed_separation_y_m() const {
     return _feed_separation_y_m;
 }
-    
+
 uint64_t ICETelescope::get_grid_size_x() const {
     return _num_cylinders;
 }
-    
+
 uint64_t ICETelescope::get_grid_size_y() const {
     return _num_dishes_per_cylinder;
 }
-    
+
 vec3d_t ICETelescope::get_phase_center_in_grid_frame() const {
-    //TODO: incorporate `roll` from ch_ephem?
+    // TODO: incorporate `roll` from ch_ephem?
     return {0.0, 0.0, 1.0};
 }
 
@@ -362,7 +369,8 @@ stream_t ice_encode_stream_id(const ice_stream_id_t s_stream_id) {
 
     return {(uint64_t)stream_id};
 }
-void ICETelescope::decode_station_id(station_id_t st_id, uint64_t& cylinder, uint64_t& polarization, uint64_t& dish_in_cyl) const {
+void ICETelescope::decode_station_id(station_id_t st_id, uint64_t& cylinder, uint64_t& polarization,
+                                     uint64_t& dish_in_cyl) const {
     const uint64_t num_elements_per_cylinder = _num_polarizations * _num_dishes_per_cylinder;
 
     cylinder = st_id / num_elements_per_cylinder;
@@ -370,10 +378,11 @@ void ICETelescope::decode_station_id(station_id_t st_id, uint64_t& cylinder, uin
     dish_in_cyl = (st_id % num_elements_per_cylinder) % _num_dishes_per_cylinder;
 }
 
-station_id_t ICETelescope::encode_station_id(uint64_t cylinder, uint64_t polarization, uint64_t dish_in_cyl) const {
+station_id_t ICETelescope::encode_station_id(uint64_t cylinder, uint64_t polarization,
+                                             uint64_t dish_in_cyl) const {
     const uint64_t num_elements_per_cylinder = _num_polarizations * _num_dishes_per_cylinder;
-    return cylinder * num_elements_per_cylinder
-        + polarization * _num_dishes_per_cylinder + dish_in_cyl;
+    return cylinder * num_elements_per_cylinder + polarization * _num_dishes_per_cylinder
+           + dish_in_cyl;
 }
 
 std::tuple<uint32_t, uint32_t, std::string> ICETelescope::parse_reorder_single(nlohmann::json j) {
@@ -388,7 +397,8 @@ std::tuple<uint32_t, uint32_t, std::string> ICETelescope::parse_reorder_single(n
     return std::make_tuple(adc_id, chan_id, serial);
 }
 
-std::tuple<std::vector<uint32_t>, std::vector<input_ctype>> ICETelescope::parse_reorder(nlohmann::json& j) {
+std::tuple<std::vector<uint32_t>, std::vector<input_ctype>>
+ICETelescope::parse_reorder(nlohmann::json& j) {
 
     uint32_t adc_id, chan_id;
     std::string serial;
@@ -410,7 +420,8 @@ std::tuple<std::vector<uint32_t>, std::vector<input_ctype>> ICETelescope::parse_
     return std::make_tuple(adc_ids, inputmap);
 }
 
-std::tuple<std::vector<uint32_t>, std::vector<input_ctype>> ICETelescope::default_reorder(size_t num_elements) {
+std::tuple<std::vector<uint32_t>, std::vector<input_ctype>>
+ICETelescope::default_reorder(size_t num_elements) {
 
     std::vector<uint32_t> adc_ids;
     std::vector<input_ctype> inputmap;
@@ -424,18 +435,20 @@ std::tuple<std::vector<uint32_t>, std::vector<input_ctype>> ICETelescope::defaul
 }
 
 std::tuple<std::vector<uint32_t>, std::vector<input_ctype>>
-ICETelescope::parse_reorder_default(const kotekan::Config& config, const std::string& path, uint64_t num_elements) {
+ICETelescope::parse_reorder_default(const kotekan::Config& config, const std::string& path,
+                                    uint64_t num_elements) {
 
     try {
-        nlohmann::json reorder_config = config.get<std::vector<nlohmann::json>>(path, "input_reorder");
+        nlohmann::json reorder_config =
+            config.get<std::vector<nlohmann::json>>(path, "input_reorder");
 
         return parse_reorder(reorder_config);
     } catch (const std::exception& e) {
         return default_reorder(num_elements);
     }
 }
-std::vector<station_id_t> ICETelescope::invert_reorder_table(const std::vector<uint32_t>& input_reorder) 
-{
+std::vector<station_id_t>
+ICETelescope::invert_reorder_table(const std::vector<uint32_t>& input_reorder) {
     std::vector<station_id_t> correlator_stations(input_reorder.size());
 
     for (station_id_t st_id = 0; st_id < input_reorder.size(); st_id++) {

--- a/lib/utils/ICETelescope.hpp
+++ b/lib/utils/ICETelescope.hpp
@@ -45,10 +45,11 @@ public:
     int64_t to_time_ns(uint64_t seq) const override;
     uint64_t to_seq(timespec time) const override;
     uint64_t seq_length_nsec() const override;
-    
+
+    ElementOrder fiducial_element_order() const override;
     station_id_t element_index_to_station_id(uint64_t el_idx, ElementOrder ord) const override;
     uint64_t station_id_to_element_index(station_id_t st_id, ElementOrder ord) const override;
-    grid_idx_2d_t station_id_to_main_array_grid_indices(station_id_t st_id) const override; 
+    grid_idx_2d_t station_id_to_main_array_grid_indices(station_id_t st_id) const override;
     vec3d_t station_id_to_feed_position_m(station_id_t st_id) const override;
     double get_feed_separation_x_m() const override;
     double get_feed_separation_y_m() const override;
@@ -95,7 +96,8 @@ protected:
 
     static GeoFrame grid_frame_from_config(const kotekan::Config& config, const std::string& path);
 
-    void decode_station_id(station_id_t st_id, uint64_t& cylinder, uint64_t& polarization, uint64_t& dish) const;
+    void decode_station_id(station_id_t st_id, uint64_t& cylinder, uint64_t& polarization,
+                           uint64_t& dish) const;
     station_id_t encode_station_id(uint64_t cylinder, uint64_t polarization, uint64_t dish) const;
 
     /**
@@ -106,10 +108,13 @@ protected:
      * @return          Tuple containing a vector of the input reorder map, and a
      *                  vector of the input labels for the index map.
      */
-    static std::tuple<std::vector<uint32_t>, std::vector<input_ctype>> parse_reorder_default(const kotekan::Config& config, const std::string& path, uint64_t num_elements);
+    static std::tuple<std::vector<uint32_t>, std::vector<input_ctype>>
+    parse_reorder_default(const kotekan::Config& config, const std::string& path,
+                          uint64_t num_elements);
 
-    static std::vector<station_id_t> invert_reorder_table(const std::vector<uint32_t>& input_reorder);
-    
+    static std::vector<station_id_t>
+    invert_reorder_table(const std::vector<uint32_t>& input_reorder);
+
     /// Number of elements (2048 for production CHIME)
     const uint64_t _num_polarizations;
     const uint64_t _num_dishes;
@@ -160,18 +165,19 @@ protected:
     // A forwarding constructor, such that derived classes can skip the main
     // ICETelescope constructor but still construct the Telescope class
     template<typename... Args>
-    ICETelescope(uint64_t num_polarizations, uint64_t num_dishes, uint64_t num_cylinders, double feed_sep_x, double feed_sep_y,  Args&&... args) : Telescope(std::forward<Args>(args)...),
-        _num_polarizations(num_polarizations), _num_dishes(num_dishes),
-        _num_elements(num_polarizations * num_dishes), _num_cylinders(num_cylinders),
-        _num_dishes_per_cylinder(num_dishes / num_cylinders),
-        _feed_separation_x_m(feed_sep_x),
-        _feed_separation_y_m(feed_sep_y) {};
+    ICETelescope(uint64_t num_polarizations, uint64_t num_dishes, uint64_t num_cylinders,
+                 double feed_sep_x, double feed_sep_y, Args&&... args) :
+        Telescope(std::forward<Args>(args)...), _num_polarizations(num_polarizations),
+        _num_dishes(num_dishes), _num_elements(num_polarizations * num_dishes),
+        _num_cylinders(num_cylinders), _num_dishes_per_cylinder(num_dishes / num_cylinders),
+        _feed_separation_x_m(feed_sep_x), _feed_separation_y_m(feed_sep_y){};
 
 private:
-    
     static std::tuple<uint32_t, uint32_t, std::string> parse_reorder_single(nlohmann::json j);
-    static std::tuple<std::vector<uint32_t>, std::vector<input_ctype>> parse_reorder(nlohmann::json& j);
-    static std::tuple<std::vector<uint32_t>, std::vector<input_ctype>> default_reorder(size_t num_elements);
+    static std::tuple<std::vector<uint32_t>, std::vector<input_ctype>>
+    parse_reorder(nlohmann::json& j);
+    static std::tuple<std::vector<uint32_t>, std::vector<input_ctype>>
+    default_reorder(size_t num_elements);
 };
 
 

--- a/lib/utils/Telescope.hpp
+++ b/lib/utils/Telescope.hpp
@@ -40,8 +40,8 @@ enum class ElementOrder : int32_t {
     // Order as received by the CHIME X-engine. Slightly scrambled, defined via table.
     CHIMECorrelator = 0,
     
-    // Arrays are [C][P][CF] where C counts cylinders west to east, P counts polarizations,
-    // CF counts feeds in a cylinder south to north.
+    // Arrays are [Cylinder][P][Feed] where Cylinder counts cylinders west to east, P counts polarizations,
+    // Feed counts feeds in a cylinder south to north.
     CHIMECylinder = 1,
 
     // Arrays are [P][D], P = polarizations, D = feed, ordered as in Cylinder

--- a/lib/utils/Telescope.hpp
+++ b/lib/utils/Telescope.hpp
@@ -1,22 +1,23 @@
 #ifndef TELESCOPE_HPP
 #define TELESCOPE_HPP
 
-#include <time.h>              // for timespec, size_t
-#include <json.hpp>            // for json
-#include <exception>           // for exception
-#include <memory>              // for unique_ptr
-#include <shared_mutex>        // for shared_mutex
-#include <string>              // for string, basic_string
-#include <cstdint>             // for uint64_t, int64_t, uint32_t, uint8_t, UINT32_MAX
-#include <vector>              // for vector
+#include "Config.hpp"         // for Config
+#include "factory.hpp"        // for FACTORY, CREATE_FACTORY, REGISTER_NAMED_TYPE_WITH_FACTORY
+#include "geoUtil.hpp"        // for GeoFrame
+#include "kotekanLogging.hpp" // for ERROR, kotekanLogging
+#include "restServer.hpp"     // for connectionInstance
+#include "timeUtil.hpp"       // for EOP
 
-#include "Config.hpp"          // for Config
-#include "factory.hpp"         // for FACTORY, CREATE_FACTORY, REGISTER_NAMED_TYPE_WITH_FACTORY
-#include "geoUtil.hpp"         // for GeoFrame
-#include "kotekanLogging.hpp"  // for ERROR, kotekanLogging
-#include "restServer.hpp"      // for connectionInstance
-#include "timeUtil.hpp"        // for EOP
-#include "fmt.hpp"             // for compile_string_to_view, format
+#include "fmt.hpp" // for compile_string_to_view, format
+
+#include <cstdint>      // for uint64_t, int64_t, uint32_t, uint8_t, UINT32_MAX
+#include <exception>    // for exception
+#include <json.hpp>     // for json
+#include <memory>       // for unique_ptr
+#include <shared_mutex> // for shared_mutex
+#include <string>       // for string, basic_string
+#include <time.h>       // for timespec, size_t
+#include <vector>       // for vector
 
 // Create the abstract factory for generating patterns
 class Telescope;
@@ -30,8 +31,8 @@ using nyquist_zone_t = std::uint8_t;
 using freq_id_t = std::uint32_t; // logical ID, not necessarily an index
 #define FREQ_ID_NOT_SET UINT32_MAX
 using station_id_t = std::uint32_t;
-using grid_idx_2d_t = std::array<int64_t, 2>;  // signed, use -1 as a sentinel for an unfilled
-                                               // location.
+using grid_idx_2d_t = std::array<int64_t, 2>; // signed, use -1 as a sentinel for an unfilled
+                                              // location.
 
 /**
  * @brief Enum labelling the ordering of feed elements in memory.
@@ -39,25 +40,26 @@ using grid_idx_2d_t = std::array<int64_t, 2>;  // signed, use -1 as a sentinel f
 enum class ElementOrder : int32_t {
     // Order as received by the CHIME X-engine. Slightly scrambled, defined via table.
     CHIMECorrelator = 0,
-    
-    // Arrays are [Cylinder][P][Feed] where Cylinder counts cylinders west to east, P counts polarizations,
+
+    // Arrays are [Cylinder][P][Feed] where Cylinder counts cylinders west to east, P counts
+    // polarizations,
     // Feed counts feeds in a cylinder south to north.
     CHIMECylinder = 1,
 
     // Arrays are [P][D], P = polarizations, D = feed, ordered as in Cylinder
-    CHIMEBeamformer = 2,        
+    CHIMEBeamformer = 2,
 
     // Ordering for pre-pathfinder CHORD. Arrays are [D][P], D-ordering is defined via table.
-    CHORDEarly = 3,   
-    
+    CHORDEarly = 3,
+
     // Ordering for production CHORD. Arrays are [P][D], D-ordering is defined via table
-    CHORDBeamformer = 4,  
+    CHORDBeamformer = 4,
 };
 
 
 std::string ElementOrder_to_string(const ElementOrder& o);   /// Convert an ElementOrder to a string
 ElementOrder ElementOrder_from_string(const std::string& s); /// Convert a string to an ElementOrder
-std::ostream& operator<<(std::ostream& os, const ElementOrder& o); 
+std::ostream& operator<<(std::ostream& os, const ElementOrder& o);
 std::string format_as(const ElementOrder& o);
 void to_json(nlohmann::json& j, const ElementOrder& o);
 void from_json(const nlohmann::json& j, ElementOrder& o);
@@ -83,82 +85,86 @@ struct stream_t {
  * frequency, etc), and for associating feed elements in memory with physical locations.
  * It contains the Earth Orientation Parameter (EOP) table,
  * which holds data to compute UT1 time and CIRS coordinate transformations from
- * instrument time. It facilitates transformations between feed baselines to CIRS coordinates and back.
+ * instrument time. It facilitates transformations between feed baselines to CIRS coordinates and
+ *back.
  *
  * Coordinate frames used by the Telescope
  * ---------------------------------------
  *
  * ## GRID ##
  *  The GRID frame is an orthonormal Cartesian coordinate system whose:
- *      - x-axis is parallel to fiducial East/West feed separation vector (pointing ~East).  
- *      - y-axis is parallel to fiducial North/South feed separation vector (pointing ~North).  
+ *      - x-axis is parallel to fiducial East/West feed separation vector (pointing ~East).
+ *      - y-axis is parallel to fiducial North/South feed separation vector (pointing ~North).
  *      - z-axis is normal to the fiducial feed plane (pointing ~Up).
  *
- *  The actual telescope feed grid on the ground is not perfectly square.  The GRID frame is an orthonormal
- *  frame which fits the physical feed locations as well as possible, as determined by the telescope
- *  developers.
+ *  The actual telescope feed grid on the ground is not perfectly square.  The GRID frame is an
+ *orthonormal frame which fits the physical feed locations as well as possible, as determined by the
+ *telescope developers.
  *
  *  Feed Positions are returned in the GRID frame.
  *
  *  The GRID origin is an optional `offset` from the TOPO origin
  *
  * ## TOPO ##
- *  The Topocentric (TOPO) frame is an orthonormal Cartesian coordinate system located at a position on the
- *  Earth.
+ *  The Topocentric (TOPO) frame is an orthonormal Cartesian coordinate system located at a position
+ *on the Earth.
  *      - x-axis is parallel to local geodetic East (increasing longitude)
  *      - y-axis is parallel to local geodecic North (increasing latitude)
  *      - z-axis is parallel to local geodetic Up (increasing altitude)
  *  The TOPO origin is at a given Latitude and Longitude in ITRS coordinates.
  *
  * ## ITRS ##
- *  The International Terrestrial Reference System (ITRS) is the internationally agreed upon coordinate
- *  system for the planet Earth. This is the coordinate system where geodetic latitude and longitude live.
- *  The IAU and IERS define the transformations between ITRS and astronomical coordinates.
- *  ITRS also has a Cartesian representation with:
+ *  The International Terrestrial Reference System (ITRS) is the internationally agreed upon
+ *coordinate system for the planet Earth. This is the coordinate system where geodetic latitude and
+ *longitude live. The IAU and IERS define the transformations between ITRS and astronomical
+ *coordinates. ITRS also has a Cartesian representation with:
  *      - x-axis directed through latitude = 0 (the Equator), longitude = 0
  *      - y-axis directed through latitude = 0 (the Equator), longitude = 90 degrees East
  *      - z-axis directed through latitude = 90 (the North Pole)
  *  The ITRS origin is located at Earth Barycenter.
  *
  * ## CIRS ##
- *  The Celestial Intermediate Reference System (CIRS) is a set of celestial coordinates defined by the IAU
- *  and IERS. This system is non-rotating with respect to the distant stars, and is aligned with the Earth's
- *  instantaneous axis of rotation. It is an intermediate step between ITRS (Earth-based) and ICRS (the fixed
- *  stars). In Kotekan we do not need realtime knowledge of the ICRS so we only go as far as the CIRS, which
- *  encodes the full rotational state of the Earth but not the precession/nutation of its axis.
+ *  The Celestial Intermediate Reference System (CIRS) is a set of celestial coordinates defined by
+ *the IAU and IERS. This system is non-rotating with respect to the distant stars, and is aligned
+ *with the Earth's instantaneous axis of rotation. It is an intermediate step between ITRS
+ *(Earth-based) and ICRS (the fixed stars). In Kotekan we do not need realtime knowledge of the ICRS
+ *so we only go as far as the CIRS, which encodes the full rotational state of the Earth but not the
+ *precession/nutation of its axis.
  *
  *  We track targets in the sky by following their fixed CIRS coordinates.
  *
- *  The ITRS <-> CIRS transformation is time dependent, and encoded by the time-dependent Earth Orientation
- *  Parameters (EOP). 
+ *  The ITRS <-> CIRS transformation is time dependent, and encoded by the time-dependent Earth
+ *Orientation Parameters (EOP).
  *
  * The Main Array Grid
  * -------------------
  *
- *  Kotekan Telescopes are formed of a "main array" of feeds in a rectilinear grid on the Earth. This grid
- *  must be planar (flat) to a good approximation, but otherwise may have arbitrary orientation on the ground.
+ *  Kotekan Telescopes are formed of a "main array" of feeds in a rectilinear grid on the Earth.
+ *This grid must be planar (flat) to a good approximation, but otherwise may have arbitrary
+ *orientation on the ground.
  *
- *  We assume (for now) the grid is near-perfect rectilinear, with feeds evenly spaced along orthogonal axes
- *  X and Y. X is the easterly-directed separation spacing, and Y is the northerly-directed spacing. Feeds
- *  in this grid have a 2D `grid_index`: (`grid_idx_x`, `grid_idx_y`).  These count from 0 beginning in the
- *  southwest corner of the main array, so any feed in the main array has NON-NEGATIVE grid indices.
+ *  We assume (for now) the grid is near-perfect rectilinear, with feeds evenly spaced along
+ *orthogonal axes X and Y. X is the easterly-directed separation spacing, and Y is the
+ *northerly-directed spacing. Feeds in this grid have a 2D `grid_index`: (`grid_idx_x`,
+ *`grid_idx_y`).  These count from 0 beginning in the southwest corner of the main array, so any
+ *feed in the main array has NON-NEGATIVE grid indices.
  *
- *  Some feeds may not be in the main array (RFI Antennae, external telescopes, maser feeds, etc). These feeds
- *  have `grid_index` = (-1, -1).
+ *  Some feeds may not be in the main array (RFI Antennae, external telescopes, maser feeds, etc).
+ *These feeds have `grid_index` = (-1, -1).
  *
- *  Feeds may not be exactly on station. Their 3D position returned by `get_feed_positions_m()` may include
- *  per-feed displacements from the fiducial station position.  Non-main-array feeds may also have a feed
- *  position. Feed positions are given in the GRID frame.
+ *  Feeds may not be exactly on station. Their 3D position returned by `get_feed_positions_m()` may
+ *include per-feed displacements from the fiducial station position.  Non-main-array feeds may also
+ *have a feed position. Feed positions are given in the GRID frame.
  *
  * ElementOrder
  * ------------
  *
- *  Different telescopes (and different parts of the pipeline for the same telescope) may place their feeds
- *  in memory via different arrangements. To return the feed position corresponding to a particular element
- *  in a data array, you must provide the element index AND an ElementOrder variable specifying the ordering
- *  of this array. Different orders may, for instance, transpose polarization and dish, or may simply permute
- *  ordering of dishes within the dish axis.
- *  
+ *  Different telescopes (and different parts of the pipeline for the same telescope) may place
+ *their feeds in memory via different arrangements. To return the feed position corresponding to a
+ *particular element in a data array, you must provide the element index AND an ElementOrder
+ *variable specifying the ordering of this array. Different orders may, for instance, transpose
+ *polarization and dish, or may simply permute ordering of dishes within the dish axis.
+ *
  *
  * REST Endpoints
  *
@@ -407,7 +413,15 @@ public:
     virtual uint64_t seq_length_nsec() const = 0;
 
     /**
-     * @brief Convert an element array index in a particular ordering into the corresponding station_id
+     * @brief Return the fiducial element order for this telescope
+     *
+     * @return Fiducial element order
+     **/
+    virtual ElementOrder fiducial_element_order() const = 0;
+
+    /**
+     * @brief Convert an element array index in a particular ordering into the corresponding
+     *station_id
      *
      * @param el_idx    Index into the element axis of an array
      * @param ord       The ordering of the array
@@ -427,7 +441,7 @@ public:
     virtual uint64_t station_id_to_element_index(station_id_t st_id, ElementOrder ord) const = 0;
 
     /**
-     * @brief Return the integral grid location for this station ID if it is an input in the 
+     * @brief Return the integral grid location for this station ID if it is an input in the
      * main array, otherwise return (-1, -1).
      *
      * @param st_id Station ID of an input element.
@@ -439,7 +453,7 @@ public:
 
     /**
      * @brief Return the 3D position in the GRID frame of this station ID.
-     
+
      * @param st_id Station ID of an input element.
      *
      * @return 3D coordinates in meters for this station ID in the GRID frame.
@@ -471,10 +485,9 @@ public:
     virtual uint64_t get_grid_size_y() const = 0;
 
     /**
-     * @brief   Return the outward-directed 3D pointing vector for the telescope phase center in the GRID
-     *          frame: n[3] = {nx, ny, nz},  |n| = 1.0.
-     * For CHIME this should be simply the zenith (n ~ {0, 0, 1}),
-     * for CHORD this is the boresight of the dishes, and depends on their co-elevation.
+     * @brief   Return the outward-directed 3D pointing vector for the telescope phase center in the
+     *GRID frame: n[3] = {nx, ny, nz},  |n| = 1.0. For CHIME this should be simply the zenith (n ~
+     *{0, 0, 1}), for CHORD this is the boresight of the dishes, and depends on their co-elevation.
      **/
     virtual vec3d_t get_phase_center_in_grid_frame() const = 0;
 
@@ -609,7 +622,7 @@ public:
      * @param   dec_cirs_deg    Reference to return target Declination in CIRS frame in degrees
      **/
     void vec_cirs_to_ra_dec(const vec3d_t& v_cirs, double& ra_cirs_deg, double& dec_cirs_deg) const;
-    
+
     /**
      * @brief   Transform the given vector from GRID to CIRS coords.
      *
@@ -625,7 +638,7 @@ public:
      * @param   eop     EOP for time of transformation.
      **/
     vec3d_t vec_cirs_to_grid(const vec3d_t& v_cirs, const EOP& eop) const;
-    
+
     /**
      * @brief   Return an observing vector (normalized vec3) in GRID
      *          coordinates, corresponding to the given CIRS RA and DEC.
@@ -638,7 +651,8 @@ public:
     grid_idx_2d_t element_index_to_main_array_grid_indices(uint64_t el_idx, ElementOrder ord) const;
     vec3d_t element_index_to_feed_position_m(uint64_t el_idx, ElementOrder ord) const;
 
-    std::vector<grid_idx_2d_t> get_main_array_grid_indices(uint64_t num_elements, ElementOrder ord) const;
+    std::vector<grid_idx_2d_t> get_main_array_grid_indices(uint64_t num_elements,
+                                                           ElementOrder ord) const;
     std::vector<vec3d_t> get_feed_positions_m(uint64_t num_elements, ElementOrder ord) const;
 
     /**
@@ -654,8 +668,8 @@ public:
      *                  phase for each position will be written to this vector.
      **/
     void fill_fringestop_phases_1d(double freq_MHz, const EOP& eop, const EOP& eop0,
-                                              const std::vector<vec3d_t> feed_positions_m,
-                                              std::vector<std::complex<float>>& phases) const;
+                                   const std::vector<vec3d_t> feed_positions_m,
+                                   std::vector<std::complex<float>>& phases) const;
 
 
 private:

--- a/python/kotekan/chordbuffer.py
+++ b/python/kotekan/chordbuffer.py
@@ -112,7 +112,7 @@ class ChordBuffer(object):
 
 def get_metadata(name, type_name, dim_names):
     metadata = dict(
-        chord_metadata_version=np.array([1, 0], dtype=np.int32),
+        chord_metadata_version=np.array([2, 0], dtype=np.int32),
         name=name,
         type=type_name,
         dim_names=dim_names,

--- a/tests/boost/test_Telescope.cpp
+++ b/tests/boost/test_Telescope.cpp
@@ -92,13 +92,19 @@ public:
     uint64_t seq_length_nsec() const override {
         return 0;
     }
-    station_id_t element_index_to_station_id(uint64_t el_idx, [[maybe_unused]] ElementOrder ord) const override {
+    ElementOrder fiducial_element_order() const override {
+        return ElementOrder::CHIMEBeamformer;
+    }
+    station_id_t element_index_to_station_id(uint64_t el_idx,
+                                             [[maybe_unused]] ElementOrder ord) const override {
         return el_idx;
     }
-    uint64_t station_id_to_element_index(station_id_t st_id, [[maybe_unused]] ElementOrder ord) const override {
+    uint64_t station_id_to_element_index(station_id_t st_id,
+                                         [[maybe_unused]] ElementOrder ord) const override {
         return st_id;
     }
-    grid_idx_2d_t station_id_to_main_array_grid_indices([[maybe_unused]] station_id_t st_id) const override {
+    grid_idx_2d_t
+    station_id_to_main_array_grid_indices([[maybe_unused]] station_id_t st_id) const override {
         return grid_idx_2d_t{-1, -1};
     }
     vec3d_t station_id_to_feed_position_m([[maybe_unused]] station_id_t st_id) const override {


### PR DESCRIPTION
Clean up writing telescope metadata:
- Omit superfluous `num_elements`
- Do not write `input_order`; these metadata describe the telescope, not just one dataset. (The dataset is still unambiguously described by the dataset metadata.)
- Write dish array as 2D HDF5 array, not as 1D array of 1D arrays

Read and check telescope metadata:
- When reading a file, check metadata for consistency, and abort if inconsistent (wrong number of dishes etc.)