### PR TITLE
Adopt ndarray buffers in producer stages and configs

### DIFF
--- a/config/chime_upgrade_n2.j2
+++ b/config/chime_upgrade_n2.j2
@@ -149,14 +149,16 @@ vis_pool:
 
 host_voltage_buffers:
   num_frames: baseband_buffer_depth
-  frame_size: samples_per_data_set * num_elements * num_freq_host_buf
+  value_type: int4x2_swapped_withoffset
+  extents: [1, samples_per_data_set * num_elements * num_freq_host_buf / 2048, 2048]
+  dimnames: [F, T, E]
   metadata_pool: main_pool
   use_hugepages: true
   numa_0:
     numa_node: 0
 {%- for id in range(num_freq_gpu_buf) %}
     host_voltage_buffer_{{ id }}:
-      kotekan_buffer: standard
+      kotekan_buffer: ndarray
 {%- endfor %}
 host_voltage_ringbuffer:
   kotekan_buffer: ring
@@ -165,9 +167,10 @@ host_voltage_ringbuffer:
 
 {%- for id in range(num_freq_gpu_buf // 4) %}
 lost_samples_buffer_{{ id }}:
-  kotekan_buffer: standard
+  kotekan_buffer: ndarray
   num_frames: 2 * host_buffer_depth
-  frame_size: samples_per_data_set
+  value_type: uint8
+  extents: [samples_per_data_set]
   metadata_pool: main_pool
 {%- endfor %}
 
@@ -336,15 +339,18 @@ baseband_merge:
 # Buffers
 
 host_bf_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_int8 * num_dishes * num_polarizations
+    value_type: int8
+    extents: [num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 host_pl_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_buffer_depth
-    frame_size: (64 / 8) * (num_dishes / 8) * num_polarizations * (num_freq_gpu_buf / 4) * (samples_per_data_set / 2 / 64)
+    value_type: uint1x8
+    # produced by lostSamplesToPLMask (also asserted by CountLostPLSamplesScalar consumer)
+    extents: [samples_per_data_set / 2 / 64, num_freq_gpu_buf / 4, num_polarizations, num_dishes / 8, 64 / 8]
     metadata_pool: main_pool
 host_pl_mask_ringbuffer:
     kotekan_buffer: ring
@@ -453,10 +459,12 @@ set_scatter_indices:
 
 # Buffers
 
+# Produced by parseReorderDefault (set_scatter_indices): int32 "scatter_indices".
 host_scatter_indices_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_int32 * num_dishes * num_polarizations
+    value_type: int32
+    extents: [num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 host_xposed_voltage_ringbuffer:
@@ -538,12 +546,12 @@ host_rfi_S012tilde_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_SKtilde_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: gpu_buffer_depth
-    frame_size: sizeof_float32 * 3 * num_freq_gpu_buf * rfi_num_times
-    type: float32
-    dimnames: ["Trfi", "F", "S"]
-    shape: [rfi_num_times, num_freq_gpu_buf, 3]
+    value_type: float32
+    # GPU producer cudaRFISKtilde rfi_SKtilde (leading extent = per-frame rfi_num_times);
+    # also validated by RfiFrameMask in_buf as {Trfi, F, SK}.
+    extents: [rfi_num_times, num_freq_gpu_buf, 3]
     metadata_pool: main_pool
 host_rfi_SKtilde_ringbuffer:
     kotekan_buffer: ring
@@ -555,12 +563,12 @@ host_rfi_SKtilde_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_RFImask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: gpu_buffer_depth
-    frame_size: num_freq_gpu_buf * samples_per_data_set / 8
-    type: uint1x8
-    dimnames: ["T8hi128", "F", "T8lo128"]
-    shape: [samples_per_data_set / 8 / 128, num_freq_gpu_buf, 128]
+    value_type: uint1x8
+    # GPU producer cudaRFISKtilde rfi_RFImask (leading = per-frame samples/(8*128));
+    # also validated by RfiMaskSum/lostSamplesToN2Counts/cudaCorrelator as RFImask.
+    extents: [samples_per_data_set / 8 / 128, num_freq_gpu_buf, 128]
     metadata_pool: main_pool
 host_rfi_RFImask_ringbuffer:
     kotekan_buffer: ring
@@ -572,12 +580,11 @@ host_rfi_RFImask_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_SKbar_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: gpu_buffer_depth
-    frame_size: sizeof_float32 * num_dishes * num_polarizations * 3 * num_freq_gpu_buf * rfi_num_times_bar
-    type: float32
-    dimnames: ["Trfi", "F", "S", "P", "D"]
-    shape: [rfi_num_times_bar, num_freq_gpu_buf, 3, num_polarizaions, num_dishes]
+    value_type: float32
+    # GPU producer cudaRFISKbar rfi_SKbar (leading = per-frame rfi_num_times_bar).
+    extents: [rfi_num_times_bar, num_freq_gpu_buf, 3, num_polarizations, num_dishes]
     metadata_pool: main_pool
 host_rfi_SKbar_ringbuffer:
     kotekan_buffer: ring
@@ -589,12 +596,11 @@ host_rfi_SKbar_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_SKbartilde_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: gpu_buffer_depth
-    frame_size: sizeof_float32 * 3 * num_freq_gpu_buf * rfi_num_times_bar
-    type: float32
-    dimnames: ["Trfi", "F", "S"]
-    shape: [rfi_num_times_bar, num_freq_gpu_buf, 3]
+    value_type: float32
+    # GPU producer cudaRFISKbar rfi_SKbartilde (leading = per-frame rfi_num_times_bar).
+    extents: [rfi_num_times_bar, num_freq_gpu_buf, 3]
     metadata_pool: main_pool
 host_rfi_SKbartilde_ringbuffer:
     kotekan_buffer: ring
@@ -607,9 +613,11 @@ host_rfi_SKbartilde_ringbuffer:
 
 # The mask for second stage RFI excision.
 host_rfi_RFIframemask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: gpu_buffer_depth
-    frame_size: (samples_per_data_set / n2k_sub_integration_ntime) * num_local_freq
+    value_type: uint8
+    # produced by RfiFrameMask (out_buf): {num_integrations, num_local_freq}
+    extents: [samples_per_data_set / n2k_sub_integration_ntime, num_local_freq]
     zero_new_frames: true
     zero_value: 0xFF
     metadata_pool: main_pool
@@ -836,28 +844,41 @@ n2k_counts_triangle_num_blocks: n2k_counts_linear_num_blocks * (n2k_counts_linea
 n2k_counts_triangle_size: n2k_counts_blocksize * n2k_counts_blocksize * n2k_counts_triangle_num_blocks
 
 host_n2k_correlation_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: gpu_buffer_depth
     use_hugepages: true
-    frame_size: sizeof_int32 * num_components * n2k_correlation_triangle_size * num_freq_gpu_buf * n2k_num_subintegrations
+    value_type: int32
+    # produced by cudaCorrelator (n2k_correlation): NDArrayBuffer<int32,6>
+    # cudaCorrelator uses (num_elements+1)/16 = (2048+1)/16 = 128 blocks, same as
+    # CPU num_elements/16 = 128 (num_elements=2048 is a multiple of 16; no triangle divergence).
+    extents: [n2k_num_subintegrations, num_freq_gpu_buf, n2k_correlation_triangle_num_blocks, n2k_correlation_blocksize, n2k_correlation_blocksize, num_components]
     metadata_pool: main_pool
 
 host_n2k_counts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: gpu_buffer_depth
-    frame_size: sizeof_int32 * n2k_counts_triangle_size * num_freq_gpu_buf * n2k_num_subintegrations
+    value_type: int32
+    # produced by lostSamplesToN2Counts (n2k_counts): NDArrayBuffer<int32,5>
+    # ntiles = (num_elements/64)*(1+num_elements/64)/2 = 32*33/2 = 528, matches
+    # config n2k_counts_triangle_num_blocks (= (n2k_counts_num_elements+1)/8 triangle) since
+    # num_elements=2048 makes both = 528 (no divergence).
+    extents: [n2k_num_subintegrations, num_freq_gpu_buf, n2k_counts_triangle_num_blocks, n2k_counts_blocksize, n2k_counts_blocksize]
     metadata_pool: main_pool
 
 host_n2k_RFIcounts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: gpu_buffer_depth
-    frame_size: sizeof_int32 * num_freq_gpu_buf * n2k_num_subintegrations
+    value_type: int32
+    # produced by RfiMaskSum (out_buf): {num_integrations, num_local_freq}
+    extents: [samples_per_data_set / n2k_sub_integration_ntime, num_freq_gpu_buf]
     metadata_pool: main_pool
 
 host_n2k_PLcounts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: gpu_buffer_depth
-    frame_size: sizeof_int32 * num_freq_gpu_buf * n2k_num_subintegrations
+    value_type: int32
+    # produced by CountLostPLSamplesScalar (out_buf): {num_integrations, num_local_freq}
+    extents: [samples_per_data_set / n2k_sub_integration_ntime, num_freq_gpu_buf]
     metadata_pool: main_pool
 
 # Stages

--- a/config/chime_upgrade_test_gains.j2
+++ b/config/chime_upgrade_test_gains.j2
@@ -303,9 +303,10 @@ dbg_read_lostsamples_{{ id }}:
 # Buffers
 
 host_bf_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_int8 * num_dishes * num_polarizations
+    value_type: int8
+    extents: [num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 host_pl_mask_buffer:

--- a/config/chord_pathfinder.j2
+++ b/config/chord_pathfinder.j2
@@ -197,20 +197,23 @@ n2_pool:
     num_metadata_objects: 16 * buffer_depth
 
 # Bad feed mask - marks which feeds to exclude from RFI calculations
-# Shape: [P, D] = [2, num_dishes] - all ones means all feeds are good
+# Produced by inventBFMask: int8 "bf_mask" [P, D] = [num_polarizations, num_dishes].
+# All ones (0xFF) means all feeds are good.
 host_bf_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_int8 * num_dishes * num_polarizations
+    value_type: int8
+    extents: [num_polarizations, num_dishes]
     metadata_pool: main_pool
     zero_new_frames: true
     zero_value: 0xFF
     numa_node: 0
 
 host_bf_mask_buffer_1:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_int8 * num_dishes * num_polarizations
+    value_type: int8
+    extents: [num_polarizations, num_dishes]
     metadata_pool: main_pool
     zero_new_frames: true
     zero_value: 0xFF
@@ -222,8 +225,9 @@ network_input_buffers:
     frame_size: dpdk_output_frame_size
     metadata_pool: main_pool
     use_hugepages: true
-    
-    # The workers share an output buffer
+
+    # The workers share an output buffer.
+    # Fed by dpdkCore (crs16BoardCaptureWorker handler) -> leave standard.
     network_input_buffer_0:
         zero_new_frames: true
         numa_node: 0
@@ -234,13 +238,32 @@ network_input_buffers:
         numa_node: 1
         zero_value: 0x88
         kotekan_buffer: standard
-    # Main voltage buffer after transpose
-    host_voltage_buffer_0:
-        kotekan_buffer: standard
-        numa_node: 0
-    host_voltage_buffer_1:
-        kotekan_buffer: standard
-        numa_node: 1
+
+# Main voltage buffer after transpose.
+# Produced by TransposeBasebandArray: int4x2_swapped_withoffset "E"
+# [timesamples_per_frame, NUM_LOCAL_FREQ, 2, NUM_ELEMENTS/2] = [samples_per_data_set, 384, 2, 64].
+# The stage uses compile-time macros NUM_LOCAL_FREQ=384, NUM_ELEMENTS=128 (it fatally checks the
+# config num_local_freq/num_elements equal them); this config sets num_local_freq=384,
+# num_elements=128, so the static extents below are valid. These live outside the
+# network_input_buffers group: that group's frame_size is for the dpdk buffers, while
+# ndarray buffers derive their size from the descriptor.
+host_voltage_buffer_0:
+    kotekan_buffer: ndarray
+    num_frames: host_side_buffer_depth
+    value_type: int4x2_swapped_withoffset
+    extents: [samples_per_data_set, num_local_freq, 2, num_elements / 2]
+    metadata_pool: main_pool
+    use_hugepages: true
+    numa_node: 0
+
+host_voltage_buffer_1:
+    kotekan_buffer: ndarray
+    num_frames: host_side_buffer_depth
+    value_type: int4x2_swapped_withoffset
+    extents: [samples_per_data_set, num_local_freq, 2, num_elements / 2]
+    metadata_pool: main_pool
+    use_hugepages: true
+    numa_node: 1
 
 
 packet_receipt_bitmap_buffers:
@@ -264,125 +287,157 @@ packet_receipt_bitmap_buffers:
         kotekan_buffer: standard
         numa_node: 1
 
-# These are the dummy RFI masks produced by DPDK
+# These are the dummy RFI masks produced by ProcessPacketMask (rfi_mask_buf).
+# uint1x8 "RFImask" [samples_per_data_set/1024, num_local_freq, 128] {T8hi128, F, T8lo128}.
 host_rfi_RFImask_dummy_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: num_local_freq * samples_per_data_set / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 1024, num_local_freq, 128]
     zero_new_frames: true
     zero_value: 0xFF
     metadata_pool: main_pool
 
 host_rfi_RFImask_dummy_buffer_1:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: num_local_freq * samples_per_data_set / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 1024, num_local_freq, 128]
     zero_new_frames: true
     zero_value: 0xFF
     numa_node: 1
     metadata_pool: main_pool
 
-# Note this is the expanded version of the pl_mask, produced by DPDK. It will be compressed to
-# the normal PL mask before being sent to the GPU.
+# Note this is the expanded version of the pl_mask, produced by ProcessPacketMask (pl_mask_buf).
+# It will be compressed to the normal PL mask before being sent to the GPU.
+# uint1x8 "pl_mask_exp" [samples_per_data_set/64, num_local_freq, 2, num_elements/8/2, 8]
+# {Thi64, F, P, D8, Tlo64}.
 host_pl_mask_exp_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / 64) * (num_local_freq) * (num_elements / 8) * 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 64, num_local_freq, 2, num_elements / 8 / 2, 8]
     metadata_pool: main_pool
 
 host_pl_mask_exp_buffer_1:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / 64) * (num_local_freq) * (num_elements / 8) * 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 64, num_local_freq, 2, num_elements / 8 / 2, 8]
     metadata_pool: main_pool
     numa_node: 1
 
 # This is the PL mask, sent to GPU and used for n2k_counts and the RFI SK system.
+# Produced by PLMaskExpandedToCompact (out_buf): uint1x8 "pl_mask"
+# [samples_per_data_set/128, (num_local_freq+3)/4, 2, (num_elements/8)/2, 8]
+# {T2hi64, F4, P, D8, T2lo64}. num_local_freq=384 -> (384+3)/4 = 96 = num_local_freq/4.
 host_pl_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / 128) * (num_local_freq/4) * (num_elements / 8) * 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 128, (num_local_freq + 3) / 4, 2, (num_elements / 8) / 2, 8]
     metadata_pool: main_pool
 
 host_pl_mask_buffer_1:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / 128) * (num_local_freq/4) * (num_elements / 8) * 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 128, (num_local_freq + 3) / 4, 2, (num_elements / 8) / 2, 8]
     metadata_pool: main_pool
     numa_node: 1
 
 # This contains the SK statistics averaged over elements.
+# GPU output (cudaCopyFromRingbuffer of cudaRFISKtilde rfi_SKtilde) and consumed by RfiFrameMask:
+# float32 "SKtilde" [samples_per_data_set/rfi_downsampling_factor, num_local_freq, 3] {Trfi, F, SK}.
 host_rfi_sktilde_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / rfi_downsampling_factor) * num_local_freq * 3 * sizeof_float32
+    value_type: float32
+    extents: [samples_per_data_set / rfi_downsampling_factor, num_local_freq, 3]
     metadata_pool: main_pool
 
 host_rfi_sktilde_buffer_1:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / rfi_downsampling_factor) * num_local_freq * 3 * sizeof_float32
+    value_type: float32
+    extents: [samples_per_data_set / rfi_downsampling_factor, num_local_freq, 3]
     metadata_pool: main_pool
     numa_node: 1
 
 # This is the RFI Mask recieved from the GPU, that was applied to produce n2k_correlation & n2k_counts.
 # It may contain either the dummy DPDK-generated mask or the real mask computed by SKtilde.
+# GPU output (cudaCopyFromRingbuffer of rfi_RFImask) and consumed by RfiMaskSum:
+# uint1x8 "RFImask" [samples_per_data_set/1024, num_local_freq, 128] {T8hi128, F, T8lo128}.
 host_rfi_RFImask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: num_local_freq * samples_per_data_set / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 1024, num_local_freq, 128]
     zero_new_frames: true
     zero_value: 0xFF
     metadata_pool: main_pool
 
 host_rfi_RFImask_buffer_1:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: num_local_freq * samples_per_data_set / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 1024, num_local_freq, 128]
     zero_new_frames: true
     zero_value: 0xFF
     numa_node: 1
     metadata_pool: main_pool
 
+# Produced by RfiMaskSum (out_buf): int32 "RFImask_counts"
+# [samples_per_data_set/sub_integration_ntime, num_local_freq] {Tc, F}.
 host_rfi_RFImask_counts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * sizeof_int32
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     metadata_pool: main_pool
 
 host_rfi_RFImask_counts_buffer_1:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * sizeof_int32
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     metadata_pool: main_pool
     numa_node: 1
 
+# Produced by CountLostPLSamplesScalar (out_buf): int32 "pl_lost_counts_scalar"
+# [samples_per_data_set/sub_integration_ntime, num_local_freq] {Tc, F}.
 host_pl_counts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * sizeof_int32
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     metadata_pool: main_pool
 
 host_pl_counts_buffer_1:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * sizeof_int32
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     metadata_pool: main_pool
     numa_node: 1
 
 # The mask for second stage RFI excision.
+# Produced by RfiFrameMask (out_buf): uint8 "RFIFrameMask"
+# [samples_per_data_set/sub_integration_ntime, num_local_freq] {Tc, F}.
 host_rfi_RFIframemask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq
+    value_type: uint8
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     zero_new_frames: true
     zero_value: 0xFF
     metadata_pool: main_pool
 
 host_rfi_RFIframemask_buffer_1:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq
+    value_type: uint8
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     zero_new_frames: true
     zero_value: 0xFF
     metadata_pool: main_pool
@@ -391,16 +446,23 @@ host_rfi_RFIframemask_buffer_1:
 vis_blocksize: 16
 vis_num_blocks_lin: num_elements / vis_blocksize
 vis_num_blocks: vis_num_blocks_lin * (vis_num_blocks_lin + 1) / 2
+# GPU output (cudaOutputData of cudaCorrelator n2k_correlation): int32 "n2k_correlation"
+# [samples_per_data_set/sub_integration_ntime, num_local_freq, vis_num_blocks, 16, 16, 2]
+# {Tc, F, DPhi, DPlo1, DPlo2, C}. Block-count note: cudaCorrelator uses (num_elements+1)/16
+# while the CPU side uses num_elements/16; at num_elements=128 both equal 8, so vis_num_blocks=36
+# matches the kernel's triangle_num_blocks.
 host_correlation_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: num_local_freq * (samples_per_data_set / sub_integration_ntime) * 16 * 16 * vis_num_blocks * 2 * sizeof_gpu_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, vis_num_blocks, vis_blocksize, vis_blocksize, 2]
     metadata_pool: main_pool
 
 host_correlation_buffer_1:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: num_local_freq * (samples_per_data_set / sub_integration_ntime) * 16 * 16 * vis_num_blocks * 2 * sizeof_gpu_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, vis_num_blocks, vis_blocksize, vis_blocksize, 2]
     metadata_pool: main_pool
     numa_node: 1
 
@@ -408,16 +470,23 @@ host_correlation_buffer_1:
 counts_blocksize: 8
 counts_num_blocks_lin: (num_elements / 8) / counts_blocksize
 counts_num_blocks: (counts_num_blocks_lin * (counts_num_blocks_lin + 1)) / 2
+# GPU output (cudaOutputData of cudaPL1bitCorrelator n2k_counts): int32 "n2k_counts"
+# [samples_per_data_set/sub_integration_ntime, num_local_freq, counts_num_blocks, 8, 8]
+# {Tc, F, D8Phi, D8Plo1, D8Plo2}. Block-count note: cudaPL1bitCorrelator uses
+# (num_elements/8+1)/8 while the CPU side uses (num_elements/8)/8; at num_elements=128 both equal 2,
+# so counts_num_blocks=3 matches the kernel's triangle_num_blocks.
 host_counts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * counts_num_blocks * counts_blocksize * counts_blocksize * sizeof_gpu_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, counts_num_blocks, counts_blocksize, counts_blocksize]
     metadata_pool: main_pool
 
 host_counts_buffer_1:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * counts_num_blocks * counts_blocksize * counts_blocksize * sizeof_gpu_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, counts_num_blocks, counts_blocksize, counts_blocksize]
     metadata_pool: main_pool
     numa_node: 1
 

--- a/config/chord_pathfinder_recv.j2
+++ b/config/chord_pathfinder_recv.j2
@@ -153,7 +153,6 @@ n2_pool:
 
 
 
-
 # Receive subset N2 buffer
 
 n2_recv_subset_buffer:

--- a/config/ci-tests/cpu_batch/run_n2accum.yaml
+++ b/config/ci-tests/cpu_batch/run_n2accum.yaml
@@ -90,39 +90,45 @@ n2_pool:
     num_metadata_objects: 16 * buffer_depth
 
 fake_correlation_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * vis_num_blocks * vis_blocksize * vis_blocksize * 2 * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, vis_num_blocks, vis_blocksize, vis_blocksize, 2]
     metadata_pool: main_pool
 
 fake_counts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * counts_num_blocks * counts_blocksize * counts_blocksize * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, counts_num_blocks, counts_blocksize, counts_blocksize]
     metadata_pool: main_pool
 
 fake_rfimask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set * num_local_freq) / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 1024, num_local_freq, 128]
     metadata_pool: main_pool
 
 fake_rficounts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     metadata_pool: main_pool
 
 fake_plcounts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     metadata_pool: main_pool
 
 fake_rfi_frame_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq
+    value_type: uint8
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     metadata_pool: main_pool
 
 n2_buffer:

--- a/config/ci-tests/cpu_batch/run_n2accum_chime.yaml
+++ b/config/ci-tests/cpu_batch/run_n2accum_chime.yaml
@@ -64,39 +64,45 @@ vis_pool:
     num_metadata_objects: num_local_freq * buffer_depth
 
 fake_correlation_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * vis_num_blocks * vis_blocksize * vis_blocksize * 2 * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, vis_num_blocks, vis_blocksize, vis_blocksize, 2]
     metadata_pool: main_pool
 
 fake_counts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * counts_num_blocks * counts_blocksize * counts_blocksize * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, counts_num_blocks, counts_blocksize, counts_blocksize]
     metadata_pool: main_pool
 
 fake_rfimask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set * num_local_freq) / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 1024, num_local_freq, 128]
     metadata_pool: main_pool
 
 fake_rficounts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     metadata_pool: main_pool
 
 fake_plcounts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     metadata_pool: main_pool
 
 fake_rfi_frame_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq
+    value_type: uint8
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     metadata_pool: main_pool
 
 n2_buffer:

--- a/config/ci-tests/cpu_batch/test_lostSamplesToPLMask.yaml
+++ b/config/ci-tests/cpu_batch/test_lostSamplesToPLMask.yaml
@@ -29,23 +29,29 @@ main_pool:
 # Buffers
 lost_samples_buffers:
     num_frames: buffer_depth
-    frame_size: num_frame_samples
     metadata_pool: main_pool
+    # Shared frame descriptor (scope-inherited by all three buffers)
+    value_type: uint8
+    extents: [num_frame_samples]
+    dimnames: ["T"]
     lost_samples_buffer_0:
-        kotekan_buffer: standard
+        kotekan_buffer: ndarray
     lost_samples_buffer_1:
-        kotekan_buffer: standard
+        kotekan_buffer: ndarray
     lost_samples_buffer_2:
-        kotekan_buffer: standard
+        kotekan_buffer: ndarray
 
 pl_mask_buffers:
     num_frames: buffer_depth
-    frame_size: num_frame_samples/pl_mask_downsampling_factor * num_dishes/pl_mask_dishes_per_bin * num_polarizations * num_freq_bins / 8
     metadata_pool: main_pool
+    # Shared frame descriptor (scope-inherited by both buffers)
+    value_type: uint1x8
+    extents: [num_frame_samples / pl_mask_downsampling_factor / pl_mask_hilo_split, num_freq_bins, num_polarizations, num_dishes / pl_mask_dishes_per_bin, pl_mask_hilo_split / 8]
+    dimnames: ["T2hi64", "F4", "P", "D8", "T2lo64"]
     out_pl_mask_buffer:
-        kotekan_buffer: standard
+        kotekan_buffer: ndarray
     cmp_pl_mask_buffer:
-        kotekan_buffer: standard
+        kotekan_buffer: ndarray
 
 # Kotekan stages
 gen_test_data:

--- a/config/ci-tests/cpu_batch/test_send_recv.yaml
+++ b/config/ci-tests/cpu_batch/test_send_recv.yaml
@@ -1,6 +1,8 @@
 ---
 #
-# Just a simple test pipeline that generates random data, does a send/recieve, for different buffer types.
+# A simple test pipeline that generates random data and does a send/receive,
+# for each buffer type: standard, N2, and ndarray (the latter both with and
+# without the optional descriptor labels declared in config).
 #
 type: config
 log_level: INFO
@@ -39,19 +41,23 @@ earth_rotation_data:
 # Pools
 main_pool:
     kotekan_metadata_pool: chordMetadata
-    num_metadata_objects: 4 * buffer_depth
+    num_metadata_objects: 8 * buffer_depth
 
 N2_pool:
     kotekan_metadata_pool: N2Metadata
     num_metadata_objects: 2 * buffer_depth
 
 # Buffers
+#
+# `standard` frames are opaque bytes (int4x2 is one byte per sample, so
+# frame_size == num_frame_samples). bufferRecv attaches whatever descriptor it
+# receives from the wire. The recv buffers mirror their send counterparts.
+
 send_buffer:
     kotekan_buffer: standard
     num_frames: buffer_depth
     frame_size: num_frame_samples
     metadata_pool: main_pool
-
 recv_buffer:
     kotekan_buffer: standard
     num_frames: buffer_depth
@@ -63,7 +69,6 @@ send_buffer_noCT:
     num_frames: buffer_depth
     frame_size: num_frame_samples
     metadata_pool: main_pool
-
 recv_buffer_noCT:
     kotekan_buffer: standard
     num_frames: buffer_depth
@@ -75,12 +80,46 @@ send_N2_buffer:
     metadata_pool: N2_pool
     n2_layout: "FullUpperTri"
     num_frames: buffer_depth
-
 recv_N2_buffer:
     kotekan_buffer: N2
     metadata_pool: N2_pool
     n2_layout: "FullUpperTri"
     num_frames: buffer_depth
+
+# ndarray with a full descriptor: the labels (quantity_name, dimnames) are
+# declared in config, so bufferRecv validates the received shape against them.
+send_ndarray_buffer:
+    kotekan_buffer: ndarray
+    num_frames: buffer_depth
+    value_type: int4x2
+    quantity_name: voltage
+    extents: [num_frame_samples]
+    dimnames: ["S"]
+    metadata_pool: main_pool
+recv_ndarray_buffer:
+    kotekan_buffer: ndarray
+    num_frames: buffer_depth
+    value_type: int4x2
+    quantity_name: voltage
+    extents: [num_frame_samples]
+    dimnames: ["S"]
+    metadata_pool: main_pool
+
+# ndarray with only the structural fields: the labels are omitted from config
+# and supplied by the producing stage (and, on the recv side, by the frame
+# received over the wire).
+send_ndarray_nolabel_buffer:
+    kotekan_buffer: ndarray
+    num_frames: buffer_depth
+    value_type: int4x2
+    extents: [num_frame_samples]
+    metadata_pool: main_pool
+recv_ndarray_nolabel_buffer:
+    kotekan_buffer: ndarray
+    num_frames: buffer_depth
+    value_type: int4x2
+    extents: [num_frame_samples]
+    metadata_pool: main_pool
 
 
 # Kotekan stages
@@ -89,12 +128,11 @@ recv_N2_buffer:
 
 gen_buffer_data:
     log_level: WARN
-    # type: const
-    # value: 34 # 1i # 34 # = 2 + 2i
     type: random_signed
     value: 1532
     kotekan_stage: testDataGen
     out_buf: send_buffer
+    name: voltage
     array_shape: [2048]
     dim_name: ["S"]
     num_frames: 6
@@ -116,12 +154,11 @@ buffer_recv_standard:
 
 gen_buffer_data_noCT:
     log_level: WARN
-    # type: const
-    # value: 34 # 1i # 34 # = 2 + 2i
     type: random_signed
     value: 1532
     kotekan_stage: testDataGen
     out_buf: send_buffer_noCT
+    name: voltage
     array_shape: [2048]
     dim_name: ["S"]
     num_frames: 6
