### PR TITLE
Python: remove Python2 support

### DIFF
--- a/python/kotekan/__init__.py
+++ b/python/kotekan/__init__.py
@@ -1,9 +1,3 @@
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
 from ._version import get_versions
 
 # Should probably set this from the overall kotekan version

--- a/python/kotekan/baseband_buffer.py
+++ b/python/kotekan/baseband_buffer.py
@@ -1,12 +1,5 @@
 """Read a BasebandBuffer dump into python.
 """
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 import ctypes
 import glob
 import numpy as np

--- a/python/kotekan/frbbuffer.py
+++ b/python/kotekan/frbbuffer.py
@@ -1,12 +1,5 @@
 """Read a frbBuffer dump into python.
 """
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 import ctypes
 import os
 import io

--- a/python/kotekan/hfbbuffer.py
+++ b/python/kotekan/hfbbuffer.py
@@ -1,12 +1,5 @@
 """Read a HFBBuffer dump into python.
 """
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 import ctypes
 import os
 import io

--- a/python/kotekan/n2buffer.py
+++ b/python/kotekan/n2buffer.py
@@ -1,12 +1,5 @@
 """Read an N2Buffer dump into python.
 """
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 import ctypes
 import os
 import io

--- a/python/kotekan/psrbuffer.py
+++ b/python/kotekan/psrbuffer.py
@@ -1,12 +1,5 @@
 """Read a pulsarPostProcess dump into python.
 """
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 from ctypes import Structure, c_uint, c_uint8, c_uint32, sizeof
 import os
 import io

--- a/python/kotekan/pulsar_timing.py
+++ b/python/kotekan/pulsar_timing.py
@@ -1,11 +1,3 @@
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
-
 import numpy as np
 import tempfile
 from subprocess import run, CalledProcessError

--- a/python/kotekan/runner.py
+++ b/python/kotekan/runner.py
@@ -1,14 +1,5 @@
 """Use Python to run a kotekan instance, particularly for testing.
 """
-
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
-
 import itertools
 import json
 import os

--- a/python/kotekan/scripts/ctl.py
+++ b/python/kotekan/scripts/ctl.py
@@ -1,11 +1,3 @@
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
-
 import requests
 from requests.compat import urljoin, urlsplit
 import click

--- a/python/kotekan/scripts/polyco_tools.py
+++ b/python/kotekan/scripts/polyco_tools.py
@@ -1,10 +1,3 @@
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 import click
 import yaml
 import json

--- a/python/kotekan/timespec.py
+++ b/python/kotekan/timespec.py
@@ -1,10 +1,3 @@
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 import ctypes
 
 import numpy as np

--- a/python/kotekan/visbuffer.py
+++ b/python/kotekan/visbuffer.py
@@ -1,12 +1,5 @@
 """Read a visBuffer dump into python.
 """
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 import ctypes
 import os
 import io

--- a/python/kotekan/visutil.py
+++ b/python/kotekan/visutil.py
@@ -1,11 +1,5 @@
 """Miscellaneous utilities.
 """
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
 
 
 class prod_ctype(object):

--- a/python/scripts/kernel_utilization.py
+++ b/python/scripts/kernel_utilization.py
@@ -1,10 +1,3 @@
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 import requests
 from tabulate import tabulate
 import os

--- a/python/scripts/make_pdf_vis.py
+++ b/python/scripts/make_pdf_vis.py
@@ -2,13 +2,6 @@
 
 # Imports
 
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 import sys
 import matplotlib
 

--- a/python/scripts/make_pdf_vis.py
+++ b/python/scripts/make_pdf_vis.py
@@ -1,4 +1,4 @@
-#!/opt/anaconda/bin/python
+#!/usr/bin/env python3
 
 # Imports
 

--- a/python/scripts/pyPlotN2.py
+++ b/python/scripts/pyPlotN2.py
@@ -1,10 +1,3 @@
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 import numpy as np
 import matplotlib
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,10 +1,3 @@
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 from os import path
 from setuptools import setup, find_packages
 import versioneer

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,3 @@
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 #
 # Configures tests based upon command line arguments to pytest
 #

