### PR TITLE
Validate input descriptors in consumer, reader, and pass-through stages

### DIFF
--- a/lib/cuda/cudaCopyFromRingbuffer.cpp
+++ b/lib/cuda/cudaCopyFromRingbuffer.cpp
@@ -10,6 +10,7 @@
 #include <stdexcept>           // for runtime_error
 #include <tuple>               // for tuple, make_tuple
 
+#include "NDArray.hpp"         // for GenericNDArray
 #include "Symbol.hpp"          // for Symbol
 #include "chordMetadata.hpp"   // for chordMetadata
 #include "cudaUtils.hpp"       // for CHECK_CUDA_ERROR
@@ -175,10 +176,10 @@ cudaEvent_t cudaCopyFromRingbuffer::execute(cudaPipelineState& pipestate,
             dimnames.push_back(
                 std::string(out_meta->dim_name[d],
                             strnlen(out_meta->dim_name[d], sizeof(out_meta->dim_name[d]))));
-        out_buffer->allocate_ndarray_frame_desc(out_meta->type, out_meta->get_name(), extents,
-                                                dimnames);
+        out_buffer->ensure_frame_desc(kotekan::GenericNDArray::describe(
+            out_meta->type, out_meta->get_name(), extents, dimnames));
         /* test that things are consistent */
-        out_meta->check_frame_desc(out_buffer->get_ndarray_frame_desc());
+        out_meta->check_frame_desc(out_buffer->get_frame_desc<kotekan::GenericNDArray>());
 
     } else {
         int out_id = gpu_frame_id % _gpu_buffer_depth;

--- a/lib/cuda/cudaOutputData.cpp
+++ b/lib/cuda/cudaOutputData.cpp
@@ -13,6 +13,7 @@
 #include <memory>              // for shared_ptr, __shared_ptr_access, dynamic_pointer_cast
 #include <tuple>               // for tuple, make_tuple
 
+#include "NDArray.hpp"         // for GenericNDArray
 #include "Symbol.hpp"          // for Symbol
 #include "chordMetadata.hpp"   // for chordMetadata
 #include "cudaUtils.hpp"       // for CHECK_CUDA_ERROR
@@ -138,10 +139,11 @@ cudaEvent_t cudaOutputData::execute(cudaPipelineState&,
 
                     // difficult to move to constructor since it depends on frame_desc in the
                     // signal_buffer which may not be set at contructor time
-                    output_buffer->allocate_ndarray_frame_desc(chord->type, chord->get_name(),
-                                                               dimensions, dimnames);
+                    output_buffer->ensure_frame_desc(kotekan::GenericNDArray::describe(
+                        chord->type, chord->get_name(), dimensions, dimnames));
                     /* test that things are consistent */
-                    chord->check_frame_desc(output_buffer->get_ndarray_frame_desc());
+                    chord->check_frame_desc(
+                        output_buffer->get_frame_desc<kotekan::GenericNDArray>());
                 }
             }
         }

--- a/lib/dpdk/iceBoardShuffle.hpp
+++ b/lib/dpdk/iceBoardShuffle.hpp
@@ -9,6 +9,7 @@
 #define ICE_BOARD_SHUFFLE_HPP
 
 #include "Config.hpp"
+#include "NDArray.hpp" // for GenericNDArray, NDArray
 #include "Telescope.hpp"
 #include "buffer.hpp"
 #include "bufferContainer.hpp"
@@ -274,11 +275,12 @@ iceBoardShuffle::iceBoardShuffle(kotekan::Config& config, const std::string& uni
         out_bufs[i] = buffer_container.get_buffer(buffer_names[i]);
         out_bufs[i]->register_producer(unique_name);
         /* new style array description */
-        out_bufs[i]
-            ->allocate_ndarray_frame_desc<
-                kotekan::GetType<kotekan::int4x2_swapped_withoffset>::type, 3>(
-                "E", {1, ptrdiff_t(out_bufs[i]->frame_size) / sample_size, sample_size},
-                {"F", "T", "E"});
+        out_bufs[i]->ensure_frame_desc(
+            kotekan::NDArray<kotekan::GetType<kotekan::int4x2_swapped_withoffset>::type,
+                             3>::describe("E",
+                                          {1, ptrdiff_t(out_bufs[i]->frame_size) / sample_size,
+                                           sample_size},
+                                          {"F", "T", "E"}));
     }
 
     lost_samples_buf =