@@ -169,7 +206,59 @@ buffer_recv_n2:
     buf: recv_N2_buffer
     listen_port: 11025
 
-# Verify buffers are the same.
+# ndarray buffer (labels declared in config): generate and send/recv
+
+gen_ndarray_data:
+    log_level: WARN
+    type: random_signed
+    value: 1532
+    kotekan_stage: testDataGen
+    out_buf: send_ndarray_buffer
+    name: voltage
+    array_shape: [2048]
+    dim_name: ["S"]
+    num_frames: 6
+
+buffer_send_ndarray:
+    kotekan_stage: bufferSend
+    buf: send_ndarray_buffer
+    server_ip: 127.0.0.1
+    server_port: 11027
+    retry_time: 1.0
+    drop_frames: false
+
+buffer_recv_ndarray:
+    kotekan_stage: bufferRecv
+    buf: recv_ndarray_buffer
+    listen_port: 11027
+
+# ndarray buffer (labels supplied by the stage, not config): generate and send/recv
+
+gen_ndarray_nolabel_data:
+    log_level: WARN
+    type: random_signed
+    value: 1532
+    kotekan_stage: testDataGen
+    out_buf: send_ndarray_nolabel_buffer
+    name: voltage
+    array_shape: [2048]
+    dim_name: ["S"]
+    num_frames: 6
+
+buffer_send_ndarray_nolabel:
+    kotekan_stage: bufferSend
+    buf: send_ndarray_nolabel_buffer
+    server_ip: 127.0.0.1
+    server_port: 11028
+    retry_time: 1.0
+    drop_frames: false
+
+buffer_recv_ndarray_nolabel:
+    kotekan_stage: bufferRecv
+    buf: recv_ndarray_nolabel_buffer
+    listen_port: 11028
+
+# Verify each recv buffer matches its send buffer (data and metadata).
 
 check_standard_send_recv:
     kotekan_stage: testDataCheckUchar
@@ -195,6 +284,22 @@ check_n2_send_recv:
     trigger_exit_on_pass: false
     check_metadata: true
 
+check_ndarray_send_recv:
+    kotekan_stage: testDataCheckUchar
+    first_buf: send_ndarray_buffer
+    second_buf: recv_ndarray_buffer
+    num_frames_to_test: buffer_depth
+    trigger_exit_on_pass: false
+    check_metadata: true
+
+check_ndarray_nolabel_send_recv:
+    kotekan_stage: testDataCheckUchar
+    first_buf: send_ndarray_nolabel_buffer
+    second_buf: recv_ndarray_nolabel_buffer
+    num_frames_to_test: buffer_depth
+    trigger_exit_on_pass: false
+    check_metadata: true
+
 # Monitor recv buffers for completion, shutdown after some inactivity if none.
 
 buffer_monitor:
@@ -206,4 +311,6 @@ buffer_monitor:
         - recv_buffer
         - recv_buffer_noCT
         - recv_N2_buffer
+        - recv_ndarray_buffer
+        - recv_ndarray_nolabel_buffer
     clean_exit_after_frames: 6 # Trigger success after this many frames have been seen

--- a/config/ci-tests/cpu_batch/verify_lost_samples_n2k_counts.yaml
+++ b/config/ci-tests/cpu_batch/verify_lost_samples_n2k_counts.yaml
@@ -45,31 +45,37 @@ main_pool:
 # Buffers
 lost_samples_buffers:
     num_frames: buffer_depth
-    frame_size: samples_per_data_set
     metadata_pool: main_pool
+    # Shared frame descriptor (scope-inherited by all three buffers)
+    value_type: uint8
+    extents: [samples_per_data_set]
+    dimnames: ["T"]
     lost_samples_buffer_0:
-        kotekan_buffer: standard
+        kotekan_buffer: ndarray
     lost_samples_buffer_1:
-        kotekan_buffer: standard
+        kotekan_buffer: ndarray
     lost_samples_buffer_2:
-        kotekan_buffer: standard
+        kotekan_buffer: ndarray
 
 host_rfi_RFImask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: samples_per_data_set * num_local_freq / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 1024, num_local_freq, 128]
     metadata_pool: main_pool
 
 host_pl_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: ((samples_per_data_set / pl_mask_downsampling_factor) * (num_local_freq / 4) * (num_elements / pl_mask_dishes_per_bin)) / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / pl_mask_downsampling_factor / 64, num_freq_bins, num_polarizations, num_dishes / pl_mask_dishes_per_bin, 8]
     metadata_pool: main_pool
 
 dummy_pl_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: ((samples_per_data_set / pl_mask_downsampling_factor) * (num_local_freq / 4) * (num_elements / 8)) / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / pl_mask_downsampling_factor / 64, num_freq_bins, num_polarizations, num_dishes / pl_mask_dishes_per_bin, 8]
     metadata_pool: main_pool
 
 # host_n2k_counts_buffer:
@@ -79,21 +85,24 @@ dummy_pl_mask_buffer:
 #     metadata_pool: main_pool
 
 host_ls_counts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * counts_num_blocks * counts_blocksize * counts_blocksize * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, counts_num_blocks, counts_blocksize, counts_blocksize]
     metadata_pool: main_pool
 
 simulated_pl_mask_exp_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set * (num_local_freq) * (num_elements / 8)) / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 64, num_local_freq, 2, num_elements / 8 / 2, 8]
     metadata_pool: main_pool
 
 simulated_n2k_counts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * counts_num_blocks * counts_blocksize * counts_blocksize * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, counts_num_blocks, counts_blocksize, counts_blocksize]
     metadata_pool: main_pool
 
 ###############################

--- a/config/ci-tests/gpu_batch/test_n2k_writeHDF5.yaml
+++ b/config/ci-tests/gpu_batch/test_n2k_writeHDF5.yaml
@@ -48,21 +48,24 @@ main_pool:
 
 # Buffers
 host_voltage_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: samples_per_data_set * num_elements * num_local_freq
+    value_type: int4x2_swapped_withoffset
+    extents: [samples_per_data_set, num_local_freq, 2, num_elements / 2]
     metadata_pool: main_pool
 
 host_rfi_RFImask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: num_local_freq * samples_per_data_set / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 1024, num_local_freq, 128]
     metadata_pool: main_pool
 
 host_correlation_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: num_local_freq * (samples_per_data_set / sub_integration_ntime) * 16 * 16 * num_vis_blocks * 2 * sizeof_int
+    value_type: int32
+    extents: [num_times / sub_integration_ntime, num_local_freq, num_vis_blocks, 16, 16, 2]
     metadata_pool: main_pool
 
 # Ringbuffer signalling buffer

--- a/config/ci-tests/gpu_batch/test_xpose2048.j2
+++ b/config/ci-tests/gpu_batch/test_xpose2048.j2
@@ -39,20 +39,22 @@ main_pool:
 # Buffers
 
 host_scatter_indices_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_int32 * num_dishes * num_polarizations
+    value_type: int32
+    extents: [num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 host_voltage_buffers:
   num_frames: host_buffer_depth
-  frame_size: samples_per_data_set * num_elements * num_freq_host_buf
   metadata_pool: main_pool
   numa_0:
     numa_node: 0
 {%- for id in range(num_freq_gpu_buf) %}
     host_voltage_buffer_{{ id }}:
-      kotekan_buffer: standard
+      kotekan_buffer: ndarray
+      value_type: int4x2_swapped_withoffset
+      extents: [num_freq_host_buf, samples_per_data_set, num_elements]
 {%- endfor %}
 
 host_voltage_ringbuffer:
@@ -67,17 +69,19 @@ host_xposed_voltage_ringbuffer:
 
 host_xposed_voltage_buffer:
   num_frames: host_buffer_depth
-  frame_size: samples_per_data_set * num_elements * num_freq_gpu_buf
   metadata_pool: main_pool
   host_xposed_voltage_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
+    value_type: int4x2_swapped_withoffset
+    extents: [samples_per_data_set, num_freq_gpu_buf, num_polarizations, num_dishes]
 
 cpu_xposed_voltage_buffer:
   num_frames: host_buffer_depth
-  frame_size: samples_per_data_set * num_elements * num_freq_gpu_buf
   metadata_pool: main_pool
   cpu_xposed_voltage_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
+    value_type: int4x2_swapped_withoffset
+    extents: [samples_per_data_set, num_freq_gpu_buf, num_polarizations, num_dishes]
 # Stages
 
 set_voltage:

--- a/config/ci-tests/gpu_batch/verify_cuda_n2k.yaml
+++ b/config/ci-tests/gpu_batch/verify_cuda_n2k.yaml
@@ -47,51 +47,59 @@ main_pool:
 
 # Buffers
 host_voltage_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: samples_per_data_set * num_local_freq * num_elements
+    value_type: int4x2_swapped_withoffset
+    extents: [samples_per_data_set, num_local_freq, num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 host_rfi_RFImask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: samples_per_data_set * num_local_freq / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 1024, num_local_freq, 128]
     metadata_pool: main_pool
 
 host_pl_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: ((samples_per_data_set / 2) * (num_local_freq / 4) * (num_elements / 8)) / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 128, num_local_freq / 4, num_polarizations, num_dishes / 8, 8]
     metadata_pool: main_pool
 
 host_correlation_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * vis_num_blocks * vis_blocksize * vis_blocksize * 2 * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, vis_num_blocks, vis_blocksize, vis_blocksize, 2]
     metadata_pool: main_pool
 
 host_counts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * counts_num_blocks * counts_blocksize * counts_blocksize * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, counts_num_blocks, counts_blocksize, counts_blocksize]
     metadata_pool: main_pool
 
 simulated_correlation_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * vis_num_blocks * vis_blocksize * vis_blocksize * 2 * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, vis_num_blocks, vis_blocksize, vis_blocksize, 2]
     metadata_pool: main_pool
 
 simulated_pl_mask_exp_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set * (num_local_freq) * (num_elements / 8)) / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 64, num_local_freq, num_polarizations, (num_elements / 8) / 2, 8]
     metadata_pool: main_pool
 
 simulated_counts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * counts_num_blocks * counts_blocksize * counts_blocksize * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, counts_num_blocks, counts_blocksize, counts_blocksize]
     metadata_pool: main_pool
 
 # Ringbuffer signalling buffer

--- a/config/ci-tests/gpu_batch/verify_cuda_n2k_corr.yaml
+++ b/config/ci-tests/gpu_batch/verify_cuda_n2k_corr.yaml
@@ -47,27 +47,31 @@ main_pool:
 
 # Buffers
 host_voltage_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: samples_per_data_set * num_local_freq * num_elements
+    value_type: int4x2_swapped_withoffset
+    extents: [samples_per_data_set, num_local_freq, num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 host_rfi_RFImask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: samples_per_data_set * num_local_freq / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 1024, num_local_freq, 128]
     metadata_pool: main_pool
 
 host_correlation_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * vis_num_blocks * vis_blocksize * vis_blocksize * 2 * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, vis_num_blocks, vis_blocksize, vis_blocksize, 2]
     metadata_pool: main_pool
 
 simulated_correlation_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * vis_num_blocks * vis_blocksize * vis_blocksize * 2 * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, vis_num_blocks, vis_blocksize, vis_blocksize, 2]
     metadata_pool: main_pool
 
 # Ringbuffer signalling buffer

--- a/config/ci-tests/gpu_batch/verify_cuda_n2k_pl1bitcorr.yaml
+++ b/config/ci-tests/gpu_batch/verify_cuda_n2k_pl1bitcorr.yaml
@@ -42,27 +42,31 @@ main_pool:
 
 # Buffers
 host_pl_mask_exp_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set * num_local_freq * (num_elements / 8)) / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 64, num_local_freq, num_polarizations, (num_elements / 8) / 2, 8]
     metadata_pool: main_pool
 
 host_rfi_RFImask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: num_local_freq * samples_per_data_set / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 1024, num_local_freq, 128]
     metadata_pool: main_pool
 
 host_counts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * counts_num_blocks * counts_blocksize * counts_blocksize * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, counts_num_blocks, counts_blocksize, counts_blocksize]
     metadata_pool: main_pool
 
 simulated_counts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * counts_num_blocks * counts_blocksize * counts_blocksize * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, counts_num_blocks, counts_blocksize, counts_blocksize]
     metadata_pool: main_pool
 
 # Ringbuffer signalling buffer

--- a/config/ci-tests/gpu_batch/verify_cuda_n2k_plexp.yaml
+++ b/config/ci-tests/gpu_batch/verify_cuda_n2k_plexp.yaml
@@ -37,21 +37,24 @@ main_pool:
 
 # Buffers
 host_pl_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: ((samples_per_data_set / 2) * (num_local_freq / 4) * (num_elements / 8)) / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 128, num_local_freq / 4, num_polarizations, num_dishes / 8, 8]
     metadata_pool: main_pool
 
 host_pl_mask_exp_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set * num_local_freq * (num_elements / 8)) / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 64, num_local_freq, num_polarizations, (num_elements / 8) / 2, 8]
     metadata_pool: main_pool
 
 simulated_pl_mask_exp_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set * num_local_freq * (num_elements / 8)) / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 64, num_local_freq, num_polarizations, (num_elements / 8) / 2, 8]
     metadata_pool: main_pool
 
 # Ringbuffer signalling buffer

--- a/config/ci-tests/gpu_batch/verify_cuda_pl_accum.yaml
+++ b/config/ci-tests/gpu_batch/verify_cuda_pl_accum.yaml
@@ -35,15 +35,17 @@ main_pool:
     num_metadata_objects: 20 * buffer_depth
 
 host_pl_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: ((samples_per_data_set / 2) * (num_local_freq / 4) * (num_elements / 8)) / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 128, num_local_freq / 4, num_polarizations, num_dishes / 8, 8]
     metadata_pool: main_pool
 
 host_pl_counts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * num_elements * sizeof_long
+    value_type: uint64
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 host_pl_lost_counts_buffer:
@@ -53,9 +55,10 @@ host_pl_lost_counts_buffer:
     metadata_pool: main_pool
 
 simulated_pl_counts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * num_elements * sizeof_long
+    value_type: uint64
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 

--- a/config/ci-tests/gpu_batch/verify_cuda_rfi_s012.yaml
+++ b/config/ci-tests/gpu_batch/verify_cuda_rfi_s012.yaml
@@ -36,33 +36,38 @@ main_pool:
 
 # Buffers
 raw_voltage_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: samples_per_data_set * num_local_freq * num_elements
+    value_type: int4x2_swapped_withoffset
+    extents: [samples_per_data_set, num_local_freq, num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 host_voltage_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: samples_per_data_set * num_local_freq * num_elements
+    value_type: int4x2_swapped_withoffset
+    extents: [samples_per_data_set, num_local_freq, 2, num_elements / 2]
     metadata_pool: main_pool
 
 host_pl_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: ((samples_per_data_set / 2) * (num_local_freq / 4) * (num_elements / 8)) / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 128, num_local_freq / 4, num_polarizations, num_dishes / 8, 8]
     metadata_pool: main_pool
 
 host_rfi_s012_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / rfi_downsampling_factor) * num_local_freq * 3 * num_elements * sizeof_long
+    value_type: uint64
+    extents: [samples_per_data_set / rfi_downsampling_factor, num_local_freq, 3, num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 simulated_rfi_s012_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / rfi_downsampling_factor) * num_local_freq * 3 * num_elements * sizeof_long
+    value_type: uint64
+    extents: [samples_per_data_set / rfi_downsampling_factor, num_local_freq, 3, num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 

--- a/config/ci-tests/gpu_batch/verify_cuda_rfi_s012bar.yaml
+++ b/config/ci-tests/gpu_batch/verify_cuda_rfi_s012bar.yaml
@@ -38,21 +38,24 @@ main_pool:
 # Buffers
 
 host_rfi_s012_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / rfi_downsampling_factor) * num_local_freq * 3 * num_elements * sizeof_long
+    value_type: uint64
+    extents: [samples_per_data_set / rfi_downsampling_factor, num_local_freq, 3, num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 host_rfi_s012bar_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / rfi_downsampling_factor / rfi_second_downsampling_factor) * num_local_freq * 3 * num_elements * sizeof_long
+    value_type: uint64
+    extents: [samples_per_data_set / rfi_downsampling_factor / rfi_second_downsampling_factor, num_local_freq, 3, num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 simulated_rfi_s012bar_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / rfi_downsampling_factor / rfi_second_downsampling_factor) * num_local_freq * 3 * num_elements * sizeof_long
+    value_type: uint64
+    extents: [samples_per_data_set / rfi_downsampling_factor / rfi_second_downsampling_factor, num_local_freq, 3, num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 

--- a/config/ci-tests/gpu_batch/verify_cuda_rfi_s012tilde.yaml
+++ b/config/ci-tests/gpu_batch/verify_cuda_rfi_s012tilde.yaml
@@ -37,27 +37,31 @@ main_pool:
 # Buffers
 
 host_bf_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: num_elements
+    value_type: int8
+    extents: [num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 host_rfi_s012_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / rfi_downsampling_factor) * num_local_freq * 3 * num_elements * sizeof_long
+    value_type: uint64
+    extents: [samples_per_data_set / rfi_downsampling_factor, num_local_freq, 3, num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 host_rfi_s012tilde_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / rfi_downsampling_factor) * num_local_freq * 3 * sizeof_long
+    value_type: uint64
+    extents: [samples_per_data_set / rfi_downsampling_factor, num_local_freq, 3]
     metadata_pool: main_pool
 
 simulated_rfi_s012tilde_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / rfi_downsampling_factor) * num_local_freq * 3 * sizeof_long
+    value_type: uint64
+    extents: [samples_per_data_set / rfi_downsampling_factor, num_local_freq, 3]
     metadata_pool: main_pool
 
 

--- a/config/ci-tests/gpu_batch/verify_cuda_rfi_skbar.yaml
+++ b/config/ci-tests/gpu_batch/verify_cuda_rfi_skbar.yaml
@@ -47,45 +47,52 @@ main_pool:
 # Buffers
 
 host_bf_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: num_elements
+    value_type: int8
+    extents: [num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 host_rfi_s012bar_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: rfi_num_times_bar * num_local_freq * 3 * num_elements * sizeof_long
+    value_type: uint64
+    extents: [rfi_num_times_bar, num_local_freq, 3, num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 host_rfi_skbar_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: rfi_num_times_bar * num_local_freq * 3 * num_elements * sizeof_float
+    value_type: float32
+    extents: [rfi_num_times_bar, num_local_freq, 3, num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 host_rfi_skbartilde_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: rfi_num_times_bar * num_local_freq * 3 * sizeof_float
+    value_type: float32
+    extents: [rfi_num_times_bar, num_local_freq, 3]
     metadata_pool: main_pool
 
 simulated_rfi_skbar_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: rfi_num_times_bar * num_local_freq * 3 * num_elements * sizeof_float
+    value_type: float32
+    extents: [rfi_num_times_bar, num_local_freq, 3, num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 simulated_rfi_skbartilde_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: rfi_num_times_bar * num_local_freq * 3 * sizeof_float
+    value_type: float32
+    extents: [rfi_num_times_bar, num_local_freq, 3]
     metadata_pool: main_pool
 
 simulated_rfi_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: samples_per_data_set * num_local_freq / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 1024, num_local_freq, 128]
     metadata_pool: main_pool
 
 

--- a/config/ci-tests/gpu_batch/verify_cuda_rfi_sktilde.yaml
+++ b/config/ci-tests/gpu_batch/verify_cuda_rfi_sktilde.yaml
@@ -50,45 +50,52 @@ main_pool:
 # Buffers
 
 host_bf_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: num_elements
+    value_type: int8
+    extents: [num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 host_rfi_s012_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / rfi_downsampling_factor) * num_local_freq * 3 * num_elements * sizeof_long
+    value_type: uint64
+    extents: [samples_per_data_set / rfi_downsampling_factor, num_local_freq, 3, num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 host_rfi_sktilde_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / rfi_downsampling_factor) * num_local_freq * 3 * sizeof_float
+    value_type: float32
+    extents: [samples_per_data_set / rfi_downsampling_factor, num_local_freq, 3]
     metadata_pool: main_pool
 
 host_rfi_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: samples_per_data_set * num_local_freq / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 1024, num_local_freq, 128]
     metadata_pool: main_pool
 
 simulated_rfi_sk_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / rfi_downsampling_factor) * num_local_freq * 3 * num_elements * sizeof_float
+    value_type: float32
+    extents: [samples_per_data_set / rfi_downsampling_factor, num_local_freq, 3, num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 simulated_rfi_sktilde_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / rfi_downsampling_factor) * num_local_freq * 3 * sizeof_float
+    value_type: float32
+    extents: [samples_per_data_set / rfi_downsampling_factor, num_local_freq, 3]
     metadata_pool: main_pool
 
 simulated_rfi_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: samples_per_data_set * num_local_freq / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 1024, num_local_freq, 128]
     metadata_pool: main_pool
 
 

--- a/config/ci-tests/gpu_batch/verify_fake_n2k.yaml
+++ b/config/ci-tests/gpu_batch/verify_fake_n2k.yaml
@@ -49,45 +49,52 @@ main_pool:
 
 # Buffers
 host_voltage_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: samples_per_data_set * num_local_freq * num_elements
+    value_type: int4x2_swapped_withoffset
+    extents: [samples_per_data_set, num_local_freq, num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 host_rfi_RFImask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: samples_per_data_set * num_local_freq / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 1024, num_local_freq, 128]
     metadata_pool: main_pool
 
 host_pl_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: ((samples_per_data_set / 2) * (num_local_freq / 4) * (num_elements / 8)) / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 128, num_local_freq / 4, num_polarizations, num_dishes / 8, 8]
     metadata_pool: main_pool
 
 host_correlation_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * vis_num_blocks * vis_blocksize * vis_blocksize * 2 * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, vis_num_blocks, vis_blocksize, vis_blocksize, 2]
     metadata_pool: main_pool
 
 host_counts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * counts_num_blocks * counts_blocksize * counts_blocksize * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, counts_num_blocks, counts_blocksize, counts_blocksize]
     metadata_pool: main_pool
 
 fake_correlation_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * vis_num_blocks * vis_blocksize * vis_blocksize * 2 * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, vis_num_blocks, vis_blocksize, vis_blocksize, 2]
     metadata_pool: main_pool
 
 fake_counts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * counts_num_blocks * counts_blocksize * counts_blocksize * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, counts_num_blocks, counts_blocksize, counts_blocksize]
     metadata_pool: main_pool
 
 # Ringbuffer signalling buffer

--- a/config/ci-tests/standalone/test_pipeline.j2
+++ b/config/ci-tests/standalone/test_pipeline.j2
@@ -147,39 +147,48 @@ n2_pool:
 
 # Buffers
 host_voltage_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: samples_per_data_set * num_elements * num_local_freq
+    value_type: int4x2_swapped_withoffset
+    extents: [samples_per_data_set, num_local_freq, num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 host_rfi_RFImask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: num_local_freq * samples_per_data_set / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 1024, num_local_freq, 128]
     metadata_pool: main_pool
 
 host_pl_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / 128) * (num_local_freq / 4) * 2 * (num_dishes / 8) * 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 128, num_local_freq / 4, num_polarizations, num_dishes / 8, 8]
     metadata_pool: main_pool
 
 vis_blocksize: 16
 vis_num_blocks_lin: num_elements / vis_blocksize
 vis_num_blocks: vis_num_blocks_lin * (vis_num_blocks_lin + 1) / 2
 host_correlation_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: num_local_freq * (samples_per_data_set / sub_integration_ntime) * 16 * 16 * vis_num_blocks * 2 * sizeof_gpu_int
+    value_type: int32
+    # num_elements=1024: cudaCorrelator (num_elements+1)/16=64 == N2Accumulate num_elements/16=64
+    # -> vis_num_blocks=2080 from both producer and consumer; safe to flip.
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, vis_num_blocks, vis_blocksize, vis_blocksize, 2]
     metadata_pool: main_pool
 
 counts_blocksize: 8
 counts_num_blocks_lin: (num_elements / 8) / counts_blocksize
 counts_num_blocks: (counts_num_blocks_lin * (counts_num_blocks_lin + 1)) / 2
 host_counts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * counts_num_blocks * counts_blocksize * counts_blocksize * sizeof_gpu_int
+    value_type: int32
+    # num_elements=1024: cudaPL1bitCorrelator (num_pol*num_dishes/8+1)/8=16 ==
+    # N2Accumulate num_elements/(8*counts_blocksize)=16 -> counts_num_blocks=136 from both; safe.
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, counts_num_blocks, counts_blocksize, counts_blocksize]
     metadata_pool: main_pool
 
 n2_buffer:
@@ -430,6 +439,7 @@ n2_accumulate:
     packet_loss_is_scalar: True
     num_subintegrations_per_bin: {{ num_subintegrations_per_bin }}
     input_order: CHORDBeamformer
+    variance_mode: EvenOddPosDef
 
 
 # Add eigen calculation

--- a/config/fengine/include/bb_charts.j2
+++ b/config/fengine/include/bb_charts.j2
@@ -21,27 +21,31 @@ bb_scale: 12
 # Buffers
 
 host_bb_beam_positions_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float32 * 2 * bb_num_beams
+    value_type: float32
+    extents: [bb_num_beams, 2]
     metadata_pool: main_pool
 
 host_bb_beam_ids_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_uint64 * bb_num_beams
+    value_type: uint64
+    extents: [bb_num_beams]
     metadata_pool: main_pool
 
 host_bb_phase_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: num_components * num_dishes * bb_num_beams * num_polarizations * num_frequencies
+    value_type: int8
+    extents: [num_frequencies, num_polarizations, bb_num_beams, num_dishes, num_components]
     metadata_pool: main_pool
 
 host_bb_shift_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_int32 * bb_num_beams * num_polarizations * num_frequencies
+    value_type: int32
+    extents: [num_frequencies, num_polarizations, bb_num_beams]
     metadata_pool: main_pool
 
 host_bb_beams_buffer:

--- a/config/fengine/include/bb_chime.j2
+++ b/config/fengine/include/bb_chime.j2
@@ -21,27 +21,31 @@ bb_scale: 12
 # Buffers
 
 host_bb_beam_positions_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float32 * 2 * bb_num_beams
+    value_type: float32
+    extents: [bb_num_beams, 2]
     metadata_pool: main_pool
 
 host_bb_beam_ids_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_uint64 * bb_num_beams
+    value_type: uint64
+    extents: [bb_num_beams]
     metadata_pool: main_pool
 
 host_bb_phase_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: num_components * num_dishes * bb_num_beams * num_polarizations * num_frequencies
+    value_type: int8
+    extents: [num_frequencies, num_polarizations, bb_num_beams, num_dishes, num_components]
     metadata_pool: main_pool
 
 host_bb_shift_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_int32 * bb_num_beams * num_polarizations * num_frequencies
+    value_type: int32
+    extents: [num_frequencies, num_polarizations, bb_num_beams]
     metadata_pool: main_pool
 
 host_bb_beams_buffer:

--- a/config/fengine/include/bb_chord.j2
+++ b/config/fengine/include/bb_chord.j2
@@ -21,27 +21,31 @@ bb_scale: 12
 # Buffers
 
 host_bb_beam_positions_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float32 * 2 * bb_num_beams
+    value_type: float32
+    extents: [bb_num_beams, 2]
     metadata_pool: main_pool
 
 host_bb_beam_ids_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_uint64 * bb_num_beams
+    value_type: uint64
+    extents: [bb_num_beams]
     metadata_pool: main_pool
 
 host_bb_phase_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: num_components * num_dishes * bb_num_beams * num_polarizations * num_frequencies
+    value_type: int8
+    extents: [num_frequencies, num_polarizations, bb_num_beams, num_dishes, num_components]
     metadata_pool: main_pool
 
 host_bb_shift_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_int32 * bb_num_beams * num_polarizations * num_frequencies
+    value_type: int32
+    extents: [num_frequencies, num_polarizations, bb_num_beams]
     metadata_pool: main_pool
 
 host_bb_beams_buffer:

--- a/config/fengine/include/bb_hirax.j2
+++ b/config/fengine/include/bb_hirax.j2
@@ -21,27 +21,31 @@ bb_scale: 12
 # Buffers
 
 host_bb_beam_positions_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float32 * 2 * bb_num_beams
+    value_type: float32
+    extents: [bb_num_beams, 2]
     metadata_pool: main_pool
 
 host_bb_beam_ids_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_uint64 * bb_num_beams
+    value_type: uint64
+    extents: [bb_num_beams]
     metadata_pool: main_pool
 
 host_bb_phase_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: num_components * num_dishes * bb_num_beams * num_polarizations * num_frequencies
+    value_type: int8
+    extents: [num_frequencies, num_polarizations, bb_num_beams, num_dishes, num_components]
     metadata_pool: main_pool
 
 host_bb_shift_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_int32 * bb_num_beams * num_polarizations * num_frequencies
+    value_type: int32
+    extents: [num_frequencies, num_polarizations, bb_num_beams]
     metadata_pool: main_pool
 
 host_bb_beams_buffer:

--- a/config/fengine/include/bb_pathfinder.j2
+++ b/config/fengine/include/bb_pathfinder.j2
@@ -21,27 +21,31 @@ bb_scale: 12
 # Buffers
 
 host_bb_beam_positions_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float32 * 2 * bb_num_beams