--- a/tests/notest_baseband_readout.py
+++ b/tests/notest_baseband_readout.py
@@ -1,10 +1,3 @@
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 from collections import defaultdict
 from dataclasses import dataclass
 import os

--- a/tests/notest_fringestop.py
+++ b/tests/notest_fringestop.py
@@ -1,14 +1,3 @@
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-import astropy.constants as const
-import astropy.units as units
-import astropy.time
-import erfa
-
-# === End Python 2/3 compatibility
-
 import pytest
 import numpy as np
 

--- a/tests/notest_n2_accumulate_multifreq.py
+++ b/tests/notest_n2_accumulate_multifreq.py
@@ -1,10 +1,3 @@
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 import pytest
 import numpy as np
 

--- a/tests/test_accumulate.py
+++ b/tests/test_accumulate.py
@@ -1,10 +1,3 @@
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 import pytest
 import numpy as np
 

--- a/tests/test_accumulate_multifreq.py
+++ b/tests/test_accumulate_multifreq.py
@@ -1,10 +1,3 @@
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 import pytest
 import numpy as np
 

--- a/tests/test_applygains.py
+++ b/tests/test_applygains.py
@@ -1,10 +1,3 @@
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 import pytest
 import numpy as np
 import h5py

--- a/tests/test_badinputflag.py
+++ b/tests/test_badinputflag.py
@@ -1,10 +1,3 @@
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 import pytest
 import numpy as np
 import time

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -1,10 +1,3 @@
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 import pytest
 import numpy as np
 

--- a/tests/test_countcheck.py
+++ b/tests/test_countcheck.py
@@ -1,10 +1,3 @@
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 import pytest
 import time
 

--- a/tests/test_dataset_broker.py
+++ b/tests/test_dataset_broker.py
@@ -1,10 +1,3 @@
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 import pytest
 import os.path
 import re

--- a/tests/test_fake_pulsar.py
+++ b/tests/test_fake_pulsar.py
@@ -1,10 +1,3 @@
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 import pytest
 import numpy as np
 

--- a/tests/test_frb_post_process.py
+++ b/tests/test_frb_post_process.py
@@ -1,10 +1,3 @@
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 import glob
 import pytest
 from os import path

--- a/tests/test_freqsplit.py
+++ b/tests/test_freqsplit.py
@@ -1,10 +1,3 @@
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 import pytest
 import numpy as np
 import os

--- a/tests/test_freqsubset.py
+++ b/tests/test_freqsubset.py
@@ -1,10 +1,3 @@
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 import pytest
 import numpy as np
 import os

--- a/tests/test_inputsubset.py
+++ b/tests/test_inputsubset.py
@@ -1,10 +1,3 @@
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 import pytest
 import numpy as np
 

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -1,10 +1,3 @@
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 #
 # Script to run each of the CHIME verification tests
 #

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1,10 +1,3 @@
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 import pytest
 import numpy as np
 

--- a/tests/test_n2_time_downsample.py
+++ b/tests/test_n2_time_downsample.py
@@ -1,10 +1,3 @@
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 import pytest
 import numpy as np
 from astropy.time import Time, TimeDelta

--- a/tests/test_networkbuffer.py
+++ b/tests/test_networkbuffer.py
@@ -1,10 +1,3 @@
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 import concurrent.futures
 import pytest
 import os

--- a/tests/test_prodsubset_autos.py
+++ b/tests/test_prodsubset_autos.py
@@ -1,10 +1,3 @@
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 import pytest
 import numpy as np
 import h5py

--- a/tests/test_prodsubset_baseline.py
+++ b/tests/test_prodsubset_baseline.py
@@ -1,10 +1,3 @@
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 import pytest
 import numpy as np
 