@@ -490,7 +492,7 @@ inline bool iceBoardShuffle::advance_frames(uint64_t new_seq, bool first_time) {
         meta->set_strides_simple();
         // frame_desc set in constructor
         /* test that things are consistent */
-        meta->check_frame_desc(out_bufs[i]->get_ndarray_frame_desc());
+        meta->check_frame_desc(out_bufs[i]->get_frame_desc<kotekan::GenericNDArray>());
 
         // Print out the chordMetadata
         DEBUG("chordMetadata: seq: {:d} freq_id: {:d} dim[0]: {:d} dim[1]: {:d}",
@@ -542,10 +544,11 @@ inline bool iceBoardShuffle::advance_frames(uint64_t new_seq, bool first_time) {
     std::strncpy(meta->name, "lost_samples", sizeof meta->name);
     meta->set_strides_simple();
     /* new style array description */
-    lost_samples_buf->allocate_ndarray_frame_desc<kotekan::GetType<kotekan::uint8>::type, 1>(
-        "lost_samples", {ptrdiff_t(lost_samples_buf->frame_size)}, {"T"});
+    lost_samples_buf->ensure_frame_desc(
+        kotekan::NDArray<kotekan::GetType<kotekan::uint8>::type, 1>::describe(
+            "lost_samples", {ptrdiff_t(lost_samples_buf->frame_size)}, {"T"}));
     /* test that things are consistent */
-    meta->check_frame_desc(lost_samples_buf->get_ndarray_frame_desc());
+    meta->check_frame_desc(lost_samples_buf->get_frame_desc<kotekan::GenericNDArray>());
 
 
     return true;

--- a/lib/stages/CountLostPLSamplesScalar.cpp
+++ b/lib/stages/CountLostPLSamplesScalar.cpp
@@ -8,6 +8,7 @@
 #include "Config.hpp"           // for Config
 #include "DataType.hpp"         // for uint1x8_t
 #include "N2Util.hpp"           // for frameID, modulo
+#include "NDArray.hpp"          // for NDArray, GenericNDArray, Config
 #include "StageFactory.hpp"     // for REGISTER_KOTEKAN_STAGE
 #include "buffer.hpp"           // for Buffer
 #include "bufferContainer.hpp"  // for bufferContainer
@@ -137,13 +138,13 @@ CountLostPLSamplesScalar::CountLostPLSamplesScalar(Config& config, const std::st
     }
 
     // Make frame desc for produced buffer (this also checks the size)
-    in_buf->allocate_ndarray_frame_desc<kotekan::uint1x8_t, 5>(
+    in_buf->require_frame_desc(kotekan::NDArray<kotekan::uint1x8_t, 5>::describe(
         "pl_mask",
         {div_noremainder(_samples_per_data_set, 128), (_num_local_freq + 3) / 4, _num_polarizations,
          div_noremainder(_num_dishes, 8), 64 / 8},
-        {"T2hi64", "F4", "P", "D8", "T2lo64"});
-    out_buf->allocate_ndarray_frame_desc<int32_t, 2>(
-        "pl_lost_counts_scalar", {_num_integrations, _num_local_freq}, {"Tc", "F"});
+        {"T2hi64", "F4", "P", "D8", "T2lo64"}));
+    out_buf->require_frame_desc(kotekan::NDArray<int32_t, 2>::describe(
+        "pl_lost_counts_scalar", {_num_integrations, _num_local_freq}, {"Tc", "F"}));
 }
 
 CountLostPLSamplesScalar::~CountLostPLSamplesScalar() {}
@@ -276,14 +277,14 @@ void CountLostPLSamplesScalar::main_thread() {
         meta_out->deepCopy(meta_in);
 
         // Set NDArray fields
-        meta_out->set_from_frame_desc(out_buf->get_ndarray_frame_desc());
+        meta_out->set_from_frame_desc(out_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // Set non-NDArray things.
         meta_out->set_time_downsampling_fpga(
             div_noremainder(meta_in->get_time_downsampling_fpga(), 128) * _sub_integration_ntime);
 
         // test that things are consistent
-        meta_out->check_frame_desc(out_buf->get_ndarray_frame_desc());
+        meta_out->check_frame_desc(out_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         in_buf->mark_frame_empty(unique_name, in_frame_id++);
         out_buf->mark_frame_full(unique_name, out_frame_id++);

--- a/lib/stages/EigenN2Iter.cpp
+++ b/lib/stages/EigenN2Iter.cpp
@@ -83,10 +83,8 @@ EigenN2Iter::EigenN2Iter(Config& config, const std::string& unique_name,
         FATAL_ERROR("EigenN2Iter stage requires an 'N2' buffer type for in_buf and out_buf.");
 
     // Validate that input and output buffers have N2 frame descriptors set
-    auto in_desc =
-        std::dynamic_pointer_cast<const kotekan::N2FrameDesc>(in_buf->get_frame_description());
-    auto out_desc =
-        std::dynamic_pointer_cast<const kotekan::N2FrameDesc>(out_buf->get_frame_description());
+    auto in_desc = in_buf->get_frame_desc<kotekan::N2FrameDesc>();
+    auto out_desc = out_buf->get_frame_desc<kotekan::N2FrameDesc>();
     if (!in_desc || !out_desc) {
         FATAL_ERROR("EigenN2Iter: Input and output buffers must have N2FrameDesc set");
     }
@@ -110,8 +108,7 @@ EigenN2Iter::EigenN2Iter(Config& config, const std::string& unique_name,
             FATAL_ERROR("EigenN2Iter stage requires 'N2' buffer type for failed_buf.");
 
         // Validate that input and failed buffers have N2 frame descriptors set
-        auto failed_desc = std::dynamic_pointer_cast<const kotekan::N2FrameDesc>(
-            failed_buf->get_frame_description());
+        auto failed_desc = failed_buf->get_frame_desc<kotekan::N2FrameDesc>();
         if (!failed_desc) {
             FATAL_ERROR("EigenN2Iter: failed_buf buffer must have N2FrameDesc set");
         }

--- a/lib/stages/N2Accumulate.cpp
+++ b/lib/stages/N2Accumulate.cpp
@@ -28,6 +28,7 @@
 #include "Hash.hpp"               // for operator!=
 #include "N2FrameDesc.hpp"        // for N2FrameDesc
 #include "N2Layout.hpp"           // for N2Layout
+#include "NDArray.hpp"            // for GenericNDArray
 #include "dataset.hpp"            // for dset_id_t
 #include "div.hpp"                // for div_ceil, num_triangle_blocks
 #include "jsonMetadata.hpp"       // for MAX_NUM_RFI_THRESHOLDS
@@ -202,35 +203,35 @@ N2Accumulate::N2Accumulate(Config& config, const std::string& unique_name,
     _accum_bin_idx = -1;
 
     // Ensure incoming buffer shapes and type are correct
-    in_buf->allocate_ndarray_frame_desc(kotekan::int32, "n2k_correlation",
-                                        {_n_integrations_per_n2k_frame, _num_freq_per_n2k_frame,
-                                         _n2k_correlation_num_blocks, _n2k_correlation_blocksize,
-                                         _n2k_correlation_blocksize, 2},
-                                        {"Tc", "F", "DPhi", "DPlo1", "DPlo2", "C"});
+    in_buf->require_frame_desc(kotekan::GenericNDArray::describe(
+        kotekan::int32, "n2k_correlation",
+        {_n_integrations_per_n2k_frame, _num_freq_per_n2k_frame, _n2k_correlation_num_blocks,
+         _n2k_correlation_blocksize, _n2k_correlation_blocksize, 2},
+        {"Tc", "F", "DPhi", "DPlo1", "DPlo2", "C"}));
 
-    in_counts_buf->allocate_ndarray_frame_desc(kotekan::int32, "n2k_counts",
-                                               {_n_integrations_per_n2k_frame,
-                                                _num_freq_per_n2k_frame, _n2k_counts_num_blocks,
-                                                _n2k_counts_blocksize, _n2k_counts_blocksize},
-                                               {"Tc", "F", "D8Phi", "D8Plo1", "D8Plo2"});
+    in_counts_buf->require_frame_desc(kotekan::GenericNDArray::describe(
+        kotekan::int32, "n2k_counts",
+        {_n_integrations_per_n2k_frame, _num_freq_per_n2k_frame, _n2k_counts_num_blocks,
+         _n2k_counts_blocksize, _n2k_counts_blocksize},
+        {"Tc", "F", "D8Phi", "D8Plo1", "D8Plo2"}));
 
-    in_rficounts_buf->allocate_ndarray_frame_desc(
+    in_rficounts_buf->require_frame_desc(kotekan::GenericNDArray::describe(
         kotekan::int32, "RFImask_counts", {_n_integrations_per_n2k_frame, _num_freq_per_n2k_frame},
-        {"Tc", "F"});
+        {"Tc", "F"}));
 
-    in_plcounts_buf->allocate_ndarray_frame_desc(
+    in_plcounts_buf->require_frame_desc(kotekan::GenericNDArray::describe(
         kotekan::int32, "pl_lost_counts_scalar",
-        {_n_integrations_per_n2k_frame, _num_freq_per_n2k_frame}, {"Tc", "F"});
+        {_n_integrations_per_n2k_frame, _num_freq_per_n2k_frame}, {"Tc", "F"}));
 
-    in_rfiframemask_buf->allocate_ndarray_frame_desc(
+    in_rfiframemask_buf->require_frame_desc(kotekan::GenericNDArray::describe(
         kotekan::uint8, "RFIFrameMask", {_n_integrations_per_n2k_frame, _num_freq_per_n2k_frame},
-        {"Tc", "F"});
+        {"Tc", "F"}));
 
 
     // Validate that the output buffer's frame descriptor (set by bufferFactory) matches
     // what this stage will produce
     {
-        auto out_frame_desc = out_buf->get_frame_description();
+        auto out_frame_desc = out_buf->get_frame_desc();
         if (!out_frame_desc) {
             FATAL_ERROR("N2Accumulate: Output buffer {:s} does not have a frame descriptor set",
                         out_buf->buffer_name);

--- a/lib/stages/N2FrameToVisFrame.cpp
+++ b/lib/stages/N2FrameToVisFrame.cpp
@@ -50,7 +50,7 @@ n2FrameToVisFrame::n2FrameToVisFrame(Config& config, const std::string& unique_n
     // N2FrameDesc's are constructed on buffer creation (before stages) so this object will
     // exist with the correct data.
     const std::shared_ptr<const kotekan::N2FrameDesc> n2_frame_desc =
-        std::dynamic_pointer_cast<const kotekan::N2FrameDesc>(n2_buf->get_frame_description());
+        n2_buf->get_frame_desc<kotekan::N2FrameDesc>();
     if (!n2_frame_desc) {
         FATAL_ERROR("n2_buf does not have N2 Frame Descriptor");
     }

--- a/lib/stages/N2Subset.cpp
+++ b/lib/stages/N2Subset.cpp
@@ -48,7 +48,7 @@ N2Subset::N2Subset(Config& config, const std::string& unique_name,
     }
 
     // Get and validate frame descriptors
-    auto in_frame_desc = in_buf->get_frame_description();
+    auto in_frame_desc = in_buf->get_frame_desc();
     if (!in_frame_desc) {
         FATAL_ERROR("N2Subset: in_buf does not have a frame descriptor set");
     }
@@ -57,7 +57,7 @@ N2Subset::N2Subset(Config& config, const std::string& unique_name,
         FATAL_ERROR("N2Subset: in_buf does not have an N2FrameDesc");
     }
 
-    auto out_frame_desc = out_buf->get_frame_description();
+    auto out_frame_desc = out_buf->get_frame_desc();
     if (!out_frame_desc) {
         FATAL_ERROR("N2Subset: out_buf does not have a frame descriptor set");
     }

--- a/lib/stages/N2TimeDownsample.cpp
+++ b/lib/stages/N2TimeDownsample.cpp
@@ -45,8 +45,8 @@ N2TimeDownsample::N2TimeDownsample(Config& config, const std::string& unique_nam
     out_buf->register_producer(unique_name);
 
     // Validate that input and output buffers have compatible N2 frame descriptors
-    auto in_desc = in_buf->get_frame_description();
-    auto out_desc = out_buf->get_frame_description();
+    auto in_desc = in_buf->get_frame_desc();
+    auto out_desc = out_buf->get_frame_desc();
     if (!in_desc || !out_desc) {
         FATAL_ERROR("N2TimeDownsample: Input and output buffers must have frame descriptors set");
     }

--- a/lib/stages/PLMaskExpandedToCompact.cpp
+++ b/lib/stages/PLMaskExpandedToCompact.cpp
@@ -14,6 +14,7 @@
 #include "kotekanLogging.hpp"   // for FATAL_ERROR, INFO
 #include "fmt.hpp"              // for compile_string_to_view
 #include "DataType.hpp"         // for DataType
+#include "NDArray.hpp"
 
 using kotekan::bufferContainer;
 using kotekan::Config;
@@ -64,14 +65,14 @@ STAGE_CONSTRUCTOR(PLMaskExpandedToCompact) {
     }
 
     // Set up ndarray frame descriptor for the input and output
-    in_buf->allocate_ndarray_frame_desc(
+    in_buf->require_frame_desc(kotekan::GenericNDArray::describe(
         kotekan::uint1x8, "pl_mask_exp",
         {(ptrdiff_t)(T / 64), (ptrdiff_t)F, 2, (ptrdiff_t)(E_div_8 / 2), 8},
-        {"Thi64", "F", "P", "D8", "Tlo64"});
-    out_buf->allocate_ndarray_frame_desc(
+        {"Thi64", "F", "P", "D8", "Tlo64"}));
+    out_buf->require_frame_desc(kotekan::GenericNDArray::describe(
         kotekan::uint1x8, "pl_mask",
         {(ptrdiff_t)(T / 128), (ptrdiff_t)F_compact, 2, (ptrdiff_t)(E_div_8 / 2), 8},
-        {"T2hi64", "F4", "P", "D8", "T2lo64"});
+        {"T2hi64", "F4", "P", "D8", "T2lo64"}));
 
     INFO("PLMaskExpandedToCompact: Expanded [T/64={:d}][F={:d}][E/8={:d}] -> "
          "Compact [T/128={:d}][F4={:d}][E/8={:d}]",
@@ -174,7 +175,7 @@ void PLMaskExpandedToCompact::main_thread() {
         out_meta->deepCopy(in_meta);
 
         // Set NDArray meta from the frame descriptor
-        out_meta->set_from_frame_desc(out_buf->get_ndarray_frame_desc());
+        out_meta->set_from_frame_desc(out_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // Other updates from in_meta
         // Compact mask covers 128 baseband samples per uint64 (vs 64 for expanded)

--- a/lib/stages/ProcessPacketMask.cpp
+++ b/lib/stages/ProcessPacketMask.cpp
@@ -14,6 +14,7 @@
 #include "kotekanLogging.hpp"   // for INFO, DEBUG2
 #include "fmt.hpp"              // for compile_string_to_view, format, fmt
 #include "DataType.hpp"         // for DataType
+#include "NDArray.hpp"
 
 using kotekan::bufferContainer;
 using kotekan::Config;
@@ -130,10 +131,10 @@ STAGE_CONSTRUCTOR(ProcessPacketMask) {
             pl_mask_buf->frame_size, expected_pl_mask_size, T / 64, num_frequency, E / 8));
     }
 
-    pl_mask_buf->allocate_ndarray_frame_desc(
+    pl_mask_buf->require_frame_desc(kotekan::GenericNDArray::describe(
         kotekan::uint1x8, "pl_mask_exp",
         {time_long * time_short / 64, num_frequency, 2, element_long * element_short / 8 / 2, 8},
-        {"Thi64", "F", "P", "D8", "Tlo64"});
+        {"Thi64", "F", "P", "D8", "Tlo64"}));
 
     // Validate rfi_mask buffer size
     // rfi_mask shape: uint8_t [T/1024][F][128] where T = time_long * time_short
@@ -145,9 +146,9 @@ STAGE_CONSTRUCTOR(ProcessPacketMask) {
                         rfi_mask_buf->frame_size, expected_rfi_mask_size, T / 1024, num_frequency));
     }
 
-    rfi_mask_buf->allocate_ndarray_frame_desc(kotekan::uint1x8, "RFImask",
-                                              {time_long * time_short / 1024, num_frequency, 128},
-                                              {"T8hi128", "F", "T8lo128"});
+    rfi_mask_buf->require_frame_desc(kotekan::GenericNDArray::describe(
+        kotekan::uint1x8, "RFImask", {time_long * time_short / 1024, num_frequency, 128},
+        {"T8hi128", "F", "T8lo128"}));
 
     INFO("ProcessPacketMask: Initialized with {:d} receipt bitmap buffers",
          receipt_bitmap_bufs.size());

--- a/lib/stages/RfiFrameMask.cpp
+++ b/lib/stages/RfiFrameMask.cpp
@@ -25,6 +25,7 @@
 #include "restServer.hpp"       // for restServer, connectionInstance
 #include "fmt.hpp"              // for compile_string_to_view, format, format_string
 #include "DataType.hpp"         // for DataType
+#include "NDArray.hpp"          // for GenericNDArray, Config
 #include "Stage.hpp"            // for Stage
 #include "jsonMetadata.hpp"     // for MAX_NUM_RFI_THRESHOLDS
 
@@ -174,9 +175,11 @@ RfiFrameMask::RfiFrameMask(Config& config, const std::string& unique_name,
     out_buf = get_buffer("out_buf");
     out_buf->register_producer(unique_name);
 
-    // Ensure outgoing buffer is standard type
-    if (out_buf->buffer_type != "standard")
-        FATAL_ERROR("RfiFrameMask out_buf ({:s}) is not of type standard.", out_buf->buffer_name);
+    // The output buffer must carry an NDArray frame descriptor (declared with
+    // `kotekan_buffer: ndarray` in the config); require_frame_desc below validates
+    // its shape/type.
+    if (out_buf->buffer_type != "ndarray")
+        FATAL_ERROR("RfiFrameMask out_buf ({:s}) is not of type ndarray.", out_buf->buffer_name);
 
     // Sanity checks on initialization
     {
@@ -208,10 +211,10 @@ RfiFrameMask::RfiFrameMask(Config& config, const std::string& unique_name,
 
     // Set up frame descriptors. This also checks their shape, type, and size is consistent with
     // other stages in the pipeline.
-    in_buf->allocate_ndarray_frame_desc(kotekan::float32, "SKtilde",
-                                        {_rfi_num_times, _num_local_freq, 3}, {"Trfi", "F", "SK"});
-    out_buf->allocate_ndarray_frame_desc(kotekan::uint8, "RFIFrameMask",
-                                         {_num_integrations, _num_local_freq}, {"Tc", "F"});
+    in_buf->require_frame_desc(kotekan::GenericNDArray::describe(
+        kotekan::float32, "SKtilde", {_rfi_num_times, _num_local_freq, 3}, {"Trfi", "F", "SK"}));
+    out_buf->require_frame_desc(kotekan::GenericNDArray::describe(
+        kotekan::uint8, "RFIFrameMask", {_num_integrations, _num_local_freq}, {"Tc", "F"}));
 
     // Initialize current RFI excision status, the "next" values are taken care of by the
     // configUpdater)
@@ -335,7 +338,7 @@ void RfiFrameMask::main_thread() {
         // Start with a copy
         out_meta->deepCopy(in_meta);
         // Set the array shape stuff from the frame descriptor.
-        out_meta->set_from_frame_desc(out_buf->get_ndarray_frame_desc());
+        out_meta->set_from_frame_desc(out_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // Set other metadata we changed or added.
         out_meta->set_time_downsampling_fpga(
@@ -350,7 +353,7 @@ void RfiFrameMask::main_thread() {
         out_meta->set_rfi_frame_excision_thresholds(meta_thresholds);
 
         // Check we're consistent with the frame desc, just in case!
-        out_meta->check_frame_desc(out_buf->get_ndarray_frame_desc());
+        out_meta->check_frame_desc(out_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // Advance to the next frame
         in_buf->mark_frame_empty(unique_name, in_frame_id++);

--- a/lib/stages/RfiMaskSum.cpp
+++ b/lib/stages/RfiMaskSum.cpp
@@ -15,6 +15,7 @@
 #include "kotekanLogging.hpp"   // for FATAL_ERROR, DEBUG, INFO
 #include "fmt.hpp"              // for compile_string_to_view
 #include "DataType.hpp"         // for DataType
+#include "NDArray.hpp"          // for GenericNDArray, Config
 #include "Stage.hpp"            // for Stage
 
 
@@ -102,9 +103,11 @@ RfiMaskSum::RfiMaskSum(Config& config, const std::string& unique_name,
     out_buf = get_buffer("out_buf");
     out_buf->register_producer(unique_name);
 
-    // Ensure outgoing buffer is of type N2
-    if (out_buf->buffer_type != "standard")
-        FATAL_ERROR("RfiMaskSum out_buf ({:s}) is not of type standard.", out_buf->buffer_name);
+    // The output buffer must carry an NDArray frame descriptor (declared with
+    // `kotekan_buffer: ndarray` in the config); require_frame_desc below validates
+    // its shape/type.
+    if (out_buf->buffer_type != "ndarray")
+        FATAL_ERROR("RfiMaskSum out_buf ({:s}) is not of type ndarray.", out_buf->buffer_name);
 
     // Sanity checks on initialization
     {
@@ -142,12 +145,12 @@ RfiMaskSum::RfiMaskSum(Config& config, const std::string& unique_name,
         FATAL_ERROR("RfiMaskSum in_buf ({:s}) has frame size {:d}. Expected {:d}.",
                     in_buf->buffer_name, in_buf->frame_size, in_rfimask_frame_size);
 
-    in_buf->allocate_ndarray_frame_desc(
+    in_buf->require_frame_desc(kotekan::GenericNDArray::describe(
         kotekan::uint1x8, "RFImask",
         {div_noremainder(_samples_per_data_set, 1024), _num_local_freq, 1024 / 8},
-        {"T8hi128", "F", "T8lo128"});
-    out_buf->allocate_ndarray_frame_desc(kotekan::int32, "RFImask_counts",
-                                         {_num_integrations, _num_local_freq}, {"Tc", "F"});
+        {"T8hi128", "F", "T8lo128"}));
+    out_buf->require_frame_desc(kotekan::GenericNDArray::describe(
+        kotekan::int32, "RFImask_counts", {_num_integrations, _num_local_freq}, {"Tc", "F"}));
 }
 
 void RfiMaskSum::main_thread() {
@@ -187,11 +190,11 @@ void RfiMaskSum::main_thread() {
         const std::shared_ptr<chordMetadata> out_meta = get_chord_metadata(out_buf, out_frame_id);
 
         out_meta->deepCopy(in_meta);
-        out_meta->set_from_frame_desc(out_buf->get_ndarray_frame_desc());
+        out_meta->set_from_frame_desc(out_buf->get_frame_desc<kotekan::GenericNDArray>());
         out_meta->set_time_downsampling_fpga(
             div_noremainder(in_meta->get_time_downsampling_fpga(), 1024) * _sub_integration_ntime);
 
-        out_meta->check_frame_desc(out_buf->get_ndarray_frame_desc());
+        out_meta->check_frame_desc(out_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // Advance to the next frame
         in_buf->mark_frame_empty(unique_name, in_frame_id++);

--- a/lib/stages/TransposeBasebandArray.cpp
+++ b/lib/stages/TransposeBasebandArray.cpp
@@ -15,6 +15,7 @@
 #include "kotekanLogging.hpp"   // for INFO, DEBUG, ERROR
 #include "fmt.hpp"              // for compile_string_to_view, format, fmt
 #include "DataType.hpp"         // for DataType
+#include "NDArray.hpp"
 
 #ifdef __AVX512F__
 #include <immintrin.h>          // for __m512i, _mm512_stream_si512, _mm512_set1_epi8, _mm512_se...
@@ -152,9 +153,9 @@ STAGE_CONSTRUCTOR(TransposeBasebandArray) {
     // Set the output buffer frame ndarray shape
 
     // Confusingly the array name is "E" for electric field
-    out_buf->allocate_ndarray_frame_desc(
+    out_buf->require_frame_desc(kotekan::GenericNDArray::describe(
         kotekan::int4x2_swapped_withoffset, "E",
-        {timesamples_per_frame, NUM_LOCAL_FREQ, 2, NUM_ELEMENTS / 2}, {"T", "F", "P", "D"});
+        {timesamples_per_frame, NUM_LOCAL_FREQ, 2, NUM_ELEMENTS / 2}, {"T", "F", "P", "D"}));
 
     INFO("TransposeBasebandArray: Input shape: [{:d}][{:d}][{:d}][{:d}][{:d}]", time_long,
          NUM_LOCAL_FREQ, ELEMENT_LONG, TIME_SHORT, ELEMENT_SHORT);

--- a/lib/stages/asdfFileRead.cpp
+++ b/lib/stages/asdfFileRead.cpp
@@ -1,5 +1,6 @@
 #include <Config.hpp>             // for Config
 #include <DataType.hpp>           // for string_to_type, type_to_string, DataType
+#include <NDArray.hpp>            // for GenericNDArray
 #include <Stage.hpp>              // for Stage
 #include <StageFactory.hpp>       // for REGISTER_KOTEKAN_STAGE
 #include <Symbol.hpp>             // for Symbol
@@ -224,9 +225,10 @@ public:
                         const std::string dim_name = dim_names->at(d)->get_maybe_string().value();
                         dimnames.push_back(dim_name);
                     }
-                    buffer->allocate_ndarray_frame_desc(value_type, name, dimensions, dimnames);
+                    buffer->require_frame_desc(
+                        kotekan::GenericNDArray::describe(value_type, name, dimensions, dimnames));
                     /* test that things are consistent */
-                    meta->check_frame_desc(buffer->get_ndarray_frame_desc());
+                    meta->check_frame_desc(buffer->get_frame_desc<kotekan::GenericNDArray>());
                 }
 
 

--- a/lib/stages/asdfFileWrite.cpp
+++ b/lib/stages/asdfFileWrite.cpp
@@ -140,8 +140,11 @@ public:
             assert(metadata_is_chord(mc) || metadata_is_N2(mc));
             const std::shared_ptr<const chordMetadata> meta = get_chord_metadata(mc);
             const std::shared_ptr<const kotekan::GenericNDArray> frame_desc =
-                buffer->get_ndarray_frame_desc();
-            assert(frame_desc);
+                buffer->get_frame_desc<kotekan::GenericNDArray>();
+            if (!frame_desc)
+                FATAL_ERROR("Buffer \"{:s}\" has no NDArray frame descriptor; asdfFileWrite "
+                            "needs one to describe the written array",
+                            buffer->buffer_name);
 
             const double this_time = current_time();
             const double elapsed_time = this_time - start_time;

--- a/lib/stages/bufferDelay.cpp
+++ b/lib/stages/bufferDelay.cpp
@@ -94,11 +94,11 @@ void bufferDelay::main_thread() {
                 in_buf->pass_metadata(in_frame_release_id, out_buf, out_frame_id);
                 in_buf->swap_frames(in_frame_release_id, out_buf, out_frame_id);
             }
-            const auto in_frame_desc = in_buf->get_frame_description();
+            const auto in_frame_desc = in_buf->get_frame_desc();
             if (in_frame_desc) {
-                out_buf->set_frame_desc(in_frame_desc);
+                out_buf->require_frame_desc(in_frame_desc);
             } else {
-                assert(!out_buf->get_frame_description());
+                assert(!out_buf->get_frame_desc());
             }
 
             DEBUG("Reached maximum no. of frames to hold. Releasing oldest frame... in_frame_id: "

--- a/lib/stages/bufferMerge.cpp
+++ b/lib/stages/bufferMerge.cpp
@@ -116,11 +116,11 @@ void bufferMerge::main_thread() {
                 in_buf->pass_metadata(in_frame_id, out_buf, out_frame_id);
 
                 // Link frame description
-                const auto in_frame_desc = in_buf->get_frame_description();
+                const auto in_frame_desc = in_buf->get_frame_desc();
                 if (in_frame_desc) {
-                    out_buf->set_frame_desc(in_frame_desc);
+                    out_buf->require_frame_desc(in_frame_desc);
                 } else {
-                    assert(!out_buf->get_frame_description());
+                    assert(!out_buf->get_frame_desc());
                 }
 
                 // Copy or swap the frame.

--- a/lib/stages/bufferQuiet.cpp
+++ b/lib/stages/bufferQuiet.cpp
@@ -135,11 +135,11 @@ void bufferQuiet::main_thread() {
                 // this just copies the shared pointer, and is only valid since
                 // a frame description must never change
             }
-            const auto in_frame_desc = in_buf->get_frame_description();
+            const auto in_frame_desc = in_buf->get_frame_desc();
             if (in_frame_desc) {
-                out_buf->set_frame_desc(in_frame_desc);
+                out_buf->require_frame_desc(in_frame_desc);
             } else {
-                assert(!out_buf->get_frame_description());
+                assert(!out_buf->get_frame_desc());
             }
 
             DEBUG("Releasing frame... in_frame_id: {:d}, in_frame_hold_ctr: {:d}, "

--- a/lib/stages/bufferRecv.cpp
+++ b/lib/stages/bufferRecv.cpp
@@ -20,6 +20,7 @@
 #include <utility>                // for pair
 
 #include "Config.hpp"             // for Config
+#include "NDArray.hpp"            // for GenericNDArray, Config
 #include "StageFactory.hpp"       // for REGISTER_KOTEKAN_STAGE
 #include "Symbol.hpp"             // for Symbol
 #include "buffer.hpp"             // for Buffer, buffer_free, buffer_malloc
@@ -550,7 +551,6 @@ void connInstance::internal_read_callback() {
                 if (metadata)
                     metadata->set_from_bytes((char*)metadata_space, buf_frame_header.metadata_size);
 
-                // TODO: actuall transfer the NDArray information
                 auto chord = std::dynamic_pointer_cast<chordMetadata>(metadata);
                 if (chord) {
                     /* new style array description */
@@ -562,10 +562,14 @@ void connInstance::internal_read_callback() {
                                         strnlen(chord->dim_name[d], sizeof(chord->dim_name[d])));
                     }
 
-                    buf->allocate_ndarray_frame_desc(chord->type, chord->get_name(), dimensions,
-                                                     dimnames);
+                    // The frame descriptor is discovered from the received frame,
+                    // so ensure_frame_desc: attach it when the receive buffer is
+                    // undeclared (e.g. `standard`), or validate the received shape
+                    // against the buffer's declared descriptor when it has one.
+                    buf->ensure_frame_desc(kotekan::GenericNDArray::describe(
+                        chord->type, chord->get_name(), dimensions, dimnames));
                     /* test that things are consistent */
-                    chord->check_frame_desc(buf->get_ndarray_frame_desc());
+                    chord->check_frame_desc(buf->get_frame_desc<kotekan::GenericNDArray>());
                 }
 
                 buf->mark_frame_full(producer_name, frame_id);

--- a/lib/stages/hdf5FileRead.cpp
+++ b/lib/stages/hdf5FileRead.cpp
@@ -2,6 +2,7 @@
 
 #include <Config.hpp>          // for Config
 #include <DataType.hpp>        // for string_to_type, DataType
+#include <NDArray.hpp>         // for GenericNDArray
 #include <Stage.hpp>           // for Stage
 #include <StageFactory.hpp>    // for REGISTER_KOTEKAN_STAGE
 #include <Symbol.hpp>          // for Symbol
@@ -294,9 +295,10 @@ public:
                     std::vector<ptrdiff_t> dimensions(dims.begin(), dims.end());
                     std::vector<kotekan::Symbol> dimnames(dim_names.begin(), dim_names.end());
 
-                    buffer->allocate_ndarray_frame_desc(value_type, name, dimensions, dimnames);
+                    buffer->require_frame_desc(
+                        kotekan::GenericNDArray::describe(value_type, name, dimensions, dimnames));
                     /* test that things are consistent */
-                    meta->check_frame_desc(buffer->get_ndarray_frame_desc());
+                    meta->check_frame_desc(buffer->get_frame_desc<kotekan::GenericNDArray>());
                 }
 
                 // Read buffer

--- a/lib/stages/hdf5FileReadSingleFile.cpp
+++ b/lib/stages/hdf5FileReadSingleFile.cpp
@@ -20,6 +20,7 @@
 
 #include "Config.hpp"                          // for Config
 #include "DataType.hpp"                        // for string_to_type, DataType
+#include "NDArray.hpp"                         // for GenericNDArray
 #include "Stage.hpp"                           // for Stage
 #include "StageFactory.hpp"                    // for REGISTER_KOTEKAN_STAGE
 #include "Symbol.hpp"                          // for Symbol
@@ -185,11 +186,11 @@ public:
                     break;
 
                 // Set metadata
-                buffer->allocate_ndarray_frame_desc(type, kotekan::Symbol(name), new_dims,
-                                                    new_dim_names);
+                buffer->require_frame_desc(kotekan::GenericNDArray::describe(
+                    type, kotekan::Symbol(name), new_dims, new_dim_names));
                 buffer->allocate_new_metadata_object(frame_id);
                 const auto& meta = get_chord_metadata(buffer->get_metadata(frame_id));
-                meta->set_from_frame_desc(buffer->get_ndarray_frame_desc());
+                meta->set_from_frame_desc(buffer->get_frame_desc<kotekan::GenericNDArray>());
 
                 meta->set_coarse_freq(frequency_channels);
                 meta->set_freq_upchan_factor(new_freq_upchan_factor);

--- a/lib/stages/hdf5FileWrite.cpp
+++ b/lib/stages/hdf5FileWrite.cpp
@@ -591,8 +591,12 @@ public:
                     assert(metadata_is_chord(mc));
                     const std::shared_ptr<const chordMetadata> meta = get_chord_metadata(mc);
                     const std::shared_ptr<const kotekan::GenericNDArray> frame_desc =
-                        buffer->get_ndarray_frame_desc();
-                    assert(frame_desc);
+                        buffer->get_frame_desc<kotekan::GenericNDArray>();
+                    if (!frame_desc)
+                        FATAL_ERROR(
+                            "Buffer \"{:s}\" has no NDArray frame descriptor; hdf5FileWrite "
+                            "needs one to write CHORD-metadata frames",
+                            buffer->buffer_name);
                     write_chord(frame, meta, frame_desc, frame_counter);
                 } else if (metadata_is_N2(mc)) {
                     assert(metadata_is_N2(mc));

--- a/lib/stages/lostSamplesToN2Counts.cpp
+++ b/lib/stages/lostSamplesToN2Counts.cpp
@@ -8,6 +8,7 @@
 #include "Config.hpp"           // for Config
 #include "DataType.hpp"         // for DataType, GetType_t
 #include "N2Util.hpp"           // for frameID, modulo
+#include "NDArray.hpp"          // for NDArray, GenericNDArray, Config
 #include "StageFactory.hpp"     // for REGISTER_KOTEKAN_STAGE
 #include "buffer.hpp"           // for Buffer
 #include "bufferContainer.hpp"  // for bufferContainer
@@ -91,11 +92,10 @@ lostSamplesToN2Counts::lostSamplesToN2Counts(Config& config, const std::string& 
             "Number of lost_samples buffers ({:d}) does not evenly divide total frequencies ({:d})",
             _nbufs, num_n2k_freq);
 
-    // Check rfi make frame size against expectation
-    size_t _expected_rfi_frame_size = num_n2k_freq * samples_per_data_set / BITS_PER_BYTE;
-    if (rfi_mask_buf->frame_size != _expected_rfi_frame_size)
-        FATAL_ERROR("Unexpected frame size for rfi_mask {:d} - expected {:d}",
-                    rfi_mask_buf->frame_size, _expected_rfi_frame_size);
+    // Check the rfi mask shape against expectation
+    rfi_mask_buf->require_frame_desc(kotekan::NDArray<kotekan::uint1x8_t, 3>::describe(
+        "RFImask", {std::ptrdiff_t(samples_per_data_set / 1024), std::ptrdiff_t(num_n2k_freq), 128},
+        {"T8hi128", "F", "T8lo128"}));
 
     // This is a bit of a misnomer - the lost_samples buffer does not _include_
     // multiple frequencies, but information may be shared by multiple frequencies
@@ -120,11 +120,12 @@ lostSamplesToN2Counts::lostSamplesToN2Counts(Config& config, const std::string& 
     // Set the frame description
     // The buffer name and axis names are the same as those set in
     // cudaPL1butCorrelator
-    n2k_counts_buf->allocate_ndarray_frame_desc<kotekan::GetType_t<kotekan::int32>, 5>(
-        "n2k_counts",
-        {static_cast<long>(_num_subintegrations), static_cast<long>(num_n2k_freq),
-         static_cast<long>(_counts_ntiles), COUNTS_BLOCK_SIZE, COUNTS_BLOCK_SIZE},
-        {"Tc", "F", "D8Phi", "D8Plo1", "D8Plo2"});
+    n2k_counts_buf->require_frame_desc(
+        kotekan::NDArray<kotekan::GetType_t<kotekan::int32>, 5>::describe(
+            "n2k_counts",
+            {static_cast<long>(_num_subintegrations), static_cast<long>(num_n2k_freq),
+             static_cast<long>(_counts_ntiles), COUNTS_BLOCK_SIZE, COUNTS_BLOCK_SIZE},
+            {"Tc", "F", "D8Phi", "D8Plo1", "D8Plo2"}));
 }
 
 lostSamplesToN2Counts::~lostSamplesToN2Counts() {}
@@ -256,7 +257,7 @@ void lostSamplesToN2Counts::main_thread() {
         // Update metadata from the frame description
         std::shared_ptr<chordMetadata> meta =
             get_chord_metadata(n2k_counts_buf, n2k_counts_buf_frame_id);
-        meta->set_from_frame_desc(n2k_counts_buf->get_ndarray_frame_desc());
+        meta->set_from_frame_desc(n2k_counts_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // Set additional metadata not handled by the helper, including
         // the name and FPGA time-sample downsampling
@@ -264,7 +265,7 @@ void lostSamplesToN2Counts::main_thread() {
         meta->set_time_downsampling_fpga(sub_integration_ntime);
 
         // Check that frame desc and metadata match
-        meta->check_frame_desc(n2k_counts_buf->get_ndarray_frame_desc());
+        meta->check_frame_desc(n2k_counts_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // Release the current frames and increment to the next frame ID
         n2k_counts_buf->mark_frame_full(unique_name, n2k_counts_buf_frame_id);

--- a/lib/stages/lostSamplesToPLMask.cpp
+++ b/lib/stages/lostSamplesToPLMask.cpp
@@ -65,14 +65,15 @@ lostSamplesToPLMask::lostSamplesToPLMask(Config& config, const std::string& uniq
         FATAL_ERROR("Unexpected frames sizes for pl_mask {:d} and lost_samples {:d}",
                     pl_mask_buf->frame_size, lost_samples_bufs.at(0)->frame_size);
 
-    pl_mask_buf->allocate_ndarray_frame_desc<kotekan::GetType_t<kotekan::uint1x8>, 5>(
-        "pl_mask",
-        {ptrdiff_t(lost_samples_bufs.at(0)->frame_size / PL_MASK_DOWNSAMPLING_FACTOR
-                   / PL_MASK_HILO_SPLIT),
-         ptrdiff_t(lost_samples_bufs.size()), num_polarizations,
-         num_dishes / PL_MASK_DISHES_PER_BIN,
-         PL_MASK_HILO_SPLIT / BITS_PER_BYTE /* because we count uint1x8, not uint1 */},
-        {"T2hi64", "F4", "P", "D8", "T2lo64"});
+    pl_mask_buf->require_frame_desc(
+        kotekan::NDArray<kotekan::GetType_t<kotekan::uint1x8>, 5>::describe(
+            "pl_mask",
+            {ptrdiff_t(lost_samples_bufs.at(0)->frame_size / PL_MASK_DOWNSAMPLING_FACTOR
+                       / PL_MASK_HILO_SPLIT),
+             ptrdiff_t(lost_samples_bufs.size()), num_polarizations,
+             num_dishes / PL_MASK_DISHES_PER_BIN,
+             PL_MASK_HILO_SPLIT / BITS_PER_BYTE /* because we count uint1x8, not uint1 */},
+            {"T2hi64", "F4", "P", "D8", "T2lo64"}));
 }
 
 lostSamplesToPLMask::~lostSamplesToPLMask() {}
@@ -100,10 +101,10 @@ void lostSamplesToPLMask::main_thread() {
             // constant for all iterations but only set by the producer before
             // it marks the frame as full, so cannot be checked before the first
             // wait_for_full_frame()
-            auto const expected_lost_samples_frame_desc = kotekan::GenericNDArray::create(
-                kotekan::DataType::uint8, "lost_samples", {ptrdiff_t(lost_samples_buf->frame_size)},
-                {"T"}, nullptr);
-            assert(*lost_samples_buf->get_ndarray_frame_desc()
+            auto const expected_lost_samples_frame_desc =
+                kotekan::GenericNDArray::describe(kotekan::DataType::uint8, "lost_samples",
+                                                  {ptrdiff_t(lost_samples_buf->frame_size)}, {"T"});
+            assert(*lost_samples_buf->get_frame_desc<kotekan::GenericNDArray>()
                    == *expected_lost_samples_frame_desc);
 
             // pl_mask buffer_format [time / 2 % 64][dish / 8][polr][freq / 4][time / 2 / 64]
@@ -146,7 +147,8 @@ void lostSamplesToPLMask::main_thread() {
                 pl_mask_meta->deepCopy(lost_samples_meta);
 
                 // update array description
-                pl_mask_meta->set_from_frame_desc(pl_mask_buf->get_ndarray_frame_desc());
+                pl_mask_meta->set_from_frame_desc(
+                    pl_mask_buf->get_frame_desc<kotekan::GenericNDArray>());
 
                 // update metadata
                 pl_mask_meta->set_time_downsampling_fpga(pl_mask_meta->get_time_downsampling_fpga()
@@ -185,7 +187,7 @@ void lostSamplesToPLMask::main_thread() {
         lost_samples_buf_frame_id =
             (lost_samples_buf_frame_id + 1) % lost_samples_bufs.at(0)->num_frames;
 
-        pl_mask_meta->check_frame_desc(pl_mask_buf->get_ndarray_frame_desc());
+        pl_mask_meta->check_frame_desc(pl_mask_buf->get_frame_desc<kotekan::GenericNDArray>());
         pl_mask_buf->mark_frame_full(unique_name, pl_mask_buf_frame_id);
         pl_mask_buf_frame_id = (pl_mask_buf_frame_id + 1) % pl_mask_buf->num_frames;
     }

--- a/lib/stages/parseReorderDefault.cpp
+++ b/lib/stages/parseReorderDefault.cpp
@@ -13,6 +13,7 @@
 #include <tuple>                // for get
 
 #include "DataType.hpp"         // for DataType
+#include "NDArray.hpp"          // for GenericNDArray
 #include "StageFactory.hpp"     // for REGISTER_KOTEKAN_STAGE
 #include "Telescope.hpp"        // for Telescope, ElementOrder
 #include "bufferContainer.hpp"  // for bufferContainer
@@ -63,21 +64,21 @@ parseReorderDefault::parseReorderDefault(Config& config, const std::string& uniq
 
 #if 0 // this is what it should be
     if(_input_order == ElementOrder::CHIMECorrelator) {
-          _out_buf->allocate_ndarray_frame_desc(kotekan::int32, _name, {_num_polarizations*_num_dishes},
-                                                {"E"});
+          _out_buf->require_frame_desc(kotekan::GenericNDArray::describe(kotekan::int32, _name, {_num_polarizations*_num_dishes},
+                                                {"E"}));
     } else if(_input_order == ElementOrder::CHIMECylinder) {
-          _out_buf->allocate_ndarray_frame_desc(kotekan::int32, _name, {_num_chime_cylinders, _num_polarizations, _num_dishes/_num_chime_cylinders},
-                                                {"C", "P", "D"});
+          _out_buf->require_frame_desc(kotekan::GenericNDArray::describe(kotekan::int32, _name, {_num_chime_cylinders, _num_polarizations, _num_dishes/_num_chime_cylinders},
+                                                {"C", "P", "D"}));
     } else if(_input_order == ElementOrder::CHIMEBeamformer) {
-          _out_buf->allocate_ndarray_frame_desc(kotekan::int32, _name, {_num_polarizations, _num_dishes},
-                                                {"P", "D"});
+          _out_buf->require_frame_desc(kotekan::GenericNDArray::describe(kotekan::int32, _name, {_num_polarizations, _num_dishes},
+                                                {"P", "D"}));
     } else {
         FATAL_ERROR("Unexpected input_order {:s}", _input_order);
     }
 #else
     // this is what xpose2048 expects
-    _out_buf->allocate_ndarray_frame_desc(kotekan::int32, _name, {_num_polarizations, _num_dishes},
-                                          {"P", "D"});
+    _out_buf->require_frame_desc(kotekan::GenericNDArray::describe(
+        kotekan::int32, _name, {_num_polarizations, _num_dishes}, {"P", "D"}));
 #endif
 }
     
@@ -129,8 +130,8 @@ void parseReorderDefault::main_thread() {
 
         chordmeta->set_frame_counter(0); // these do not actually change with time
 
-        chordmeta->set_from_frame_desc(_out_buf->get_ndarray_frame_desc());
-        chordmeta->check_frame_desc(_out_buf->get_ndarray_frame_desc());
+        chordmeta->set_from_frame_desc(_out_buf->get_frame_desc<kotekan::GenericNDArray>());
+        chordmeta->check_frame_desc(_out_buf->get_frame_desc<kotekan::GenericNDArray>());
 
         _out_buf->mark_frame_full(unique_name, frame_id);
 

--- a/lib/stages/rawFileWrite.cpp
+++ b/lib/stages/rawFileWrite.cpp
@@ -11,6 +11,7 @@
 #include <memory>                   // for shared_ptr, __shared_ptr_access
 
 #include "Config.hpp"               // for Config
+#include "NDArray.hpp"              // for GenericNDArray, Config
 #include "StageFactory.hpp"         // for REGISTER_KOTEKAN_STAGE
 #include "buffer.hpp"               // for Buffer
 #include "bufferContainer.hpp"      // for bufferContainer
@@ -74,7 +75,7 @@ void rawFileWrite::main_thread() {
             break;
 
         // Check for NDArray on first frame (after producer may have set the descriptor)
-        if (buf->get_ndarray_frame_desc()) {
+        if (buf->get_frame_desc<kotekan::GenericNDArray>()) {
             FATAL_ERROR(
                 "rawFileWrite does not support NDArray buffers. The NDArray frame descriptor "
                 "is set dynamically and will not be written to the file.");

--- a/lib/stages/rfiBroadcast.cpp
+++ b/lib/stages/rfiBroadcast.cpp
@@ -126,7 +126,12 @@ void rfiBroadcast::main_thread() {
     const size_t FSE = FS * num_elements;
 
     // Sort out the rfi mask buffer time stride
-    auto rfi_frame_desc = rfi_mask_buf->get_ndarray_frame_desc();
+    auto rfi_frame_desc = rfi_mask_buf->get_frame_desc<kotekan::GenericNDArray>();
+    if (!rfi_frame_desc)
+        FATAL_ERROR("rfi_mask_buf ({:s}) has no NDArray frame descriptor; rfiBroadcast needs the "
+                    "mask shape, so declare the buffer with `kotekan_buffer: ndarray` in the "
+                    "config",
+                    rfi_mask_buf->buffer_name);
     auto _rfi_frame_rank = rfi_frame_desc->get_rank();
     auto _rfi_frame_dims = rfi_frame_desc->get_extents();
     size_t _rfi_t_hi = _rfi_frame_dims[_rfi_frame_rank - 1];

--- a/lib/utils/N2FrameView.cpp
+++ b/lib/utils/N2FrameView.cpp
@@ -31,7 +31,7 @@ N2FrameView::N2FrameView(Buffer* buf, int frame_id) :
 
     FrameView(buf, frame_id),
     _metadata(std::static_pointer_cast<N2Metadata>(buf->metadata[frame_id])),
-    _desc(validate_desc_type(buf->get_frame_description())),
+    _desc(validate_desc_type(buf->get_frame_desc())),
 
     // Set the const refs to the structural metadata
     n2_layout(_desc->get_n2_layout()), num_elements(_desc->get_num_elements()),

--- a/tests/boost/test_N2Subset.cpp
+++ b/tests/boost/test_N2Subset.cpp
@@ -106,7 +106,7 @@ BOOST_AUTO_TEST_CASE(test_fulluppertri_to_autocorrelations) {
     size_t in_frame_size = N2FrameDesc::calculate_frame_size(num_elements, num_ev, in_num_prod);
     Buffer in_buf(num_frames, in_frame_size, pool, in_buf_name, "N2", 0, false, false,
                   std::vector<int>{}, true);
-    in_buf.set_frame_desc(
+    in_buf.ensure_frame_desc(
         std::make_shared<N2FrameDesc>(num_elements, num_ev, in_num_prod, N2Layout::FullUpperTri));
     in_buf.register_producer("test_producer");
 
@@ -115,7 +115,7 @@ BOOST_AUTO_TEST_CASE(test_fulluppertri_to_autocorrelations) {
     size_t out_frame_size = N2FrameDesc::calculate_frame_size(num_elements, num_ev, out_num_prod);
     Buffer out_buf(num_frames, out_frame_size, pool, out_buf_name, "N2", 0, false, false,
                    std::vector<int>{}, true);
-    out_buf.set_frame_desc(std::make_shared<N2FrameDesc>(num_elements, num_ev, out_num_prod,
+    out_buf.ensure_frame_desc(std::make_shared<N2FrameDesc>(num_elements, num_ev, out_num_prod,
                                                          N2Layout::Autocorrelations));
 
     // Create buffer container
@@ -206,7 +206,7 @@ BOOST_AUTO_TEST_CASE(test_fulluppertri_to_general_subset) {
     size_t in_frame_size = N2FrameDesc::calculate_frame_size(num_elements, num_ev, in_num_prod);
     Buffer in_buf(num_frames, in_frame_size, pool, in_buf_name, "N2", 0, false, false,
                   std::vector<int>{}, true);
-    in_buf.set_frame_desc(
+    in_buf.ensure_frame_desc(
         std::make_shared<N2FrameDesc>(num_elements, num_ev, in_num_prod, N2Layout::FullUpperTri));
     in_buf.register_producer("test_producer");
 
@@ -215,7 +215,7 @@ BOOST_AUTO_TEST_CASE(test_fulluppertri_to_general_subset) {
         N2FrameDesc::calculate_frame_size(num_elements, num_ev, product_list.size());
     Buffer out_buf(num_frames, out_frame_size, pool, out_buf_name, "N2", 0, false, false,
                    std::vector<int>{}, true);
-    out_buf.set_frame_desc(std::make_shared<N2FrameDesc>(num_elements, num_ev, product_list.size(),
+    out_buf.ensure_frame_desc(std::make_shared<N2FrameDesc>(num_elements, num_ev, product_list.size(),
                                                          N2Layout::GeneralSubset, product_list));
 
     // Create buffer container
@@ -287,13 +287,13 @@ BOOST_AUTO_TEST_CASE(test_autocorrelations_to_autocorrelations) {
 
     Buffer in_buf(num_frames, frame_size, pool, in_buf_name, "N2", 0, false, false,
                   std::vector<int>{}, true);
-    in_buf.set_frame_desc(
+    in_buf.ensure_frame_desc(
         std::make_shared<N2FrameDesc>(num_elements, num_ev, num_prod, N2Layout::Autocorrelations));
     in_buf.register_producer("test_producer");
 
     Buffer out_buf(num_frames, frame_size, pool, out_buf_name, "N2", 0, false, false,
                    std::vector<int>{}, true);
-    out_buf.set_frame_desc(
+    out_buf.ensure_frame_desc(
         std::make_shared<N2FrameDesc>(num_elements, num_ev, num_prod, N2Layout::Autocorrelations));
 
     // Create buffer container
@@ -368,7 +368,7 @@ BOOST_AUTO_TEST_CASE(test_have_inputs_subset) {
     size_t in_frame_size = N2FrameDesc::calculate_frame_size(num_elements, num_ev, in_num_prod);
     Buffer in_buf(num_frames, in_frame_size, pool, in_buf_name, "N2", 0, false, false,
                   std::vector<int>{}, true);
-    in_buf.set_frame_desc(
+    in_buf.ensure_frame_desc(
         std::make_shared<N2FrameDesc>(num_elements, num_ev, in_num_prod, N2Layout::FullUpperTri));
     in_buf.register_producer("test_producer");
 
@@ -377,7 +377,7 @@ BOOST_AUTO_TEST_CASE(test_have_inputs_subset) {
         N2FrameDesc::calculate_frame_size(num_elements, num_ev, product_list.size());
     Buffer out_buf(num_frames, out_frame_size, pool, out_buf_name, "N2", 0, false, false,
                    std::vector<int>{}, true);
-    out_buf.set_frame_desc(std::make_shared<N2FrameDesc>(num_elements, num_ev, product_list.size(),
+    out_buf.ensure_frame_desc(std::make_shared<N2FrameDesc>(num_elements, num_ev, product_list.size(),
                                                          N2Layout::InputORMasked, product_list));
 
     // Create buffer container
@@ -450,7 +450,7 @@ BOOST_AUTO_TEST_CASE(test_only_inputs_subset) {
     size_t in_frame_size = N2FrameDesc::calculate_frame_size(num_elements, num_ev, in_num_prod);
     Buffer in_buf(num_frames, in_frame_size, pool, in_buf_name, "N2", 0, false, false,
                   std::vector<int>{}, true);
-    in_buf.set_frame_desc(
+    in_buf.ensure_frame_desc(
         std::make_shared<N2FrameDesc>(num_elements, num_ev, in_num_prod, N2Layout::FullUpperTri));
     in_buf.register_producer("test_producer");
 
@@ -459,7 +459,7 @@ BOOST_AUTO_TEST_CASE(test_only_inputs_subset) {
         N2FrameDesc::calculate_frame_size(num_elements, num_ev, product_list.size());
     Buffer out_buf(num_frames, out_frame_size, pool, out_buf_name, "N2", 0, false, false,
                    std::vector<int>{}, true);
-    out_buf.set_frame_desc(std::make_shared<N2FrameDesc>(num_elements, num_ev, product_list.size(),
+    out_buf.ensure_frame_desc(std::make_shared<N2FrameDesc>(num_elements, num_ev, product_list.size(),
                                                          N2Layout::InputANDMasked, product_list));
 
     // Create buffer container

--- a/tests/boost/test_eigenStages.cpp
+++ b/tests/boost/test_eigenStages.cpp
@@ -183,8 +183,8 @@ static EigenResults run_pipeline(const EigenStageTestParams& p, const string& st
 
     // Set frame descriptors for N2 buffers (required by stages)
     if (n2_desc) {
-        in_buf.set_frame_desc(n2_desc);
-        out_buf.set_frame_desc(n2_desc);
+        in_buf.ensure_frame_desc(n2_desc);
+        out_buf.ensure_frame_desc(n2_desc);
     }
 
     kotekan::bufferContainer bc;
@@ -446,8 +446,8 @@ run_n2_pipeline_pair(const EigenStageTestParams& params_a,
         s.out_buf = std::make_unique<Buffer>(
             s.params.total_frames, frame_size, pool, s.out_buf_name, "N2", 0,
             false, false, std::vector<int>{}, true);
-        s.in_buf->set_frame_desc(n2_desc);
-        s.out_buf->set_frame_desc(n2_desc);
+        s.in_buf->ensure_frame_desc(n2_desc);
+        s.out_buf->ensure_frame_desc(n2_desc);
         bc.add_buffer(s.in_buf_name, s.in_buf.get());
         bc.add_buffer(s.out_buf_name, s.out_buf.get());
         // Hold the output frames so we can inspect them after the stage exits.

--- a/tests/boost/test_hdf5N2Write.cpp
+++ b/tests/boost/test_hdf5N2Write.cpp
@@ -282,7 +282,7 @@ BOOST_AUTO_TEST_CASE(test_visfiledata_add_frame_single_slot) {
     const size_t frame_size = N2FrameDesc::calculate_frame_size(num_input, num_ev, num_prod);
     auto pool = metadataPool::create(1, sizeof(N2Metadata), "test_pool", "N2Metadata");
     Buffer buf(1, frame_size, pool, "n2buf", "N2", 1, false, false, std::vector<int>{}, true);
-    buf.set_frame_desc(std::make_shared<kotekan::N2FrameDesc>(num_input, num_ev, num_prod,
+    buf.ensure_frame_desc(std::make_shared<kotekan::N2FrameDesc>(num_input, num_ev, num_prod,
                                                               N2Layout::FullUpperTri));
 
     buf.allocate_new_metadata_object(0);
@@ -360,7 +360,7 @@ BOOST_AUTO_TEST_CASE(test_visfiledata_era_and_fraction_guards) {
     const size_t frame_size = N2FrameDesc::calculate_frame_size(num_input, num_ev, num_prod);
     auto pool = metadataPool::create(2, sizeof(N2Metadata), "pool_guard", "N2Metadata");
     Buffer buf(2, frame_size, pool, "n2buf_guard", "N2", 1, false, false, std::vector<int>{}, true);
-    buf.set_frame_desc(std::make_shared<kotekan::N2FrameDesc>(num_input, num_ev, num_prod,
+    buf.ensure_frame_desc(std::make_shared<kotekan::N2FrameDesc>(num_input, num_ev, num_prod,
                                                               N2Layout::FullUpperTri));
 
     // Prepare frame view and two metadata instances for the same (f,t)
@@ -493,7 +493,7 @@ BOOST_AUTO_TEST_CASE(test_writer_base_dir_conflict_detection) {
     auto pool = metadataPool::create(2, sizeof(N2Metadata), "pool_conflict", "N2Metadata");
     Buffer buf(2, frame_size, pool, in_buf_name, "N2", /*numa*/ 0, /*huge*/ false,
                /*mlock*/ false, /*producers*/ std::vector<int>{}, /*zero_new_frames*/ true);
-    buf.set_frame_desc(
+    buf.ensure_frame_desc(
         std::make_shared<N2FrameDesc>(num_input, num_ev, num_prod, N2Layout::FullUpperTri));
     buf.register_producer("test-producer");
     kotekan::bufferContainer bc;
@@ -540,7 +540,7 @@ BOOST_AUTO_TEST_CASE(test_writer_full_block_transpose) {
     auto pool = metadataPool::create(2, sizeof(N2Metadata), "pool_full", "N2Metadata");
     Buffer buf(2, frame_size, pool, in_buf_name, "N2", /*numa*/ 0, /*huge*/ false,
                /*mlock*/ false, /*producers*/ std::vector<int>{}, /*zero_new_frames*/ true);
-    buf.set_frame_desc(
+    buf.ensure_frame_desc(
         std::make_shared<N2FrameDesc>(num_input, num_ev, num_prod, N2Layout::FullUpperTri));
     buf.register_producer("test-producer");
     kotekan::bufferContainer bc;
@@ -631,7 +631,7 @@ BOOST_AUTO_TEST_CASE(test_writer_partial_flush_on_exit) {
     auto pool = metadataPool::create(2, sizeof(N2Metadata), "pool_partial", "N2Metadata");
     Buffer buf(2, frame_size, pool, in_buf_name, "N2", /*numa*/ 0, /*huge*/ false,
                /*mlock*/ false, /*producers*/ std::vector<int>{}, /*zero_new_frames*/ true);
-    buf.set_frame_desc(
+    buf.ensure_frame_desc(
         std::make_shared<N2FrameDesc>(num_input, num_ev, num_prod, N2Layout::FullUpperTri));
     buf.register_producer("test-producer");
     kotekan::bufferContainer bc;
@@ -712,7 +712,7 @@ BOOST_AUTO_TEST_CASE(test_writer_multi_file_rollover) {
         num_input, num_ev, N2FrameDesc::get_num_prod(num_input, N2Layout::FullUpperTri));
     auto pool = metadataPool::create(2, sizeof(N2Metadata), "pool_roll", "N2Metadata");
     Buffer buf(2, frame_size, pool, in_buf_name, "N2", 0, false, false, std::vector<int>{}, true);
-    buf.set_frame_desc(std::make_shared<N2FrameDesc>(
+    buf.ensure_frame_desc(std::make_shared<N2FrameDesc>(
         num_input, num_ev, N2FrameDesc::get_num_prod(num_input, N2Layout::FullUpperTri),
         N2Layout::FullUpperTri));
     buf.register_producer("test-producer");
@@ -795,7 +795,7 @@ BOOST_AUTO_TEST_CASE(test_writer_distinct_window_names) {
         num_input, num_ev, N2FrameDesc::get_num_prod(num_input, N2Layout::FullUpperTri));
     auto pool = metadataPool::create(2, sizeof(N2Metadata), "pool_subsec", "N2Metadata");
     Buffer buf(2, frame_size, pool, in_buf_name, "N2", 0, false, false, std::vector<int>{}, true);
-    buf.set_frame_desc(std::make_shared<N2FrameDesc>(
+    buf.ensure_frame_desc(std::make_shared<N2FrameDesc>(
         num_input, num_ev, N2FrameDesc::get_num_prod(num_input, N2Layout::FullUpperTri),
         N2Layout::FullUpperTri));
     buf.register_producer("test-producer");
@@ -869,7 +869,7 @@ BOOST_AUTO_TEST_CASE(test_writer_timeout_finalize_zero_threshold) {
         num_input, num_ev, N2FrameDesc::get_num_prod(num_input, N2Layout::FullUpperTri));
     auto pool = metadataPool::create(8, sizeof(N2Metadata), "pool_timeout", "N2Metadata");
     Buffer buf(8, frame_size, pool, in_buf_name, "N2", 0, false, false, std::vector<int>{}, true);
-    buf.set_frame_desc(std::make_shared<N2FrameDesc>(
+    buf.ensure_frame_desc(std::make_shared<N2FrameDesc>(
         num_input, num_ev, N2FrameDesc::get_num_prod(num_input, N2Layout::FullUpperTri),
         N2Layout::FullUpperTri));
     buf.register_producer("test-producer");
@@ -945,7 +945,7 @@ BOOST_AUTO_TEST_CASE(test_writer_drop_if_final_exists) {
         num_input, num_ev, N2FrameDesc::get_num_prod(num_input, N2Layout::FullUpperTri));
     auto pool = metadataPool::create(2, sizeof(N2Metadata), "pool_drop", "N2Metadata");
     Buffer buf(2, frame_size, pool, in_buf_name, "N2", 0, false, false, std::vector<int>{}, true);
-    buf.set_frame_desc(std::make_shared<N2FrameDesc>(
+    buf.ensure_frame_desc(std::make_shared<N2FrameDesc>(
         num_input, num_ev, N2FrameDesc::get_num_prod(num_input, N2Layout::FullUpperTri),
         N2Layout::FullUpperTri));
     buf.register_producer("test-producer");
@@ -1037,7 +1037,7 @@ BOOST_AUTO_TEST_CASE(test_writer_geometry_basic) {
         num_input, num_ev, N2FrameDesc::get_num_prod(num_input, N2Layout::FullUpperTri));
     auto pool = metadataPool::create(4, sizeof(N2Metadata), "pool_geom", "N2Metadata");
     Buffer buf(4, frame_size, pool, in_buf_name, "N2", 0, false, false, std::vector<int>{}, true);
-    buf.set_frame_desc(std::make_shared<N2FrameDesc>(
+    buf.ensure_frame_desc(std::make_shared<N2FrameDesc>(
         num_input, num_ev, N2FrameDesc::get_num_prod(num_input, N2Layout::FullUpperTri),
         N2Layout::FullUpperTri));
     buf.register_producer("test-producer");

--- a/tests/test_lostsamples_to_n2counts.py
+++ b/tests/test_lostsamples_to_n2counts.py
@@ -45,10 +45,13 @@ class FakeRFIBuffer(runner.InputBuffer):
 
         self.buffer_block = {
             self.name: {
-                "kotekan_buffer": "standard",
+                "kotekan_buffer": "ndarray",
                 "metadata_pool": "main_pool",
                 "num_frames": "buffer_depth",
-                "frame_size": "(samples_per_data_set * num_local_freq) / 8",
+                "value_type": "uint1x8",
+                "quantity_name": "RFImask",
+                "extents": [samples_per_data_set // 1024, num_local_freq, 128],
+                "dimnames": ["T8hi128", "F", "T8lo128"],
             }
         }
 
@@ -57,7 +60,7 @@ class FakeRFIBuffer(runner.InputBuffer):
             "out_buf": self.name,
             "type": "const1x8",
             "value": 85,  # alternating 10101010...
-            "name": stage_name,
+            "name": "RFImask",
             "array_shape": [samples_per_data_set // 1024, num_local_freq, 128],
             "dim_name": ["T8hi128", "F", "T8lo128"],
         }
@@ -137,10 +140,19 @@ class DumpCountsBuffer(runner.OutputBuffer):
 
         self.buffer_block = {
             self.name: {
-                "kotekan_buffer": "standard",
+                "kotekan_buffer": "ndarray",
                 "metadata_pool": "main_pool",
                 "num_frames": "buffer_depth",
-                "frame_size": "sizeof_int * num_local_freq * counts_ntiles * 8 * 8 * samples_per_data_set / sub_integration_ntime",
+                "value_type": "int32",
+                "quantity_name": "n2k_counts",
+                "extents": [
+                    "samples_per_data_set / sub_integration_ntime",
+                    "num_local_freq",
+                    "counts_ntiles",
+                    8,
+                    8,
+                ],
+                "dimnames": ["Tc", "F", "D8Phi", "D8Plo1", "D8Plo2"],
             }
         }
 

--- a/tests/test_parseReorderDefault.py
+++ b/tests/test_parseReorderDefault.py
@@ -26,9 +26,12 @@ global_params = {
     # KotekanStageTester adds a "main_pool" section
     # Buffers
     "reorder_buffer": {
-        "kotekan_buffer": "standard",
+        "kotekan_buffer": "ndarray",
         "num_frames": 1,
-        "frame_size": 2048 * 4,
+        "value_type": "int32",
+        "quantity_name": "scatter_indices",
+        "extents": ["num_polarizations", "num_dishes"],
+        "dimnames": ["P", "D"],
         "metadata_pool": "main_pool",
     },
     # dump to disk to inspect manually

--- a/tests/test_pl_count_lost_scalar.py
+++ b/tests/test_pl_count_lost_scalar.py
@@ -194,6 +194,8 @@ def pllostcounts_data(tmpdir_factory, setup, plmask_data):
         dtype=np.int32,
         max_frames=num_frames,
         input_order="CHIMEBeamformer",
+        quantity_name="pl_lost_counts_scalar",
+        dimnames=["Tc", "F"],
     )
 
     # The test stage!

--- a/tests/test_rfi_framemask.py
+++ b/tests/test_rfi_framemask.py
@@ -187,6 +187,8 @@ def rfiframemask_data(tmpdir_factory, setup, sktilde_data):
         dtype=np.uint8,
         max_frames=num_frames,
         input_order="CHIMEBeamformer",
+        quantity_name="RFIFrameMask",
+        dimnames=["Tc", "F"],
     )
 
     # The test stage!

--- a/tests/test_rfi_masksum.py
+++ b/tests/test_rfi_masksum.py
@@ -161,6 +161,8 @@ def rfimasksum_data(tmpdir_factory, setup):
         dtype=np.int32,
         max_frames=num_frames,
         input_order="CHIMEBeamformer",
+        quantity_name="RFImask_counts",
+        dimnames=["Tc", "F"],
     )
 
     test = runner.KotekanStageTester(


### PR DESCRIPTION
Migrate the remaining stages to the FrameDesc API so they validate the descriptors of the now-ndarray buffers they read: the N2/PL/RFI consumers (N2Accumulate, RfiFrameMask, RfiMaskSum, lostSamples*, parseReorderDefault, CountLostPLSamplesScalar, ...) require_frame_desc on their inputs (replacing manual frame_size checks); file readers/writers and bufferRecv require a declared descriptor; pass-throughs (bufferDelay/Merge/Quiet) validate the propagated descriptor. The runtime-derived copy-out stages (cudaCopyFromRingbuffer, cudaOutputData, iceBoardShuffle) stay on set_frame_desc, which now validates against config when one is declared. Updates the consumer pytest cases accordingly.