+    value_type: float32
+    extents: [bb_num_beams, 2]
     metadata_pool: main_pool
 
 host_bb_beam_ids_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_uint64 * bb_num_beams
+    value_type: uint64
+    extents: [bb_num_beams]
     metadata_pool: main_pool
 
 host_bb_phase_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: num_components * num_dishes * bb_num_beams * num_polarizations * num_frequencies
+    value_type: int8
+    extents: [num_frequencies, num_polarizations, bb_num_beams, num_dishes, num_components]
     metadata_pool: main_pool
 
 host_bb_shift_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_int32 * bb_num_beams * num_polarizations * num_frequencies
+    value_type: int32
+    extents: [num_frequencies, num_polarizations, bb_num_beams]
     metadata_pool: main_pool
 
 host_bb_beams_buffer:

--- a/config/fengine/include/fengine_charts.j2
+++ b/config/fengine/include/fengine_charts.j2
@@ -113,15 +113,17 @@ num_times: 16384                 # frame length is 16384 * 3.333 us = 54.613 ms
 # Buffers
 
 host_bf_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_int8 * num_dishes * num_polarizations
+    value_type: int8
+    extents: [num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 host_pl_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (64 / 8) * (num_dishes / 8) * num_polarizations * (num_frequencies / 4) * (num_times / 2 / 64)
+    value_type: uint1x8
+    extents: [num_times / 2 / 64, num_frequencies / 4, num_polarizations, num_dishes / 8, 64 / 8]
     metadata_pool: main_pool
 host_pl_mask_ringbuffer:
     kotekan_buffer: ring

--- a/config/fengine/include/fengine_chime.j2
+++ b/config/fengine/include/fengine_chime.j2
@@ -90,15 +90,17 @@ num_times: 16384                # frame length is 16384 * 2.56 us = 41.94304 ms
 # Buffers
 
 host_bf_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_int8 * num_dishes * num_polarizations
+    value_type: int8
+    extents: [num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 host_pl_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (64 / 8) * (num_dishes / 8) * num_polarizations * (num_frequencies / 4) * (num_times / 2 / 64)
+    value_type: uint1x8
+    extents: [num_times / 2 / 64, num_frequencies / 4, num_polarizations, num_dishes / 8, 64 / 8]
     metadata_pool: main_pool
 host_pl_mask_ringbuffer:
     kotekan_buffer: ring
@@ -106,9 +108,10 @@ host_pl_mask_ringbuffer:
     metadata_pool: main_pool
 
 host_pl_expanded_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (64 / 8) * (num_dishes / 8) * num_polarizations * num_frequencies * (num_times / 64)
+    value_type: uint1x8
+    extents: [num_times / 64, num_frequencies, num_polarizations, num_dishes / 8, 64 / 8]
     metadata_pool: main_pool
 host_pl_expanded_mask_ringbuffer:
     kotekan_buffer: ring
@@ -117,18 +120,21 @@ host_pl_expanded_mask_ringbuffer:
 
 host_voltage_buffers:
   num_frames: buffer_depth
-  frame_size: num_dishes * num_polarizations * num_times
+  value_type: int4x2_swapped_withoffset
+  extents: [1, num_times, num_polarizations * num_dishes]
+  dimnames: ["F", "T", "E"]
   metadata_pool: main_pool
   numa_0:
 {% for id in range(16) %}   # num_frequencies = 16
     host_voltage_buffer_{{ id }}:
-      kotekan_buffer: standard
+      kotekan_buffer: ndarray
 {% endfor %}
 
 host_voltage_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: num_dishes * num_polarizations * num_frequencies * num_times
+    value_type: int4x2_swapped_withoffset
+    extents: [num_times, num_frequencies, num_polarizations, num_dishes]
     metadata_pool: main_pool
 host_voltage_ringbuffer:
     kotekan_buffer: ring

--- a/config/fengine/include/fengine_chord.j2
+++ b/config/fengine/include/fengine_chord.j2
@@ -94,15 +94,17 @@ num_times: 8192                 # frame length is 8192 * 5.12 us = 41.94304 ms
 # Buffers
 
 host_bf_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_int8 * num_dishes * num_polarizations
+    value_type: int8
+    extents: [num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 host_pl_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (64 / 8) * (num_dishes / 8) * num_polarizations * (num_frequencies / 4) * (num_times / 2 / 64)
+    value_type: uint1x8
+    extents: [num_times / 2 / 64, num_frequencies / 4, num_polarizations, num_dishes / 8, 64 / 8]
     metadata_pool: main_pool
 host_pl_mask_ringbuffer:
     kotekan_buffer: ring
@@ -110,9 +112,10 @@ host_pl_mask_ringbuffer:
     metadata_pool: main_pool
 
 host_pl_expanded_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (64 / 8) * (num_dishes / 8) * num_polarizations * num_frequencies * (num_times / 64)
+    value_type: uint1x8
+    extents: [num_times / 64, num_frequencies, num_polarizations, num_dishes / 8, 64 / 8]
     metadata_pool: main_pool
 host_pl_expanded_mask_ringbuffer:
     kotekan_buffer: ring
@@ -120,9 +123,10 @@ host_pl_expanded_mask_ringbuffer:
     metadata_pool: main_pool
 
 host_voltage_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: num_dishes * num_polarizations * num_frequencies * num_times
+    value_type: int4x2_swapped_withoffset
+    extents: [num_times, num_frequencies, num_polarizations, num_dishes]
     metadata_pool: main_pool
 host_voltage_ringbuffer:
     kotekan_buffer: ring

--- a/config/fengine/include/fengine_hirax.j2
+++ b/config/fengine/include/fengine_hirax.j2
@@ -93,15 +93,17 @@ num_times: 16384                # frame length is 16384 * 2.56 us = 41.94304 ms
 # Buffers
 
 host_bf_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_int8 * num_dishes * num_polarizations
+    value_type: int8
+    extents: [num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 host_pl_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (64 / 8) * (num_dishes / 8) * num_polarizations * (num_frequencies / 4) * (num_times / 2 / 64)
+    value_type: uint1x8
+    extents: [num_times / 2 / 64, num_frequencies / 4, num_polarizations, num_dishes / 8, 64 / 8]
     metadata_pool: main_pool
 host_pl_mask_ringbuffer:
     kotekan_buffer: ring
@@ -109,9 +111,10 @@ host_pl_mask_ringbuffer:
     metadata_pool: main_pool
 
 host_pl_expanded_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (64 / 8) * (num_dishes / 8) * num_polarizations * num_frequencies * (num_times / 64)
+    value_type: uint1x8
+    extents: [num_times / 64, num_frequencies, num_polarizations, num_dishes / 8, 64 / 8]
     metadata_pool: main_pool
 host_pl_expanded_mask_ringbuffer:
     kotekan_buffer: ring
@@ -119,9 +122,10 @@ host_pl_expanded_mask_ringbuffer:
     metadata_pool: main_pool
 
 host_voltage_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: num_dishes * num_polarizations * num_frequencies * num_times
+    value_type: int4x2_swapped_withoffset
+    extents: [num_times, num_frequencies, num_polarizations, num_dishes]
     metadata_pool: main_pool
 host_voltage_ringbuffer:
     kotekan_buffer: ring

--- a/config/fengine/include/fengine_pathfinder.j2
+++ b/config/fengine/include/fengine_pathfinder.j2
@@ -126,15 +126,17 @@ num_times: 8192                 # frame length is 8192 * 5.12 us = 41.94304 ms
 # Buffers
 
 host_bf_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_int8 * num_dishes * num_polarizations
+    value_type: int8
+    extents: [num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 host_pl_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (64 / 8) * (num_dishes / 8) * num_polarizations * (num_frequencies / 4) * (num_times / 2 / 64)
+    value_type: uint1x8
+    extents: [num_times / 2 / 64, num_frequencies / 4, num_polarizations, num_dishes / 8, 64 / 8]
     metadata_pool: main_pool
 host_pl_mask_ringbuffer:
     kotekan_buffer: ring
@@ -142,9 +144,10 @@ host_pl_mask_ringbuffer:
     metadata_pool: main_pool
 
 host_pl_expanded_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (64 / 8) * (num_dishes / 8) * num_polarizations * num_frequencies * (num_times / 64)
+    value_type: uint1x8
+    extents: [num_times / 64, num_frequencies, num_polarizations, num_dishes / 8, 64 / 8]
     metadata_pool: main_pool
 host_pl_expanded_mask_ringbuffer:
     kotekan_buffer: ring
@@ -152,9 +155,10 @@ host_pl_expanded_mask_ringbuffer:
     metadata_pool: main_pool
 
 host_voltage_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: num_dishes * num_polarizations * num_frequencies * num_times
+    value_type: int4x2_swapped_withoffset
+    extents: [num_times, num_frequencies, num_polarizations, num_dishes]
     metadata_pool: main_pool
 host_voltage_ringbuffer:
     kotekan_buffer: ring

--- a/config/fengine/include/frb_charts.j2
+++ b/config/fengine/include/frb_charts.j2
@@ -25,27 +25,31 @@ frb_chunk_size: 256
 # Phases
 
 host_frb1_U32_phase_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * num_components * num_dishes_y * num_dishes_x * upchan_U32_max_num_channels * 32 * num_polarizations
+    value_type: float16
+    extents: [upchan_U32_max_num_channels * 32, num_polarizations, num_dishes_y, num_dishes_x, num_components]
     metadata_pool: main_pool
 
 host_frb2_beam_positions_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float32 * 2 * frb2_num_beams
+    value_type: float32
+    extents: [frb2_num_beams, 2]
     metadata_pool: main_pool
 
 host_frb2_beam_ids_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_uint64 * frb2_num_beams
+    value_type: uint64
+    extents: [frb2_num_beams]
     metadata_pool: main_pool
 
 host_frb2_weights_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * (2 * num_dishes_y) * (2 * num_dishes_x) * (frb2_num_beams_x * frb2_num_beams_y) * (upchan_all_max_output_channel - upchan_all_min_output_channel)
+    value_type: float16
+    extents: [upchan_all_max_output_channel - upchan_all_min_output_channel, frb2_num_beams, frb1_num_beams_Q, frb1_num_beams_P]
     metadata_pool: main_pool
 
 # Beams

--- a/config/fengine/include/frb_chime.j2
+++ b/config/fengine/include/frb_chime.j2
@@ -26,27 +26,31 @@ frb_chunk_size: 256
 # Phases
 
 host_frb1_U16_phase_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * num_components * num_dishes_y * num_dishes_x * upchan_U16_max_num_channels * 16 * num_polarizations
+    value_type: float16
+    extents: [upchan_U16_max_num_channels * 16, num_polarizations, num_dishes_x, num_dishes_y, num_components]
     metadata_pool: main_pool
 
 host_frb2_beam_positions_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float32 * 2 * frb2_num_beams
+    value_type: float32
+    extents: [frb2_num_beams, 2]
     metadata_pool: main_pool
 
 host_frb2_beam_ids_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_uint64 * frb2_num_beams
+    value_type: uint64
+    extents: [frb2_num_beams]
     metadata_pool: main_pool
 
 host_frb2_weights_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * (2 * num_dishes_y) * (2 * num_dishes_x) * (frb2_num_beams_x * frb2_num_beams_y) * (upchan_U16_max_output_channel - upchan_U16_min_output_channel)
+    value_type: float16
+    extents: [upchan_U16_max_output_channel - upchan_U16_min_output_channel, frb2_num_beams, frb1_num_beams_Q, frb1_num_beams_P]
     metadata_pool: main_pool
 
 # Beams

--- a/config/fengine/include/frb_chord.j2
+++ b/config/fengine/include/frb_chord.j2
@@ -25,63 +25,73 @@ frb_chunk_size: 256
 # Phases
 
 host_frb1_U1_phase_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * num_components * num_dishes_y * num_dishes_x * upchan_U1_max_num_channels * 1 * num_polarizations
+    value_type: float16
+    extents: [upchan_U1_max_num_channels * 1, num_polarizations, num_dishes_y, num_dishes_x, num_components]
     metadata_pool: main_pool
 
 host_frb1_U2_phase_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * num_components * num_dishes_y * num_dishes_x * upchan_U2_max_num_channels * 2 * num_polarizations
+    value_type: float16
+    extents: [upchan_U2_max_num_channels * 2, num_polarizations, num_dishes_y, num_dishes_x, num_components]
     metadata_pool: main_pool
 
 host_frb1_U4_phase_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * num_components * num_dishes_y * num_dishes_x * upchan_U4_max_num_channels * 4 * num_polarizations
+    value_type: float16
+    extents: [upchan_U4_max_num_channels * 4, num_polarizations, num_dishes_y, num_dishes_x, num_components]
     metadata_pool: main_pool
 
 host_frb1_U8_phase_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * num_components * num_dishes_y * num_dishes_x * upchan_U8_max_num_channels * 8 * num_polarizations
+    value_type: float16
+    extents: [upchan_U8_max_num_channels * 8, num_polarizations, num_dishes_y, num_dishes_x, num_components]
     metadata_pool: main_pool
 
 host_frb1_U16_phase_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * num_components * num_dishes_y * num_dishes_x * upchan_U16_max_num_channels * 16 * num_polarizations
+    value_type: float16
+    extents: [upchan_U16_max_num_channels * 16, num_polarizations, num_dishes_y, num_dishes_x, num_components]
     metadata_pool: main_pool
 
 host_frb1_U32_phase_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * num_components * num_dishes_y * num_dishes_x * upchan_U32_max_num_channels * 32 * num_polarizations
+    value_type: float16
+    extents: [upchan_U32_max_num_channels * 32, num_polarizations, num_dishes_y, num_dishes_x, num_components]
     metadata_pool: main_pool
 
 host_frb1_U64_phase_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * num_components * num_dishes_y * num_dishes_x * upchan_U64_max_num_channels * 64 * num_polarizations
+    value_type: float16
+    extents: [upchan_U64_max_num_channels * 64, num_polarizations, num_dishes_y, num_dishes_x, num_components]
     metadata_pool: main_pool
 
 host_frb2_beam_positions_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float32 * 2 * frb2_num_beams
+    value_type: float32
+    extents: [frb2_num_beams, 2]
     metadata_pool: main_pool
 
 host_frb2_beam_ids_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_uint64 * frb2_num_beams
+    value_type: uint64
+    extents: [frb2_num_beams]
     metadata_pool: main_pool
 
 host_frb2_weights_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * (2 * num_dishes_y) * (2 * num_dishes_x) * (frb2_num_beams_x * frb2_num_beams_y) * (upchan_all_max_output_channel - upchan_all_min_output_channel)
+    value_type: float16
+    extents: [upchan_all_max_output_channel - upchan_all_min_output_channel, frb2_num_beams, frb1_num_beams_Q, frb1_num_beams_P]
     metadata_pool: main_pool
 
 # Beams

--- a/config/fengine/include/frb_hirax.j2
+++ b/config/fengine/include/frb_hirax.j2
@@ -25,39 +25,45 @@ frb_chunk_size: 256
 # Phases
 
 host_frb1_U8_phase_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * num_components * num_dishes_y * num_dishes_x * upchan_U8_max_num_channels * 8 * num_polarizations
+    value_type: float16
+    extents: [upchan_U8_max_num_channels * 8, num_polarizations, num_dishes_y, num_dishes_x, num_components]
     metadata_pool: main_pool
 
 host_frb1_U16_phase_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * num_components * num_dishes_y * num_dishes_x * upchan_U16_max_num_channels * 16 * num_polarizations
+    value_type: float16
+    extents: [upchan_U16_max_num_channels * 16, num_polarizations, num_dishes_y, num_dishes_x, num_components]
     metadata_pool: main_pool
 
 host_frb1_U32_phase_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * num_components * num_dishes_y * num_dishes_x * upchan_U32_max_num_channels * 32 * num_polarizations
+    value_type: float16
+    extents: [upchan_U32_max_num_channels * 32, num_polarizations, num_dishes_y, num_dishes_x, num_components]
     metadata_pool: main_pool
 
 host_frb2_beam_positions_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float32 * 2 * frb2_num_beams
+    value_type: float32
+    extents: [frb2_num_beams, 2]
     metadata_pool: main_pool
 
 host_frb2_beam_ids_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_uint64 * frb2_num_beams
+    value_type: uint64
+    extents: [frb2_num_beams]
     metadata_pool: main_pool
 
 host_frb2_weights_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * (2 * num_dishes_y) * (2 * num_dishes_x) * (frb2_num_beams_x * frb2_num_beams_y) * (upchan_all_max_output_channel - upchan_all_min_output_channel)
+    value_type: float16
+    extents: [upchan_all_max_output_channel - upchan_all_min_output_channel, frb2_num_beams, frb1_num_beams_Q, frb1_num_beams_P]
     metadata_pool: main_pool
 
 # Beams

--- a/config/fengine/include/frb_pathfinder.j2
+++ b/config/fengine/include/frb_pathfinder.j2
@@ -25,63 +25,73 @@ frb_chunk_size: 256
 # Phases
 
 host_frb1_U1_phase_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * num_components * num_dishes_y * num_dishes_x * upchan_U1_max_num_channels * 1 * num_polarizations
+    value_type: float16
+    extents: [upchan_U1_max_num_channels * 1, num_polarizations, num_dishes_y, num_dishes_x, num_components]
     metadata_pool: main_pool
 
 host_frb1_U2_phase_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * num_components * num_dishes_y * num_dishes_x * upchan_U2_max_num_channels * 2 * num_polarizations
+    value_type: float16
+    extents: [upchan_U2_max_num_channels * 2, num_polarizations, num_dishes_y, num_dishes_x, num_components]
     metadata_pool: main_pool
 
 host_frb1_U4_phase_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * num_components * num_dishes_y * num_dishes_x * upchan_U4_max_num_channels * 4 * num_polarizations
+    value_type: float16
+    extents: [upchan_U4_max_num_channels * 4, num_polarizations, num_dishes_y, num_dishes_x, num_components]
     metadata_pool: main_pool
 
 host_frb1_U8_phase_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * num_components * num_dishes_y * num_dishes_x * upchan_U8_max_num_channels * 8 * num_polarizations
+    value_type: float16
+    extents: [upchan_U8_max_num_channels * 8, num_polarizations, num_dishes_y, num_dishes_x, num_components]
     metadata_pool: main_pool
 
 host_frb1_U16_phase_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * num_components * num_dishes_y * num_dishes_x * upchan_U16_max_num_channels * 16 * num_polarizations
+    value_type: float16
+    extents: [upchan_U16_max_num_channels * 16, num_polarizations, num_dishes_y, num_dishes_x, num_components]
     metadata_pool: main_pool
 
 host_frb1_U32_phase_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * num_components * num_dishes_y * num_dishes_x * upchan_U32_max_num_channels * 32 * num_polarizations
+    value_type: float16
+    extents: [upchan_U32_max_num_channels * 32, num_polarizations, num_dishes_y, num_dishes_x, num_components]
     metadata_pool: main_pool
 
 host_frb1_U64_phase_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * num_components * num_dishes_y * num_dishes_x * upchan_U64_max_num_channels * 64 * num_polarizations
+    value_type: float16
+    extents: [upchan_U64_max_num_channels * 64, num_polarizations, num_dishes_y, num_dishes_x, num_components]
     metadata_pool: main_pool
 
 host_frb2_beam_positions_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float32 * 2 * frb2_num_beams
+    value_type: float32
+    extents: [frb2_num_beams, 2]
     metadata_pool: main_pool
 
 host_frb2_beam_ids_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_uint64 * frb2_num_beams
+    value_type: uint64
+    extents: [frb2_num_beams]
     metadata_pool: main_pool
 
 host_frb2_weights_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * (2 * num_dishes_y) * (2 * num_dishes_x) * (frb2_num_beams_x * frb2_num_beams_y) * (upchan_all_max_output_channel - upchan_all_min_output_channel)
+    value_type: float16
+    extents: [upchan_all_max_output_channel - upchan_all_min_output_channel, frb2_num_beams, frb1_num_beams_Q, frb1_num_beams_P]
     metadata_pool: main_pool
 
 # Beams

--- a/config/fengine/include/hfb_chime.j2
+++ b/config/fengine/include/hfb_chime.j2
@@ -21,27 +21,31 @@ hfb2_beam_separation_y: 90.0 / 256
 # Phases
 
 host_hfb1_U128_phase_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * num_components * num_dishes_y * num_dishes_x * upchan_hfb_upchan_U128_max_num_channels * 128 * num_polarizations
+    value_type: float16
+    extents: [upchan_hfb_upchan_U128_max_num_channels * 128, num_polarizations, num_dishes_x, num_dishes_y, num_components]
     metadata_pool: main_pool
 
 host_hfb2_beam_positions_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float32 * 2 * hfb2_num_beams
+    value_type: float32
+    extents: [hfb2_num_beams, 2]
     metadata_pool: main_pool
 
 host_hfb2_beam_ids_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_uint64 * hfb2_num_beams
+    value_type: uint64
+    extents: [hfb2_num_beams]
     metadata_pool: main_pool
 
 host_hfb2_weights_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * (2 * num_dishes_y) * (2 * num_dishes_x) * (hfb2_num_beams_x * hfb2_num_beams_y) * upchan_hfb_upchan_U128_max_num_output_channels
+    value_type: float16
+    extents: [upchan_hfb_upchan_U128_max_num_output_channels, hfb2_num_beams, frb1_num_beams_Q, frb1_num_beams_P]
     metadata_pool: main_pool
 
 # Beams

--- a/config/fengine/include/n2k_charts.j2
+++ b/config/fengine/include/n2k_charts.j2
@@ -28,33 +28,38 @@ n2k_counts_triangle_num_blocks: n2k_counts_linear_num_blocks * (n2k_counts_linea
 n2k_counts_triangle_size: n2k_counts_blocksize * n2k_counts_blocksize * n2k_counts_triangle_num_blocks
 
 host_n2k_correlation_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: sizeof_int32 * num_components * n2k_correlation_triangle_size * num_frequencies * n2k_num_subintegrations
+    value_type: int32
+    extents: [n2k_num_subintegrations, num_frequencies, n2k_correlation_triangle_num_blocks, n2k_correlation_blocksize, n2k_correlation_blocksize, 2]
     metadata_pool: main_pool
 
 host_n2k_counts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: sizeof_int32 * n2k_counts_triangle_size * num_frequencies * n2k_num_subintegrations
+    value_type: int32
+    extents: [n2k_num_subintegrations, num_frequencies, n2k_counts_triangle_num_blocks, n2k_counts_blocksize, n2k_counts_blocksize]
     metadata_pool: main_pool
 
 host_n2k_plcounts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: sizeof_int32 * num_frequencies * n2k_num_subintegrations
+    value_type: int32
+    extents: [n2k_num_subintegrations, num_frequencies]
     metadata_pool: main_pool
 
 host_n2k_rficounts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: sizeof_int32 * num_frequencies * n2k_num_subintegrations
+    value_type: int32
+    extents: [n2k_num_subintegrations, num_frequencies]
     metadata_pool: main_pool
 
 host_n2k_rfiframemask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: sizeof_uint8 * num_frequencies * n2k_num_subintegrations
+    value_type: uint8
+    extents: [n2k_num_subintegrations, num_frequencies]
     metadata_pool: main_pool
 
 host_n2_vis_buffer:

--- a/config/fengine/include/n2k_chime.j2
+++ b/config/fengine/include/n2k_chime.j2
@@ -28,33 +28,38 @@ n2k_counts_triangle_num_blocks: n2k_counts_linear_num_blocks * (n2k_counts_linea
 n2k_counts_triangle_size: n2k_counts_blocksize * n2k_counts_blocksize * n2k_counts_triangle_num_blocks
 
 host_n2k_correlation_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: sizeof_int32 * num_components * n2k_correlation_triangle_size * num_frequencies * n2k_num_subintegrations
+    value_type: int32
+    extents: [n2k_num_subintegrations, num_frequencies, n2k_correlation_triangle_num_blocks, n2k_correlation_blocksize, n2k_correlation_blocksize, 2]
     metadata_pool: main_pool
 
 host_n2k_counts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: sizeof_int32 * n2k_counts_triangle_size * num_frequencies * n2k_num_subintegrations
+    value_type: int32
+    extents: [n2k_num_subintegrations, num_frequencies, n2k_counts_triangle_num_blocks, n2k_counts_blocksize, n2k_counts_blocksize]
     metadata_pool: main_pool
 
 host_n2k_plcounts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: sizeof_int32 * num_frequencies * n2k_num_subintegrations
+    value_type: int32
+    extents: [n2k_num_subintegrations, num_frequencies]
     metadata_pool: main_pool
 
 host_n2k_rficounts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: sizeof_int32 * num_frequencies * n2k_num_subintegrations
+    value_type: int32
+    extents: [n2k_num_subintegrations, num_frequencies]
     metadata_pool: main_pool
 
 host_n2k_rfiframemask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: sizeof_uint8 * num_frequencies * n2k_num_subintegrations
+    value_type: uint8
+    extents: [n2k_num_subintegrations, num_frequencies]
     metadata_pool: main_pool
 
 host_n2_vis_buffer:

--- a/config/fengine/include/n2k_chord.j2
+++ b/config/fengine/include/n2k_chord.j2
@@ -28,33 +28,38 @@ n2k_counts_triangle_num_blocks: n2k_counts_linear_num_blocks * (n2k_counts_linea
 n2k_counts_triangle_size: n2k_counts_blocksize * n2k_counts_blocksize * n2k_counts_triangle_num_blocks
 
 host_n2k_correlation_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: sizeof_int32 * num_components * n2k_correlation_triangle_size * num_frequencies * n2k_num_subintegrations
+    value_type: int32
+    extents: [n2k_num_subintegrations, num_frequencies, n2k_correlation_triangle_num_blocks, n2k_correlation_blocksize, n2k_correlation_blocksize, 2]
     metadata_pool: main_pool
 
 host_n2k_counts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: sizeof_int32 * n2k_counts_triangle_size * num_frequencies * n2k_num_subintegrations
+    value_type: int32
+    extents: [n2k_num_subintegrations, num_frequencies, n2k_counts_triangle_num_blocks, n2k_counts_blocksize, n2k_counts_blocksize]
     metadata_pool: main_pool
 
 host_n2k_plcounts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: sizeof_int32 * num_frequencies * n2k_num_subintegrations
+    value_type: int32
+    extents: [n2k_num_subintegrations, num_frequencies]
     metadata_pool: main_pool
 
 host_n2k_rficounts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: sizeof_int32 * num_frequencies * n2k_num_subintegrations
+    value_type: int32
+    extents: [n2k_num_subintegrations, num_frequencies]
     metadata_pool: main_pool
 
 host_n2k_rfiframemask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: sizeof_uint8 * num_frequencies * n2k_num_subintegrations
+    value_type: uint8
+    extents: [n2k_num_subintegrations, num_frequencies]
     metadata_pool: main_pool
 
 host_n2_vis_buffer:

--- a/config/fengine/include/n2k_hirax.j2
+++ b/config/fengine/include/n2k_hirax.j2
@@ -28,33 +28,38 @@ n2k_counts_triangle_num_blocks: n2k_counts_linear_num_blocks * (n2k_counts_linea
 n2k_counts_triangle_size: n2k_counts_blocksize * n2k_counts_blocksize * n2k_counts_triangle_num_blocks
 
 host_n2k_correlation_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_int32 * num_components * n2k_correlation_triangle_size * num_frequencies * n2k_num_subintegrations
+    value_type: int32
+    extents: [n2k_num_subintegrations, num_frequencies, n2k_correlation_triangle_num_blocks, n2k_correlation_blocksize, n2k_correlation_blocksize, 2]
     metadata_pool: main_pool
 
 host_n2k_counts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_int32 * n2k_counts_triangle_size * num_frequencies * n2k_num_subintegrations
+    value_type: int32
+    extents: [n2k_num_subintegrations, num_frequencies, n2k_counts_triangle_num_blocks, n2k_counts_blocksize, n2k_counts_blocksize]
     metadata_pool: main_pool
 
 host_n2k_plcounts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: sizeof_int32 * num_frequencies * n2k_num_subintegrations
+    value_type: int32
+    extents: [n2k_num_subintegrations, num_frequencies]
     metadata_pool: main_pool
 
 host_n2k_rficounts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: sizeof_int32 * num_frequencies * n2k_num_subintegrations
+    value_type: int32
+    extents: [n2k_num_subintegrations, num_frequencies]
     metadata_pool: main_pool
 
 host_n2k_rfiframemask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: sizeof_uint8 * num_frequencies * n2k_num_subintegrations
+    value_type: uint8
+    extents: [n2k_num_subintegrations, num_frequencies]
     metadata_pool: main_pool
 
 host_n2_vis_buffer:

--- a/config/fengine/include/n2k_pathfinder.j2
+++ b/config/fengine/include/n2k_pathfinder.j2
@@ -28,33 +28,38 @@ n2k_counts_triangle_num_blocks: n2k_counts_linear_num_blocks * (n2k_counts_linea
 n2k_counts_triangle_size: n2k_counts_blocksize * n2k_counts_blocksize * n2k_counts_triangle_num_blocks
 
 host_n2k_correlation_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: sizeof_int32 * num_components * n2k_correlation_triangle_size * num_frequencies * n2k_num_subintegrations
+    value_type: int32
+    extents: [n2k_num_subintegrations, num_frequencies, n2k_correlation_triangle_num_blocks, n2k_correlation_blocksize, n2k_correlation_blocksize, 2]
     metadata_pool: main_pool
 
 host_n2k_counts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: sizeof_int32 * n2k_counts_triangle_size * num_frequencies * n2k_num_subintegrations
+    value_type: int32
+    extents: [n2k_num_subintegrations, num_frequencies, n2k_counts_triangle_num_blocks, n2k_counts_blocksize, n2k_counts_blocksize]
     metadata_pool: main_pool
 
 host_n2k_plcounts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: sizeof_int32 * num_frequencies * n2k_num_subintegrations
+    value_type: int32
+    extents: [n2k_num_subintegrations, num_frequencies]
     metadata_pool: main_pool
 
 host_n2k_rficounts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: sizeof_int32 * num_frequencies * n2k_num_subintegrations
+    value_type: int32
+    extents: [n2k_num_subintegrations, num_frequencies]
     metadata_pool: main_pool
 
 host_n2k_rfiframemask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: sizeof_uint8 * num_frequencies * n2k_num_subintegrations
+    value_type: uint8
+    extents: [n2k_num_subintegrations, num_frequencies]
     metadata_pool: main_pool
 
 host_n2_vis_buffer:

--- a/config/fengine/include/n2k_smallfinder.j2
+++ b/config/fengine/include/n2k_smallfinder.j2
@@ -28,15 +28,17 @@ n2k_counts_triangle_num_blocks: n2k_counts_linear_num_blocks * (n2k_counts_linea
 n2k_counts_triangle_size: n2k_counts_blocksize * n2k_counts_blocksize * n2k_counts_triangle_num_blocks
 
 host_n2k_correlation_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_int32 * num_components * n2k_correlation_triangle_size * num_frequencies * n2k_num_subintegrations
+    value_type: int32
+    extents: [n2k_num_subintegrations, num_frequencies, n2k_correlation_triangle_num_blocks, n2k_correlation_blocksize, n2k_correlation_blocksize, 2]
     metadata_pool: main_pool
 
 host_n2k_counts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_int32 * n2k_counts_triangle_size * num_frequencies * n2k_num_subintegrations
+    value_type: int32
+    extents: [n2k_num_subintegrations, num_frequencies, n2k_counts_triangle_num_blocks, n2k_counts_blocksize, n2k_counts_blocksize]
     metadata_pool: main_pool
 
 ################################################################################

--- a/config/fengine/include/rfi_charts.j2
+++ b/config/fengine/include/rfi_charts.j2
@@ -74,12 +74,10 @@ host_rfi_S012tilde_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_SKtilde_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_float32 * 3 * num_frequencies * rfi_num_times
-    type: float32
-    dimnames: ["Trfi", "F", "S"]
-    shape: [rfi_num_times, num_frequencies, 3]
+    value_type: float32
+    extents: [rfi_num_times, num_frequencies, 3]
     metadata_pool: main_pool
 host_rfi_SKtilde_ringbuffer:
     kotekan_buffer: ring
@@ -91,12 +89,10 @@ host_rfi_SKtilde_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_RFImask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: num_frequencies * num_times / 8
-    type: uint1x8
-    dimnames: ["T8hi128", "F", "T8lo128"]
-    shape: [num_times / 8 / 128, num_frequencies, 128]
+    value_type: uint1x8
+    extents: [num_times / 8 / 128, num_frequencies, 128]
     metadata_pool: main_pool
 host_rfi_RFImask_ringbuffer:
     kotekan_buffer: ring

--- a/config/fengine/include/rfi_chime.j2
+++ b/config/fengine/include/rfi_chime.j2
@@ -26,12 +26,10 @@ rfi_num_times: 32               # 1.31072 ms cadence
 rfi_num_times_bar: 1            # 41.94304 ms cadence
 
 host_rfi_S012_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_uint64 * num_dishes * num_polarizations * 3 * num_frequencies * rfi_num_times
-    type: uint64
-    dimnames: ["Trfi", "F", "S", "P", "D"]
-    shape: [rfi_num_times, num_frequencies, 3, num_polarizations, num_dishes]
+    value_type: uint64
+    extents: [rfi_num_times, num_frequencies, 3, num_polarizations, num_dishes]
     metadata_pool: main_pool
 host_rfi_S012_ringbuffer:
     kotekan_buffer: ring
@@ -43,12 +41,10 @@ host_rfi_S012_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_S012bar_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_uint64 * num_dishes * num_polarizations * 3 * num_frequencies * rfi_num_times_bar
-    type: uint64
-    dimnames: ["Trfibar", "F", "S", "P", "D"]
-    shape: [rfi_num_times_bar, num_frequencies, 3, num_polarizations, num_dishes]
+    value_type: uint64
+    extents: [rfi_num_times_bar, num_frequencies, 3, num_polarizations, num_dishes]
     metadata_pool: main_pool
 host_rfi_S012bar_ringbuffer:
     kotekan_buffer: ring
@@ -60,12 +56,10 @@ host_rfi_S012bar_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_S012tilde_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_uint64 * 3 * num_frequencies * rfi_num_times
-    type: uint64
-    dimnames: ["Trfi", "F", "S"]
-    shape: [rfi_num_times, num_frequencies, 3]
+    value_type: uint64
+    extents: [rfi_num_times, num_frequencies, 3]
     metadata_pool: main_pool
 host_rfi_S012tilde_ringbuffer:
     kotekan_buffer: ring
@@ -77,12 +71,10 @@ host_rfi_S012tilde_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_SKtilde_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_float32 * 3 * num_frequencies * rfi_num_times
-    type: float32
-    dimnames: ["Trfi", "F", "S"]
-    shape: [rfi_num_times, num_frequencies, 3]
+    value_type: float32
+    extents: [rfi_num_times, num_frequencies, 3]
     metadata_pool: main_pool
 host_rfi_SKtilde_ringbuffer:
     kotekan_buffer: ring
@@ -94,12 +86,10 @@ host_rfi_SKtilde_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_RFImask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: num_frequencies * num_times / 8
-    type: uint1x8
-    dimnames: ["T8hi128", "F", "T8lo128"]
-    shape: [num_times / 8 / 128, num_frequencies, 128]
+    value_type: uint1x8
+    extents: [num_times / 8 / 128, num_frequencies, 128]
     metadata_pool: main_pool
 host_rfi_RFImask_ringbuffer:
     kotekan_buffer: ring
@@ -111,12 +101,10 @@ host_rfi_RFImask_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_SKbar_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_float32 * num_dishes * num_polarizations * 3 * num_frequencies * rfi_num_times_bar
-    type: float32
-    dimnames: ["Trfi", "F", "S", "P", "D"]
-    shape: [rfi_num_times_bar, num_frequencies, 3, num_polarizaions, num_dishes]
+    value_type: float32
+    extents: [rfi_num_times_bar, num_frequencies, 3, num_polarizations, num_dishes]
     metadata_pool: main_pool
 host_rfi_SKbar_ringbuffer:
     kotekan_buffer: ring
@@ -128,12 +116,10 @@ host_rfi_SKbar_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_SKbartilde_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_float32 * 3 * num_frequencies * rfi_num_times_bar
-    type: float32
-    dimnames: ["Trfi", "F", "S"]
-    shape: [rfi_num_times_bar, num_frequencies, 3]
+    value_type: float32
+    extents: [rfi_num_times_bar, num_frequencies, 3]
     metadata_pool: main_pool
 host_rfi_SKbartilde_ringbuffer:
     kotekan_buffer: ring

--- a/config/fengine/include/rfi_chord.j2
+++ b/config/fengine/include/rfi_chord.j2
@@ -25,12 +25,10 @@ rfi_num_times: 32               # 1.31072 ms cadence
 rfi_num_times_bar: 1            # 41.94304 ms cadence
 
 host_rfi_S012_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_uint64 * num_dishes * num_polarizations * 3 * num_frequencies * rfi_num_times
-    type: uint64
-    dimnames: ["Trfi", "F", "S", "P", "D"]
-    shape: [rfi_num_times, num_frequencies, 3, num_polarizations, num_dishes]
+    value_type: uint64
+    extents: [rfi_num_times, num_frequencies, 3, num_polarizations, num_dishes]
     metadata_pool: main_pool
 host_rfi_S012_ringbuffer:
     kotekan_buffer: ring
@@ -42,12 +40,10 @@ host_rfi_S012_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_S012bar_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_uint64 * num_dishes * num_polarizations * 3 * num_frequencies * rfi_num_times_bar
-    type: uint64
-    dimnames: ["Trfibar", "F", "S", "P", "D"]
-    shape: [rfi_num_times_bar, num_frequencies, 3, num_polarizations, num_dishes]
+    value_type: uint64
+    extents: [rfi_num_times_bar, num_frequencies, 3, num_polarizations, num_dishes]
     metadata_pool: main_pool
 host_rfi_S012bar_ringbuffer:
     kotekan_buffer: ring
@@ -59,12 +55,10 @@ host_rfi_S012bar_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_S012tilde_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_uint64 * 3 * num_frequencies * rfi_num_times
-    type: uint64
-    dimnames: ["Trfi", "F", "S"]
-    shape: [rfi_num_times, num_frequencies, 3]
+    value_type: uint64
+    extents: [rfi_num_times, num_frequencies, 3]
     metadata_pool: main_pool
 host_rfi_S012tilde_ringbuffer:
     kotekan_buffer: ring
@@ -76,12 +70,10 @@ host_rfi_S012tilde_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_SKtilde_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_float32 * 3 * num_frequencies * rfi_num_times
-    type: float32
-    dimnames: ["Trfi", "F", "S"]
-    shape: [rfi_num_times, num_frequencies, 3]
+    value_type: float32
+    extents: [rfi_num_times, num_frequencies, 3]
     metadata_pool: main_pool
 host_rfi_SKtilde_ringbuffer:
     kotekan_buffer: ring
@@ -93,12 +85,10 @@ host_rfi_SKtilde_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_RFImask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: num_frequencies * num_times / 8
-    type: uint1x8
-    dimnames: ["T8hi128", "F", "T8lo128"]
-    shape: [num_times / 8 / 128, num_frequencies, 128]
+    value_type: uint1x8
+    extents: [num_times / 8 / 128, num_frequencies, 128]
     metadata_pool: main_pool
 host_rfi_RFImask_ringbuffer:
     kotekan_buffer: ring
@@ -110,12 +100,10 @@ host_rfi_RFImask_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_SKbar_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_float32 * num_dishes * num_polarizations * 3 * num_frequencies * rfi_num_times_bar
-    type: float32
-    dimnames: ["Trfi", "F", "S", "P", "D"]
-    shape: [rfi_num_times_bar, num_frequencies, 3, num_polarizaions, num_dishes]
+    value_type: float32
+    extents: [rfi_num_times_bar, num_frequencies, 3, num_polarizations, num_dishes]
     metadata_pool: main_pool
 host_rfi_SKbar_ringbuffer:
     kotekan_buffer: ring
@@ -127,12 +115,10 @@ host_rfi_SKbar_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_SKbartilde_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_float32 * 3 * num_frequencies * rfi_num_times_bar
-    type: float32
-    dimnames: ["Trfi", "F", "S"]
-    shape: [rfi_num_times_bar, num_frequencies, 3]
+    value_type: float32
+    extents: [rfi_num_times_bar, num_frequencies, 3]
     metadata_pool: main_pool
 host_rfi_SKbartilde_ringbuffer:
     kotekan_buffer: ring

--- a/config/fengine/include/rfi_hirax.j2
+++ b/config/fengine/include/rfi_hirax.j2
@@ -25,12 +25,10 @@ rfi_num_times: 32               # 1.31072 ms cadence
 rfi_num_times_bar: 1            # 41.94304 ms cadence
 
 host_rfi_S012_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_uint64 * num_dishes * num_polarizations * 3 * num_frequencies * rfi_num_times
-    type: uint64
-    dimnames: ["Trfi", "F", "S", "P", "D"]
-    shape: [rfi_num_times, num_frequencies, 3, num_polarizations, num_dishes]
+    value_type: uint64
+    extents: [rfi_num_times, num_frequencies, 3, num_polarizations, num_dishes]
     metadata_pool: main_pool
 host_rfi_S012_ringbuffer:
     kotekan_buffer: ring
@@ -42,12 +40,10 @@ host_rfi_S012_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_S012bar_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_uint64 * num_dishes * num_polarizations * 3 * num_frequencies * rfi_num_times_bar
-    type: uint64
-    dimnames: ["Trfibar", "F", "S", "P", "D"]
-    shape: [rfi_num_times_bar, num_frequencies, 3, num_polarizations, num_dishes]
+    value_type: uint64
+    extents: [rfi_num_times_bar, num_frequencies, 3, num_polarizations, num_dishes]
     metadata_pool: main_pool
 host_rfi_S012bar_ringbuffer:
     kotekan_buffer: ring
@@ -59,12 +55,10 @@ host_rfi_S012bar_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_S012tilde_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_uint64 * 3 * num_frequencies * rfi_num_times
-    type: uint64
-    dimnames: ["Trfi", "F", "S"]
-    shape: [rfi_num_times, num_frequencies, 3]
+    value_type: uint64
+    extents: [rfi_num_times, num_frequencies, 3]
     metadata_pool: main_pool
 host_rfi_S012tilde_ringbuffer:
     kotekan_buffer: ring
@@ -76,12 +70,10 @@ host_rfi_S012tilde_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_SKtilde_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_float32 * 3 * num_frequencies * rfi_num_times
-    type: float32
-    dimnames: ["Trfi", "F", "S"]
-    shape: [rfi_num_times, num_frequencies, 3]
+    value_type: float32
+    extents: [rfi_num_times, num_frequencies, 3]
     metadata_pool: main_pool
 host_rfi_SKtilde_ringbuffer:
     kotekan_buffer: ring
@@ -93,12 +85,10 @@ host_rfi_SKtilde_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_RFImask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: num_frequencies * num_times / 8
-    type: uint1x8
-    dimnames: ["T8hi128", "F", "T8lo128"]
-    shape: [num_times / 8 / 128, num_frequencies, 128]
+    value_type: uint1x8
+    extents: [num_times / 8 / 128, num_frequencies, 128]
     metadata_pool: main_pool
 host_rfi_RFImask_ringbuffer:
     kotekan_buffer: ring
@@ -110,12 +100,10 @@ host_rfi_RFImask_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_SKbar_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_float32 * num_dishes * num_polarizations * 3 * num_frequencies * rfi_num_times_bar
-    type: float32
-    dimnames: ["Trfi", "F", "S", "P", "D"]
-    shape: [rfi_num_times_bar, num_frequencies, 3, num_polarizaions, num_dishes]
+    value_type: float32
+    extents: [rfi_num_times_bar, num_frequencies, 3, num_polarizations, num_dishes]
     metadata_pool: main_pool
 host_rfi_SKbar_ringbuffer:
     kotekan_buffer: ring
@@ -127,12 +115,10 @@ host_rfi_SKbar_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_SKbartilde_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_float32 * 3 * num_frequencies * rfi_num_times_bar
-    type: float32
-    dimnames: ["Trfi", "F", "S"]
-    shape: [rfi_num_times_bar, num_frequencies, 3]
+    value_type: float32
+    extents: [rfi_num_times_bar, num_frequencies, 3]
     metadata_pool: main_pool
 host_rfi_SKbartilde_ringbuffer:
     kotekan_buffer: ring

--- a/config/fengine/include/rfi_pathfinder.j2
+++ b/config/fengine/include/rfi_pathfinder.j2
@@ -25,12 +25,10 @@ rfi_num_times: 32               # 1.31072 ms cadence
 rfi_num_times_bar: 1            # 41.94304 ms cadence
 
 host_rfi_S012_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_uint64 * num_dishes * num_polarizations * 3 * num_frequencies * rfi_num_times
-    type: uint64
-    dimnames: ["Trfi", "F", "S", "P", "D"]
-    shape: [rfi_num_times, num_frequencies, 3, num_polarizations, num_dishes]
+    value_type: uint64
+    extents: [rfi_num_times, num_frequencies, 3, num_polarizations, num_dishes]
     metadata_pool: main_pool
 host_rfi_S012_ringbuffer:
     kotekan_buffer: ring
@@ -42,12 +40,10 @@ host_rfi_S012_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_S012bar_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_uint64 * num_dishes * num_polarizations * 3 * num_frequencies * rfi_num_times_bar
-    type: uint64
-    dimnames: ["Trfibar", "F", "S", "P", "D"]
-    shape: [rfi_num_times_bar, num_frequencies, 3, num_polarizations, num_dishes]
+    value_type: uint64
+    extents: [rfi_num_times_bar, num_frequencies, 3, num_polarizations, num_dishes]
     metadata_pool: main_pool
 host_rfi_S012bar_ringbuffer:
     kotekan_buffer: ring
@@ -59,12 +55,10 @@ host_rfi_S012bar_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_S012tilde_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_uint64 * 3 * num_frequencies * rfi_num_times
-    type: uint64
-    dimnames: ["Trfi", "F", "S"]
-    shape: [rfi_num_times, num_frequencies, 3]
+    value_type: uint64
+    extents: [rfi_num_times, num_frequencies, 3]
     metadata_pool: main_pool
 host_rfi_S012tilde_ringbuffer:
     kotekan_buffer: ring
@@ -76,12 +70,10 @@ host_rfi_S012tilde_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_SKtilde_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_float32 * 3 * num_frequencies * rfi_num_times
-    type: float32
-    dimnames: ["Trfi", "F", "S"]
-    shape: [rfi_num_times, num_frequencies, 3]
+    value_type: float32
+    extents: [rfi_num_times, num_frequencies, 3]
     metadata_pool: main_pool
 host_rfi_SKtilde_ringbuffer:
     kotekan_buffer: ring
@@ -93,12 +85,10 @@ host_rfi_SKtilde_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_RFImask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 4 * buffer_depth # 4 times larger as buffer for a slow N2Accumulate
-    frame_size: num_frequencies * num_times / 8
-    type: uint1x8
-    dimnames: ["T8hi128", "F", "T8lo128"]
-    shape: [num_times / 8 / 128, num_frequencies, 128]
+    value_type: uint1x8
+    extents: [num_times / 8 / 128, num_frequencies, 128]
     metadata_pool: main_pool
 host_rfi_RFImask_ringbuffer:
     kotekan_buffer: ring
@@ -110,12 +100,10 @@ host_rfi_RFImask_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_SKbar_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_float32 * num_dishes * num_polarizations * 3 * num_frequencies * rfi_num_times_bar
-    type: float32
-    dimnames: ["Trfi", "F", "S", "P", "D"]
-    shape: [rfi_num_times_bar, num_frequencies, 3, num_polarizaions, num_dishes]
+    value_type: float32
+    extents: [rfi_num_times_bar, num_frequencies, 3, num_polarizations, num_dishes]
     metadata_pool: main_pool
 host_rfi_SKbar_ringbuffer:
     kotekan_buffer: ring
@@ -127,12 +115,10 @@ host_rfi_SKbar_ringbuffer:
     metadata_pool: main_pool
 
 host_rfi_SKbartilde_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: sizeof_float32 * 3 * num_frequencies * rfi_num_times_bar
-    type: float32
-    dimnames: ["Trfi", "F", "S"]
-    shape: [rfi_num_times_bar, num_frequencies, 3]
+    value_type: float32
+    extents: [rfi_num_times_bar, num_frequencies, 3]
     metadata_pool: main_pool
 host_rfi_SKbartilde_ringbuffer:
     kotekan_buffer: ring

--- a/config/fengine/include/upchan_charts.j2
+++ b/config/fengine/include/upchan_charts.j2
@@ -83,9 +83,10 @@ upchan_all_max_output_channel: upchan_U1_max_output_channel
 # Gains
 
 host_upchan_U32_gain_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * upchan_U32_max_num_channels * 32
+    value_type: float16
+    extents: [upchan_U32_max_num_channels * 32]
     metadata_pool: main_pool
 
 # Voltages

--- a/config/fengine/include/upchan_chime.j2
+++ b/config/fengine/include/upchan_chime.j2
@@ -33,9 +33,10 @@ upchan_U16_max_num_output_channels: upchan_U16_max_output_channel - upchan_U16_m
 # Gains
 
 host_upchan_U16_gain_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * upchan_U16_max_num_channels * 16
+    value_type: float16
+    extents: [upchan_U16_max_num_channels * 16]
     metadata_pool: main_pool
 
 # Voltages

--- a/config/fengine/include/upchan_chord.j2
+++ b/config/fengine/include/upchan_chord.j2
@@ -114,39 +114,45 @@ upchan_all_max_output_channel: upchan_U1_max_output_channel
 # Gains
 
 host_upchan_U2_gain_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * upchan_U2_max_num_channels * 2
+    value_type: float16
+    extents: [upchan_U2_max_num_channels * 2]
     metadata_pool: main_pool
 
 host_upchan_U4_gain_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * upchan_U4_max_num_channels * 4
+    value_type: float16
+    extents: [upchan_U4_max_num_channels * 4]
     metadata_pool: main_pool
 
 host_upchan_U8_gain_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * upchan_U8_max_num_channels * 8
+    value_type: float16
+    extents: [upchan_U8_max_num_channels * 8]
     metadata_pool: main_pool
 
 host_upchan_U16_gain_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * upchan_U16_max_num_channels * 16
+    value_type: float16
+    extents: [upchan_U16_max_num_channels * 16]
     metadata_pool: main_pool
 
 host_upchan_U32_gain_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * upchan_U32_max_num_channels * 32
+    value_type: float16
+    extents: [upchan_U32_max_num_channels * 32]
     metadata_pool: main_pool
 
 host_upchan_U64_gain_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * upchan_U64_max_num_channels * 64
+    value_type: float16
+    extents: [upchan_U64_max_num_channels * 64]
     metadata_pool: main_pool
 
 # Voltages

--- a/config/fengine/include/upchan_hfb_chime.j2
+++ b/config/fengine/include/upchan_hfb_chime.j2
@@ -38,9 +38,10 @@ upchan_hfb_upchan_U128_max_num_output_channels: upchan_hfb_upchan_U128_max_outpu
 # Gains
 
 host_upchan_hfb_U128_gain_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * upchan_hfb_upchan_U128_max_num_channels * 128
+    value_type: float16
+    extents: [upchan_hfb_upchan_U128_max_num_channels * 128]
     metadata_pool: main_pool
 
 # Voltages

--- a/config/fengine/include/upchan_hirax.j2
+++ b/config/fengine/include/upchan_hirax.j2
@@ -95,21 +95,24 @@ upchan_all_max_output_channel: upchan_U1_max_output_channel
 # Gains
 
 host_upchan_U8_gain_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * upchan_U8_max_num_channels * 8
+    value_type: float16
+    extents: [upchan_U8_max_num_channels * 8]
     metadata_pool: main_pool
 
 host_upchan_U16_gain_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * upchan_U16_max_num_channels * 16
+    value_type: float16
+    extents: [upchan_U16_max_num_channels * 16]
     metadata_pool: main_pool
 
 host_upchan_U32_gain_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * upchan_U32_max_num_channels * 32
+    value_type: float16
+    extents: [upchan_U32_max_num_channels * 32]
     metadata_pool: main_pool
 
 # Voltages

--- a/config/fengine/include/upchan_pathfinder.j2
+++ b/config/fengine/include/upchan_pathfinder.j2
@@ -143,39 +143,45 @@ upchan_all_max_output_channel: upchan_U1_max_output_channel
 # Gains
 
 host_upchan_U2_gain_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * upchan_U2_max_num_channels * 2
+    value_type: float16
+    extents: [upchan_U2_max_num_channels * 2]
     metadata_pool: main_pool
 
 host_upchan_U4_gain_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * upchan_U4_max_num_channels * 4
+    value_type: float16
+    extents: [upchan_U4_max_num_channels * 4]
     metadata_pool: main_pool
 
 host_upchan_U8_gain_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * upchan_U8_max_num_channels * 8
+    value_type: float16
+    extents: [upchan_U8_max_num_channels * 8]
     metadata_pool: main_pool
 
 host_upchan_U16_gain_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * upchan_U16_max_num_channels * 16
+    value_type: float16
+    extents: [upchan_U16_max_num_channels * 16]
     metadata_pool: main_pool
 
 host_upchan_U32_gain_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * upchan_U32_max_num_channels * 32
+    value_type: float16
+    extents: [upchan_U32_max_num_channels * 32]
     metadata_pool: main_pool
 
 host_upchan_U64_gain_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_float16 * upchan_U64_max_num_channels * 64
+    value_type: float16
+    extents: [upchan_U64_max_num_channels * 64]
     metadata_pool: main_pool
 
 # Voltages

--- a/config/fengine/include/xpose2048_chime.j2
+++ b/config/fengine/include/xpose2048_chime.j2
@@ -143,9 +143,10 @@ scatter_indices: [
 # Buffers
 
 host_scatter_indices_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_int32 * num_dishes * num_polarizations
+    value_type: int32
+    extents: [num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 host_xposed_voltage_buffer:

--- a/config/scheduled-tests/send-recv-asdfwrite.yaml
+++ b/config/scheduled-tests/send-recv-asdfwrite.yaml
@@ -16,15 +16,17 @@ main_pool:
 
 # Buffers
 send_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: num_frame_samples
+    value_type: int4x2
+    extents: [num_frame_samples]
     metadata_pool: main_pool
 
 recv_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: num_frame_samples
+    value_type: int4x2
+    extents: [num_frame_samples]
     metadata_pool: main_pool
 
 

--- a/config/tests/chord_pathfinder_core.j2
+++ b/config/tests/chord_pathfinder_core.j2
@@ -11,73 +11,83 @@
 #########
 
 host_rfi_RFImask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: num_local_freq * samples_per_data_set / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 1024, num_local_freq, 128]
     zero_new_frames: true
     zero_value: 0xFF
     metadata_pool: main_pool
 
 host_rfi_RFImask_buffer_1:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: num_local_freq * samples_per_data_set / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 1024, num_local_freq, 128]
     zero_new_frames: true
     zero_value: 0xFF
     numa_node: 1
     metadata_pool: main_pool
 
 host_rfi_sktilde_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / rfi_downsampling_factor) * num_local_freq * 3 * sizeof_float32
+    value_type: float32
+    extents: [samples_per_data_set / rfi_downsampling_factor, num_local_freq, 3]
     metadata_pool: main_pool
 
 host_rfi_sktilde_buffer_1:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / rfi_downsampling_factor) * num_local_freq * 3 * sizeof_float32
+    value_type: float32
+    extents: [samples_per_data_set / rfi_downsampling_factor, num_local_freq, 3]
     metadata_pool: main_pool
     numa_node: 1
 
 host_rfi_RFImask_counts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * sizeof_int32
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     metadata_pool: main_pool
 
 host_rfi_RFImask_counts_buffer_1:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * sizeof_int32
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     metadata_pool: main_pool
     numa_node: 1
 
 host_pl_counts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * sizeof_int32
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     metadata_pool: main_pool
 
 host_pl_counts_buffer_1:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * sizeof_int32
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     metadata_pool: main_pool
     numa_node: 1
 
 host_rfi_RFIframemask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq
+    value_type: uint8
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     zero_new_frames: true
     zero_value: 0xFF
     metadata_pool: main_pool
 
 host_rfi_RFIframemask_buffer_1:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq
+    value_type: uint8
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     zero_new_frames: true
     zero_value: 0xFF
     metadata_pool: main_pool
@@ -87,15 +97,17 @@ vis_blocksize: 16
 vis_num_blocks_lin: num_elements / vis_blocksize
 vis_num_blocks: vis_num_blocks_lin * (vis_num_blocks_lin + 1) / 2
 host_correlation_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: num_local_freq * (samples_per_data_set / sub_integration_ntime) * 16 * 16 * vis_num_blocks * 2 * sizeof_gpu_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, vis_num_blocks, vis_blocksize, vis_blocksize, 2]
     metadata_pool: main_pool
 
 host_correlation_buffer_1:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: num_local_freq * (samples_per_data_set / sub_integration_ntime) * 16 * 16 * vis_num_blocks * 2 * sizeof_gpu_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, vis_num_blocks, vis_blocksize, vis_blocksize, 2]
     metadata_pool: main_pool
     numa_node: 1
 
@@ -104,15 +116,17 @@ counts_blocksize: 8
 counts_num_blocks_lin: (num_elements / 8) / counts_blocksize
 counts_num_blocks: (counts_num_blocks_lin * (counts_num_blocks_lin + 1)) / 2
 host_counts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * counts_num_blocks * counts_blocksize * counts_blocksize * sizeof_gpu_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, counts_num_blocks, counts_blocksize, counts_blocksize]
     metadata_pool: main_pool
 
 host_counts_buffer_1:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * counts_num_blocks * counts_blocksize * counts_blocksize * sizeof_gpu_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, counts_num_blocks, counts_blocksize, counts_blocksize]
     metadata_pool: main_pool
     numa_node: 1
 

--- a/config/tests/chord_pathfinder_dpdk.j2
+++ b/config/tests/chord_pathfinder_dpdk.j2
@@ -27,13 +27,29 @@ network_input_buffers:
         numa_node: 1
         zero_value: 0x88
         kotekan_buffer: standard
-    # Main voltage buffer after transpose
-    host_voltage_buffer_0:
-        kotekan_buffer: standard
-        numa_node: 0
-    host_voltage_buffer_1:
-        kotekan_buffer: standard
-        numa_node: 1
+
+# Main voltage buffer after transpose.
+# Produced by TransposeBasebandArray: int4x2_swapped_withoffset "E". These live outside the
+# network_input_buffers group: that group's frame_size is for the dpdk buffers, while
+# ndarray buffers derive their size from the descriptor.
+host_voltage_buffer_0:
+    kotekan_buffer: ndarray
+    log_level: info
+    num_frames: host_side_buffer_depth
+    value_type: int4x2_swapped_withoffset
+    extents: [samples_per_data_set, num_local_freq, 2, num_elements / 2]
+    metadata_pool: main_pool
+    use_hugepages: true
+    numa_node: 0
+host_voltage_buffer_1:
+    kotekan_buffer: ndarray
+    log_level: info
+    num_frames: host_side_buffer_depth
+    value_type: int4x2_swapped_withoffset
+    extents: [samples_per_data_set, num_local_freq, 2, num_elements / 2]
+    metadata_pool: main_pool
+    use_hugepages: true
+    numa_node: 1
 
 packet_receipt_bitmap_buffers:
     log_level: info
@@ -57,18 +73,21 @@ packet_receipt_bitmap_buffers:
         kotekan_buffer: standard
         numa_node: 1
 
+# Produced by ProcessPacketMask (rfi_mask_buf): uint1x8 "RFImask".
 host_rfi_RFImask_dummy_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: num_local_freq * samples_per_data_set / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 1024, num_local_freq, 128]
     zero_new_frames: true
     zero_value: 0xFF
     metadata_pool: main_pool
 
 host_rfi_RFImask_dummy_buffer_1:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: num_local_freq * samples_per_data_set / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 1024, num_local_freq, 128]
     zero_new_frames: true
     zero_value: 0xFF
     numa_node: 1
@@ -76,46 +95,52 @@ host_rfi_RFImask_dummy_buffer_1:
 
 # Note this is the expanded version of the pl_mask, which is used for correlator input
 host_pl_mask_exp_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / 64) * (num_local_freq) * (num_elements / 8) * 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 64, num_local_freq, num_polarizations, (num_elements / 8) / 2, 8]
     metadata_pool: main_pool
 
 host_pl_mask_exp_buffer_1:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / 64) * (num_local_freq) * (num_elements / 8) * 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 64, num_local_freq, num_polarizations, (num_elements / 8) / 2, 8]
     metadata_pool: main_pool
     numa_node: 1
 
 host_pl_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / 128) * (num_local_freq/4) * (num_elements / 8) * 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 128, (num_local_freq + 3) / 4, num_polarizations, (num_elements / 8) / 2, 8]
     metadata_pool: main_pool
 
 host_pl_mask_buffer_1:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / 128) * (num_local_freq/4) * (num_elements / 8) * 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 128, (num_local_freq + 3) / 4, num_polarizations, (num_elements / 8) / 2, 8]
     metadata_pool: main_pool
     numa_node: 1
 
 # Bad feed mask - marks which feeds to exclude from RFI calculations
 # Shape: [P, D] = [2, num_dishes] - all ones means all feeds are good
 host_bf_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_int8 * num_dishes * num_polarizations
