### PR TITLE
Add the ndarray buffer type and FrameDesc Buffer API

### DIFF
--- a/docs/sphinx/dev/dev_buffers.rst
+++ b/docs/sphinx/dev/dev_buffers.rst
@@ -4,5 +4,169 @@
 Buffers
 ************
 
-More detailed info about buffers, whatever a stage writer could need to know...
+Buffers connect stages: a stage (optionally) reads from input buffers and
+(optionally) writes to output buffers, and the buffer takes care of the
+synchronization between them, so stages never signal each other directly.
 
+The core ``Buffer`` is a fixed-size, supporting multi-producer multi-consumer
+access to a pool of frames. Each frame is a contiguous block of memory, with
+``num_frames`` frames of ``frame_size`` bytes each. A producer asks for an
+*empty* frame (``wait_for_empty_frame``), fills it, and marks it *full*
+(``mark_frame_full``); a consumer waits for a *full* frame
+(``wait_for_full_frame``), reads it, and marks it *empty*
+(``mark_frame_empty``). A frame is recycled once every registered consumer
+has marked it empty. All of these calls are thread safe and, used
+correctly, deadlock free.
+
+Points a stage writer should know:
+
+- Producers and consumers each register with the buffer by name; a buffer
+  may have several of each. Consumers must never write to frames. A buffer
+  with no registered consumer drops its frames (logging an INFO).
+- Each frame can carry a metadata object drawn from the buffer's
+  ``metadata_pool``, and -- depending on the buffer type -- the buffer
+  carries a frame descriptor (see below).
+- Frame memory is not zeroed between uses: a producer must overwrite (or
+  zero) the whole frame unless zeroing is explicitly enabled.
+- Buffers are declared in the YAML config as ``kotekan_buffer:`` blocks
+  and built by the buffer factory at startup. The buffer's name is the
+  path of its config block, and stages receive their buffers through the
+  ``bufferContainer``.
+- ``RingBuffer`` is the exception to the frame model: it coordinates
+  access to a ring of elements in memory it does not itself own (e.g. a
+  ring in GPU memory), and its producers and consumers may run at
+  different cadences.
+
+Buffer types
+============
+
+``kotekan_buffer`` selects the buffer type. Every buffer block takes
+``log_level`` (usually inherited) and optionally ``metadata_pool`` and
+``numa_node``. Frame-oriented buffers (all types except ``ring``) also
+require ``num_frames``, plus the optional allocation tunables
+``use_hugepages`` (off), ``mlock_frames`` (on), ``zero_new_frames`` (on),
+``zero_value`` (0), and ``cpu_affinity`` (unset).
+
+Type-specific parameters are required unless marked *optional*:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 12 48 40
+
+   * - Type
+     - Type-specific parameters
+     - Frame descriptor
+   * - ``ndarray``
+     - *Structural (required):*
+
+       - ``value_type`` -- kotekan ``DataType`` name (``float32``,
+         ``int4x2``, ...)
+       - ``extents`` -- list of dimension sizes; entries may be arithmetic
+         expressions over other config values
+
+       *Labels (optional):*
+
+       - ``quantity_name`` -- label for the stored quantity
+       - ``dimnames`` -- list of axis labels, one per extent
+
+       Omitted labels are supplied by the producing stage (see below).
+       ``frame_size`` is derived from the descriptor.
+     - ``GenericNDArray``, built from the config block and attached at
+       startup
+   * - ``N2``
+     - - ``num_elements`` -- number of correlator inputs
+       - ``num_ev`` -- number of eigenvectors
+       - ``n2_layout`` -- product layout (``FullUpperTri``,
+         ``Autocorrelations``, ...; see ``N2Layout``)
+
+       ``frame_size`` is derived from the descriptor.
+     - ``N2FrameDesc``, built from the config block and attached at
+       startup
+   * - ``standard``
+     - - ``frame_size`` -- frame size in bytes, set explicitly
+     - none declared; stages may attach one at runtime via
+       ``ensure_frame_desc`` / ``require_frame_desc``
+   * - ``vis``
+     - - ``num_elements`` -- number of correlator inputs
+       - ``num_ev`` -- number of eigenvectors
+       - ``num_prod`` (*optional*) -- number of products; defaults to the
+         full triangle
+
+       ``frame_size`` is computed from these.
+     - none (layout is handled by ``VisFrameView``)
+   * - ``hfb``
+     - - ``num_frb_total_beams`` -- number of FRB beams
+       - ``factor_upchan`` -- upchannelization factor (sub-frequencies)
+
+       ``frame_size`` is computed from these.
+     - none (layout is handled by ``HFBFrameView``)
+   * - ``ring``
+     - - ``ring_buffer_size`` -- ring capacity in bytes (the API speaks of
+         abstract *elements*, but all current users count bytes); the
+         buffer manages access only, the memory is owned elsewhere
+     - none
+
+For new pipelines, prefer ``ndarray`` (or ``N2`` for correlation products)
+wherever a frame is a typed array: the descriptor documents the shape in
+the config and lets stages validate it at startup. ``standard`` remains
+for opaque or byte-oriented frames.
+
+Frame descriptors
+=================
+
+Buffers may carry a *frame descriptor* describing the data in each frame: a
+``GenericNDArray`` for ``ndarray`` buffers,
+or an ``N2FrameDesc`` for ``N2`` buffers. The descriptor is declared in the
+buffer's config block, built by the buffer factory at startup, and
+``frame_size`` is derived from it (see :ref:`user_config`).
+
+For an ``ndarray`` descriptor the **structural** fields (``value_type``,
+``extents``) are required -- they fix the byte layout the factory allocates --
+while the **label** fields (``quantity_name``, ``dimnames``) are typically
+optional, although may be specified or required by a stage. A config may
+therefore declare only the structure, leaving labels for the producing
+stage to supply; when both producer and consumer expect a label it must agree.
+
+The model is: **buffers carry their own description; stages validate
+against it** (and optionally complete any labels the config omitted to minimize
+repetition).
+
+Rationale
+---------
+
+- Some stages work with arbitrary frame shapes, or move bytes without
+  interpreting them, so a buffer's description cannot always come from the
+  stages that touch it.
+- Validation is the primary safety mechanism: producer, consumer, and
+  config descriptions should be cross-checked at startup, so mismatches
+  appear at launch (with both descriptions printed) rather than downstream.
+- Shapes stay visible in the config, next to the pipeline wiring, for
+  review and debugging without consulting stage source.
+- Descriptor requirements depend on stage requirements and buffer types:
+  ``standard`` buffers carry none, ``ndarray`` buffers carry
+  partial descriptors, and ``N2`` buffers carry the full descriptor.
+
+Authoring guidance
+------------------
+
+- Write ``extents`` as expressions over the genuinely tunable config scalars
+  (``samples_per_data_set``, ``num_dishes``, ...). Fixed algorithm geometry
+  (tile and block sizes, packing factors) has a single correct value:
+  prefer defining it in one place in the code rather than presenting it in
+  config as a tunable.
+- Stages with fixed shape requirements (GPU kernels and their CPU
+  counterparts) should validate exactly, via
+  ``Buffer::require_frame_desc(NDArray<T, D>::describe(...))`` -- a missing
+  or mismatched descriptor is fatal. Stages that adapt to their input should
+  check only the properties they require (value type, a particular axis,
+  divisibility) and size their work from the descriptor.
+- Stages that read data produced elsewhere (file readers, network receivers)
+  validate the shape they discover against the buffer's declared descriptor
+  with ``Buffer::require_frame_desc`` -- memory is allocated from the config
+  before any data arrives. ``Buffer::ensure_frame_desc`` is the right call for
+  shapes derived in code at runtime (e.g. GPU pipeline copy-out) where the
+  buffer may or may not be declared: it attaches the descriptor when the buffer
+  has none, otherwise reconciles -- validating the structure and completing any
+  unset labels. The two differ only in the undeclared case: ``require_frame_desc``
+  is fatal when no descriptor is present (config must declare it), whereas
+  ``ensure_frame_desc`` attaches one.

--- a/docs/sphinx/dev/dev_stage_tutorial.rst
+++ b/docs/sphinx/dev/dev_stage_tutorial.rst
@@ -91,6 +91,10 @@ Now, let us create the header file.
 
 To let the compiler know about the stage, add it to lib/stages/CMakeLists.txt.
 
+If the buffer carries a frame descriptor (an ``ndarray`` buffer), the stage
+can validate its expected shape against it in the constructor; see
+:ref:`dev_buffers`.
+
 
 Writing a Producer/Consumer Stage
 ---------------------------------

--- a/docs/sphinx/user/user_config.rst
+++ b/docs/sphinx/user/user_config.rst
@@ -36,8 +36,8 @@ omit metadata entirely.
 
 Common keys (unless noted otherwise):
 