--- a/tests/test_prodsubset_have_inputs.py
+++ b/tests/test_prodsubset_have_inputs.py
@@ -1,10 +1,3 @@
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 import pytest
 import numpy as np
 

--- a/tests/test_prodsubset_only_inputs.py
+++ b/tests/test_prodsubset_only_inputs.py
@@ -1,10 +1,3 @@
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 import pytest
 import numpy as np
 

--- a/tests/test_psr_post_process.py
+++ b/tests/test_psr_post_process.py
@@ -1,10 +1,3 @@
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 import glob
 import itertools
 import pytest

--- a/tests/test_rawviswriter.py
+++ b/tests/test_rawviswriter.py
@@ -1,10 +1,3 @@
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 import pytest
 import numpy as np
 import h5py

--- a/tests/test_receiveflags.py
+++ b/tests/test_receiveflags.py
@@ -1,10 +1,3 @@
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 import pytest
 import numpy as np
 import pdb

--- a/tests/test_replacevis.py
+++ b/tests/test_replacevis.py
@@ -1,10 +1,3 @@
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 import pytest
 import numpy as np
 

--- a/tests/test_sample_autocorr.py
+++ b/tests/test_sample_autocorr.py
@@ -1,10 +1,3 @@
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 """SampleAutocorr is a REST-triggered on-demand stage; its compute kernel is the
 single-channel reduction of SimpleCrosscorr (AA only), which is covered
 end-to-end in ``test_simple_crosscorr.py``. The test here is therefore a

--- a/tests/test_simple_crosscorr.py
+++ b/tests/test_simple_crosscorr.py
@@ -1,10 +1,3 @@
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 import os
 import struct
 

--- a/tests/test_time_downsample.py
+++ b/tests/test_time_downsample.py
@@ -1,10 +1,3 @@
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 import pytest
 import numpy as np
 

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,10 +1,3 @@
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 import pytest
 import numpy as np
 

--- a/tests/test_transpose.py
+++ b/tests/test_transpose.py
@@ -1,10 +1,3 @@
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 import pytest
 import numpy as np
 import h5py

--- a/tests/test_truncate.py
+++ b/tests/test_truncate.py
@@ -1,10 +1,3 @@
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 import pytest
 import numpy as np
 

--- a/tests/test_valve.py
+++ b/tests/test_valve.py
@@ -1,10 +1,3 @@
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 import pytest
 import numpy as np
 

--- a/tests/test_vissharedmem_validation.py
+++ b/tests/test_vissharedmem_validation.py
@@ -1,10 +1,3 @@
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa pylint: disable=W0401, W0614
-
-# == End Python 2/3 compatibility
-
 import copy
 import logging
 import numpy as np

--- a/tests/test_vissharedmemreaderwriter.py
+++ b/tests/test_vissharedmemreaderwriter.py
@@ -1,10 +1,3 @@
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa pylint: disable=W0401, W0614
-
-# == End Python 2/3 compatibility
-
 import logging
 import numpy as np
 import os

--- a/tests/test_vissharedmemwriter.py
+++ b/tests/test_vissharedmemwriter.py
@@ -1,10 +1,3 @@
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa pylint: disable=W0401, W0614
-
-# == End Python 2/3 compatibility
-
 import mmap
 import os
 import posix_ipc

--- a/tests/test_vistestpattern.py
+++ b/tests/test_vistestpattern.py
@@ -1,10 +1,3 @@
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 import pytest
 import numpy as np
 import csv

--- a/tests/test_viswriter.py
+++ b/tests/test_viswriter.py
@@ -1,10 +1,3 @@
-# === Start Python 2/3 compatibility
-from __future__ import absolute_import, division, print_function, unicode_literals
-from future.builtins import *  # noqa  pylint: disable=W0401, W0614
-from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
-
-# === End Python 2/3 compatibility
-
 import pytest
 import numpy as np
 import h5py


### PR DESCRIPTION
this patch removes "future" packages that were introduced to support both Python3 and Python2 but that are missing from very modern Python3 installations.