+    value_type: int8
+    extents: [num_polarizations, num_dishes]
     metadata_pool: main_pool
     zero_new_frames: true
     zero_value: 0xFF
     numa_node: 0
 
 host_bf_mask_buffer_1:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_int8 * num_dishes * num_polarizations
+    value_type: int8
+    extents: [num_polarizations, num_dishes]
     metadata_pool: main_pool
     zero_new_frames: true
     zero_value: 0xFF

--- a/config/tests/chord_pathfinder_fake_input.j2
+++ b/config/tests/chord_pathfinder_fake_input.j2
@@ -6,65 +6,79 @@
 # Buffers
 
 # Main voltage buffer
+# testDataGen (gen_fake_voltage, type random_signed_offset -> int4x2_swapped_withoffset,
+# array_shape [samples_per_data_set, num_local_freq, num_polarizations, num_dishes]).
 host_voltage_buffer_0:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: samples_per_data_set * num_local_freq * num_elements
+    value_type: int4x2_swapped_withoffset
+    extents: [samples_per_data_set, num_local_freq, num_polarizations, num_dishes]
     metadata_pool: main_pool
     numa_node: 0
 host_voltage_buffer_1:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: samples_per_data_set * num_local_freq * num_elements
+    value_type: int4x2_swapped_withoffset
+    extents: [samples_per_data_set, num_local_freq, num_polarizations, num_dishes]
     metadata_pool: main_pool
     numa_node: 1
 
 