-- ``kotekan_buffer``: buffer type; supported values are ``standard``, ``vis``, ``N2``, ``hfb``, and
-  ``ring``.
+- ``kotekan_buffer``: buffer type; supported values are ``standard``, ``ndarray``, ``vis``, ``N2``,
+  ``hfb``, and ``ring``.
 - ``num_frames``: depth of frame-based buffers (everything except ``ring``). Pick a size that covers
   the latency of downstream stages.
 - ``metadata_pool``: optional for ``standard`` buffers; name of a :ref:`metadata pool
@@ -51,6 +51,16 @@ Common keys (unless noted otherwise):
 Type-specific notes:
 
 - ``standard`` – raw byte buffers. You must set ``frame_size`` in bytes.
+- ``ndarray`` – frames holding a single typed multi-dimensional array. The **required** structural
+  fields are ``value_type`` (a kotekan ``DataType`` name such as ``float32`` or ``int4x2``) and
+  ``extents`` (a list of dimension sizes; entries may be arithmetic expressions referencing other
+  config values, e.g. ``samples_per_data_set / upchan_factor``) -- these fix the byte layout the
+  factory allocates. The semantic labels ``quantity_name`` and ``dimnames`` (a list of axis labels,
+  one per extent) are **optional**: when omitted, the producing stage supplies them; when given,
+  the stage validates against them. ``frame_size`` is derived from the descriptor, and the frame
+  descriptor is attached to the buffer at startup, so stages can validate against it (or read
+  shapes from it) from their constructors onward. Typically paired with a ``chordMetadata`` pool.
+  See :ref:`dev_buffers` for the descriptor model and authoring guidance.
 - ``vis`` – visibility frames sized automatically from ``num_elements``, ``num_ev``, and optional
   ``num_prod`` (defaults to an upper-triangular visibility matrix). Numeric types are fixed
   (complex floats for visibilities/EVs, floats for weights/flags). The attached metadata type is

--- a/lib/core/Config.hpp
+++ b/lib/core/Config.hpp
@@ -88,30 +88,13 @@ public:
                                      T>::type* = nullptr>
     T get(const std::string& base_path, const std::string& name) const {
         nlohmann::json json_value = get_value(base_path, name);
-        T value;
         try {
-            // If the expected type is a number and the value
-            // isn't already a number then try using the configEval parser
-            if (std::is_arithmetic<T>::value && !json_value.is_number()) {
-                try {
-                    Config::configEval<T> eval(*this, base_path, name);
-                    value = eval.compute_result();
-                } catch (std::exception const& ex) {
-                    throw std::runtime_error(
-                        fmt::format(fmt("Failed to evaluate: '{:s}' with message: '{:s}' for name "
-                                        "{:s} in path {:s}"),
-                                    json_value.get<std::string>(), ex.what(), name, base_path));
-                }
-            } else {
-                value = checked_conversion<T>(json_value.get<LargeType<T>>());
-            }
+            return eval<T>(base_path, json_value);
         } catch (std::exception const& ex) {
             throw std::runtime_error(fmt::format(
                 fmt("The value {:s} in path {:s} is not of type '{:s}' or doesn't exist: {:s}"),
                 name, base_path, demangle<T>(), ex.what()));
         }
-
-        return value;
     }
 
     /**
@@ -135,6 +118,36 @@ public:
         }
 
         return value;
+    }
+
+    /**
+     * @brief Evaluate a JSON value (a number, or an arithmetic expression
+     *        string) in the config scope given by @c base_path.
+     *
+     * Like @c get() for arithmetic types, but operates on a value that is
+     * not directly addressable by a config path -- e.g. the elements of an
+     * array value, inside which @c get() cannot evaluate expressions.
+     * Variables in the expression are resolved with the usual config
+     * scoping rules, relative to @c base_path.
+     *
+     * @param base_path Config scope used to resolve variables in the expression.
+     * @param value     The JSON value to evaluate (a number or an expression string).
+     * @return  The evaluated value.
+     */
+    template<class T,
+             typename std::enable_if<std::is_arithmetic<T>::value && !std::is_same<bool, T>::value,
+                                     T>::type* = nullptr>
+    T eval(const std::string& base_path, const nlohmann::json& value) const {
+        if (value.is_number())
+            return checked_conversion<T>(value.get<LargeType<T>>());
+        try {
+            Config::configEval<T> evaluator(*this, base_path, value);
+            return evaluator.compute_result();
+        } catch (std::exception const& ex) {
+            throw std::runtime_error(
+                fmt::format(fmt("Failed to evaluate: '{:s}' with message: '{:s}' in path {:s}"),
+                            value.dump(), ex.what(), base_path));
+        }
     }
 
     /**
@@ -292,7 +305,8 @@ private:
     class configEval {
 
     public:
-        configEval(const Config& _config, const std::string& base_path, const std::string& name);
+        configEval(const Config& _config, const std::string& base_path,
+                   const nlohmann::json& value);
 
         ~configEval();
 
@@ -342,17 +356,15 @@ T Config::get_default(const std::string& base_path, const std::string& name,
 
 template<class Type>
 Config::configEval<Type>::configEval(const Config& _config, const std::string& base_path,
-                                     const std::string& name) :
+                                     const nlohmann::json& value) :
     config(_config), unique_name(base_path) {
 
-    nlohmann::json value = config.get_value(base_path, name);
-
-    if (!(value.is_string() || value.is_number())) {
-        throw std::runtime_error(fmt::format(
-            fmt("The value {:s} in path {:s} isn't a number or string to eval or does not exist."),
-            name, base_path));
+    if (!value.is_string()) {
+        throw std::runtime_error(
+            fmt::format(fmt("The value '{:s}' in path {:s} isn't a string to evaluate."),
+                        value.dump(), base_path));
     }
-    const std::string& expression = value.get<std::string>();
+    const std::string expression = value.get<std::string>();
 
     static const std::regex re(
         R"((-?(?:0|[1-9][0-9]*)(?:\.[0-9]*)?(?:[eE][+\-]?[0-9]+)?|\+|\*|\-|\/|\)|\(|[a-zA-Z][a-zA-Z0-9_]*))",

--- a/lib/core/buffer.cpp
+++ b/lib/core/buffer.cpp
@@ -767,7 +767,8 @@ void Buffer::private_copy_frame(int dest_frame_id, Buffer* src, int src_frame_id
 bool is_frame_buffer(GenericBuffer* buf) {
     // See also bufferFactory::new_buffer()
     return (buf->buffer_type == "standard") || (buf->buffer_type == "vis")
-           || (buf->buffer_type == "hfb") || (buf->buffer_type == "N2");
+           || (buf->buffer_type == "hfb") || (buf->buffer_type == "N2")
+           || (buf->buffer_type == "ndarray");
 }
 
 uint8_t* buffer_malloc(size_t len, int numa_node, bool use_hugepages, bool mlock_frames,

--- a/lib/core/buffer.hpp
+++ b/lib/core/buffer.hpp
@@ -531,139 +531,149 @@ public:
     void safe_swap_frame(int src_frame_id, Buffer* dest_buf, int dest_frame_id);
 
     /**
-     * @brief Allocates a new frame description object holding a D dimensional
-     *        array of type T, or checks the given values are consistent with
-     *        the existing frame descriptor, if it exists.
-     * @param[in] extents Array extentds in the D dimensions
-     * @param[in] dimnames Array axis labels in the D dimensions
+     * @brief Requires that a frame descriptor is attached to this buffer
+     *        (fatal if not), then ensures it conforms to @p desc.
+     *
+     * Stages should use this method to rigidly enforce that a frame descriptor
+     * is attached to the buffer and conforms to their requirements. This fatals
+     * if no descriptor has been attached -- i.e. the buffer was not declared with
+     * a described type.
+     *
+     * See also @c ensure_frame_desc(). The difference is that `require` fatals on a
+     * missing or incompatible descriptor, whereas `ensure` attaches @p desc when
+     * none is present. Use `require` when a missing config declaration is an error;
+     * use `ensure` when the stage may legitimately originate the descriptor (e.g. a
+     * runtime-discovered GPU copy-out writing an undeclared buffer).
+     *
+     * Thread-safe.
      */
+    void require_frame_desc(std::shared_ptr<const kotekan::FrameDesc> desc = nullptr) {
+        buffer_lock lock(mutex);
+        if (!frames_desc)
+            FATAL_ERROR(
+                "Buffer {:s} has no frame descriptor to validate against; declare the buffer "
+                "with a described buffer type (e.g. `kotekan_buffer: ndarray`) in the config",
+                buffer_name);
+        if (desc)
+            _ensure_frame_desc_locked(std::move(desc));
+    }
+
+    /**
+     * @brief Ensures the buffer's frame descriptor conforms to @p new_desc:
+     *        attaches it if none is present, otherwise reconciles the two.
+     *
+     * If no descriptor is attached yet, @p new_desc is recorded. Otherwise the
+     * existing and given descriptors are reconciled: their structural fields
+     * (value_type, extents, and hence byte size) must match, any unset (empty)
+     * labels (quantity_name, dimnames) are filled in from the other side, and
+     * labels set on both sides must agree -- any conflict is fatal. For
+     * non-NDArray descriptors reconciliation is a strict equality check. The
+     * reconciled descriptor replaces the stored one.
+     *
+     * See also @c require_frame_desc(). The difference is that `require` fatals on a
+     * missing or incompatible descriptor, whereas `ensure` attaches @p desc when
+     * none is present. Use `require` when a missing config declaration is an error;
+     * use `ensure` when the stage may legitimately originate the descriptor (e.g. a
+     * runtime-discovered GPU copy-out writing an undeclared buffer).
+     *
+     * Thread-safe.
+     */
+    void ensure_frame_desc(std::shared_ptr<const kotekan::FrameDesc> new_desc) {
+        buffer_lock lock(mutex);
+        _ensure_frame_desc_locked(std::move(new_desc));
+    }
+
+    /**
+     * @brief Internal: attach @p new_desc, or reconcile it with the existing
+     *        descriptor, assuming the buffer @c mutex is already held.
+     *
+     * Shared, lock-free implementation of @c ensure_frame_desc() and
+     * @c require_frame_desc(). If no descriptor is attached, @p new_desc is
+     * recorded. Otherwise the two are reconciled: for NDArray descriptors the
+     * structural fields must match, unset labels are filled in and set labels
+     * validated (see @c kotekan::GenericNDArray::reconcile()), and the stored
+     * descriptor is replaced only when labels are completed; any other descriptor
+     * is compared for strict equality. A label/structural conflict, or a byte size
+     * that disagrees with @c frame_size, is fatal.
+     *
+     * The leading underscore marks this as an internal helper: it does not take
+     * the lock and is not part of the public API. Do not call it directly -- use
+     * @c ensure_frame_desc() or @c require_frame_desc().
+     *
+     * @param[in] new_desc The descriptor to attach or reconcile against.
+     */
+    void _ensure_frame_desc_locked(std::shared_ptr<const kotekan::FrameDesc> new_desc) {
+        if (new_desc->get_byte_size() != frame_size) {
+            FATAL_ERROR(
+                "Buffer {:s} frame description size ({:d}) does not match frame_size ({:d})",
+                buffer_name, new_desc->get_byte_size(), frame_size);
+        }
+        if (!frames_desc) {
+            frames_desc = std::move(new_desc);
+            return;
+        }
+        auto cur = std::dynamic_pointer_cast<const kotekan::GenericNDArray>(frames_desc);
+        auto inc = std::dynamic_pointer_cast<const kotekan::GenericNDArray>(new_desc);
+        if (cur && inc) {
+            try {
+                // reconcile() returns a completed descriptor when @p new_desc
+                // fills in labels, or nullptr when nothing changes (keep ours).
+                if (auto merged = kotekan::GenericNDArray::reconcile(*cur, *inc))
+                    frames_desc = std::move(merged);
+            } catch (const std::exception& e) {
+                FATAL_ERROR("Buffer {:s} frame description mismatch (existing vs new): {:s}",
+                            buffer_name, e.what());
+            }
+            return;
+        }
+        if (*frames_desc != *new_desc) {
+            FATAL_ERROR("Buffer {:s} frame description mismatch (existing vs new): {:s}",
+                        buffer_name, frames_desc->describe_mismatch(*new_desc));
+        }
+    }
+
+    /**
+     * @brief Legacy frame descriptor API (deprecated).
+     *
+     * These forward to @c ensure_frame_desc()/@c get_frame_desc<T>() and exist
+     * only so not-yet-migrated stages keep compiling while the codebase moves to
+     * the FrameDesc API. They are removed once every caller is migrated.
+     */
+    void set_frame_desc(std::shared_ptr<const kotekan::FrameDesc> new_desc) {
+        ensure_frame_desc(std::move(new_desc));
+    }
+
     template<typename T, std::size_t D>
     void allocate_ndarray_frame_desc(kotekan::Symbol quantity_name,
                                      const std::array<std::ptrdiff_t, D>& extents,
                                      const std::array<kotekan::Symbol, D>& dimnames) {
-        buffer_lock lock(mutex);
-        if (!frames_desc)
-            frames_desc =
-                std::make_shared<kotekan::NDArray<T, D>>(quantity_name, extents, dimnames, nullptr);
-        else {
-            auto nd_desc = std::dynamic_pointer_cast<const kotekan::GenericNDArray>(frames_desc);
-            if (!nd_desc) {
-                FATAL_ERROR("Frame desc mismatch: existing desc is not an NDArray");
-            }
-            if (D != nd_desc->get_rank())
-                FATAL_ERROR("Rank mismatch: {:d} != {:d}", D, nd_desc->get_rank());
-            if (kotekan::GetDataType_v<T> != nd_desc->get_value_datatype())
-                FATAL_ERROR("Type mismatch: {:s} != {:s}",
-                            kotekan::type_to_string(kotekan::GetDataType_v<T>),
-                            kotekan::type_to_string(nd_desc->get_value_datatype()));
-            if (quantity_name != nd_desc->get_quantity_name())
-                FATAL_ERROR("Quantity name mismatch: {:s} != {:s}", quantity_name,
-                            nd_desc->get_quantity_name());
-            if (!std::equal(extents.begin(), extents.end(), nd_desc->get_extents().begin())) {
-                // Building individual strings with move() avoids nasty constexpr/fmt::join
-                // compilation error.
-                auto ex1_j = fmt::join(extents, ", ");
-                auto ex2_j = fmt::join(nd_desc->get_extents(), ", ");
-                std::string ex1_str = fmt::format("{}", std::move(ex1_j));
-                std::string ex2_str = fmt::format("{}", std::move(ex2_j));
-                FATAL_ERROR("Extents do not match: [{:s}] != [{:s}]", ex1_str, ex2_str);
-            }
-            if (!std::equal(dimnames.begin(), dimnames.end(), nd_desc->get_dimnames().begin()))
-                FATAL_ERROR("Dimnames do not match: [{:s}] != [{:s}]", fmt::join(dimnames, ", "),
-                            fmt::join(nd_desc->get_dimnames(), ", "));
-        }
-
-        if (frames_desc->get_byte_size() != frame_size) {
-            FATAL_ERROR("Buffer {:s} ndarray_frame_desc has size {:d}, does not match buffer "
-                        "frame_size {:d}",
-                        buffer_name, frames_desc->get_byte_size(), frame_size);
-        }
+        ensure_frame_desc(kotekan::NDArray<T, D>::describe(quantity_name, extents, dimnames));
     }
 
-    /**
-     * @brief Allocates a new frame description object holding a D dimensional
-     *        array of type T, or checks the given values are consistent with
-     *        the existing frame descriptor, if it exists.
-     * @param[in] value_type the kotekan type enumerator of the values stored
-     * @param[in] rank dimensionality of the data array
-     * @param[in] extents Array extentds in the D dimensions
-     * @param[in] dimnames Array axis labels in the D dimensions
-     */
     void allocate_ndarray_frame_desc(kotekan::DataType value_type, kotekan::Symbol quantity_name,
                                      const std::vector<std::ptrdiff_t>& extents,
                                      const std::vector<kotekan::Symbol>& dimnames) {
-        buffer_lock lock(mutex);
-        if (!frames_desc) {
-            frames_desc = kotekan::GenericNDArray::create(value_type, quantity_name, extents,
-                                                          dimnames, nullptr);
-        } else {
-            auto nd_desc = std::dynamic_pointer_cast<const kotekan::GenericNDArray>(frames_desc);
-            if (!nd_desc) {
-                FATAL_ERROR("Frame desc mismatch: existing desc is not an NDArray");
-                return;
-            }
-            if (extents.size() != nd_desc->get_rank())
-                FATAL_ERROR("Rank mismatch: {:d} != {:d}", extents.size(), nd_desc->get_rank());
-            if (value_type != nd_desc->get_value_datatype())
-                FATAL_ERROR("Type mismatch: {:s} != {:s}", kotekan::type_to_string(value_type),
-                            kotekan::type_to_string(nd_desc->get_value_datatype()));
-            if (quantity_name != nd_desc->get_quantity_name())
-                FATAL_ERROR("Quantity name mismatch: {:s} != {:s}", quantity_name,
-                            nd_desc->get_quantity_name());
-            if (extents != nd_desc->get_extents())
-                FATAL_ERROR("Extents do not match: [{:s}] != [{:s}]",
-                            fmt::format("{:s}", fmt::join(extents, ", ")),
-                            fmt::format("{:s}", fmt::join(nd_desc->get_extents(), ", ")));
-            if (dimnames != nd_desc->get_dimnames())
-                FATAL_ERROR("Dimnames do not match: [{:s}] != [{:s}]",
-                            fmt::format("{:s}", fmt::join(dimnames, ", ")),
-                            fmt::format("{:s}", fmt::join(nd_desc->get_dimnames(), ", ")));
-        }
-
-        if (frames_desc->get_byte_size() != frame_size) {
-            FATAL_ERROR("Buffer {:s} ndarray_frame_desc has size {:d}, does not match buffer "
-                        "frame_size {:d}",
-                        buffer_name, frames_desc->get_byte_size(), frame_size);
-        }
+        ensure_frame_desc(
+            kotekan::GenericNDArray::describe(value_type, quantity_name, extents, dimnames));
     }
 
-    /**
-     * @brief provides read access to the array description
-     * @return The NDArray data structure describing the array. If type of frames_desc is
-     * not GenericNDArray, this will return nullptr.
-     */
     std::shared_ptr<const kotekan::GenericNDArray> get_ndarray_frame_desc() {
-        buffer_lock lock(mutex);
-        return std::dynamic_pointer_cast<const kotekan::GenericNDArray>(frames_desc);
+        return get_frame_desc<kotekan::GenericNDArray>();
+    }
+
+    std::shared_ptr<const kotekan::FrameDesc> get_frame_description() {
+        return get_frame_desc<kotekan::FrameDesc>();
     }
 
     /**
      * @brief provides read access to the frame description
-     * @return The data structure describing the frame
+     * @return The data structure describing the frame, cast to T. Returns
+     *         nullptr if no descriptor is attached or it is not a T.
      */
-    std::shared_ptr<const kotekan::FrameDesc> get_frame_description() {
+    template<typename T = kotekan::FrameDesc>
+    std::shared_ptr<const T> get_frame_desc() {
         buffer_lock lock(mutex);
-        return frames_desc;
-    }
-
-    /**
-     * @brief Sets the frame description
-     */
-    void set_frame_desc(std::shared_ptr<const kotekan::FrameDesc> new_desc) {
-        buffer_lock lock(mutex);
-
-        if (new_desc->get_byte_size() != frame_size) {
-            FATAL_ERROR("Frame description size ({:d}) is unexpected, buffer provides ({:d})",
-                        new_desc->get_byte_size(), frame_size);
-        }
-
-        if (!frames_desc) {
-            frames_desc = new_desc;
-        } else {
-            if (*frames_desc != *new_desc) {
-                ERROR("Frame description mismatch!");
-            }
-        }
+        return std::dynamic_pointer_cast<const T>(frames_desc);
     }
 
     /**

--- a/lib/core/bufferFactory.cpp
+++ b/lib/core/bufferFactory.cpp
@@ -10,12 +10,13 @@
 #include "FrameDesc.hpp"       // for FrameDesc
 #include "HFBFrameView.hpp"    // for HFBFrameView
 #include "N2FrameDesc.hpp"     // for N2FrameDesc
+#include "NDArray.hpp"         // for GenericNDArray
 #include "buffer.hpp"          // for GenericBuffer, Buffer
+#include "fmt.hpp"             // for compile_string_to_view, format, fmt
 #include "kotekanLogging.hpp"  // for INFO_NON_OO
 #include "metadata.hpp"        // for metadataPool
 #include "ringbuffer.hpp"      // for RingBuffer
 #include "visBuffer.hpp"       // for VisFrameView
-#include "fmt.hpp"             // for compile_string_to_view, format, fmt
 
 using json = nlohmann::json;
 using std::map;
@@ -81,8 +82,8 @@ GenericBuffer* bufferFactory::new_buffer(const string& type_name, const string& 
         pool = metadataPools[metadataPool_name];
     }
 
-    // See also buffer::is_frame_buffer(), which looks for these three strings ("standard", "vis",
-    // "hfb")
+    // See also buffer::is_frame_buffer(), which looks for these frame-buffer type strings
+    // ("standard", "vis", "hfb", "N2", "ndarray")
     size_t frame_size = 0;
     std::shared_ptr<kotekan::FrameDesc> frame_desc = nullptr;
     if (type_name == "standard") {
@@ -91,6 +92,9 @@ GenericBuffer* bufferFactory::new_buffer(const string& type_name, const string& 
         frame_size = VisFrameView::calculate_frame_size(config, location);
     } else if (type_name == "N2") {
         frame_desc = std::make_shared<N2FrameDesc>(config, location);
+        frame_size = frame_desc->get_byte_size();
+    } else if (type_name == "ndarray") {
+        frame_desc = GenericNDArray::from_config(config, location);
         frame_size = frame_desc->get_byte_size();
     } else if (type_name == "hfb") {
         frame_size = HFBFrameView::calculate_frame_size(config, location);
@@ -113,7 +117,7 @@ GenericBuffer* bufferFactory::new_buffer(const string& type_name, const string& 
 
         // Set frame descriptor if one was created
         if (frame_desc) {
-            static_cast<Buffer*>(buf)->set_frame_desc(frame_desc);
+            static_cast<Buffer*>(buf)->ensure_frame_desc(frame_desc);
         }
 
     } else if (type_name == "ring") {

--- a/lib/metadata/DataType.hpp
+++ b/lib/metadata/DataType.hpp
@@ -230,7 +230,7 @@ inline std::ostream& operator<<(std::ostream& os, const float16_t x) {
 
 // This enum lets us talk about the various datatypes we're using.
 enum DataType {
-    unknown_type, // keep this as first entry for GenericNDArray::create
+    unknown_type, // keep this as first entry for GenericNDArray::describe
     uint1x8,      // 8 bools (packed into a type)
     uint4x2,      // 2 unsigned 4-bit integers (packed into a byte)
     uint8,
@@ -257,7 +257,7 @@ enum DataType {
     cfloat16,
     cfloat32,
     cfloat64,
-    end_type, // keep the as the last entry for GenericNDArray::create
+    end_type, // keep the as the last entry for GenericNDArray::describe
 };
 
 // Number of bits (not bytes!) in a type. For packed types, say how

--- a/lib/metadata/FrameDesc.hpp
+++ b/lib/metadata/FrameDesc.hpp
@@ -4,6 +4,8 @@
 #include "Symbol.hpp"
 
 #include <iostream>
+#include <sstream>
+#include <string>
 
 namespace kotekan {
 
@@ -11,23 +13,33 @@ class FrameDesc {
 public:
     virtual ~FrameDesc() = default;
 
-    // A stored name for the quantity represented by this frame description
+    /// A stored name for the quantity represented by this frame description
     virtual Symbol get_quantity_name() const = 0;
 
-    // Output the frame description, useful for logging or debugging
+    /// Output the frame description, useful for logging or debugging
     virtual void output_framedesc(std::ostream& os) const = 0;
 
-    // Verify compatibility between descriptors
+    /// Describe how this descriptor differs from `other`, for error messages.
+    /// The default prints both descriptions; subclasses may return a more
+    /// targeted description.
+    virtual std::string describe_mismatch(const FrameDesc& other) const {
+        std::ostringstream this_os, other_os;
+        output_framedesc(this_os);
+        other.output_framedesc(other_os);
+        return "existing:\n" + this_os.str() + "new:\n" + other_os.str();
+    }
+
+    /// Verify compatibility between descriptors
     virtual bool operator==(const FrameDesc& other) const = 0;
 
     virtual bool operator!=(const FrameDesc& other) const {
         return !(*this == other);
     }
 
-    // Get the size of the frame in bytes
+    /// Get the size of the frame in bytes
     virtual size_t get_byte_size() const = 0;
 
-    // Strict type checking helper
+    /// Strict type checking helper
     template<typename T>
     const T* as() const {
         return dynamic_cast<const T*>(this);

--- a/lib/metadata/NDArray.cpp
+++ b/lib/metadata/NDArray.cpp
@@ -1,3 +1,7 @@
+#include "Config.hpp"   // for Config
+#include "DataType.hpp" // for operator<<
+#include "Symbol.hpp"   // for operator<<, Symbol
+
 #include <NDArray.hpp>
 #include <sys/types.h>    // for ssize_t
 #include <cassert>        // for assert
@@ -50,8 +54,7 @@ void GenericNDArray::output_framedesc(std::ostream& os) const {
 template<DataType my_datatype, size_t my_rank>
 static inline std::shared_ptr<GenericNDArray>
 make_NDArray(const DataType datatype, const Symbol quantity_name,
-             const std::vector<std::ptrdiff_t>& extents, const std::vector<Symbol>& dimnames,
-             void* data) {
+             const std::vector<std::ptrdiff_t>& extents, const std::vector<Symbol>& dimnames) {
     // recurse until datatype matches
     if constexpr (my_datatype == unknown_type) {
         assert(my_datatype != unknown_type);
@@ -64,25 +67,151 @@ make_NDArray(const DataType datatype, const Symbol quantity_name,
         } else if (int(extents.size()) == my_rank) {
             // both match
             return std::shared_ptr<GenericNDArray>(new NDArray<GetType_t<my_datatype>, my_rank>(
-                quantity_name, extents, dimnames, static_cast<GetType_t<my_datatype>*>(data)));
+                quantity_name, extents, dimnames, static_cast<GetType_t<my_datatype>*>(nullptr)));
         } else {
             return make_NDArray<my_datatype, my_rank - 1>(datatype, quantity_name, extents,
-                                                          dimnames, data);
+                                                          dimnames);
         }
     } else {
         return make_NDArray<DataType(my_datatype - 1), my_rank>(datatype, quantity_name, extents,
-                                                                dimnames, data);
+                                                                dimnames);
     }
 }
 
-std::shared_ptr<GenericNDArray> GenericNDArray::create(const DataType value_datatype,
-                                                       const Symbol quantity_name,
-                                                       const std::vector<std::ptrdiff_t>& extents,
-                                                       const std::vector<Symbol>& dimnames,
-                                                       void* data) {
+std::shared_ptr<GenericNDArray> GenericNDArray::describe(const DataType value_datatype,
+                                                         const Symbol quantity_name,
+                                                         const std::vector<std::ptrdiff_t>& extents,
+                                                         const std::vector<Symbol>& dimnames) {
     assert(extents.size() == dimnames.size() && "Sizes of extents and dimnames must aggree");
     return make_NDArray<DataType(end_type - 1), max_rank>(value_datatype, quantity_name, extents,
-                                                          dimnames, data);
+                                                          dimnames);
+}
+
+std::shared_ptr<GenericNDArray> GenericNDArray::from_config(const Config& config,
+                                                            const std::string& location) {
+    const std::string type_name = config.get<std::string>(location, "value_type");
+    const DataType value_datatype = string_to_type(type_name);
+    if (value_datatype == unknown_type)
+        throw std::runtime_error(fmt::format(
+            fmt("GenericNDArray: unknown value_type '{:s}' in path {:s}"), type_name, location));
+
+    // `quantity_name` and `dimnames` are semantic labels: they are OPTIONAL in
+    // config. When omitted, the descriptor is left with unset (empty) labels and
+    // the producing stage fills them in via Buffer::ensure_frame_desc(); when
+    // given, the stage validates against them. `value_type` and `extents` are
+    // structural (they fix the byte layout the bufferFactory allocates) and are
+    // required.
+    const Symbol quantity_name(config.get_default<std::string>(location, "quantity_name", ""));
+
+    // Extent entries may be arithmetic expressions referencing other
+    // (scoped) config values, so evaluate them individually.
+    const auto extents_json = config.get<std::vector<nlohmann::json>>(location, "extents");
+    std::vector<std::ptrdiff_t> extents;
+    extents.reserve(extents_json.size());
+    for (const auto& extent : extents_json)
+        extents.push_back(config.eval<std::ptrdiff_t>(location, extent));
+
+    if (extents.empty() || extents.size() > max_rank)
+        throw std::runtime_error(
+            fmt::format(fmt("GenericNDArray: rank {:d} is outside [1, {:d}] in path {:s}"),
+                        extents.size(), max_rank, location));
+    for (std::size_t d = 0; d < extents.size(); ++d)
+        if (extents[d] <= 0)
+            throw std::runtime_error(fmt::format(
+                fmt("GenericNDArray: extent {:d} of dimension {:d} is not positive in path {:s}"),
+                extents[d], d, location));
+
+    const auto dimname_strings =
+        config.get_default<std::vector<std::string>>(location, "dimnames", {});
+    std::vector<Symbol> dimnames;
+    if (dimname_strings.empty()) {
+        // Labels omitted: leave one unset (empty) label per axis for a stage to fill.
+        dimnames.assign(extents.size(), Symbol(""));
+    } else {
+        if (dimname_strings.size() != extents.size())
+            throw std::runtime_error(fmt::format(
+                fmt("GenericNDArray: extents size ({:d}) does not match dimnames size ({:d}) in "
+                    "path {:s}"),
+                extents.size(), dimname_strings.size(), location));
+        dimnames.reserve(dimname_strings.size());
+        for (const auto& dimname : dimname_strings)
+            dimnames.emplace_back(dimname);
+        for (std::size_t d = 0; d < dimnames.size(); ++d)
+            for (std::size_t d1 = 0; d1 < d; ++d1)
+                if (dimnames[d] == dimnames[d1])
+                    throw std::runtime_error(fmt::format(
+                        fmt("GenericNDArray: duplicate dimname '{:s}' in path {:s}"),
+                        std::string(dimnames[d]), location));
+    }
+
+    return describe(value_datatype, quantity_name, extents, dimnames);
+}
+
+std::shared_ptr<GenericNDArray> GenericNDArray::reconcile(const GenericNDArray& a,
+                                                          const GenericNDArray& b) {
+    // Structural fields must match exactly.
+    if (a.get_value_datatype() != b.get_value_datatype())
+        throw std::runtime_error(fmt::format(fmt("value type mismatch: {:s} != {:s}"),
+                                             type_to_string(a.get_value_datatype()),
+                                             type_to_string(b.get_value_datatype())));
+    if (a.get_extents() != b.get_extents())
+        throw std::runtime_error(fmt::format(fmt("extents do not match: {:s} != {:s}"),
+                                             format_vector(a.get_extents()),
+                                             format_vector(b.get_extents())));
+
+    // Labels: an unset (empty) label is filled from the other side; labels set
+    // on both sides must agree.
+    const Symbol unset("");
+    auto merge_label = [&unset](const Symbol& x, const Symbol& y, const char* what) -> Symbol {
+        if (x == unset)
+            return y;
+        if (y == unset)
+            return x;
+        if (x == y)
+            return x;
+        throw std::runtime_error(fmt::format(fmt("{:s} mismatch: {:s} != {:s}"), what,
+                                             std::string(x), std::string(y)));
+    };
+
+    const Symbol quantity_name =
+        merge_label(a.get_quantity_name(), b.get_quantity_name(), "quantity name");
+    const std::vector<Symbol> da = a.get_dimnames();
+    const std::vector<Symbol> db = b.get_dimnames();
+    std::vector<Symbol> dimnames(da.size());
+    for (std::size_t d = 0; d < da.size(); ++d)
+        dimnames[d] = merge_label(da[d], db[d], "dimname");
+
+    // `b` contributed no labels that `a` lacked: nothing to complete, so signal
+    // "no change" (the caller keeps the existing descriptor).
+    if (quantity_name == a.get_quantity_name() && dimnames == da)
+        return nullptr;
+    return describe(a.get_value_datatype(), quantity_name, a.get_extents(), dimnames);
+}
+
+std::string GenericNDArray::structure_mismatch(const GenericNDArray& other) const {
+    if (get_value_datatype() != other.get_value_datatype())
+        return fmt::format(fmt("value type mismatch: {:s} != {:s}"),
+                           type_to_string(get_value_datatype()),
+                           type_to_string(other.get_value_datatype()));
+    if (get_quantity_name() != other.get_quantity_name())
+        return fmt::format(fmt("quantity name mismatch: {:s} != {:s}"), get_quantity_name(),
+                           other.get_quantity_name());
+    if (get_rank() != other.get_rank())
+        return fmt::format(fmt("rank mismatch: {:d} != {:d}"), get_rank(), other.get_rank());
+    if (get_extents() != other.get_extents())
+        return fmt::format(fmt("extents do not match: {:s} != {:s}"), format_vector(get_extents()),
+                           format_vector(other.get_extents()));
+    if (get_dimnames() != other.get_dimnames())
+        return fmt::format(fmt("dimnames do not match: {:s} != {:s}"),
+                           format_vector(get_dimnames()), format_vector(other.get_dimnames()));
+    return std::string();
+}
+
+std::string GenericNDArray::describe_mismatch(const FrameDesc& other) const {
+    const GenericNDArray* nd = dynamic_cast<const GenericNDArray*>(&other);
+    if (!nd)
+        return FrameDesc::describe_mismatch(other);
+    return structure_mismatch(*nd);
 }
 
 bool GenericNDArray::operator==(const FrameDesc& other_desc) const {
@@ -91,15 +220,7 @@ bool GenericNDArray::operator==(const FrameDesc& other_desc) const {
         return false;
     const GenericNDArray& other = *other_ptr;
 
-    if (this->get_value_datatype() != other.get_value_datatype())
-        return false;
-    if (this->get_quantity_name() != other.get_quantity_name())
-        return false;
-    if (this->get_rank() != other.get_rank())
-        return false;
-    if (this->get_extents() != other.get_extents())
-        return false;
-    if (this->get_dimnames() != other.get_dimnames())
+    if (!structure_mismatch(other).empty())
         return false;
     if (this->get_strides() != other.get_strides())
         return false;

--- a/lib/metadata/NDArray.hpp
+++ b/lib/metadata/NDArray.hpp
@@ -77,67 +77,115 @@ make_arrays_from_pairs(std::initializer_list<std::pair<T, U>> values) {
 // - new type `NDBuffer`?
 // - add functions to allocate/deallocate buffer?
 
-// A `GenericNDArray` is similar to a numpy array. Neither the type
-// nor the rank are known at compile time. This is convenient e.g.
-// when reading data from a file, but it prevents efficient operations
-// on array elements.
+class Config;
+
+/// A `GenericNDArray` is similar to a numpy array. Neither the type
+/// nor the rank are known at compile time. This is convenient e.g.
+/// when reading data from a file, but it prevents efficient operations
+/// on array elements.
 class GenericNDArray : public FrameDesc {
 public:
-    // create an NDArray based on run-time type information
+    /// create a descriptor (an NDArray without data) based on run-time type
+    /// information, e.g. for Buffer::ensure_frame_desc / require_frame_desc. An
+    /// empty `quantity_name`, or empty `dimnames` entries, are treated as unset
+    /// labels (see reconcile()).
+    static std::shared_ptr<GenericNDArray> describe(const DataType value_datatype,
+                                                    const Symbol quantity_name,
+                                                    const std::vector<std::ptrdiff_t>& extents,
+                                                    const std::vector<Symbol>& dimnames);
+
+    /// create an NDArray frame descriptor from a config block. Reads the
+    /// structural `value_type` and `extents` (required) and the semantic labels
+    /// `quantity_name` and `dimnames` (optional -- left unset when omitted, for
+    /// the producing stage to fill in). Extent entries may be arithmetic
+    /// expressions referencing other (scoped) config values. The data pointer is
+    /// null; the result describes shape only (e.g. for Buffer::ensure_frame_desc).
+    /// Throws std::runtime_error on invalid or inconsistent config values.
+    static std::shared_ptr<GenericNDArray> from_config(const Config& config,
+                                                       const std::string& location);
+
+    /// Combine two descriptors of the same buffer. The structural fields
+    /// (value_type, extents) must match. For the label fields (quantity_name,
+    /// dimnames), an unset (empty) label on `a` is filled from `b`, and labels
+    /// set on both sides must agree. Returns the completed descriptor when `a`
+    /// gained labels from `b`, or nullptr when nothing changed (so the caller can
+    /// keep its existing descriptor). Throws std::runtime_error on any structural
+    /// or label conflict. Used by Buffer::ensure_frame_desc to merge a
+    /// config-declared descriptor with the one a stage supplies.
+    static std::shared_ptr<GenericNDArray> reconcile(const GenericNDArray& a,
+                                                     const GenericNDArray& b);
+
+    /// Deprecated alias for describe(); the data pointer is ignored. Retained so
+    /// not-yet-migrated callers compile while the codebase moves to describe();
+    /// removed once every caller is migrated.
     static std::shared_ptr<GenericNDArray> create(const DataType value_datatype,
                                                   const Symbol quantity_name,
                                                   const std::vector<std::ptrdiff_t>& extents,
-                                                  const std::vector<Symbol>& dimnames, void* data);
-    static const size_t max_rank = 10;
+                                                  const std::vector<Symbol>& dimnames, void* /*data*/) {
+        return describe(value_datatype, quantity_name, extents, dimnames);
+    }
+    /// constexpr makes this an inline variable (C++17), so odr-uses (e.g.
+    /// passing it by reference to fmt::format) link without an out-of-line
+    /// definition.
+    static constexpr size_t max_rank = 10;
     virtual ~GenericNDArray() {}
-    // The value (element) type
+    /// The value (element) type
     virtual DataType get_value_datatype() const = 0;
-    // The number of bytes for each value (element)
+    /// The number of bytes for each value (element)
     virtual std::size_t get_value_type_size() const = 0;
-    // The stored quantity_name
+    /// The stored quantity_name
     Symbol get_quantity_name() const override = 0;
-    // The rank (number of dimensions)
+    /// The rank (number of dimensions)
     virtual std::size_t get_rank() const = 0;
-    // Pointer to the array data
+    /// Pointer to the array data
     virtual const void* get_data() const = 0;
     virtual void* get_data() = 0;
-    // The array extents (array shape)
+    /// The array extents (array shape)
     virtual std::vector<std::ptrdiff_t> get_extents() const = 0;
     virtual std::ptrdiff_t get_extent(std::size_t d) const = 0;
-    // Is the array empty?
+    /// Is the array empty?
     virtual bool get_empty() const = 0;
-    // The array size. (This is the product of the extents.)
+    /// The array size. (This is the product of the extents.)
     virtual std::ptrdiff_t get_size() const = 0;
-    // The names of the array dimensions
+    /// The names of the array dimensions
     virtual std::vector<Symbol> get_dimnames() const = 0;
     virtual Symbol get_dimname(std::size_t d) const = 0;
-    // The array strides. Strides can have any value (including negative).
+    /// The array strides. Strides can have any value (including negative).
     virtual std::vector<std::ptrdiff_t> get_strides() const = 0;
     virtual std::ptrdiff_t get_stride(std::size_t d) const = 0;
 
-    // FrameDesc override
+    /// FrameDesc override
     size_t get_byte_size() const override {
         return get_size() * get_value_type_size();
     }
 
-    // Output the array description (framedesc), useful for logging or debugging
+    /// Output the array description (framedesc), useful for logging or debugging
     void output_framedesc(std::ostream& os) const override;
 
-    // Compare two NDArrays, useful to compare metadata
+    /// Describe the first structural difference (value type, quantity name,
+    /// rank, extents, dimnames) between this descriptor and `other`; returns
+    /// an empty string when they match. Strides and data are not compared.
+    std::string structure_mismatch(const GenericNDArray& other) const;
+
+    /// FrameDesc override: the structural difference when `other` is also an
+    /// NDArray, else the default both-descriptions dump.
+    std::string describe_mismatch(const FrameDesc& other) const override;
+
+    /// Compare two NDArrays, useful to compare metadata
     bool operator==(const FrameDesc& other) const override;
 };
 
-// A `NDArray<T,D>` is a `D`-dimensional array of type `T`. Different
-// from `GenericNDArray`, its elements can be accessed efficiently. If
-// you are writing C++ code that processes multi-dimensional arrays
-// then this class is a fine choice.
+/// A `NDArray<T,D>` is a `D`-dimensional array of type `T`. Different
+/// from `GenericNDArray`, its elements can be accessed efficiently. If
+/// you are writing C++ code that processes multi-dimensional arrays
+/// then this class is a fine choice.
 template<typename T, std::size_t D>
 class NDArray : public GenericNDArray {
 public:
-    // Value (element) type
+    /// Value (element) type
     using value_type = T;
     constexpr static DataType value_datatype = GetDataType_v<T>;
-    // Rank (number of dimensions)
+    /// Rank (number of dimensions)
     constexpr static std::size_t rank = D;
     constexpr static std::size_t value_type_size = sizeof(T);
 
@@ -163,18 +211,26 @@ private:
     std::array<Symbol, D> m_dimnames;
 
 public:
-    // No default constructor
+    /// No default constructor
     NDArray() = delete;
 
-    // No copy constructors
+    /// No copy constructors
     NDArray(const NDArray&) = delete;
     NDArray& operator=(const NDArray&) = delete;
 
-    // Move constructors
+    /// Move constructors
     NDArray(NDArray&&) = default;
     NDArray& operator=(NDArray&&) = default;
 
-    // Construct from extents and dimension names
+    /// Create a descriptor (an NDArray without data), e.g. for
+    /// Buffer::ensure_frame_desc / require_frame_desc
+    static std::shared_ptr<NDArray<T, D>> describe(const Symbol quantity_name,
+                                                   const std::array<std::ptrdiff_t, D>& extents,
+                                                   const std::array<Symbol, D>& dimnames) {
+        return std::make_shared<NDArray<T, D>>(quantity_name, extents, dimnames, nullptr);
+    }
+
+    /// Construct from extents and dimension names
     NDArray(const Symbol quantity_name, const std::vector<std::ptrdiff_t>& extents,
             const std::vector<Symbol>& dimnames, T* data) {
         assert(extents.size() == D && "extents size must match dimensionality D");
@@ -226,7 +282,7 @@ public:
     //     m_data = data;
     // }
 
-    // Get a pointer to the first element
+    /// Get a pointer to the first element
     const T* data() const {
         return m_data;
     }
@@ -234,12 +290,12 @@ public:
         return m_data;
     }
 
-    // The (physical) quantity_name
+    /// The (physical) quantity_name
     Symbol quantity_name() const {
         return m_quantity_name;
     }
 
-    // The array extents (array shape)
+    /// The array extents (array shape)
     std::array<std::ptrdiff_t, D> extents() const {
         return m_extents;
     }
@@ -248,17 +304,17 @@ public:
         return m_extents[d];
     }
 
-    // Is the array empty?
+    /// Is the array empty?
     bool empty() const {
         return size() == 0;
     }
 
-    // The array size. (This is the product of the extents.)
+    /// The array size. (This is the product of the extents.)
     std::ptrdiff_t size() const {
         return m_size;
     }
 
-    // The names of the array dimensions
+    /// The names of the array dimensions
     std::array<Symbol, D> dimnames() const {
         return m_dimnames;
     }
@@ -267,7 +323,7 @@ public:
         return m_dimnames[d];
     }
 
-    // The array strides. Strides can have any value (including negative).
+    /// The array strides. Strides can have any value (including negative).
     std::array<std::ptrdiff_t, D> strides() const {
         return m_strides;
     }
@@ -276,7 +332,7 @@ public:
         return m_strides[d];
     }
 
-    // Convert an array index to an offset, using the strides
+    /// Convert an array index to an offset, using the strides
     template<typename I = std::ptrdiff_t>
     std::ptrdiff_t index2offset(const std::array<I, D>& ind) const {
         for (std::size_t d = 0; d < D; ++d)
@@ -287,7 +343,7 @@ public:
         return off;
     }
 
-    // Access an array element by index
+    /// Access an array element by index
     template<typename I = std::ptrdiff_t>
     const T& operator()(const std::array<I, D>& ind) const {
         return m_data[index2offset(ind)];
@@ -305,7 +361,7 @@ public:
         return (*this)(std::array<std::ptrdiff_t, sizeof...(Inds)>{inds...});
     }
 
-    // A const iterator
+    /// A const iterator
     class ConstIterator {
         const NDArray<T, D>* m_parent;
         std::array<std::ptrdiff_t, D> m_indices;
@@ -421,9 +477,12 @@ private:
 
         for (std::size_t d = 0; d < D; ++d)
             m_dimnames.at(d) = dimnames.at(d);
+        // Unset (empty) labels are permitted on multiple axes; only set labels
+        // must be unique.
         for (std::size_t d = 0; d < D; ++d)
             for (std::size_t d1 = 0; d1 < d; ++d1)
-                assert(m_dimnames.at(d) != m_dimnames.at(d1));
+                assert(m_dimnames.at(d) == Symbol("")
+                       || m_dimnames.at(d) != m_dimnames.at(d1));
 
         m_size = 1;
         for (std::size_t d = D; d > 0; --d) {

--- a/tests/boost/CMakeLists.txt
+++ b/tests/boost/CMakeLists.txt
@@ -182,6 +182,19 @@ target_link_libraries(test_CHORDTelescope PRIVATE kotekan_utils)
 add_executable(test_N2FrameDesc test_N2FrameDesc.cpp)
 target_link_libraries(test_N2FrameDesc PRIVATE kotekan_metadata kotekan_utils libexternal)
 
+# test_NDArrayBufferConfig - config-driven NDArray frame descriptors and the `ndarray` buffer type
+# in bufferFactory
+add_executable(test_NDArrayBufferConfig test_NDArrayBufferConfig.cpp)
+target_link_libraries(
+    test_NDArrayBufferConfig
+    PRIVATE libexternal
+            kotekan_libs
+            kotekan_utils
+            kotekan_core
+            -Wl,--whole-archive
+            kotekan_metadata
+            -Wl,--no-whole-archive)
+
 # test_N2Subset - tests for N2Subset stage
 add_executable(test_N2Subset test_N2Subset.cpp)
 target_link_libraries(

--- a/tests/boost/test_NDArrayBufferConfig.cpp
+++ b/tests/boost/test_NDArrayBufferConfig.cpp
@@ -1,0 +1,243 @@
+#define BOOST_TEST_MODULE "test_NDArrayBufferConfig"
+
+#include <boost/test/included/unit_test.hpp>
+#include <cstddef>   // for ptrdiff_t, size_t
+#include <map>       // for map
+#include <memory>    // for shared_ptr
+#include <stdexcept> // for runtime_error
+#include <string>    // for string
+#include <vector>    // for vector
+
+// the code to test:
+#include "Config.hpp"        // for Config
+#include "NDArray.hpp"       // for GenericNDArray
+#include "Symbol.hpp"        // for Symbol
+#include "buffer.hpp"        // for Buffer, is_frame_buffer
+#include "bufferFactory.hpp" // for bufferFactory
+#include "metadata.hpp"      // for metadataPool
+
+#include "json.hpp" // for json
+
+using kotekan::Config;
+using kotekan::GenericNDArray;
+using kotekan::Symbol;
+
+using json = nlohmann::json;
+
+// Config::eval evaluates numbers and expression strings in a config scope.
+BOOST_AUTO_TEST_CASE(config_eval) {
+    json json_config = {{"num_local_freq", 16}, {"samples_per_data_set", 1024}};
+    Config config;
+    config.update_config(json_config);
+
+    BOOST_CHECK_EQUAL(config.eval<std::ptrdiff_t>("/", json(42)), 42);
+    BOOST_CHECK_EQUAL(config.eval<std::ptrdiff_t>("/", json("num_local_freq")), 16);
+    BOOST_CHECK_EQUAL(config.eval<std::ptrdiff_t>("/", json("num_local_freq * 2")), 32);
+    BOOST_CHECK_EQUAL(
+        config.eval<std::ptrdiff_t>("/", json("samples_per_data_set / num_local_freq + 1")), 65);
+
+    // Unknown variables, malformed expressions, and non-evaluable json fail
+    BOOST_CHECK_THROW(config.eval<std::ptrdiff_t>("/", json("not_defined + 1")),
+                      std::runtime_error);
+    BOOST_CHECK_THROW(config.eval<std::ptrdiff_t>("/", json("5 +")), std::runtime_error);
+    BOOST_CHECK_THROW(config.eval<std::ptrdiff_t>("/", json::object()), std::runtime_error);
+}
+
+// GenericNDArray::from_config builds a frame descriptor from a config block,
+// with extent entries evaluated as (scoped) arithmetic expressions.
+BOOST_AUTO_TEST_CASE(from_config) {
+    json json_config = {{"num_local_freq", 16},
+                        {"samples_per_data_set", 1024},
+                        {"my_buf",
+                         {{"value_type", "uint8"},
+                          {"quantity_name", "voltage"},
+                          {"extents", {"num_local_freq", "samples_per_data_set / 2", 4}},
+                          {"dimnames", {"F", "T", "D"}}}}};
+    Config config;
+    config.update_config(json_config);
+
+    auto desc = GenericNDArray::from_config(config, "/my_buf");
+    BOOST_REQUIRE(desc);
+    BOOST_CHECK(desc->get_value_datatype() == kotekan::uint8);
+    BOOST_CHECK(desc->get_quantity_name() == Symbol("voltage"));
+    BOOST_CHECK_EQUAL(desc->get_rank(), 3);
+    BOOST_CHECK_EQUAL(desc->get_extent(0), 16);
+    BOOST_CHECK_EQUAL(desc->get_extent(1), 512);
+    BOOST_CHECK_EQUAL(desc->get_extent(2), 4);
+    BOOST_CHECK(desc->get_dimname(0) == Symbol("F"));
+    BOOST_CHECK(desc->get_dimname(1) == Symbol("T"));
+    BOOST_CHECK(desc->get_dimname(2) == Symbol("D"));
+    BOOST_CHECK_EQUAL(desc->get_byte_size(), 16 * 512 * 4);
+}
+
+// Build a Config holding a single buffer block at /my_buf.
+static Config make_config(json block) {
+    json json_config = {{"my_buf", std::move(block)}};
+    Config config;
+    config.update_config(json_config);
+    return config;
+}
+
+// Invalid config blocks fail loudly at construction.
+BOOST_AUTO_TEST_CASE(from_config_errors) {
+    // unknown value_type
+    {
+        Config config = make_config({{"value_type", "complex128"},
+                                     {"quantity_name", "q"},
+                                     {"extents", {4}},
+                                     {"dimnames", {"X"}}});
+        BOOST_CHECK_THROW(GenericNDArray::from_config(config, "/my_buf"), std::runtime_error);
+    }
+    // missing required structural key (value_type)
+    {
+        Config config = make_config({{"extents", {4}}, {"dimnames", {"X"}}});
+        BOOST_CHECK_THROW(GenericNDArray::from_config(config, "/my_buf"), std::runtime_error);
+    }
+    // extents / dimnames size mismatch
+    {
+        Config config = make_config({{"value_type", "float32"},
+                                     {"quantity_name", "q"},
+                                     {"extents", {4, 2}},
+                                     {"dimnames", {"X"}}});
+        BOOST_CHECK_THROW(GenericNDArray::from_config(config, "/my_buf"), std::runtime_error);
+    }
+    // non-positive extent
+    {
+        Config config = make_config({{"value_type", "float32"},
+                                     {"quantity_name", "q"},
+                                     {"extents", {4, 0}},
+                                     {"dimnames", {"X", "Y"}}});
+        BOOST_CHECK_THROW(GenericNDArray::from_config(config, "/my_buf"), std::runtime_error);
+    }
+    // empty extents (rank 0)
+    {
+        Config config = make_config({{"value_type", "float32"},
+                                     {"quantity_name", "q"},
+                                     {"extents", json::array()},
+                                     {"dimnames", json::array()}});
+        BOOST_CHECK_THROW(GenericNDArray::from_config(config, "/my_buf"), std::runtime_error);
+    }
+    // duplicate dimnames
+    {
+        Config config = make_config({{"value_type", "float32"},
+                                     {"quantity_name", "q"},
+                                     {"extents", {4, 2}},
+                                     {"dimnames", {"X", "X"}}});
+        BOOST_CHECK_THROW(GenericNDArray::from_config(config, "/my_buf"), std::runtime_error);
+    }
+}
+
+// quantity_name and dimnames are optional labels: omitting them leaves the
+// descriptor with unset (empty) labels for a stage to fill in via reconcile().
+BOOST_AUTO_TEST_CASE(optional_labels_and_reconcile) {
+    // from_config with only the structural fields succeeds; labels are unset.
+    Config config = make_config({{"value_type", "float32"}, {"extents", {4, 2}}});
+    auto partial = GenericNDArray::from_config(config, "/my_buf");
+    BOOST_REQUIRE(partial);
+    BOOST_CHECK(partial->get_quantity_name() == Symbol(""));
+    BOOST_CHECK(partial->get_dimname(0) == Symbol(""));
+    BOOST_CHECK(partial->get_dimname(1) == Symbol(""));
+
+    // a fully-labelled descriptor of the same structure
+    auto full = GenericNDArray::describe(kotekan::float32, Symbol("gain"), {4, 2},
+                                         {Symbol("F"), Symbol("E")});
+
+    // reconcile fills the unset labels from the labelled side
+    auto merged = GenericNDArray::reconcile(*partial, *full);
+    BOOST_REQUIRE(merged);
+    BOOST_CHECK(merged->get_quantity_name() == Symbol("gain"));
+    BOOST_CHECK(merged->get_dimname(0) == Symbol("F"));
+    BOOST_CHECK(merged->get_dimname(1) == Symbol("E"));
+    // the reverse adds nothing (`full` already has all labels) -> nullptr
+    BOOST_CHECK(!GenericNDArray::reconcile(*full, *partial));
+
+    // structural mismatch (extents) throws
+    auto other_extents = GenericNDArray::describe(kotekan::float32, Symbol("gain"), {2, 4},
+                                                  {Symbol("F"), Symbol("E")});
+    BOOST_CHECK_THROW(GenericNDArray::reconcile(*full, *other_extents), std::runtime_error);
+
+    // conflicting set labels throw
+    auto other_label = GenericNDArray::describe(kotekan::float32, Symbol("other"), {4, 2},
+                                                {Symbol("F"), Symbol("E")});
+    BOOST_CHECK_THROW(GenericNDArray::reconcile(*full, *other_label), std::runtime_error);
+}
+
+// The bufferFactory creates `ndarray` buffers with the frame descriptor
+// attached at startup and frame_size derived from it -- and stage-style
+// ensure_frame_desc calls then act as pure validators.
+BOOST_AUTO_TEST_CASE(buffer_factory_ndarray) {
+    json json_config = {{"log_level", "off"},
+                        {"num_local_freq", 16},
+                        {"gain_buffer",
+                         {{"kotekan_buffer", "ndarray"},
+                          {"value_type", "float32"},
+                          {"quantity_name", "gains"},
+                          {"extents", {"num_local_freq", 4}},
+                          {"dimnames", {"F", "G"}},
+                          {"num_frames", 2},
+                          {"metadata_pool", "none"}}}};
+    Config config;
+    config.update_config(json_config);
+
+    std::map<std::string, std::shared_ptr<metadataPool>> pools;
+    kotekan::bufferFactory factory(config, pools);
+    auto buffers = factory.build_buffers();
+    BOOST_REQUIRE_EQUAL(buffers.size(), 1);
+
+    auto* buf = dynamic_cast<Buffer*>(buffers.at("gain_buffer"));
+    BOOST_REQUIRE(buf);
+    BOOST_CHECK(is_frame_buffer(buf));
+    BOOST_CHECK_EQUAL(buf->frame_size, 16 * 4 * sizeof(float));
+
+    // The descriptor is present before any stage would run
+    auto desc = buf->get_frame_desc<kotekan::GenericNDArray>();
+    BOOST_REQUIRE(desc);
+    BOOST_CHECK(desc->get_value_datatype() == kotekan::float32);
+    BOOST_CHECK(desc->get_quantity_name() == Symbol("gains"));
+    BOOST_CHECK_EQUAL(desc->get_rank(), 2);
+    BOOST_CHECK_EQUAL(desc->get_extent(0), 16);
+    BOOST_CHECK_EQUAL(desc->get_extent(1), 4);
+
+    // A stage-style declare call now validates against the factory-set
+    // descriptor instead of allocating (the migration "auto-degrade"
+    // property); a matching call passes through silently.
+    buf->ensure_frame_desc(
+        kotekan::NDArray<float, 2>::describe(Symbol("gains"), {16, 4}, {Symbol("F"), Symbol("G")}));
+    BOOST_CHECK(buf->get_frame_desc<kotekan::GenericNDArray>() == desc);
+
+    // ... and a MISMATCHING declare call is fatal. (Under the boost test
+    // build, FATAL_ERROR throws std::runtime_error via KTK_BOOST_ERR before
+    // raising SIGTERM, so the fatal paths are testable with CHECK_THROW.)
+    // Same byte size, swapped extents/dimnames -- reaches the field checks:
+    BOOST_CHECK_THROW((buf->ensure_frame_desc(kotekan::NDArray<float, 2>::describe(
+                          Symbol("gains"), {4, 16}, {Symbol("G"), Symbol("F")}))),
+                      std::runtime_error);
+    // Same byte size and shape, wrong value type:
+    BOOST_CHECK_THROW((buf->ensure_frame_desc(kotekan::NDArray<int32_t, 2>::describe(
+                          Symbol("gains"), {16, 4}, {Symbol("F"), Symbol("G")}))),
+                      std::runtime_error);
+    // Same byte size and shape, wrong quantity name:
+    BOOST_CHECK_THROW((buf->ensure_frame_desc(kotekan::NDArray<float, 2>::describe(
+                          Symbol("not_gains"), {16, 4}, {Symbol("F"), Symbol("G")}))),
+                      std::runtime_error);
+
+    // ensure_frame_desc with a mismatching descriptor of equal byte size is
+    // fatal (previously only a soft ERROR):
+    BOOST_CHECK_THROW(buf->ensure_frame_desc(GenericNDArray::describe(
+                          kotekan::float32, Symbol("gains"), {4, 16}, {Symbol("G"), Symbol("F")})),
+                      std::runtime_error);
+    // ... as is one with the wrong byte size:
+    BOOST_CHECK_THROW(buf->ensure_frame_desc(GenericNDArray::describe(
+                          kotekan::float32, Symbol("gains"), {16, 8}, {Symbol("F"), Symbol("G")})),
+                      std::runtime_error);
+    // The recorded descriptor is unchanged by any of the rejected calls
+    BOOST_CHECK(buf->get_frame_desc<kotekan::GenericNDArray>() == desc);
+
+    // Setting an equal descriptor again is accepted
+    buf->ensure_frame_desc(GenericNDArray::describe(kotekan::float32, Symbol("gains"), {16, 4},
+                                                 {Symbol("F"), Symbol("G")}));
+    BOOST_CHECK(buf->get_frame_desc<kotekan::GenericNDArray>() == desc);
+
+    for (auto& [name, b] : buffers)
+        delete b;
+}


### PR DESCRIPTION
Introduce a `kotekan_buffer: ndarray` buffer type: bufferFactory builds a GenericNDArray descriptor from config (value_type/quantity_name/extents/ dimnames), and the Buffer class gains methods ensure_frame_desc / require_frame_desc / get_frame_desc<T> .

Purely additive: the legacy allocate_ndarray_frame_desc / get_ndarray_frame_desc / get_frame_description Buffer methods and GenericNDArray::create are kept as deprecation shims that forward to the new methods, so every existing stage compiles unchanged and no stage or config uses the ndarray type yet. The shims should be removed in a later change once all callers are migrated.