+# Produced by testRFImaskGen (gen_dummy_rfi_mask, name "RFImask", type const -> uint1x8;
+# shape [samples_per_data_set / 1024, num_local_freq, 128] is fixed in testRFImaskGen.cpp:133).
 host_rfi_RFImask_dummy_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: num_local_freq * samples_per_data_set / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 1024, num_local_freq, 128]
     zero_new_frames: true
     zero_value: 0xFF
     metadata_pool: main_pool
 
 host_rfi_RFImask_dummy_buffer_1:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: num_local_freq * samples_per_data_set / 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 1024, num_local_freq, 128]
     zero_new_frames: true
     zero_value: 0xFF
     numa_node: 1
     metadata_pool: main_pool
 
+# testDataGen (gen_fake_pl_mask, type random1x8 -> uint1x8, name "pl_mask").
+# extents = [samples_per_data_set/128, (num_local_freq+3)/4, num_polarizations, num_dishes/8, 8]
 host_pl_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / 128) * (num_local_freq/4) * (num_elements / 8) * 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 128, (num_local_freq + 3) / 4, num_polarizations, num_dishes / 8, 8]
     metadata_pool: main_pool
 
 host_pl_mask_buffer_1:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_side_buffer_depth
-    frame_size: (samples_per_data_set / 128) * (num_local_freq/4) * (num_elements / 8) * 8
+    value_type: uint1x8
+    extents: [samples_per_data_set / 128, (num_local_freq + 3) / 4, num_polarizations, num_dishes / 8, 8]
     metadata_pool: main_pool
     numa_node: 1
 
 # Bad feed mask - marks which feeds to exclude from RFI calculations
 # Shape: [P, D] = [2, num_dishes] - all ones means all feeds are good
 host_bf_mask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_int8 * num_dishes * num_polarizations
+    value_type: int8
+    extents: [num_polarizations, num_dishes]
     metadata_pool: main_pool
     zero_new_frames: true
     zero_value: 0xFF
     numa_node: 0
 
 host_bf_mask_buffer_1:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: 1
-    frame_size: sizeof_int8 * num_dishes * num_polarizations
+    value_type: int8
+    extents: [num_polarizations, num_dishes]
     metadata_pool: main_pool
     zero_new_frames: true
     zero_value: 0xFF

--- a/config/tests/thrash_n2accum_chime.yaml
+++ b/config/tests/thrash_n2accum_chime.yaml
@@ -91,33 +91,43 @@ n2_pool:
     num_metadata_objects: 16 * buffer_depth
 
 fake_correlation_buffer:
-    kotekan_buffer: standard
+    # num_elements=2048: corr_lin_blocks=num_elements/16=128, vis_num_blocks=128*129/2=8256.
+    # testN2kGen, testLostCountsGen, and N2Accumulate all use num_elements/16, so the
+    # producer and consumer agree on the block count.
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * vis_num_blocks * vis_blocksize * vis_blocksize * 2 * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, vis_num_blocks, vis_blocksize, vis_blocksize, 2]
     metadata_pool: main_pool
 
 fake_counts_buffer:
-    kotekan_buffer: standard
+    # num_elements=2048: count_lin_blocks=(num_elements/8)/8=32, counts_num_blocks=32*33/2=528.
+    # testN2kGen, testLostCountsGen (in_buf validator), and N2Accumulate all use (num_elements/8)/8.
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * counts_num_blocks * counts_blocksize * counts_blocksize * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, counts_num_blocks, counts_blocksize, counts_blocksize]
     metadata_pool: main_pool
 
 fake_rficounts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     metadata_pool: main_pool
 
 fake_plcounts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     metadata_pool: main_pool
 
 fake_rfiframemask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq
+    value_type: uint8
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     metadata_pool: main_pool
 
 n2_buffer:

--- a/config/tests/thrash_n2accum_chord.yaml
+++ b/config/tests/thrash_n2accum_chord.yaml
@@ -91,33 +91,43 @@ n2_pool:
     num_metadata_objects: 16 * buffer_depth
 
 fake_correlation_buffer:
-    kotekan_buffer: standard
+    # num_elements=1024: corr_lin_blocks=num_elements/16=64, vis_num_blocks=64*65/2=2080.
+    # testN2kGen, testLostCountsGen, and N2Accumulate all use num_elements/16, so the
+    # producer and consumer agree on the block count.
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * vis_num_blocks * vis_blocksize * vis_blocksize * 2 * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, vis_num_blocks, vis_blocksize, vis_blocksize, 2]
     metadata_pool: main_pool
 
 fake_counts_buffer:
-    kotekan_buffer: standard
+    # num_elements=1024: count_lin_blocks=(num_elements/8)/8=16, counts_num_blocks=16*17/2=136.
+    # testN2kGen, testLostCountsGen (in_buf validator), and N2Accumulate all use (num_elements/8)/8.
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * counts_num_blocks * counts_blocksize * counts_blocksize * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, counts_num_blocks, counts_blocksize, counts_blocksize]
     metadata_pool: main_pool
 
 fake_rficounts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     metadata_pool: main_pool
 
 fake_plcounts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     metadata_pool: main_pool
 
 fake_rfiframemask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq
+    value_type: uint8
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     metadata_pool: main_pool
 
 n2_buffer:

--- a/config/tests/thrash_n2accum_pathfinder.yaml
+++ b/config/tests/thrash_n2accum_pathfinder.yaml
@@ -91,33 +91,43 @@ n2_pool:
     num_metadata_objects: 16 * buffer_depth
 
 fake_correlation_buffer:
-    kotekan_buffer: standard
+    # num_elements=128: corr_lin_blocks=num_elements/16=8, vis_num_blocks=8*9/2=36.
+    # testN2kGen, testLostCountsGen, and N2Accumulate all use num_elements/16, so the
+    # producer and consumer agree on the block count.
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * vis_num_blocks * vis_blocksize * vis_blocksize * 2 * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, vis_num_blocks, vis_blocksize, vis_blocksize, 2]
     metadata_pool: main_pool
 
 fake_counts_buffer:
-    kotekan_buffer: standard
+    # num_elements=128: count_lin_blocks=(num_elements/8)/8=2, counts_num_blocks=2*3/2=3.
+    # testN2kGen, testLostCountsGen (in_buf validator), and N2Accumulate all use (num_elements/8)/8.
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * counts_num_blocks * counts_blocksize * counts_blocksize * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq, counts_num_blocks, counts_blocksize, counts_blocksize]
     metadata_pool: main_pool
 
 fake_rficounts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     metadata_pool: main_pool
 
 fake_plcounts_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq * sizeof_int
+    value_type: int32
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     metadata_pool: main_pool
 
 fake_rfiframemask_buffer:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: buffer_depth
-    frame_size: (samples_per_data_set / sub_integration_ntime) * num_local_freq
+    value_type: uint8
+    extents: [samples_per_data_set / sub_integration_ntime, num_local_freq]
     metadata_pool: main_pool
 
 n2_buffer:

--- a/lib/stages/AirspyAlign.cpp
+++ b/lib/stages/AirspyAlign.cpp
@@ -37,10 +37,10 @@ AirspyAlign::AirspyAlign(Config& config, const std::string& unique_name,
     buf_inB = get_buffer("in_bufB");
     buf_inB->register_consumer(unique_name);
 
-    // Both inputs are int16 1-D airspy sample streams; set_frame_desc
+    // Both inputs are int16 1-D airspy sample streams; ensure_frame_desc
     // records or cross-checks against airspyInput's earlier assertion.
-    buf_inA->set_frame_desc(kotekan_airspy::make_input_desc(buf_inA->frame_size / sizeof(short)));
-    buf_inB->set_frame_desc(kotekan_airspy::make_input_desc(buf_inB->frame_size / sizeof(short)));
+    buf_inA->ensure_frame_desc(kotekan_airspy::make_input_desc(buf_inA->frame_size / sizeof(short)));
+    buf_inB->ensure_frame_desc(kotekan_airspy::make_input_desc(buf_inB->frame_size / sizeof(short)));
 
     _lag_window = config.get_default<uint32_t>(unique_name, "lag_window",
                                                buf_inA->frame_size / sizeof(short));

--- a/lib/stages/SampleAutocorr.cpp
+++ b/lib/stages/SampleAutocorr.cpp
@@ -32,7 +32,7 @@ SampleAutocorr::SampleAutocorr(Config& config, const std::string& unique_name,
     buf_in->register_consumer(unique_name);
 
     // Input: cfloat32 1-D fengine spectra (consumer-only; no out_buf).
-    buf_in->set_frame_desc(
+    buf_in->ensure_frame_desc(
         kotekan_airspy::make_fengine_desc(buf_in->frame_size / (2 * sizeof(float))));
 
     _spectrum_length = config.get_default<int>(unique_name, "spectrum_length", 1024);

--- a/lib/stages/SimpleCrosscorr.cpp
+++ b/lib/stages/SimpleCrosscorr.cpp
@@ -43,9 +43,9 @@ SimpleCrosscorr::SimpleCrosscorr(Config& config, const std::string& unique_name,
     // crosscorr unit test captures buf_out via rawFileWrite. networkPowerStream
     // asserts the expected power_corr layout on its consumer side, so the
     // contract is still documented in code.
-    buf_inA->set_frame_desc(
+    buf_inA->ensure_frame_desc(
         kotekan_airspy::make_fengine_desc(buf_inA->frame_size / (2 * sizeof(float))));
-    buf_inB->set_frame_desc(
+    buf_inB->ensure_frame_desc(
         kotekan_airspy::make_fengine_desc(buf_inB->frame_size / (2 * sizeof(float))));
 }
 

--- a/lib/stages/airspyFrameDesc.hpp
+++ b/lib/stages/airspyFrameDesc.hpp
@@ -11,10 +11,10 @@
  * @file
  * @brief Frame-descriptor builders for the airspy autocorr / crosscorr pipelines.
  *
- * Uses the *buffer-level* FrameDesc mechanism (Buffer::set_frame_desc /
- * get_frame_description) -- independent of the metadata pool, which these
+ * Uses the *buffer-level* FrameDesc mechanism (Buffer::ensure_frame_desc /
+ * get_frame_desc) -- independent of the metadata pool, which these
  * pipelines run with set to "none". The convention: every airspy
- * producer/consumer stage calls @c buf->set_frame_desc on each buffer it
+ * producer/consumer stage calls @c buf->ensure_frame_desc on each buffer it
  * touches via one of these helpers. The first call records the descriptor;
  * subsequent calls compare via @c FrameDesc::operator== and ERROR on
  * mismatch -- so producer/consumer construction order is irrelevant, and a
@@ -34,8 +34,8 @@ namespace kotekan_airspy {
 
 /// Raw airspy samples: int16 1-D buffer of length @p n_samples.
 inline std::shared_ptr<kotekan::GenericNDArray> make_input_desc(std::ptrdiff_t n_samples) {
-    return kotekan::GenericNDArray::create(kotekan::DataType::int16, "airspy_samples", {n_samples},
-                                           {"sample"}, nullptr);
+    return kotekan::GenericNDArray::describe(kotekan::DataType::int16, "airspy_samples",
+                                             {n_samples}, {"sample"});
 }
 
 /// fftwEngine output spectra: cfloat32 1-D buffer of length @p n_complex.
@@ -43,8 +43,8 @@ inline std::shared_ptr<kotekan::GenericNDArray> make_input_desc(std::ptrdiff_t n
 /// descriptor records total complex elements, the consumers' indexing
 /// arithmetic comes from their own config.
 inline std::shared_ptr<kotekan::GenericNDArray> make_fengine_desc(std::ptrdiff_t n_complex) {
-    return kotekan::GenericNDArray::create(kotekan::DataType::cfloat32, "fengine_spectra",
-                                           {n_complex}, {"bin"}, nullptr);
+    return kotekan::GenericNDArray::describe(kotekan::DataType::cfloat32, "fengine_spectra",
+                                             {n_complex}, {"bin"});
 }
 
 /// SimpleCrosscorr / simpleAutocorr -> networkPowerStream layout. Per
@@ -54,7 +54,7 @@ inline std::shared_ptr<kotekan::GenericNDArray> make_fengine_desc(std::ptrdiff_t
 /// for multi-element (crosscorr), to match what the producers actually
 /// emit and what networkPowerStream walks for each element/time index.
 ///
-/// @note Only networkPowerStream (the consumer) calls set_frame_desc with
+/// @note Only networkPowerStream (the consumer) calls ensure_frame_desc with
 /// this; the producers (simpleAutocorr / SimpleCrosscorr) deliberately
 /// leave their out_buf untagged so the corr-buffer round-trip tests that
 /// use rawFileWrite still work (rawFileWrite refuses NDArray-tagged
@@ -64,12 +64,11 @@ inline std::shared_ptr<kotekan::GenericNDArray> make_fengine_desc(std::ptrdiff_t
 inline std::shared_ptr<kotekan::GenericNDArray>
 make_power_corr_desc(std::ptrdiff_t num_elements, std::ptrdiff_t spectrum_length) {
     if (num_elements == 1) {
-        return kotekan::GenericNDArray::create(kotekan::DataType::float32, "power_corr",
-                                               {spectrum_length + 1}, {"bin"}, nullptr);
+        return kotekan::GenericNDArray::describe(kotekan::DataType::float32, "power_corr",
+                                                 {spectrum_length + 1}, {"bin"});
     }
-    return kotekan::GenericNDArray::create(kotekan::DataType::float32, "power_corr",
-                                           {num_elements, spectrum_length + 1}, {"elem", "bin"},
-                                           nullptr);
+    return kotekan::GenericNDArray::describe(kotekan::DataType::float32, "power_corr",
+                                             {num_elements, spectrum_length + 1}, {"elem", "bin"});
 }
 
 } // namespace kotekan_airspy

--- a/lib/stages/airspyInput.cpp
+++ b/lib/stages/airspyInput.cpp
@@ -47,10 +47,10 @@ airspyInput::airspyInput(Config& config, const std::string& unique_name,
         return;
     }
 
-    // Buffer carries int16 1-D samples. set_frame_desc validates byte size
+    // Buffer carries int16 1-D samples. ensure_frame_desc validates byte size
     // against buf->frame_size and either records the descriptor or compares
     // against an earlier assertion -- see airspyFrameDesc.hpp.
-    buf->set_frame_desc(kotekan_airspy::make_input_desc(buf->frame_size / BYTES_PER_SAMPLE));
+    buf->ensure_frame_desc(kotekan_airspy::make_input_desc(buf->frame_size / BYTES_PER_SAMPLE));
 
     freq = config.get_default<float>(unique_name, "freq", 1420) * 1e6;             // MHz
     _sample_rate = config.get_default<float>(unique_name, "sample_bw", 2.5) * 1e6; // MSPS

--- a/lib/stages/calcBBPhase.cpp
+++ b/lib/stages/calcBBPhase.cpp
@@ -70,15 +70,15 @@ public:
         A_buffer->register_producer(unique_name);
         s_buffer->register_producer(unique_name);
 
-        bb_beam_positions_buffer->allocate_ndarray_frame_desc<float, 2>(
-            "bb_beam_positions", {bb_num_beams, 2}, {"B", "X/Y"});
-        
-        A_buffer->allocate_ndarray_frame_desc<std::int8_t, 5>(
-            "A", {num_frequencies, num_polarizations, bb_num_beams, num_dishes, num_components},
-            {"F", "P", "B", "D", "C"});
+        bb_beam_positions_buffer->require_frame_desc(kotekan::NDArray<float, 2>::describe(
+            "bb_beam_positions", {bb_num_beams, 2}, {"B", "X/Y"}));
 
-        s_buffer->allocate_ndarray_frame_desc<std::int32_t, 3>(
-            "s", {num_frequencies, num_polarizations, bb_num_beams}, {"F", "P", "B"});
+        A_buffer->require_frame_desc(kotekan::NDArray<std::int8_t, 5>::describe(
+            "A", {num_frequencies, num_polarizations, bb_num_beams, num_dishes, num_components},
+            {"F", "P", "B", "D", "C"}));
+
+        s_buffer->require_frame_desc(kotekan::NDArray<std::int32_t, 3>::describe(
+            "s", {num_frequencies, num_polarizations, bb_num_beams}, {"F", "P", "B"}));
     }
 
     virtual ~calcBBPhase() {}
@@ -135,14 +135,15 @@ public:
 
 
         // Get timing info from beam positions buffer.
-        const auto& bb_beam_positions_meta = get_chord_metadata(bb_beam_positions_buffer->get_metadata(frame_id));
+        const auto& bb_beam_positions_meta =
+            get_chord_metadata(bb_beam_positions_buffer->get_metadata(frame_id));
         uint64_t seq_num = bb_beam_positions_meta->get_fpga_seq_num();
         uint64_t time_downsampling = bb_beam_positions_meta->get_time_downsampling_fpga();
 
         // Set metadata
         A_buffer->allocate_new_metadata_object(frame_id);
         const auto& A_meta = get_chord_metadata(A_buffer->get_metadata(frame_id));
-        A_meta->set_from_frame_desc(A_buffer->get_ndarray_frame_desc());
+        A_meta->set_from_frame_desc(A_buffer->get_frame_desc<kotekan::GenericNDArray>());
         A_meta->set_fpga_seq_num(seq_num);
         A_meta->set_time_downsampling_fpga(time_downsampling);
         A_meta->set_coarse_freq(frequency_channels);
@@ -151,7 +152,7 @@ public:
 
         s_buffer->allocate_new_metadata_object(frame_id);
         const auto& s_meta = get_chord_metadata(s_buffer->get_metadata(frame_id));
-        s_meta->set_from_frame_desc(s_buffer->get_ndarray_frame_desc());
+        s_meta->set_from_frame_desc(s_buffer->get_frame_desc<kotekan::GenericNDArray>());
         s_meta->set_fpga_seq_num(seq_num);
         s_meta->set_time_downsampling_fpga(time_downsampling);
         s_meta->set_coarse_freq(frequency_channels);

--- a/lib/stages/calcFRB2Weights.cpp
+++ b/lib/stages/calcFRB2Weights.cpp
@@ -1,5 +1,6 @@
 #include "Config.hpp"                   // for Config
 #include "DataType.hpp"                 // for float16_t
+#include "NDArray.hpp"                  // for GenericNDArray
 #include "Stage.hpp"                    // for Stage
 #include "StageFactory.hpp"             // for REGISTER_KOTEKAN_STAGE
 #include "Telescope.hpp"                // for Telescope, freq_id_t
@@ -101,11 +102,11 @@ public:
         frb2_beam_positions_buffer->register_consumer(unique_name);
         W2_buffer->register_producer(unique_name);
 
-        frb2_beam_positions_buffer->allocate_ndarray_frame_desc<float, 2>(
-            "frb2_beam_positions", {frb2_num_beams, 2}, {"R", "X/Y"});
-        W2_buffer->allocate_ndarray_frame_desc<float16_t, 4>(
+        frb2_beam_positions_buffer->require_frame_desc(kotekan::NDArray<float, 2>::describe(
+            "frb2_beam_positions", {frb2_num_beams, 2}, {"R", "X/Y"}));
+        W2_buffer->require_frame_desc(kotekan::NDArray<float16_t, 4>::describe(
             "W2", {frb2_num_frequencies, frb2_num_beams, frb1_num_beams_Q, frb1_num_beams_P},
-            {"Fbar", "R", "beamQ", "beamP"});
+            {"Fbar", "R", "beamQ", "beamP"}));
     }
 
     virtual ~calcFRB2Weights() {}
@@ -179,10 +180,9 @@ public:
         assert(std::ptrdiff_t(W2_buffer->frame_size) == W2_frame_size);
 
         // Set metadata
-
         W2_buffer->allocate_new_metadata_object(frame_id);
         const auto& W2_meta = get_chord_metadata(W2_buffer->get_metadata(frame_id));
-        W2_meta->set_from_frame_desc(W2_buffer->get_ndarray_frame_desc());
+        W2_meta->set_from_frame_desc(W2_buffer->get_frame_desc<kotekan::GenericNDArray>());
         W2_meta->set_fpga_seq_num(0);           // ???
         W2_meta->set_time_downsampling_fpga(1); // ???
         W2_meta->set_coarse_freq(coarse_freq);

--- a/lib/stages/fftwEngine.cpp
+++ b/lib/stages/fftwEngine.cpp
@@ -35,7 +35,7 @@ fftwEngine::fftwEngine(Config& config, const std::string& unique_name,
     // Output is cfloat32 1-D regardless of input_type (we accept either
     // int16 reals or cint16 IQ pairs upstream, so in_buf's descriptor is
     // intentionally left for the upstream producer to assert).
-    out_buf->set_frame_desc(
+    out_buf->ensure_frame_desc(
         kotekan_airspy::make_fengine_desc(out_buf->frame_size / sizeof(fftwf_complex)));
 
     _spectrum_length = config.get_default<int>(unique_name, "spectrum_length", 128);

--- a/lib/stages/givenDataGen.cpp
+++ b/lib/stages/givenDataGen.cpp
@@ -12,6 +12,7 @@
 #include <stdexcept>            // for invalid_argument, runtime_error
 
 #include "DataType.hpp"         // for type_total_bytes, string_to_type, DataType
+#include "NDArray.hpp"          // for GenericNDArray, Config
 #include "StageFactory.hpp"     // for REGISTER_KOTEKAN_STAGE
 #include "bufferContainer.hpp"  // for bufferContainer
 #include "chordMetadata.hpp"    // for chordMetadata, get_chord_metadata, CHORD_META_MAX_DIM
@@ -111,9 +112,10 @@ void givenDataGen::main_thread() {
         }
         chordmeta->set_strides_simple();
 
-        _out_buf->allocate_ndarray_frame_desc(chordmeta->type, _name, _array_shape, _dim_name);
+        _out_buf->require_frame_desc(
+            kotekan::GenericNDArray::describe(chordmeta->type, _name, _array_shape, _dim_name));
         /* test that things are consistent */
-        chordmeta->check_frame_desc(_out_buf->get_ndarray_frame_desc());
+        chordmeta->check_frame_desc(_out_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         _out_buf->mark_frame_full(unique_name, frame_id);
 

--- a/lib/stages/loadFeedGains.cpp
+++ b/lib/stages/loadFeedGains.cpp
@@ -85,11 +85,11 @@ loadFeedGains::loadFeedGains(Config& config, const std::string& unique_name,
                         num_local_freq * num_elements * 2 * sizeof(float), buf->frame_size);
         }
         // Set frame description
-        buf->allocate_ndarray_frame_desc<kotekan::GetType_t<kotekan::float32>, 3>(
+        buf->ensure_frame_desc(kotekan::NDArray<kotekan::GetType_t<kotekan::float32>, 3>::describe(
             "gain",
             {static_cast<ptrdiff_t>(num_local_freq), static_cast<ptrdiff_t>(num_elements),
              (ptrdiff_t)2},
-            {"F", "E", "ReIm"});
+            {"F", "E", "ReIm"}));
     }
 
     // Set up callbacks for each beam_id
@@ -272,10 +272,10 @@ void loadFeedGains::main_thread() {
         // Set metadata from the frame desc, and other metadata
         buf->allocate_new_metadata_object(frame_id);
         auto meta = get_chord_metadata(buf, frame_id);
-        meta->set_from_frame_desc(buf->get_ndarray_frame_desc());
+        meta->set_from_frame_desc(buf->get_frame_desc<kotekan::GenericNDArray>());
         meta->set_name("gain");
         // Verify that frame desc and metadata match
-        meta->check_frame_desc(buf->get_ndarray_frame_desc());
+        meta->check_frame_desc(buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // load gains into the buffer, returning in the received frame
         // is invalid

--- a/lib/stages/networkPowerStream.cpp
+++ b/lib/stages/networkPowerStream.cpp
@@ -50,11 +50,11 @@ networkPowerStream::networkPowerStream(Config& config, const std::string& unique
     // Per integration the upstream emits [freqs float32 bins, 1 uint32 count]
     // per element; we expect ``times`` integrations packed into one frame.
     // The descriptor folds the count word into the float32 array (see
-    // airspyFrameDesc.hpp). When set_frame_desc has already been called by
+    // airspyFrameDesc.hpp). When ensure_frame_desc has already been called by
     // the producer (simpleAutocorr / SimpleCrosscorr), this becomes a
     // cross-check via FrameDesc::operator==; otherwise it just records
     // the expected layout for any later consumer/producer.
-    in_buf->set_frame_desc(kotekan_airspy::make_power_corr_desc(elems * times, freqs));
+    in_buf->ensure_frame_desc(kotekan_airspy::make_power_corr_desc(elems * times, freqs));
 
     freq0 = config.get_default<float>(unique_name, "freq", 600.) * 1e6;
     sample_bw = config.get_default<float>(unique_name, "sample_bw", 200.) * 1e6;

--- a/lib/stages/processFeedGains.cpp
+++ b/lib/stages/processFeedGains.cpp
@@ -81,7 +81,7 @@ processFeedGains::processFeedGains(Config& config, const std::string& unique_nam
     }
 
     // set the output buffer frame description
-    set_frame_desc(out_buf);
+    ensure_frame_desc(out_buf);
 
     // Allocate permanent buffers to hold the loaded gains in memory. These will only
     // be updated whenever the gains are updated, and get repeatedly copied
@@ -92,12 +92,12 @@ processFeedGains::processFeedGains(Config& config, const std::string& unique_nam
 
 processFeedGains::~processFeedGains() {}
 
-void processFeedGains::set_frame_desc(Buffer* buf) {
-    buf->allocate_ndarray_frame_desc<kotekan::GetType_t<kotekan::float32>, 5>(
+void processFeedGains::ensure_frame_desc(Buffer* buf) {
+    buf->ensure_frame_desc(kotekan::NDArray<kotekan::GetType_t<kotekan::float32>, 5>::describe(
         "processed_gain",
         {static_cast<ptrdiff_t>(num_beams), static_cast<ptrdiff_t>(num_local_freq),
          static_cast<ptrdiff_t>(upchan_factor), static_cast<ptrdiff_t>(num_elements), (ptrdiff_t)2},
-        {"R", "F", "U", "E", "ReIm"});
+        {"R", "F", "U", "E", "ReIm"}));
 }
 
 void processFeedGains::copy_upchannelize_f(const float* src_f, float* dst_f, size_t fid) {
@@ -188,10 +188,10 @@ void processFeedGains::main_thread() {
         // Set metadata from the frame desc, and other metadata
         out_buf->allocate_new_metadata_object(out_buf_frame_id);
         auto meta = get_chord_metadata(out_buf, out_buf_frame_id);
-        meta->set_from_frame_desc(out_buf->get_ndarray_frame_desc());
+        meta->set_from_frame_desc(out_buf->get_frame_desc<kotekan::GenericNDArray>());
         meta->set_name("processed_gain");
         // Verify that frame desc and metadata match
-        meta->check_frame_desc(out_buf->get_ndarray_frame_desc());
+        meta->check_frame_desc(out_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // copy from permanent buffer to output buffer
         // NB: this needs to happen every time, since the mask and gain buffers

--- a/lib/stages/processFeedGains.hpp
+++ b/lib/stages/processFeedGains.hpp
@@ -74,7 +74,7 @@ private:
 
     /// Create a frame desc for the output buffer. Default creates a frame desc
     /// containing [beam, freq, subfreq, element, ReIm] axes.
-    virtual void set_frame_desc(Buffer* buf);
+    virtual void ensure_frame_desc(Buffer* buf);
 
     std::vector<Buffer*> gain_buffers;
     Buffer* in_mask_buf;

--- a/lib/stages/setBBBeams.cpp
+++ b/lib/stages/setBBBeams.cpp
@@ -170,8 +170,8 @@ setBBBeams::setBBBeams(Config& config, const std::string& unique_name,
     rest_server.register_get_callback(unique_name + "/beams",
                                       std::bind(&setBBBeams::send_beams, this, _1));
 
-    out_pos_buf->allocate_ndarray_frame_desc<float, 2>("bb_beam_positions", {static_cast<ptrdiff_t>(num_beams), 2}, {"B", "X/Y"});
-    out_id_buf->allocate_ndarray_frame_desc<uint64_t, 1>("bb_beam_ids", {static_cast<ptrdiff_t>(num_beams)}, {"B"});
+    out_pos_buf->require_frame_desc(kotekan::NDArray<float, 2>::describe("bb_beam_positions", {static_cast<ptrdiff_t>(num_beams), 2}, {"B", "X/Y"}));
+    out_id_buf->require_frame_desc(kotekan::NDArray<uint64_t, 1>::describe("bb_beam_ids", {static_cast<ptrdiff_t>(num_beams)}, {"B"}));
 }
 
 setBBBeams::~setBBBeams() {
@@ -304,24 +304,24 @@ void setBBBeams::main_thread() {
         const std::shared_ptr<chordMetadata> pos_meta = get_chord_metadata(out_pos_buf, pos_frame_id);
 
         // Set ndarray sizes and timing
-        pos_meta->set_from_frame_desc(out_pos_buf->get_ndarray_frame_desc());
+        pos_meta->set_from_frame_desc(out_pos_buf->get_frame_desc<kotekan::GenericNDArray>());
         pos_meta->set_fpga_seq_num(seq_num);
         pos_meta->set_time_downsampling_fpga(time_downsampling_fpga);
 
         // Check consistency just in case
-        pos_meta->check_frame_desc(out_pos_buf->get_ndarray_frame_desc());
+        pos_meta->check_frame_desc(out_pos_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // Set id metadata
         out_id_buf->allocate_new_metadata_object(id_frame_id);
         const std::shared_ptr<chordMetadata> id_meta = get_chord_metadata(out_id_buf, id_frame_id);
 
         // Check consistency just in case
-        id_meta->set_from_frame_desc(out_id_buf->get_ndarray_frame_desc());
+        id_meta->set_from_frame_desc(out_id_buf->get_frame_desc<kotekan::GenericNDArray>());
         id_meta->set_fpga_seq_num(seq_num);
         id_meta->set_time_downsampling_fpga(time_downsampling_fpga);
 
         // Check consistency just in case
-        id_meta->check_frame_desc(out_id_buf->get_ndarray_frame_desc());
+        id_meta->check_frame_desc(out_id_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // Increment frames so next loop gets a new seq_num
         num_frames++;

--- a/lib/stages/setFRB1Phase.cpp
+++ b/lib/stages/setFRB1Phase.cpp
@@ -1,5 +1,6 @@
 #include "Config.hpp"          // for Config
 #include "DataType.hpp"        // for float16_t
+#include "NDArray.hpp"
 #include "Stage.hpp"           // for Stage
 #include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
 #include "buffer.hpp"          // for Buffer
@@ -81,14 +82,15 @@ public:
                       * num_dishes_N * num_dishes_M * num_components);
 
         // Set metadata
-        frb1_phase_buffer->allocate_ndarray_frame_desc<float16_t, 5>(
+        frb1_phase_buffer->require_frame_desc(kotekan::NDArray<float16_t, 5>::describe(
             "W",
             {upchan_max_num_channels * upchan_factor, num_polarizations, num_dishes_N, num_dishes_M,
              num_components},
-            {"F", "P", "dishN", "dishM", "C"});
+            {"F", "P", "dishN", "dishM", "C"}));
         frb1_phase_buffer->allocate_new_metadata_object(frame_id);
         const auto& frb1_phase_meta = get_chord_metadata(frb1_phase_buffer->get_metadata(frame_id));
-        frb1_phase_meta->set_from_frame_desc(frb1_phase_buffer->get_ndarray_frame_desc());
+        frb1_phase_meta->set_from_frame_desc(
+            frb1_phase_buffer->get_frame_desc<kotekan::GenericNDArray>());
         frb1_phase_meta->set_fpga_seq_num(0);           // ???
         frb1_phase_meta->set_time_downsampling_fpga(1); // ???
         std::vector<int> coarse_freq(upchan_num_channels * upchan_factor);

--- a/lib/stages/setFRBBeams.cpp
+++ b/lib/stages/setFRBBeams.cpp
@@ -150,8 +150,8 @@ setFRBBeams::setFRBBeams(Config& config, const std::string& unique_name,
     rest_server.register_get_callback(unique_name + "/beams",
                                       std::bind(&setFRBBeams::send_beams, this, _1));
 
-    out_pos_buf->allocate_ndarray_frame_desc<float, 2>("frb2_beam_positions", {static_cast<ptrdiff_t>(num_beams), 2}, {"R", "X/Y"});
-    out_id_buf->allocate_ndarray_frame_desc<uint64_t, 1>("frb2_beam_ids", {static_cast<ptrdiff_t>(num_beams)}, {"R"});
+    out_pos_buf->require_frame_desc(kotekan::NDArray<float, 2>::describe("frb2_beam_positions", {static_cast<ptrdiff_t>(num_beams), 2}, {"R", "X/Y"}));
+    out_id_buf->require_frame_desc(kotekan::NDArray<uint64_t, 1>::describe("frb2_beam_ids", {static_cast<ptrdiff_t>(num_beams)}, {"R"}));
 }
 
 setFRBBeams::~setFRBBeams() {
@@ -238,20 +238,20 @@ void setFRBBeams::main_thread() {
         out_pos_buf->allocate_new_metadata_object(pos_frame_id);
         const std::shared_ptr<chordMetadata> pos_meta = get_chord_metadata(out_pos_buf, pos_frame_id);
 
-        pos_meta->set_from_frame_desc(out_pos_buf->get_ndarray_frame_desc());
+        pos_meta->set_from_frame_desc(out_pos_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // If this gets made time-dependent, set fpga_seq_num, and fpga_time_downsampling here.
 
-        pos_meta->check_frame_desc(out_pos_buf->get_ndarray_frame_desc());
+        pos_meta->check_frame_desc(out_pos_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         out_id_buf->allocate_new_metadata_object(id_frame_id);
         const std::shared_ptr<chordMetadata> id_meta = get_chord_metadata(out_id_buf, id_frame_id);
 
-        id_meta->set_from_frame_desc(out_id_buf->get_ndarray_frame_desc());
+        id_meta->set_from_frame_desc(out_id_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // If this gets made time-dependent, set fpga_seq_num, and fpga_time_downsampling here.
 
-        id_meta->check_frame_desc(out_id_buf->get_ndarray_frame_desc());
+        id_meta->check_frame_desc(out_id_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         out_pos_buf->mark_frame_full(unique_name, pos_frame_id++);
         out_id_buf->mark_frame_full(unique_name, id_frame_id++);

--- a/lib/stages/setScatterIndices.cpp
+++ b/lib/stages/setScatterIndices.cpp
@@ -8,6 +8,7 @@
 #include <memory>               // for allocator, __shared_ptr_access, shared_ptr
 
 #include "Config.hpp"           // for Config
+#include "NDArray.hpp"
 #include "Stage.hpp"            // for Stage
 #include "StageFactory.hpp"     // for REGISTER_KOTEKAN_STAGE
 #include "buffer.hpp"           // for Buffer
@@ -63,12 +64,13 @@ public:
                == sizeof(std::int32_t) * num_polarizations * num_dishes);
 
         // Set metadata
-        scatter_indices_buffer->allocate_ndarray_frame_desc<std::int32_t, 2>(
-            "scatter_indices", {num_polarizations, num_dishes}, {"P", "D"});
+        scatter_indices_buffer->require_frame_desc(kotekan::NDArray<std::int32_t, 2>::describe(
+            "scatter_indices", {num_polarizations, num_dishes}, {"P", "D"}));
         scatter_indices_buffer->allocate_new_metadata_object(frame_id);
         const auto& scatter_indices_meta =
             get_chord_metadata(scatter_indices_buffer->get_metadata(frame_id));
-        scatter_indices_meta->set_from_frame_desc(scatter_indices_buffer->get_ndarray_frame_desc());
+        scatter_indices_meta->set_from_frame_desc(
+            scatter_indices_buffer->get_frame_desc<kotekan::GenericNDArray>());
         // scatter_indices_meta->set_fpga_seq_num(0);           // ???
         // scatter_indices_meta->set_time_downsampling_fpga(1); // ???
 

--- a/lib/stages/setUpchanGain.cpp
+++ b/lib/stages/setUpchanGain.cpp
@@ -16,6 +16,7 @@
 #include "chordMetadata.hpp"             // for chordMetadata, get_chord_metadata
 #include "kotekanLogging.hpp"            // for DEBUG
 #include "DataType.hpp"                  // for float16_t
+#include "NDArray.hpp"
 #include "fmt.hpp"                       // for compile_string_to_view, format
 
 class setUpchanGain : public kotekan::Stage {
@@ -71,12 +72,13 @@ public:
             return;
 
         // Set metadata
-        upchan_gain_buffer->allocate_ndarray_frame_desc<float16_t, 1>(
-            "G", {upchan_max_num_channels * upchan_factor}, {"Fbar"});
+        upchan_gain_buffer->require_frame_desc(kotekan::NDArray<float16_t, 1>::describe(
+            "G", {upchan_max_num_channels * upchan_factor}, {"Fbar"}));
         upchan_gain_buffer->allocate_new_metadata_object(frame_id);
         const auto& upchan_gain_meta =
             get_chord_metadata(upchan_gain_buffer->get_metadata(frame_id));
-        upchan_gain_meta->set_from_frame_desc(upchan_gain_buffer->get_ndarray_frame_desc());
+        upchan_gain_meta->set_from_frame_desc(
+            upchan_gain_buffer->get_frame_desc<kotekan::GenericNDArray>());
         upchan_gain_meta->set_fpga_seq_num(0);           // ???
         upchan_gain_meta->set_time_downsampling_fpga(1); // ???
         const auto& upchan_channels_set = upchan_schedule.get_upchan_channels(upchan_factor);

--- a/lib/stages/simpleAutocorr.cpp
+++ b/lib/stages/simpleAutocorr.cpp
@@ -42,7 +42,7 @@ simpleAutocorr::simpleAutocorr(Config& config, const std::string& unique_name,
     // test pipeline captures buf_out through rawFileWrite. networkPowerStream
     // asserts the expected power_corr layout on its consumer side, so the
     // contract is still documented in code.
-    buf_in->set_frame_desc(
+    buf_in->ensure_frame_desc(
         kotekan_airspy::make_fengine_desc(buf_in->frame_size / (2 * sizeof(float))));
 }
 

--- a/lib/stages/testDataGen.cpp
+++ b/lib/stages/testDataGen.cpp
@@ -18,6 +18,7 @@
 #include "CHORDTelescope.hpp"   // for CHORDTelescope
 #include "Config.hpp"           // for Config
 #include "DataType.hpp"         // for DataType, KOTEKAN_FLOAT16, float16_t
+#include "NDArray.hpp"          // for GenericNDArray, Config
 #include "StageFactory.hpp"     // for REGISTER_KOTEKAN_STAGE
 #include "Symbol.hpp"           // for Symbol
 #include "Telescope.hpp"        // for Telescope, stream_t
@@ -358,9 +359,10 @@ void testDataGen::main_thread() {
         const std::vector<ptrdiff_t> extents(_array_shape.begin(), _array_shape.end());
         const std::vector<kotekan::Symbol> dimnames(_dim_name.begin(), _dim_name.end());
 
-        buf->allocate_ndarray_frame_desc(chordmeta->type, _name, extents, dimnames);
+        buf->ensure_frame_desc(
+            kotekan::GenericNDArray::describe(chordmeta->type, _name, extents, dimnames));
         /* test that things are consistent */
-        chordmeta->check_frame_desc(buf->get_ndarray_frame_desc());
+        chordmeta->check_frame_desc(buf->get_frame_desc<kotekan::GenericNDArray>());
 
         if (type == "onehot") {
             int val = value;

--- a/lib/testing/FakeN2.cpp
+++ b/lib/testing/FakeN2.cpp
@@ -55,7 +55,7 @@ FakeN2::FakeN2(Config& config, const std::string& unique_name, bufferContainer& 
     out_buf->register_producer(unique_name);
 
     // Get N2 parameters from the buffer's frame descriptor (set by bufferFactory)
-    auto frame_desc = out_buf->get_frame_description();
+    auto frame_desc = out_buf->get_frame_desc();
     if (!frame_desc) {
         FATAL_ERROR("Buffer {:s} does not have a frame descriptor set", out_buf->buffer_name);
     }
@@ -322,8 +322,8 @@ ReplaceN2::ReplaceN2(Config& config, const std::string& unique_name,
     out_buf->register_producer(unique_name);
 
     // Validate that input and output buffers have compatible N2 frame descriptors
-    auto in_desc = in_buf->get_frame_description();
-    auto out_desc = out_buf->get_frame_description();
+    auto in_desc = in_buf->get_frame_desc();
+    auto out_desc = out_buf->get_frame_desc();
     if (!in_desc || !out_desc) {
         FATAL_ERROR("ReplaceN2: Input and output buffers must have frame descriptors set");
     }

--- a/lib/testing/N2FringeStop.cpp
+++ b/lib/testing/N2FringeStop.cpp
@@ -42,8 +42,8 @@ N2FringeStop::N2FringeStop(Config& config, const std::string& unique_name,
     out_buf->register_producer(unique_name);
 
     // Validate that input and output buffers have compatible N2 frame descriptors
-    auto in_desc = in_buf->get_frame_description();
-    auto out_desc = out_buf->get_frame_description();
+    auto in_desc = in_buf->get_frame_desc();
+    auto out_desc = out_buf->get_frame_desc();
     if (!in_desc || !out_desc) {
         FATAL_ERROR("N2FringeStop: Input and output buffers must have frame descriptors set");
     }

--- a/lib/testing/applyGenPL.cpp
+++ b/lib/testing/applyGenPL.cpp
@@ -1,6 +1,7 @@
 #include "applyGenPL.hpp"
 
 #include "Config.hpp"          // for Config
+#include "NDArray.hpp"         // for GenericNDArray, Config
 #include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
 #include "buffer.hpp"          // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
@@ -60,30 +61,16 @@ applyGenPL::applyGenPL(Config& config, const std::string& unique_name,
     output_buf = get_buffer("voltage_out_buf");
     output_buf->register_producer(unique_name);
 
-    size_t voltage_frame_size =
-        _samples_per_data_set * _num_local_freq * _num_elements * sizeof(char);
-    size_t pl_frame_size =
-        (_samples_per_data_set / 2) * (_num_local_freq / 4) * (_num_elements / 8) / 8;
-
-    if (input_buf->frame_size != voltage_frame_size) {
-        FATAL_ERROR("applyGenPL voltage_in_buf ({:s}) has frame size {:d}, expected {:d}.",
-                    input_buf->buffer_name, input_buf->frame_size, voltage_frame_size);
-        std::abort();
-    }
-    if (plmask_buf->frame_size != pl_frame_size) {
-        FATAL_ERROR("applyGenPL plmask_in_buf ({:s}) has frame size {:d}, expected {:d}.",
-                    plmask_buf->buffer_name, plmask_buf->frame_size, voltage_frame_size);
-        std::abort();
-    }
-    if (output_buf->frame_size != voltage_frame_size) {
-        FATAL_ERROR("applyGenPL voltage_out_buf ({:s}) has frame size {:d}, expected {:d}.",
-                    output_buf->buffer_name, output_buf->frame_size, voltage_frame_size);
-        std::abort();
-    }
-
-    output_buf->allocate_ndarray_frame_desc(
+    input_buf->require_frame_desc(kotekan::GenericNDArray::describe(
         kotekan::int4x2_swapped_withoffset, "E",
-        {_samples_per_data_set, _num_local_freq, 2, _num_elements / 2}, {"T", "F", "P", "D"});
+        {_samples_per_data_set, _num_local_freq, 2, _num_elements / 2}, {"T", "F", "P", "D"}));
+    plmask_buf->require_frame_desc(kotekan::GenericNDArray::describe(
+        kotekan::uint1x8, "pl_mask",
+        {_samples_per_data_set / 128, _num_local_freq / 4, 2, (_num_elements / 8) / 2, 8},
+        {"T2hi64", "F4", "P", "D8", "T2lo64"}));
+    output_buf->require_frame_desc(kotekan::GenericNDArray::describe(
+        kotekan::int4x2_swapped_withoffset, "E",
+        {_samples_per_data_set, _num_local_freq, 2, _num_elements / 2}, {"T", "F", "P", "D"}));
 }
 
 applyGenPL::~applyGenPL() {}

--- a/lib/testing/gpuSimulateN2kCorr.cpp
+++ b/lib/testing/gpuSimulateN2kCorr.cpp
@@ -2,6 +2,7 @@
 
 #include "Config.hpp"          // for Config
 #include "DataType.hpp"        // for DataType, GetType
+#include "NDArray.hpp"         // for NDArray, GenericNDArray, Config
 #include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
 #include "buffer.hpp"          // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
@@ -79,41 +80,24 @@ gpuSimulateN2kCorr::gpuSimulateN2kCorr(Config& config, const std::string& unique
     output_buf = get_buffer("corr_out_buf");
     output_buf->register_producer(unique_name);
 
-    // Check buffer frame sizes
-    size_t input_voltage_frame_size =
-        sizeof(char) * _num_elements * _num_local_freq * _samples_per_data_set;
-    size_t rfimask_frame_size = _num_local_freq * _samples_per_data_set / 8;
-
-    size_t num_blocks = num_triangle_blocks(_num_elements, _corr_blocksize);
-    size_t num_correlations = _samples_per_data_set / _sub_integration_ntime;
-
-    size_t corr_frame_size = 2 * sizeof(int) * _corr_blocksize * _corr_blocksize * num_blocks
-                             * _num_local_freq * num_correlations;
-
-    if (input_buf->frame_size != input_voltage_frame_size) {
-        FATAL_ERROR("network_in_buf ({:s}) has frame size {:d}, expected {:d}",
-                    input_buf->buffer_name, input_buf->frame_size, input_voltage_frame_size);
-        std::abort();
-    }
-    if (rfimask_buf->frame_size != rfimask_frame_size) {
-        FATAL_ERROR("rfimask_in_buf ({:s}) has frame size {:d}, expected {:d}",
-                    rfimask_buf->buffer_name, rfimask_buf->frame_size, rfimask_frame_size);
-        std::abort();
-    }
-    if (output_buf->frame_size != corr_frame_size) {
-        FATAL_ERROR("corr_out_buf ({:s}) has frame size {:d}, expected {:d}",
-                    output_buf->buffer_name, output_buf->frame_size, corr_frame_size);
-        std::abort();
-    }
-
     /* new style array description */
     // number of elements = number of dishes * polarizations
     int nt_inner = _sub_integration_ntime;
     int nt_outer = _samples_per_data_set / nt_inner;
-    output_buf->allocate_ndarray_frame_desc<kotekan::GetType<kotekan::int32>::type, 6>(
-        "n2k_correlation",
-        {nt_outer, _num_local_freq, num_triangle_blocks(_num_elements, _corr_blocksize), 16, 16, 2},
-        {"Tc", "F", "DPhi", "DPlo1", "DPlo2", "C"});
+    input_buf->require_frame_desc(
+        kotekan::NDArray<kotekan::int4x2_swapped_withoffset_t, 4>::describe(
+            "E", {_samples_per_data_set, _num_local_freq, 2, _num_elements / 2},
+            {"T", "F", "P", "D"}));
+    rfimask_buf->require_frame_desc(
+        kotekan::NDArray<kotekan::GetType<kotekan::uint1x8>::type, 3>::describe(
+            "RFImask", {_samples_per_data_set / 1024, _num_local_freq, 128},
+            {"T8hi128", "F", "T8lo128"}));
+    output_buf->require_frame_desc(
+        kotekan::NDArray<kotekan::GetType<kotekan::int32>::type, 6>::describe(
+            "n2k_correlation",
+            {nt_outer, _num_local_freq, num_triangle_blocks(_num_elements, _corr_blocksize), 16, 16,
+             2},
+            {"Tc", "F", "DPhi", "DPlo1", "DPlo2", "C"}));
 }
 
 gpuSimulateN2kCorr::~gpuSimulateN2kCorr() {}
@@ -285,7 +269,7 @@ void gpuSimulateN2kCorr::main_thread() {
 
         // frame_desc set in constructor
         /* test that things are consistent */
-        meta_out->check_frame_desc(output_buf->get_ndarray_frame_desc());
+        meta_out->check_frame_desc(output_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         meta_out->set_fpga_seq_num(meta_in->get_fpga_seq_num());
         meta_out->set_time_downsampling_fpga(meta_in->get_time_downsampling_fpga()

--- a/lib/testing/gpuSimulateN2kPL1bitCorr.cpp
+++ b/lib/testing/gpuSimulateN2kPL1bitCorr.cpp
@@ -2,6 +2,7 @@
 
 #include "Config.hpp"          // for Config
 #include "DataType.hpp"        // for DataType, GetType
+#include "NDArray.hpp"         // for NDArray, GenericNDArray, Config
 #include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
 #include "buffer.hpp"          // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
@@ -87,9 +88,17 @@ gpuSimulateN2kPL1bitCorr::gpuSimulateN2kPL1bitCorr(Config& config, const std::st
     int nf = _num_local_freq;
     int ne = _num_elements / 8;
     int n_blocks = num_triangle_blocks(ne, _blocksize);
-    output_buf->allocate_ndarray_frame_desc<kotekan::GetType<kotekan::int32>::type, 5>(
-        "n2k_counts", {n_integrations, nf, n_blocks, _blocksize, _blocksize},
-        {"Tc", "F", "D8Phi", "D8Plo1", "D8Plo2"});
+    input_plmask_buf->require_frame_desc(
+        kotekan::NDArray<kotekan::GetType<kotekan::uint1x8>::type, 5>::describe(
+            "pl_mask_exp", {_samples_per_data_set / 64, nf, 2, ne / 2, 8},
+            {"Thi64", "F", "P", "D8", "Tlo64"}));
+    input_rfimask_buf->require_frame_desc(
+        kotekan::NDArray<kotekan::GetType<kotekan::uint1x8>::type, 3>::describe(
+            "RFImask", {_samples_per_data_set / 1024, nf, 128}, {"T8hi128", "F", "T8lo128"}));
+    output_buf->require_frame_desc(
+        kotekan::NDArray<kotekan::GetType<kotekan::int32>::type, 5>::describe(
+            "n2k_counts", {n_integrations, nf, n_blocks, _blocksize, _blocksize},
+            {"Tc", "F", "D8Phi", "D8Plo1", "D8Plo2"}));
 }
 
 gpuSimulateN2kPL1bitCorr::~gpuSimulateN2kPL1bitCorr() {}
@@ -254,7 +263,7 @@ void gpuSimulateN2kPL1bitCorr::main_thread() {
         meta_out->set_strides_simple();
         // frame_desc set in constructor
         /* test that things are consistent */
-        meta_out->check_frame_desc(output_buf->get_ndarray_frame_desc());
+        meta_out->check_frame_desc(output_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         meta_out->set_fpga_seq_num(meta_in->get_fpga_seq_num());
         meta_out->set_time_downsampling_fpga(

--- a/lib/testing/gpuSimulateN2kPLExpand.cpp
+++ b/lib/testing/gpuSimulateN2kPLExpand.cpp
@@ -2,6 +2,7 @@
 
 #include "Config.hpp"          // for Config
 #include "DataType.hpp"        // for DataType, GetType
+#include "NDArray.hpp"         // for NDArray, GenericNDArray, Config
 #include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
 #include "buffer.hpp"          // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
@@ -45,8 +46,13 @@ gpuSimulateN2kPLExpand::gpuSimulateN2kPLExpand(Config& config, const std::string
     int nt = _samples_per_data_set / 64;
     int nf = _num_local_freq;
     int ne = _num_elements / 8;
-    output_buf->allocate_ndarray_frame_desc<kotekan::GetType<kotekan::uint1x8>::type, 5>(
-        "pl_mask_exp", {nt, nf, 2, ne / 2, 8}, {"Thi64", "F", "P", "D8", "Tlo64"});
+    input_buf->require_frame_desc(
+        kotekan::NDArray<kotekan::GetType<kotekan::uint1x8>::type, 5>::describe(
+            "pl_mask", {nt / 2, (nf + 3) / 4, 2, ne / 2, 8},
+            {"T2hi64", "F4", "P", "D8", "T2lo64"}));
+    output_buf->require_frame_desc(
+        kotekan::NDArray<kotekan::GetType<kotekan::uint1x8>::type, 5>::describe(
+            "pl_mask_exp", {nt, nf, 2, ne / 2, 8}, {"Thi64", "F", "P", "D8", "Tlo64"}));
 }
 
 gpuSimulateN2kPLExpand::~gpuSimulateN2kPLExpand() {}
@@ -172,7 +178,7 @@ void gpuSimulateN2kPLExpand::main_thread() {
         meta_out->deepCopy(meta_in);
 
         // frame_desc set in constructor
-        meta_out->set_from_frame_desc(output_buf->get_ndarray_frame_desc());
+        meta_out->set_from_frame_desc(output_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // Update changes
         meta_out->set_fpga_seq_num(meta_in->get_fpga_seq_num());
@@ -198,7 +204,7 @@ void gpuSimulateN2kPLExpand::main_thread() {
         assert(meta_out->get_nfreq() <= CHORD_META_MAX_FREQ);
 
         /* test that things are consistent */
-        meta_out->check_frame_desc(output_buf->get_ndarray_frame_desc());
+        meta_out->check_frame_desc(output_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         input_buf->mark_frame_empty(unique_name, input_frame_id);
         output_buf->mark_frame_full(unique_name, output_frame_id);

--- a/lib/testing/gpuSimulatePLMaskAccumulator.cpp
+++ b/lib/testing/gpuSimulatePLMaskAccumulator.cpp
@@ -1,6 +1,7 @@
 #include "Config.hpp"          // for Config
 #include "DataType.hpp"        // for DataType, GetType
 #include "N2Util.hpp"          // for frameID
+#include "NDArray.hpp"         // for NDArray, GenericNDArray, Config
 #include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
 #include "buffer.hpp"          // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
@@ -130,14 +131,14 @@ gpuSimulatePLMaskAccumulator::gpuSimulatePLMaskAccumulator(Config& config,
     }
 
     // Make frame desc for produced buffer (this also checks the size)
-    in_buf->allocate_ndarray_frame_desc<kotekan::uint1x8_t, 5>(
+    in_buf->require_frame_desc(kotekan::NDArray<kotekan::uint1x8_t, 5>::describe(
         "pl_mask",
         {div_noremainder(_samples_per_data_set, 128), div_noremainder(_num_local_freq, 4),
          _num_polarizations, div_noremainder(_num_dishes, 8), 64 / 8},
-        {"T2hi64", "F4", "P", "D8", "T2lo64"});
-    out_buf->allocate_ndarray_frame_desc<uint64_t, 4>(
+        {"T2hi64", "F4", "P", "D8", "T2lo64"}));
+    out_buf->require_frame_desc(kotekan::NDArray<uint64_t, 4>::describe(
         "pl_counts", {_num_integrations, _num_local_freq, _num_polarizations, _num_dishes},
-        {"Tc", "F", "P", "D"});
+        {"Tc", "F", "P", "D"}));
 }
 
 gpuSimulatePLMaskAccumulator::~gpuSimulatePLMaskAccumulator() {}
@@ -244,7 +245,7 @@ void gpuSimulatePLMaskAccumulator::main_thread() {
         // Start with a copy
         meta_out->deepCopy(meta_in);
 
-        meta_out->set_from_frame_desc(out_buf->get_ndarray_frame_desc());
+        meta_out->set_from_frame_desc(out_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // Set non-NDArray things.
         meta_out->set_fpga_seq_num(meta_in->get_fpga_seq_num());
@@ -252,7 +253,7 @@ void gpuSimulatePLMaskAccumulator::main_thread() {
             div_noremainder(meta_in->get_time_downsampling_fpga(), 128) * _sub_integration_ntime);
 
         // test that things are consistent
-        meta_out->check_frame_desc(out_buf->get_ndarray_frame_desc());
+        meta_out->check_frame_desc(out_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         INFO("Simulating GPU RFI S012 done for {:s}[{:d}] result is in {:s}[{:d}]",
              in_buf->buffer_name, in_frame_id, out_buf->buffer_name, out_frame_id);

--- a/lib/testing/gpuSimulateRFIS012.cpp
+++ b/lib/testing/gpuSimulateRFIS012.cpp
@@ -3,6 +3,7 @@
 #include "Config.hpp"          // for Config
 #include "DataType.hpp"        // for DataType, GetType
 #include "N2Util.hpp"          // for frameID
+#include "NDArray.hpp"         // for NDArray, GenericNDArray, Config
 #include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
 #include "buffer.hpp"          // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
@@ -47,10 +48,6 @@ gpuSimulateRFIS012::gpuSimulateRFIS012(Config& config, const std::string& unique
     out_rfis012_buf->register_producer(unique_name);
 
 
-    size_t voltage_size = _samples_per_data_set * _num_local_freq * _num_elements;
-    size_t plmask_size =
-        ((_samples_per_data_set / 2) * (_num_local_freq / 4) * (_num_elements / 8)) / 8;
-
     // Check input sizes and buffer compatibility
     if (_samples_per_data_set % _rfi_downsampling_factor != 0) {
         FATAL_ERROR("samples_per_data_set must be a multiple of rfi_downsampling_factor");
@@ -60,25 +57,21 @@ gpuSimulateRFIS012::gpuSimulateRFIS012(Config& config, const std::string& unique
     if (_num_elements % 8 != 0) {
         FATAL_ERROR("num_elements (num_polarizations x num_dishes) must be a multiple of 8");
     }
-    assert(_samples_per_data_set % _rfi_downsampling_factor == 0);
 
-    if (in_voltage_buf->frame_size != voltage_size) {
-        FATAL_ERROR("in_voltage_buf ({:s}) has frame size: {:d}, expected: {:d}",
-                    in_voltage_buf->buffer_name, in_voltage_buf->frame_size, voltage_size);
-    }
-    assert(in_voltage_buf->frame_size == voltage_size);
-
-    if (in_plmask_buf->frame_size != plmask_size) {
-        FATAL_ERROR("in_plmask_buf ({:s}) has frame size: {:d}, expected: {:d}",
-                    in_plmask_buf->buffer_name, in_plmask_buf->frame_size, plmask_size);
-    }
-    assert(in_plmask_buf->frame_size == plmask_size);
+    in_voltage_buf->require_frame_desc(
+        kotekan::NDArray<kotekan::int4x2_swapped_withoffset_t, 4>::describe(
+            "E", {_samples_per_data_set, _num_local_freq, _num_polarizations, _num_dishes},
+            {"T", "F", "P", "D"}));
+    in_plmask_buf->require_frame_desc(kotekan::NDArray<kotekan::uint1x8_t, 5>::describe(
+        "pl_mask",
+        {_samples_per_data_set / 128, _num_local_freq / 4, _num_polarizations, _num_dishes / 8, 8},
+        {"T2hi64", "F4", "P", "D8", "T2lo64"}));
 
     // Make frame desc for produced buffer
     int64_t nt = _samples_per_data_set / _rfi_downsampling_factor;
-    out_rfis012_buf->allocate_ndarray_frame_desc<uint64_t, 5>(
+    out_rfis012_buf->require_frame_desc(kotekan::NDArray<uint64_t, 5>::describe(
         "S012", {nt, _num_local_freq, 3, _num_polarizations, _num_dishes},
-        {"Trfi", "F", "S", "P", "D"});
+        {"Trfi", "F", "S", "P", "D"}));
 }
 
 gpuSimulateRFIS012::~gpuSimulateRFIS012() {}
@@ -213,10 +206,10 @@ void gpuSimulateRFIS012::main_thread() {
         // Start with a copy
         meta_out->deepCopy(meta_in);
 
-        meta_out->set_from_frame_desc(out_rfis012_buf->get_ndarray_frame_desc());
+        meta_out->set_from_frame_desc(out_rfis012_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // test that things are consistent
-        meta_out->check_frame_desc(out_rfis012_buf->get_ndarray_frame_desc());
+        meta_out->check_frame_desc(out_rfis012_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // Set non-NDArray things.
         meta_out->set_fpga_seq_num(meta_in->get_fpga_seq_num());

--- a/lib/testing/gpuSimulateRFIS012bar.cpp
+++ b/lib/testing/gpuSimulateRFIS012bar.cpp
@@ -3,6 +3,7 @@
 #include "Config.hpp"          // for Config
 #include "DataType.hpp"        // for DataType, GetType
 #include "N2Util.hpp"          // for frameID
+#include "NDArray.hpp"         // for NDArray, GenericNDArray, Config
 #include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
 #include "buffer.hpp"          // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
@@ -60,19 +61,16 @@ gpuSimulateRFIS012bar::gpuSimulateRFIS012bar(Config& config, const std::string& 
     assert((_samples_per_data_set / _rfi_downsampling_factor) % _rfi_second_downsampling_factor
            == 0);
 
-    size_t rfi_s012_size = (_samples_per_data_set / _rfi_downsampling_factor) * _num_local_freq * 3
-                           * _num_elements * sizeof(uint64_t);
-
-    if (in_buf->frame_size != rfi_s012_size) {
-        FATAL_ERROR("in_buf ({:s}) has frame size: {:d}, expected {:d}", in_buf->buffer_name,
-                    in_buf->frame_size, rfi_s012_size);
-    }
-    assert(in_buf->frame_size == rfi_s012_size);
+    in_buf->require_frame_desc(kotekan::NDArray<uint64_t, 5>::describe(
+        "S012",
+        {_samples_per_data_set / _rfi_downsampling_factor, _num_local_freq, 3, _num_polarizations,
+         _num_dishes},
+        {"Trfi", "F", "S", "P", "D"}));
 
     int64_t nt = _samples_per_data_set / _rfi_downsampling_factor / _rfi_second_downsampling_factor;
-    out_buf->allocate_ndarray_frame_desc<uint64_t, 5>(
+    out_buf->require_frame_desc(kotekan::NDArray<uint64_t, 5>::describe(
         "S012bar", {nt, _num_local_freq, 3, _num_polarizations, _num_dishes},
-        {"Trfibar", "F", "S", "P", "D"});
+        {"Trfibar", "F", "S", "P", "D"}));
 }
 
 gpuSimulateRFIS012bar::~gpuSimulateRFIS012bar() {}
@@ -125,10 +123,10 @@ void gpuSimulateRFIS012bar::main_thread() {
 
         // Start with a copy
         meta_out->deepCopy(meta_in);
-        meta_out->set_from_frame_desc(out_buf->get_ndarray_frame_desc());
+        meta_out->set_from_frame_desc(out_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // test that things are consistent
-        meta_out->check_frame_desc(out_buf->get_ndarray_frame_desc());
+        meta_out->check_frame_desc(out_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // Set non-NDArray things.
         meta_out->set_fpga_seq_num(meta_in->get_fpga_seq_num());

--- a/lib/testing/gpuSimulateRFIS012tilde.cpp
+++ b/lib/testing/gpuSimulateRFIS012tilde.cpp
@@ -3,6 +3,7 @@
 #include "Config.hpp"          // for Config
 #include "DataType.hpp"        // for DataType, GetType
 #include "N2Util.hpp"          // for frameID
+#include "NDArray.hpp"         // for NDArray, GenericNDArray, Config
 #include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
 #include "buffer.hpp"          // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
@@ -52,26 +53,14 @@ gpuSimulateRFIS012tilde::gpuSimulateRFIS012tilde(Config& config, const std::stri
     }
     assert(_samples_per_data_set % _rfi_downsampling_factor == 0);
 
-    size_t bf_mask_size = _num_elements;
-    size_t rfi_s012_size = (_samples_per_data_set / _rfi_downsampling_factor) * _num_local_freq * 3
-                           * _num_elements * sizeof(uint64_t);
-
-    if (in_rfi_s012_buf->frame_size != rfi_s012_size) {
-        FATAL_ERROR("in_rfi_s012_buf ({:s}) has frame size: {:d}, expected {:d}",
-                    in_rfi_s012_buf->buffer_name, in_rfi_s012_buf->frame_size, rfi_s012_size);
-    }
-    assert(in_rfi_s012_buf->frame_size == rfi_s012_size);
-
-    if (in_bf_mask_buf->frame_size != bf_mask_size) {
-        FATAL_ERROR("in_bf_mask_buf ({:s}) has frame size: {:d}, expected {:d}",
-                    in_bf_mask_buf->buffer_name, in_bf_mask_buf->frame_size, bf_mask_size);
-    }
-    assert(in_bf_mask_buf->frame_size == bf_mask_size);
-
     int64_t nt = _samples_per_data_set / _rfi_downsampling_factor;
     int64_t nf = _num_local_freq;
-    out_rfi_s012tilde_buf->allocate_ndarray_frame_desc<uint64_t, 3>("S012tilde", {nt, nf, 3},
-                                                                    {"Trfi", "F", "S"});
+    in_rfi_s012_buf->require_frame_desc(kotekan::NDArray<uint64_t, 5>::describe(
+        "S012", {nt, nf, 3, _num_polarizations, _num_dishes}, {"Trfi", "F", "S", "P", "D"}));
+    in_bf_mask_buf->require_frame_desc(kotekan::NDArray<std::int8_t, 2>::describe(
+        "bf_mask", {_num_polarizations, _num_dishes}, {"P", "D"}));
+    out_rfi_s012tilde_buf->require_frame_desc(
+        kotekan::NDArray<uint64_t, 3>::describe("S012tilde", {nt, nf, 3}, {"Trfi", "F", "S"}));
 }
 
 gpuSimulateRFIS012tilde::~gpuSimulateRFIS012tilde() {}
@@ -160,10 +149,12 @@ void gpuSimulateRFIS012tilde::main_thread() {
         // Start with a copy
         meta_out->deepCopy(meta_in);
 
-        meta_out->set_from_frame_desc(out_rfi_s012tilde_buf->get_ndarray_frame_desc());
+        meta_out->set_from_frame_desc(
+            out_rfi_s012tilde_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // test that things are consistent
-        meta_out->check_frame_desc(out_rfi_s012tilde_buf->get_ndarray_frame_desc());
+        meta_out->check_frame_desc(
+            out_rfi_s012tilde_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // Set non-NDArray things.
         meta_out->set_fpga_seq_num(meta_in->get_fpga_seq_num());

--- a/lib/testing/gpuSimulateRFISK.cpp
+++ b/lib/testing/gpuSimulateRFISK.cpp
@@ -1,6 +1,7 @@
 #include "Config.hpp"          // for Config
 #include "DataType.hpp"        // for DataType, GetType
 #include "N2Util.hpp"          // for frameID
+#include "NDArray.hpp"         // for NDArray, GenericNDArray, Config
 #include "Stage.hpp"           // for Stage
 #include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
 #include "buffer.hpp"          // for Buffer
@@ -206,46 +207,37 @@ gpuSimulateRFISK::gpuSimulateRFISK(Config& config, const std::string& unique_nam
     out_rfi_mask_buf->register_producer(unique_name);
 
     int64_t nt = _samples_per_data_set / _rfi_downsampling_factor;
-    size_t bf_mask_size = _num_elements;
-    size_t rfi_s012_size = nt * _num_local_freq * 3 * _num_elements * sizeof(uint64_t);
-
     // Check input sizes and buffer compatibility
     if (_samples_per_data_set % _rfi_downsampling_factor != 0) {
         FATAL_ERROR("samples_per_data_set must be a multiple of rfi_downsampling_factor");
     }
     assert(_samples_per_data_set % _rfi_downsampling_factor == 0);
 
-    if (in_rfi_s012_buf->frame_size != rfi_s012_size) {
-        FATAL_ERROR("in_rfi_s012_buf ({:s}) has frame size: {:d}, expected: {:d}",
-                    in_rfi_s012_buf->buffer_name, in_rfi_s012_buf->frame_size, rfi_s012_size);
-    }
-    assert(in_rfi_s012_buf->frame_size == rfi_s012_size);
-
-    if (in_bf_mask_buf->frame_size != bf_mask_size) {
-        FATAL_ERROR("in_bf_mask_buf ({:s}) has frame size: {:d}, expected: {:d}",
-                    in_bf_mask_buf->buffer_name, in_bf_mask_buf->frame_size, bf_mask_size);
-    }
-    assert(in_bf_mask_buf->frame_size == bf_mask_size);
+    in_rfi_s012_buf->require_frame_desc(kotekan::NDArray<uint64_t, 5>::describe(
+        _bar_mode ? "S012bar" : "S012", {nt, _num_local_freq, 3, _num_polarizations, _num_dishes},
+        {_bar_mode ? "Trfibar" : "Trfi", "F", "S", "P", "D"}));
+    in_bf_mask_buf->require_frame_desc(kotekan::NDArray<std::int8_t, 2>::describe(
+        "bf_mask", {_num_polarizations, _num_dishes}, {"P", "D"}));
 
     // Make frame desc for produced buffers
     if (_bar_mode) {
-        out_rfi_sk_buf->allocate_ndarray_frame_desc<float, 5>(
+        out_rfi_sk_buf->require_frame_desc(kotekan::NDArray<float, 5>::describe(
             "SKbar", {nt, _num_local_freq, 3, _num_polarizations, _num_dishes},
-            {"Trfibar", "F", "SK", "P", "D"});
-        out_rfi_sktilde_buf->allocate_ndarray_frame_desc<float, 3>(
-            "SKbartilde", {nt, _num_local_freq, 3}, {"Trfibar", "F", "SK"});
-        out_rfi_mask_buf->allocate_ndarray_frame_desc<kotekan::uint1x8_t, 3>(
+            {"Trfibar", "F", "SK", "P", "D"}));
+        out_rfi_sktilde_buf->require_frame_desc(kotekan::NDArray<float, 3>::describe(
+            "SKbartilde", {nt, _num_local_freq, 3}, {"Trfibar", "F", "SK"}));
+        out_rfi_mask_buf->require_frame_desc(kotekan::NDArray<kotekan::uint1x8_t, 3>::describe(
             "RFImask", {_samples_per_data_set / 1024, _num_local_freq, 128},
-            {"T8hi128", "F", "T8lo128"});
+            {"T8hi128", "F", "T8lo128"}));
     } else {
-        out_rfi_sk_buf->allocate_ndarray_frame_desc<float, 5>(
+        out_rfi_sk_buf->require_frame_desc(kotekan::NDArray<float, 5>::describe(
             "SK", {nt, _num_local_freq, 3, _num_polarizations, _num_dishes},
-            {"Trfi", "F", "SK", "P", "D"});
-        out_rfi_sktilde_buf->allocate_ndarray_frame_desc<float, 3>(
-            "SKtilde", {nt, _num_local_freq, 3}, {"Trfi", "F", "SK"});
-        out_rfi_mask_buf->allocate_ndarray_frame_desc<kotekan::uint1x8_t, 3>(
+            {"Trfi", "F", "SK", "P", "D"}));
+        out_rfi_sktilde_buf->require_frame_desc(kotekan::NDArray<float, 3>::describe(
+            "SKtilde", {nt, _num_local_freq, 3}, {"Trfi", "F", "SK"}));
+        out_rfi_mask_buf->require_frame_desc(kotekan::NDArray<kotekan::uint1x8_t, 3>::describe(
             "RFImask", {_samples_per_data_set / 1024, _num_local_freq, 128},
-            {"T8hi128", "F", "T8lo128"});
+            {"T8hi128", "F", "T8lo128"}));
     }
 
     // Check the size of the interpolation tables
@@ -552,14 +544,18 @@ void gpuSimulateRFISK::main_thread() {
         meta_sktilde->deepCopy(meta_in);
         meta_rfi_mask->deepCopy(meta_in);
 
-        meta_sk->set_from_frame_desc(out_rfi_sk_buf->get_ndarray_frame_desc());
-        meta_sktilde->set_from_frame_desc(out_rfi_sktilde_buf->get_ndarray_frame_desc());
-        meta_rfi_mask->set_from_frame_desc(out_rfi_mask_buf->get_ndarray_frame_desc());
+        meta_sk->set_from_frame_desc(out_rfi_sk_buf->get_frame_desc<kotekan::GenericNDArray>());
+        meta_sktilde->set_from_frame_desc(
+            out_rfi_sktilde_buf->get_frame_desc<kotekan::GenericNDArray>());
+        meta_rfi_mask->set_from_frame_desc(
+            out_rfi_mask_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // test that things are consistent
-        meta_sk->check_frame_desc(out_rfi_sk_buf->get_ndarray_frame_desc());
-        meta_sktilde->check_frame_desc(out_rfi_sktilde_buf->get_ndarray_frame_desc());
-        meta_rfi_mask->check_frame_desc(out_rfi_mask_buf->get_ndarray_frame_desc());
+        meta_sk->check_frame_desc(out_rfi_sk_buf->get_frame_desc<kotekan::GenericNDArray>());
+        meta_sktilde->check_frame_desc(
+            out_rfi_sktilde_buf->get_frame_desc<kotekan::GenericNDArray>());
+        meta_rfi_mask->check_frame_desc(
+            out_rfi_mask_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // Set non-NDArray things.
         meta_rfi_mask->set_time_downsampling_fpga(1024 * meta_in->get_time_downsampling_fpga()

--- a/lib/testing/inventBFMask.cpp
+++ b/lib/testing/inventBFMask.cpp
@@ -1,5 +1,6 @@
 #include "Config.hpp"            // for Config
 #include "DataType.hpp"          // for string_to_type, DataType
+#include "NDArray.hpp"           // for NDArray, GenericNDArray
 #include "Stage.hpp"             // for Stage
 #include "StageFactory.hpp"      // for REGISTER_KOTEKAN_STAGE
 #include "Symbol.hpp"            // for Symbol
@@ -31,9 +32,9 @@ class inventBFMask : public kotekan::Stage {
     const int num_dishes = config.get<int>(unique_name, "num_dishes");
     const int num_polarizations = config.get<int>(unique_name, "num_polarizations");
     const int num_times = config.get<int>(unique_name, "num_times");
-    const std::string mode = config.get_default<std::string>(unique_name, "mode",
-            "all_good");
-    const std::vector<int> manual_bad_feeds = config.get_default<std::vector<int>>(unique_name, "manual_bad_feeds", {});
+    const std::string mode = config.get_default<std::string>(unique_name, "mode", "all_good");
+    const std::vector<int> manual_bad_feeds =
+        config.get_default<std::vector<int>>(unique_name, "manual_bad_feeds", {});
 
     Buffer* const buffer;
 
@@ -71,11 +72,11 @@ public:
             return;
 
         // Set metadata
-        buffer->allocate_ndarray_frame_desc<std::int8_t, 2>(
-            "bf_mask", {num_polarizations, num_dishes}, {"P", "D"});
+        buffer->require_frame_desc(kotekan::NDArray<std::int8_t, 2>::describe(
+            "bf_mask", {num_polarizations, num_dishes}, {"P", "D"}));
         buffer->allocate_new_metadata_object(frame_id);
         const auto& meta = get_chord_metadata(buffer->get_metadata(frame_id));
-        meta->set_from_frame_desc(buffer->get_ndarray_frame_desc());
+        meta->set_from_frame_desc(buffer->get_frame_desc<kotekan::GenericNDArray>());
         meta->set_fpga_seq_num(frame_index * num_times);
         meta->set_time_downsampling_fpga(1);
 
@@ -92,12 +93,12 @@ public:
                 else if (mode == "all_bad")
                     frame[idx] = 0; // dish is not active
                 else if (mode == "auto") {
-                    if (tel.cast<CHORDTelescope>().get_dish_at_idx(dish).type == DishType::ArrayDish)
+                    if (tel.cast<CHORDTelescope>().get_dish_at_idx(dish).type
+                        == DishType::ArrayDish)
                         frame[idx] = 1;
                     else
                         frame[idx] = 0;
-                }
-                else 
+                } else
                     frame[idx] = 1;
             }
 

--- a/lib/testing/inventPLMask.cpp
+++ b/lib/testing/inventPLMask.cpp
@@ -1,5 +1,6 @@
 #include "Config.hpp"            // for Config
 #include "DataType.hpp"          // for string_to_type, DataType
+#include "NDArray.hpp"           // for NDArray, GenericNDArray
 #include "Stage.hpp"             // for Stage
 #include "StageFactory.hpp"      // for REGISTER_KOTEKAN_STAGE
 #include "Symbol.hpp"            // for Symbol
@@ -65,14 +66,14 @@ public:
                 return;
 
             // Set metadata
-            buffer->allocate_ndarray_frame_desc<kotekan::uint1x8_t, 5>(
+            buffer->require_frame_desc(kotekan::NDArray<kotekan::uint1x8_t, 5>::describe(
                 "pl_mask",
                 {div_noremainder(num_times, 2 * 64), div_noremainder(num_frequencies, 4),
                  num_polarizations, div_noremainder(num_dishes, 8), 64 / 8},
-                {"T2hi64", "F4", "P", "D8", "T2lo64"});
+                {"T2hi64", "F4", "P", "D8", "T2lo64"}));
             buffer->allocate_new_metadata_object(frame_id);
             const auto& meta = get_chord_metadata(buffer->get_metadata(frame_id));
-            meta->set_from_frame_desc(buffer->get_ndarray_frame_desc());
+            meta->set_from_frame_desc(buffer->get_frame_desc<kotekan::GenericNDArray>());
             meta->set_fpga_seq_num(frame_index * num_times);
             meta->set_time_downsampling_fpga(2 * 64);
 

--- a/lib/testing/inventVoltage.cpp
+++ b/lib/testing/inventVoltage.cpp
@@ -1,5 +1,6 @@
 #include "Config.hpp"            // for Config
 #include "DataType.hpp"          // for string_to_type, DataType
+#include "NDArray.hpp"           // for NDArray, GenericNDArray
 #include "Stage.hpp"             // for Stage
 #include "StageFactory.hpp"      // for REGISTER_KOTEKAN_STAGE
 #include "Symbol.hpp"            // for Symbol
@@ -80,8 +81,10 @@ public:
         buffer->register_producer(unique_name);
 
         // Set metadata
-        buffer->allocate_ndarray_frame_desc<kotekan::int4x2_swapped_withoffset_t, 4>(
-            "E", {num_times, num_frequencies, num_polarizations, num_dishes}, {"T", "F", "P", "D"});
+        buffer->require_frame_desc(
+            kotekan::NDArray<kotekan::int4x2_swapped_withoffset_t, 4>::describe(
+                "E", {num_times, num_frequencies, num_polarizations, num_dishes},
+                {"T", "F", "P", "D"}));
     }
 
     virtual ~inventVoltage() {}
@@ -154,7 +157,7 @@ public:
             buffer->allocate_new_metadata_object(frame_id);
             const auto& meta = get_chord_metadata(buffer->get_metadata(frame_id));
             meta->set_fpga_seq_num(frame_index * num_times);
-            meta->set_from_frame_desc(buffer->get_ndarray_frame_desc());
+            meta->set_from_frame_desc(buffer->get_frame_desc<kotekan::GenericNDArray>());
             meta->set_time_downsampling_fpga(1);
 
             // Set frequency information

--- a/lib/testing/inventVoltageCHIME.cpp
+++ b/lib/testing/inventVoltageCHIME.cpp
@@ -1,5 +1,6 @@
 #include "Config.hpp"            // for Config
 #include "DataType.hpp"          // for string_to_type, DataType
+#include "NDArray.hpp"           // for NDArray, GenericNDArray
 #include "Stage.hpp"             // for Stage
 #include "StageFactory.hpp"      // for REGISTER_KOTEKAN_STAGE
 #include "Symbol.hpp"            // for Symbol
@@ -79,8 +80,9 @@ public:
             buffer->register_producer(unique_name);
 
             // Set metadata
-            buffer->allocate_ndarray_frame_desc<kotekan::int4x2_swapped_withoffset_t, 3>(
-                "E", {1, num_times, num_polarizations * num_dishes}, {"F", "T", "E"});
+            buffer->require_frame_desc(
+                kotekan::NDArray<kotekan::int4x2_swapped_withoffset_t, 3>::describe(
+                    "E", {1, num_times, num_polarizations * num_dishes}, {"F", "T", "E"}));
         }
     }
 
@@ -160,7 +162,7 @@ public:
                 buffer->allocate_new_metadata_object(frame_id);
                 const auto& meta = get_chord_metadata(buffer->get_metadata(frame_id));
                 meta->set_fpga_seq_num(frame_index * num_times);
-                meta->set_from_frame_desc(buffer->get_ndarray_frame_desc());
+                meta->set_from_frame_desc(buffer->get_frame_desc<kotekan::GenericNDArray>());
                 meta->set_time_downsampling_fpga(1);
 
                 // Set frequency information

--- a/lib/testing/testLostCountsGen.cpp
+++ b/lib/testing/testLostCountsGen.cpp
@@ -1,6 +1,7 @@
 #include "Config.hpp"          // for Config
 #include "DataType.hpp"        // for DataType
 #include "N2Util.hpp"          // for frameID
+#include "NDArray.hpp"         // for NDArray, GenericNDArray, Config
 #include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
 #include "buffer.hpp"          // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
@@ -159,14 +160,14 @@ testLostCountsGen::testLostCountsGen(Config& config, const std::string& unique_n
             FATAL_ERROR("num_elements {:d} is not a multiple of {:d}", num_elements,
                         8 * n2k_counts_blocksize);
 
-        in_buf->allocate_ndarray_frame_desc<int32_t, 5>(
+        in_buf->require_frame_desc(kotekan::NDArray<int32_t, 5>::describe(
             "n2k_counts",
             {num_integrations, num_local_freq, n2k_counts_num_blocks, n2k_counts_blocksize,
              n2k_counts_blocksize},
-            {"Tc", "F", "D8Phi", "D8Plo1", "D8Plo2"});
+            {"Tc", "F", "D8Phi", "D8Plo1", "D8Plo2"}));
     }
-    out_buf->allocate_ndarray_frame_desc<int32_t, 2>(name, {num_integrations, num_local_freq},
-                                                     {"Tc", "F"});
+    out_buf->require_frame_desc(kotekan::NDArray<int32_t, 2>::describe(
+        name, {num_integrations, num_local_freq}, {"Tc", "F"}));
 }
 
 std::shared_ptr<chordMetadata> testLostCountsGen::get_new_metadata(Buffer* buf, frameID frame_id) {
@@ -189,7 +190,7 @@ std::shared_ptr<chordMetadata> testLostCountsGen::get_new_metadata(Buffer* buf, 
 }
 
 void testLostCountsGen::set_metadata(const std::shared_ptr<chordMetadata>& meta, uint64_t seq_num) {
-    meta->set_from_frame_desc(out_buf->get_ndarray_frame_desc());
+    meta->set_from_frame_desc(out_buf->get_frame_desc<kotekan::GenericNDArray>());
 
     meta->set_fpga_seq_num(seq_num);
     meta->set_time_downsampling_fpga(sub_integration_ntime);
@@ -257,7 +258,7 @@ void testLostCountsGen::main_thread() {
         set_metadata(meta, seq_num);
 
         // check frame descriptors match metadata
-        meta->check_frame_desc(out_buf->get_ndarray_frame_desc());
+        meta->check_frame_desc(out_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // If we're not repeating, or we're in the first num_frames, generate data
         if (repeat_count <= 0 || (num_frames > 0 && num_frames_generated < num_frames)) {

--- a/lib/testing/testLostSamplesToPLMask.cpp
+++ b/lib/testing/testLostSamplesToPLMask.cpp
@@ -3,6 +3,7 @@
 #include "Config.hpp" // for Config
 #include "Hash.hpp"
 #include "Metadata.hpp"        // for GenericNDArray
+#include "NDArray.hpp"         // for NDArray, GenericNDArray, Config
 #include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
 #include "buffer.hpp"          // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
@@ -64,19 +65,21 @@ testLostSamplesToPLMask::testLostSamplesToPLMask(Config& config, const std::stri
         FATAL_ERROR("Unexpected frames sizes for pl_mask {:d} and lost_samples {:d}",
                     pl_mask_buf->frame_size, lost_samples_bufs.at(0)->frame_size);
 
-    pl_mask_buf->allocate_ndarray_frame_desc<kotekan::GetType_t<kotekan::uint1x8>, 5>(
-        "pl_mask",
-        {ptrdiff_t(lost_samples_bufs.at(0)->frame_size / PL_MASK_DOWNSAMPLING_FACTOR
-                   / PL_MASK_HILO_SPLIT),
-         ptrdiff_t(lost_samples_bufs.size()), num_polarizations,
-         num_dishes / PL_MASK_DISHES_PER_BIN,
-         PL_MASK_HILO_SPLIT / BITS_PER_BYTE /* because we count uint1x8, not uint1 */},
-        {"T2hi64", "F4", "P", "D8", "T2lo64"});
+    pl_mask_buf->require_frame_desc(
+        kotekan::NDArray<kotekan::GetType_t<kotekan::uint1x8>, 5>::describe(
+            "pl_mask",
+            {ptrdiff_t(lost_samples_bufs.at(0)->frame_size / PL_MASK_DOWNSAMPLING_FACTOR
+                       / PL_MASK_HILO_SPLIT),
+             ptrdiff_t(lost_samples_bufs.size()), num_polarizations,
+             num_dishes / PL_MASK_DISHES_PER_BIN,
+             PL_MASK_HILO_SPLIT / BITS_PER_BYTE /* because we count uint1x8, not uint1 */},
+            {"T2hi64", "F4", "P", "D8", "T2lo64"}));
 
     for (int fbin = 0; fbin < num_freq_bins; ++fbin) {
         auto lost_samples_buf = lost_samples_bufs.at(fbin);
-        lost_samples_buf->allocate_ndarray_frame_desc<kotekan::GetType_t<kotekan::uint8>, 1>(
-            "lost_samples", {ptrdiff_t(lost_samples_bufs.at(0)->frame_size)}, {"T"});
+        lost_samples_buf->require_frame_desc(
+            kotekan::NDArray<kotekan::GetType_t<kotekan::uint8>, 1>::describe(
+                "lost_samples", {ptrdiff_t(lost_samples_bufs.at(0)->frame_size)}, {"T"}));
     }
 }
 
@@ -137,7 +140,7 @@ void testLostSamplesToPLMask::main_thread() {
         pl_mask_buf->allocate_new_metadata_object(frame_id);
         auto pl_mask_meta = get_chord_metadata(pl_mask_buf, frame_id);
 
-        pl_mask_meta->set_from_frame_desc(pl_mask_buf->get_ndarray_frame_desc());
+        pl_mask_meta->set_from_frame_desc(pl_mask_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // physics metadata
         // TODO: add more that dpdk adds
@@ -155,7 +158,7 @@ void testLostSamplesToPLMask::main_thread() {
         pl_mask_meta->set_freq_upchan_factor(freq_upchan_factor);
         pl_mask_meta->set_freq_upchan_index(freq_upchan_index);
 
-        pl_mask_meta->check_frame_desc(pl_mask_buf->get_ndarray_frame_desc());
+        pl_mask_meta->check_frame_desc(pl_mask_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // done
         pl_mask_buf->mark_frame_full(unique_name, frame_id);
@@ -173,7 +176,8 @@ void testLostSamplesToPLMask::main_thread() {
 
             lost_samples_buf->allocate_new_metadata_object(frame_id);
             auto lost_samples_meta = get_chord_metadata(lost_samples_buf, frame_id);
-            lost_samples_meta->set_from_frame_desc(lost_samples_buf->get_ndarray_frame_desc());
+            lost_samples_meta->set_from_frame_desc(
+                lost_samples_buf->get_frame_desc<kotekan::GenericNDArray>());
 
             // physics metadata
             // TODO: add more that dpdk adds
@@ -186,7 +190,8 @@ void testLostSamplesToPLMask::main_thread() {
                 std::vector<int>(&coarse_freq[fbin * PL_MASK_FREQS_PER_BIN],
                                  &coarse_freq[(fbin + 1) * PL_MASK_FREQS_PER_BIN]));
 
-            lost_samples_meta->check_frame_desc(lost_samples_buf->get_ndarray_frame_desc());
+            lost_samples_meta->check_frame_desc(
+                lost_samples_buf->get_frame_desc<kotekan::GenericNDArray>());
 
             // done
             lost_samples_buf->mark_frame_full(unique_name, frame_id);

--- a/lib/testing/testN2kGen.cpp
+++ b/lib/testing/testN2kGen.cpp
@@ -2,6 +2,7 @@
 
 #include "Config.hpp"          // for Config
 #include "DataType.hpp"        // for DataType
+#include "NDArray.hpp"         // for GenericNDArray
 #include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
 #include "buffer.hpp"          // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
@@ -149,14 +150,14 @@ testN2kGen::testN2kGen(Config& config, const std::string& unique_name,
         count_blocksize * count_blocksize * count_num_blocks * num_local_freq * num_integrations;
 
     // allocate frame descriptors
-    corr_buf->allocate_ndarray_frame_desc(
+    corr_buf->require_frame_desc(kotekan::GenericNDArray::describe(
         kotekan::int32, "n2k_correlation",
         {num_integrations, num_local_freq, corr_num_blocks, corr_blocksize, corr_blocksize, 2},
-        {"Tc", "F", "DPhi", "DPlo1", "DPlo2", "C"});
-    count_buf->allocate_ndarray_frame_desc(
+        {"Tc", "F", "DPhi", "DPlo1", "DPlo2", "C"}));
+    count_buf->require_frame_desc(kotekan::GenericNDArray::describe(
         kotekan::int32, "n2k_counts",
         {num_integrations, num_local_freq, count_num_blocks, count_blocksize, count_blocksize},
-        {"Tc", "F", "D8Phi", "D8Plo1", "D8Plo2"});
+        {"Tc", "F", "D8Phi", "D8Plo1", "D8Plo2"}));
 }
 
 std::shared_ptr<chordMetadata> testN2kGen::get_new_metadata(Buffer* buf, frameID frame_id) {
@@ -289,14 +290,14 @@ void testN2kGen::main_thread() {
             get_new_metadata(count_buf, count_frame_id);
 
         // fill metadata
-        corr_meta->set_from_frame_desc(corr_buf->get_ndarray_frame_desc());
-        count_meta->set_from_frame_desc(count_buf->get_ndarray_frame_desc());
+        corr_meta->set_from_frame_desc(corr_buf->get_frame_desc<kotekan::GenericNDArray>());
+        count_meta->set_from_frame_desc(count_buf->get_frame_desc<kotekan::GenericNDArray>());
         set_shared_metadata(corr_meta, seq_num);
         set_shared_metadata(count_meta, seq_num);
 
         // check frame descriptors match metadata
-        corr_meta->check_frame_desc(corr_buf->get_ndarray_frame_desc());
-        count_meta->check_frame_desc(count_buf->get_ndarray_frame_desc());
+        corr_meta->check_frame_desc(corr_buf->get_frame_desc<kotekan::GenericNDArray>());
+        count_meta->check_frame_desc(count_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // If we're not repeating, or we're in the first num_frames, generate data
         if (repeat_count <= 0 || (num_frames > 0 && num_frames_generated < num_frames)) {

--- a/lib/testing/testRFIFrameMaskGen.cpp
+++ b/lib/testing/testRFIFrameMaskGen.cpp
@@ -1,6 +1,7 @@
 #include "Config.hpp"          // for Config
 #include "DataType.hpp"        // for DataType
 #include "N2Util.hpp"          // for frameID
+#include "NDArray.hpp"         // for GenericNDArray
 #include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
 #include "buffer.hpp"          // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
@@ -139,8 +140,8 @@ testRFIFrameMaskGen::testRFIFrameMaskGen(Config& config, const std::string& uniq
     }
 
     // allocate frame descriptors
-    out_buf->allocate_ndarray_frame_desc(kotekan::uint8, name, {num_integrations, num_local_freq},
-                                         {"Tc", "F"});
+    out_buf->require_frame_desc(kotekan::GenericNDArray::describe(
+        kotekan::uint8, name, {num_integrations, num_local_freq}, {"Tc", "F"}));
 }
 
 std::shared_ptr<chordMetadata> testRFIFrameMaskGen::get_new_metadata(Buffer* buf,
@@ -165,7 +166,7 @@ std::shared_ptr<chordMetadata> testRFIFrameMaskGen::get_new_metadata(Buffer* buf
 
 void testRFIFrameMaskGen::set_metadata(const std::shared_ptr<chordMetadata>& meta,
                                        uint64_t seq_num) {
-    meta->set_from_frame_desc(out_buf->get_ndarray_frame_desc());
+    meta->set_from_frame_desc(out_buf->get_frame_desc<kotekan::GenericNDArray>());
 
     meta->set_fpga_seq_num(seq_num);
     meta->set_time_downsampling_fpga(sub_integration_ntime);
@@ -243,7 +244,7 @@ void testRFIFrameMaskGen::main_thread() {
         set_metadata(meta, seq_num);
 
         // check frame descriptors match metadata
-        meta->check_frame_desc(out_buf->get_ndarray_frame_desc());
+        meta->check_frame_desc(out_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // If we're not repeating, or we're in the first num_frames, generate data
         if (repeat_count <= 0 || (num_frames > 0 && num_frames_generated < num_frames)) {

--- a/lib/testing/testRFIS012Gen.cpp
+++ b/lib/testing/testRFIS012Gen.cpp
@@ -1,5 +1,6 @@
 #include "Config.hpp"          // for Config
 #include "DataType.hpp"        // for DataType
+#include "NDArray.hpp"         // for NDArray, GenericNDArray, Config
 #include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
 #include "buffer.hpp"          // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
@@ -164,13 +165,13 @@ testRFIS012Gen::testRFIS012Gen(Config& config, const std::string& unique_name,
 
     // allocate frame descriptor
     if (bar_mode) {
-        out_buf->allocate_ndarray_frame_desc<uint64_t, 5>(
+        out_buf->require_frame_desc(kotekan::NDArray<uint64_t, 5>::describe(
             "S012bar", {num_rfi_samples, num_local_freq, 3, num_polarizations, num_dishes},
-            {"Trfibar", "F", "S", "P", "D"});
+            {"Trfibar", "F", "S", "P", "D"}));
     } else {
-        out_buf->allocate_ndarray_frame_desc<uint64_t, 5>(
+        out_buf->require_frame_desc(kotekan::NDArray<uint64_t, 5>::describe(
             "S012", {num_rfi_samples, num_local_freq, 3, num_polarizations, num_dishes},
-            {"Trfi", "F", "S", "P", "D"});
+            {"Trfi", "F", "S", "P", "D"}));
     }
 }
 
@@ -195,7 +196,7 @@ std::shared_ptr<chordMetadata> testRFIS012Gen::get_new_metadata(frameID frame_id
 }
 
 void testRFIS012Gen::set_metadata(const std::shared_ptr<chordMetadata>& meta, uint64_t seq_num) {
-    meta->set_from_frame_desc(out_buf->get_ndarray_frame_desc());
+    meta->set_from_frame_desc(out_buf->get_frame_desc<kotekan::GenericNDArray>());
 
     meta->set_fpga_seq_num(seq_num);
     meta->set_time_downsampling_fpga(downsampling_factor);
@@ -242,7 +243,7 @@ void testRFIS012Gen::main_thread() {
         set_metadata(meta, seq_num);
 
         // check frame descriptors match metadata
-        meta->check_frame_desc(out_buf->get_ndarray_frame_desc());
+        meta->check_frame_desc(out_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // Access Strides into s012
         int64_t ds = num_elements;

--- a/lib/testing/testRFImaskGen.cpp
+++ b/lib/testing/testRFImaskGen.cpp
@@ -1,5 +1,6 @@
 #include "Config.hpp"          // for Config
 #include "DataType.hpp"        // for DataType
+#include "NDArray.hpp"         // for GenericNDArray
 #include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
 #include "buffer.hpp"          // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
@@ -130,9 +131,9 @@ testRFImaskGen::testRFImaskGen(Config& config, const std::string& unique_name,
     }
 
     // allocate frame descriptors
-    out_buf->allocate_ndarray_frame_desc(kotekan::uint1x8, name,
-                                         {samples_per_data_set / 1024, num_local_freq, 128},
-                                         {"T8hi128", "F", "T8lo128"});
+    out_buf->require_frame_desc(kotekan::GenericNDArray::describe(
+        kotekan::uint1x8, name, {samples_per_data_set / 1024, num_local_freq, 128},
+        {"T8hi128", "F", "T8lo128"}));
 
     if (out_buf->frame_size != out_buf->frames_desc->get_byte_size())
         FATAL_ERROR("out_but {:s} has frame size {:d}, expected {:d}.", out_buf->buffer_name,
@@ -159,7 +160,7 @@ std::shared_ptr<chordMetadata> testRFImaskGen::get_new_metadata(Buffer* buf, fra
 }
 
 void testRFImaskGen::set_metadata(const std::shared_ptr<chordMetadata>& meta, uint64_t seq_num) {
-    meta->set_from_frame_desc(out_buf->get_ndarray_frame_desc());
+    meta->set_from_frame_desc(out_buf->get_frame_desc<kotekan::GenericNDArray>());
 
     meta->set_fpga_seq_num(seq_num);
     meta->set_time_downsampling_fpga(1024);
@@ -226,7 +227,7 @@ void testRFImaskGen::main_thread() {
         set_metadata(meta, seq_num);
 
         // check frame descriptors match metadata
-        meta->check_frame_desc(out_buf->get_ndarray_frame_desc());
+        meta->check_frame_desc(out_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // If we're not repeating, or we're in the first num_frames, generate data
         if (repeat_count <= 0 || (num_frames > 0 && num_frames_generated < num_frames)) {

--- a/lib/testing/testXpose.cpp
+++ b/lib/testing/testXpose.cpp
@@ -2,6 +2,7 @@
 
 #include "Config.hpp"          // for Config
 #include "Metadata.hpp"        // for GenericNDArray
+#include "NDArray.hpp"         // for GenericNDArray, Config
 #include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
 #include "buffer.hpp"          // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
@@ -53,9 +54,9 @@ testXpose::testXpose(Config& config, const std::string& unique_name,
                     out_xposed_buf->frame_size,
                     num_times * num_xposed_frequencies * num_polarizations * num_dishes
                         * sizeof(uint8_t));
-    out_xposed_buf->allocate_ndarray_frame_desc(
+    out_xposed_buf->require_frame_desc(kotekan::GenericNDArray::describe(
         kotekan::int4x2_swapped_withoffset, "E",
-        {num_times, num_xposed_frequencies, num_polarizations, num_dishes}, {"T", "F", "P", "D"});
+        {num_times, num_xposed_frequencies, num_polarizations, num_dishes}, {"T", "F", "P", "D"}));
 
     scatter_indices_buf = get_buffer("scatter_indices_buf");
     scatter_indices_buf->register_producer(unique_name);
@@ -65,8 +66,8 @@ testXpose::testXpose(Config& config, const std::string& unique_name,
                     num_polarizations * num_dishes * sizeof(int32_t));
     // TODO: this is not quite correct. Really if going to cylinder order
     // the array is {4,2,256} {"C", "P", "D"}
-    scatter_indices_buf->allocate_ndarray_frame_desc(kotekan::int32, "scatter_indices",
-                                                     {num_polarizations, num_dishes}, {"P", "D"});
+    scatter_indices_buf->require_frame_desc(kotekan::GenericNDArray::describe(
+        kotekan::int32, "scatter_indices", {num_polarizations, num_dishes}, {"P", "D"}));
 
     // Register as producer for all xpose2048 input buffers
     json bufs = config.get_value(unique_name, "out_bufs");
@@ -74,9 +75,9 @@ testXpose::testXpose(Config& config, const std::string& unique_name,
         Buffer* buf = buffer_container.get_buffer(it.value().get<std::string>());
         out_bufs.push_back(buf);
         buf->register_producer(unique_name);
-        buf->allocate_ndarray_frame_desc(
+        buf->require_frame_desc(kotekan::GenericNDArray::describe(
             kotekan::int4x2_swapped_withoffset, "E",
-            {num_frequencies, num_times, num_polarizations * num_dishes}, {"F", "T", "E"});
+            {num_frequencies, num_times, num_polarizations * num_dishes}, {"F", "T", "E"}));
         if (buf->frame_size
             != num_polarizations * num_dishes * num_times * num_frequencies * sizeof(uint8_t))
             FATAL_ERROR("Input samples bufferer {:s} has unexpected size {:d} instead of {:d}",
@@ -119,8 +120,10 @@ void testXpose::main_thread() {
     scatter_indices_buf->allocate_new_metadata_object(scatter_indices_id);
     auto scatter_indices_meta = get_chord_metadata(scatter_indices_buf, scatter_indices_id);
     scatter_indices_meta->set_fpga_seq_num(0);
-    scatter_indices_meta->set_from_frame_desc(scatter_indices_buf->get_ndarray_frame_desc());
-    scatter_indices_meta->check_frame_desc(scatter_indices_buf->get_ndarray_frame_desc());
+    scatter_indices_meta->set_from_frame_desc(
+        scatter_indices_buf->get_frame_desc<kotekan::GenericNDArray>());
+    scatter_indices_meta->check_frame_desc(
+        scatter_indices_buf->get_frame_desc<kotekan::GenericNDArray>());
     scatter_indices_buf->mark_frame_full(unique_name, scatter_indices_id);
 
     // for each time
@@ -188,8 +191,10 @@ void testXpose::main_thread() {
             std::vector<int> coarse_freq(num_frequencies);
             std::iota(coarse_freq.begin(), coarse_freq.end(), buf_num * num_frequencies);
             out_meta->set_coarse_freq(coarse_freq);
-            out_meta->set_from_frame_desc(out_bufs.at(buf_num)->get_ndarray_frame_desc());
-            out_meta->check_frame_desc(out_bufs.at(buf_num)->get_ndarray_frame_desc());
+            out_meta->set_from_frame_desc(
+                out_bufs.at(buf_num)->get_frame_desc<kotekan::GenericNDArray>());
+            out_meta->check_frame_desc(
+                out_bufs.at(buf_num)->get_frame_desc<kotekan::GenericNDArray>());
             out_bufs.at(buf_num)->mark_frame_full(unique_name, out_id);
         }
 
@@ -202,8 +207,10 @@ void testXpose::main_thread() {
         std::vector<int> coarse_freq(num_xposed_frequencies);
         std::iota(coarse_freq.begin(), coarse_freq.end(), 0);
         out_xposed_meta->set_coarse_freq(coarse_freq);
-        out_xposed_meta->set_from_frame_desc(out_xposed_buf->get_ndarray_frame_desc());
-        out_xposed_meta->check_frame_desc(out_xposed_buf->get_ndarray_frame_desc());
+        out_xposed_meta->set_from_frame_desc(
+            out_xposed_buf->get_frame_desc<kotekan::GenericNDArray>());
+        out_xposed_meta->check_frame_desc(
+            out_xposed_buf->get_frame_desc<kotekan::GenericNDArray>());
         out_xposed_buf->mark_frame_full(unique_name, out_xposed_id);
 
         out_xposed_id += 1;

--- a/python/kotekan/runner.py
+++ b/python/kotekan/runner.py
@@ -827,7 +827,13 @@ class DumpVisBuffer(OutputBuffer):
 
 
 class ReadChordBuffer(InputBuffer):
-    """Write down a ChordBuffer and reads it with hdf5FileRead."""
+    """Write down a ChordBuffer and reads it with hdf5FileRead.
+
+    When the first buffer's metadata carries name/type/dim_names, the
+    kotekan buffer is declared as `kotekan_buffer: ndarray` so the frame
+    descriptor is attached at startup (and hdf5FileRead validates against
+    it); otherwise it falls back to a plain standard buffer.
+    """
 
     _buf_ind = 0
 
@@ -840,14 +846,28 @@ class ReadChordBuffer(InputBuffer):
         self.input_dir = input_dir
         self.buffer_list = buffer_list
 
-        self.buffer_block = {
-            self.name: {
-                "kotekan_buffer": "standard",
-                "metadata_pool": "main_pool",
-                "num_frames": "buffer_depth",
-                "frame_size": buffer_list[0].data.nbytes,
+        meta = buffer_list[0].metadata
+        if all(key in meta for key in ("name", "type", "dim_names")):
+            self.buffer_block = {
+                self.name: {
+                    "kotekan_buffer": "ndarray",
+                    "metadata_pool": "main_pool",
+                    "num_frames": "buffer_depth",
+                    "value_type": str(meta["type"]),
+                    "quantity_name": str(meta["name"]),
+                    "extents": [int(n) for n in buffer_list[0].data.shape],
+                    "dimnames": [str(d) for d in meta["dim_names"]],
+                }
             }
-        }
+        else:
+            self.buffer_block = {
+                self.name: {
+                    "kotekan_buffer": "standard",
+                    "metadata_pool": "main_pool",
+                    "num_frames": "buffer_depth",
+                    "frame_size": buffer_list[0].data.nbytes,
+                }
+            }
 
         stage_config = {
             "kotekan_stage": "hdf5FileRead",
@@ -874,6 +894,17 @@ class DumpChordBuffer(OutputBuffer):
     ----------
     output_dir : str
         Temp. directory to output to. Dumped files are not removed.
+    quantity_name : str, optional
+        Together with `dimnames`, declare the buffer as `kotekan_buffer:
+        ndarray`, attaching the frame descriptor at startup (the stage under
+        test then validates against it instead of allocating it). Must match
+        the descriptor the producing stage declares exactly.
+    dimnames : list of str, optional
+        Axis labels, one per entry of `shape`. See `quantity_name`.
+    value_type : str, optional
+        kotekan DataType name for the ndarray declaration. Defaults to the
+        numpy name of `dtype`, which is correct for plain types; packed
+        types (e.g. "uint1x8", "int4x2") must be given explicitly.
     """
 
     _buf_ind = 0
@@ -881,7 +912,15 @@ class DumpChordBuffer(OutputBuffer):
     name = None
 
     def __init__(
-        self, output_dir, shape, dtype, max_frames=-1, input_order="CHORDBeamformer"
+        self,
+        output_dir,
+        shape,
+        dtype,
+        max_frames=-1,
+        input_order="CHORDBeamformer",
+        quantity_name=None,
+        dimnames=None,
+        value_type=None,
     ):
         self.name = f"dumpchord_buf{self._buf_ind}"
         stage_name = f"dump{self._buf_ind}"
@@ -893,14 +932,31 @@ class DumpChordBuffer(OutputBuffer):
         self.max_frames = max_frames
         self.dtype = dtype
 
-        self.buffer_block = {
-            self.name: {
-                "kotekan_buffer": "standard",
-                "metadata_pool": "main_pool",
-                "num_frames": "buffer_depth",
-                "frame_size": self.num_entries * np.dtype(self.dtype).itemsize,
+        if quantity_name is not None:
+            if dimnames is None or len(dimnames) != len(shape):
+                raise ValueError(
+                    "dimnames must be given with quantity_name, one per axis"
+                )
+            self.buffer_block = {
+                self.name: {
+                    "kotekan_buffer": "ndarray",
+                    "metadata_pool": "main_pool",
+                    "num_frames": "buffer_depth",
+                    "value_type": value_type or np.dtype(self.dtype).name,
+                    "quantity_name": quantity_name,
+                    "extents": [int(n) for n in shape],
+                    "dimnames": list(dimnames),
+                }
             }
-        }
+        else:
+            self.buffer_block = {
+                self.name: {
+                    "kotekan_buffer": "standard",
+                    "metadata_pool": "main_pool",
+                    "num_frames": "buffer_depth",
+                    "frame_size": self.num_entries * np.dtype(self.dtype).itemsize,
+                }
+            }
 
         self.stage_block = {
             stage_name: {

--- a/tests/test_setScatterIndices.py
+++ b/tests/test_setScatterIndices.py
@@ -1,0 +1,77 @@
+"""Validate setScatterIndices against a config-declared ndarray buffer.
+
+Covers the framedesc conversion: the stage no longer *sets* its output
+descriptor but *requires* (validates) the one the bufferFactory attaches from
+an `kotekan_buffer: ndarray` declaration. The negative case confirms
+require_frame_desc actually rejects a structurally-wrong declaration (a
+transposed shape that has the same byte size) -- the property the
+order-sensitive fengine conversions rely on.
+"""
+import pytest
+import numpy as np
+import h5py
+
+from kotekan import runner
+
+if not runner.has_hdf5():
+    pytest.fail("HDF5 support not available; unable to run tests!")
+
+NUM_DISHES = 8
+NUM_POL = 2
+
+stage_params = {
+    "scatter_indices_name": "scatter_buffer",
+    "num_dishes": NUM_DISHES,
+    "num_polarizations": NUM_POL,
+    "scatter_indices": list(range(NUM_POL * NUM_DISHES)),
+}
+
+
+def _global(extents, dimnames, tmpdir):
+    return {
+        "type": "config",
+        "log_level": "INFO",
+        "num_dishes": NUM_DISHES,
+        "num_polarizations": NUM_POL,
+        "scatter_buffer": {
+            "kotekan_buffer": "ndarray",
+            "num_frames": 1,
+            "value_type": "int32",
+            "quantity_name": "scatter_indices",
+            "extents": extents,
+            "dimnames": dimnames,
+            "metadata_pool": "main_pool",
+        },
+        "write_scatter": {
+            "kotekan_stage": "hdf5FileWrite",
+            "base_dir": str(tmpdir),
+            "prefix_hostname": False,
+            "max_frames": "1",
+            "file_name": "scatter_buffer",
+            "in_buf": "scatter_buffer",
+            "input_order": "CHIMEBeamformer",
+        },
+    }
+
+
+def test_setScatterIndices_validates_matching_ndarray(tmpdir_factory):
+    """Correct ndarray declaration: require_frame_desc passes, payload is written."""
+    tmpdir = tmpdir_factory.mktemp("setScatterIndices_ok")
+    g = _global(["num_polarizations", "num_dishes"], ["P", "D"], tmpdir)
+    runner.KotekanStageTester("setScatterIndices", stage_params, None, None, g).run()
+
+    buf = h5py.File(str(tmpdir) + "/scatter_buffer.00000000.h5", "r")["scatter_buffer"]
+    assert buf.attrs["name"] == "scatter_indices"
+    assert tuple(buf.shape) == (NUM_POL, NUM_DISHES)
+    assert tuple(buf.attrs["dim_names"]) == ("P", "D")
+    assert buf.attrs["type"] == "int32"
+    assert np.all(np.asarray(buf).flatten() == np.arange(NUM_POL * NUM_DISHES))
+
+
+def test_setScatterIndices_rejects_transposed_ndarray(tmpdir_factory):
+    """Same byte size, transposed shape -> require_frame_desc must fatal."""
+    tmpdir = tmpdir_factory.mktemp("setScatterIndices_bad")
+    g = _global(["num_dishes", "num_polarizations"], ["D", "P"], tmpdir)
+    runner.KotekanStageTester(
+        "setScatterIndices", stage_params, None, None, g, expect_failure=True
+    ).run()


### PR DESCRIPTION
Migrate most descriptor-producing stages to use require_frame_desc and declare their output buffers `ndarray` in every config. A few remaining stages use standard buffers, and ensure_frame_desc, instead.