### PR TITLE
various fixes to quantizer and frb beams codes

### DIFF
--- a/lib/stages/givenDataGen.cpp
+++ b/lib/stages/givenDataGen.cpp
@@ -1,16 +1,11 @@
 #include "givenDataGen.hpp"
 
 #include "DataType.hpp"        // for type_total_bytes, string_to_type, DataType
-#include "DataType.hpp"        // for type_total_bytes, string_to_type, DataType
 #include "NDArray.hpp"         // for GenericNDArray, Config
 #include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
-#include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
 #include "bufferContainer.hpp" // for bufferContainer
-#include "bufferContainer.hpp" // for bufferContainer
-#include "chordMetadata.hpp"   // for chordMetadata, get_chord_metadata, CHORD_META_MAX_DIM
 #include "chordMetadata.hpp"   // for chordMetadata, get_chord_metadata, CHORD_META_MAX_DIM
 
-#include "fmt.hpp" // for format
 #include "fmt.hpp" // for format
 
 #include <assert.h>   // for assert
@@ -34,7 +29,8 @@ REGISTER_KOTEKAN_STAGE(givenDataGen);
 givenDataGen::givenDataGen(Config& config, const std::string& unique_name,
                            bufferContainer& buffer_container) :
     Stage(config, unique_name, buffer_container, std::bind(&givenDataGen::main_thread, this)),
-    _out_buf(get_buffer("out_buf")), _values(config.get<std::vector<int>>(unique_name, "values")),
+    _out_buf(get_buffer("out_buf")),
+    _values(config.get<std::vector<long double>>(unique_name, "values")),
     _name(config.get<kotekan::Symbol>(unique_name, "name")),
     _datatype(kotekan::string_to_type(config.get<std::string>(unique_name, "datatype"))),
     _array_shape(config.get<std::vector<ptrdiff_t>>(unique_name, "array_shape")),
@@ -89,12 +85,48 @@ void givenDataGen::main_thread() {
             break;
 
         const size_t type_size = kotekan::type_total_bytes(_datatype);
+        const bool is_float = kotekan::type_to_string(_datatype).find("float") != std::string::npos;
+        const bool is_int = kotekan::type_to_string(_datatype).find("int") != std::string::npos;
+        const bool is_complex = kotekan::type_to_string(_datatype)[0] == 'c';
+        if (!(is_float + is_int == 1)) {
+            FATAL_ERROR("Unexpected data type: {:s} which is not either int or float",
+                  kotekan::type_to_string(_datatype));
+        }
+        if (is_complex) {
+            FATAL_ERROR("Cannot currently handle complex type: {:s}", kotekan::type_to_string(_datatype));
+        }
         for (size_t i = 0; i < _values.size(); ++i) {
-            // this really makes all kinds of asusmptions
-            // only works for integers
-            // only works on little endian machines
             assert((i + 1) * type_size <= _out_buf->frame_size && "Out of bounds access");
-            std::memcpy(frame + i * type_size, &_values.at(i), type_size);
+            if (is_float) {
+                switch (_datatype) {
+                    case kotekan::float16: {
+                        const float16_t hval =
+                            static_cast<float16_t>(static_cast<double>(_values[i]));
+                        static_assert(sizeof(hval) == kotekan::type_total_bytes(kotekan::float16));
+                        std::memcpy(frame + i * type_size, &hval, type_size);
+                    } break;
+                    case kotekan::float32: {
+                        const float fval = static_cast<float>(_values[i]);
+                        static_assert(sizeof(fval) == kotekan::type_total_bytes(kotekan::float32));
+                        std::memcpy(frame + i * type_size, &fval, type_size);
+                    } break;
+                    case kotekan::float64: {
+                        const double dval = static_cast<double>(_values[i]);
+                        static_assert(sizeof(dval) == kotekan::type_total_bytes(kotekan::float64));
+                        std::memcpy(frame + i * type_size, &dval, type_size);
+                    } break;
+                    default:
+                        FATAL_ERROR("Unexpected data type: {:s}", kotekan::type_to_string(_datatype));
+                        break;
+                }
+            } else if (is_int) {
+                // this really makes all kinds of asusmptions
+                // only works on little endian machines
+                const long long ival = static_cast<long long>(_values[i]);
+                std::memcpy(frame + i * type_size, &ival, type_size);
+            } else {
+                assert(0 && "Should not ever be reached");
+            }
         }
 
         _out_buf->allocate_new_metadata_object(frame_id);

--- a/lib/stages/givenDataGen.hpp
+++ b/lib/stages/givenDataGen.hpp
@@ -21,7 +21,7 @@
  *         @buffer_format any format
  *         @buffer_metadata chordMetadata
  *
- * @conf  values                Vector of ints.
+ * @conf  values                Vector of values.
  * @conf  name                  String. Name of the quantity being set.
  * @conf  datatype              String. Kotekan datatype name.
  * @conf  array_shape           Vector of ints. Size of each dimension.
@@ -39,7 +39,7 @@ public:
 
 private:
     Buffer* const _out_buf;
-    const std::vector<int> _values;
+    const std::vector<long double> _values;
     const kotekan::Symbol _name;
     const kotekan::DataType _datatype;
     const std::vector<std::ptrdiff_t> _array_shape;

--- a/lib/testing/testDataGenFloat.cpp
+++ b/lib/testing/testDataGenFloat.cpp
@@ -1,5 +1,6 @@
 #include "testDataGenFloat.hpp"
 
+#include "CHORDTelescope.hpp"  // for CHORDTelescope
 #include "Config.hpp"          // for Config
 #include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
 #include "buffer.hpp"          // for Buffer
@@ -46,6 +47,34 @@ testDataGenFloat::testDataGenFloat(Config& config, const std::string& unique_nam
     _samples_per_data_set = config.get<uint32_t>(unique_name, "samples_per_data_set");
     _first_frame_index = config.get_default<uint32_t>(unique_name, "first_frame_index", 0);
     _gen_all_const_data = config.get_default<bool>(unique_name, "gen_all_const_data", false);
+
+    _name = config.get_default<std::string>(unique_name, "name", "E");
+    const int type_size = sizeof(float);
+    _array_shape = config.get_default<std::vector<int>>(
+        unique_name, "array_shape", std::vector<int>({int(buf->frame_size) / type_size}));
+    {
+        size_t sz = type_size;
+        for (int s : _array_shape)
+            sz *= s;
+        if (sz != buf->frame_size)
+            // clang-format off
+            throw std::invalid_argument("testDataGen: product of 'array_shape' config setting must equal the buffer frame size");
+        // clang-format on
+    }
+    _dim_name = config.get_default<std::vector<std::string>>(unique_name, "dim_name",
+                                                             std::vector<std::string>({"D"}));
+    if (_array_shape.size() != _dim_name.size()) {
+        throw std::invalid_argument("testDataGen: 'array_shape' and 'dim_name' config "
+                                    "settings must be the same length!");
+    }
+
+    // TODO: rename this parameter to `num_freq_per_stream` in the config
+    _num_freq_in_frame = config.get_default<size_t>(unique_name, "num_local_freq", 1);
+    _manual_freq_ids = config.get_default<std::vector<uint32_t>>(unique_name, "manual_freq_ids",
+                                                                 std::vector<uint32_t>());
+
+    _meta_time_downsample_factor =
+        config.get_default<int>(unique_name, "meta_time_downsample_factor", 1);
 }
 
 testDataGenFloat::~testDataGenFloat() {}
@@ -53,6 +82,7 @@ testDataGenFloat::~testDataGenFloat() {}
 void testDataGenFloat::main_thread() {
 
     int frame_id = 0;
+    int frame_id_abs = 0;
     float* frame = nullptr;
     uint64_t seq_num = _samples_per_data_set * _first_frame_index;
     bool finished_seeding_consant = false;
@@ -60,16 +90,64 @@ void testDataGenFloat::main_thread() {
 
     int link_id = 0;
 
+    auto& telescope = Telescope::instance();
+    std::string telescope_type = telescope.get_name();
+
     while (!stop_thread) {
         frame = (float*)buf->wait_for_empty_frame(unique_name, frame_id);
         if (frame == nullptr)
             break;
 
         buf->allocate_new_metadata_object(frame_id);
-        get_chord_metadata(buf, frame_id)->set_fpga_seq_num(seq_num);
+        std::shared_ptr<chordMetadata> chordmeta = get_chord_metadata(buf, frame_id);
+        chordmeta->set_fpga_seq_num(seq_num);
 
+        // TODO: Fix this, cannot change from frame to frame (and should not be "now")
         gettimeofday(&now, nullptr);
-        get_chord_metadata(buf, frame_id)->set_first_packet_recv_time(now);
+        chordmeta->set_first_packet_recv_time(now);
+
+        chordmeta->set_name(_name);
+        chordmeta->dims = (int)_array_shape.size();
+        for (int d = 0; d < chordmeta->dims; ++d)
+            chordmeta->set_array_dimension(d, _array_shape[d], _dim_name[d], _dim_scaling[d]);
+        chordmeta->set_strides_simple();
+
+        chordmeta->type = kotekan::float32;
+
+        // Set frequency channel metadata
+
+        assert(_num_freq_in_frame <= CHORD_META_MAX_FREQ);
+        std::vector<int> coarse_freq(_num_freq_in_frame);
+        std::vector<int> freq_upchan_factor(coarse_freq.size());
+        std::vector<int> freq_upchan_index(coarse_freq.size());
+        for (int f = 0; f < static_cast<int>(coarse_freq.size()); f++) {
+            if (_manual_freq_ids.size() > 0)
+                coarse_freq[f] = _manual_freq_ids[f % _manual_freq_ids.size()];
+            else if (telescope_type == "CHORDTelescope")
+                coarse_freq[f] = telescope.cast<CHORDTelescope>().min_science_freq_id() + f;
+            else
+                coarse_freq[f] = f;
+            freq_upchan_factor[f] = 1;
+            freq_upchan_index[f] = 0;
+        }
+
+        chordmeta->set_coarse_freq(coarse_freq);
+        chordmeta->set_freq_upchan_factor(freq_upchan_factor);
+        chordmeta->set_freq_upchan_index(freq_upchan_index);
+
+        chordmeta->set_frame_counter(frame_id_abs);
+
+        // this needs the decoded type
+        // could be moved into constructor, but need the bit of code above
+        /* new style array description */
+        const std::vector<ptrdiff_t> extents(_array_shape.begin(), _array_shape.end());
+        const std::vector<kotekan::Symbol> dimnames(_dim_name.begin(), _dim_name.end());
+        const std::vector<ptrdiff_t> dimscalings(_dim_scaling.begin(), _dim_scaling.end());
+
+        buf->ensure_frame_desc(kotekan::GenericNDArray::describe(chordmeta->type, _name, extents,
+                                                                 dimnames, dimscalings));
+        /* test that things are consistent */
+        chordmeta->check_frame_desc(buf->get_frame_desc<kotekan::GenericNDArray>());
 
         // std::random_device rd;
         // std::mt19937 gen(rd());
@@ -95,6 +173,7 @@ void testDataGenFloat::main_thread() {
 
         buf->mark_frame_full(unique_name, frame_id);
 
+        frame_id_abs += 1;
         frame_id = (frame_id + 1) % buf->num_frames;
 
         if (_pathfinder_test_mode == true) {

--- a/lib/testing/testDataGenFloat.cpp
+++ b/lib/testing/testDataGenFloat.cpp
@@ -49,7 +49,17 @@ testDataGenFloat::testDataGenFloat(Config& config, const std::string& unique_nam
     _gen_all_const_data = config.get_default<bool>(unique_name, "gen_all_const_data", false);
 
     _name = config.get_default<std::string>(unique_name, "name", "E");
-    const int type_size = sizeof(float);
+
+    _value_type = kotekan::string_to_type(
+        config.get_default<std::string>(unique_name, "value_type", "float32"));
+    if(!(_value_type == kotekan::float16 || _value_type == kotekan::float32 || _value_type == kotekan::float64)) {
+        FATAL_ERROR(
+            "value_type must be on of {:s}, {:s}, or {:s}, but got {:s}",
+            kotekan::type_to_string(kotekan::float16), kotekan::type_to_string(kotekan::float32),
+            kotekan::type_to_string(kotekan::float64), kotekan::type_to_string(_value_type));
+    }
+
+    const int type_size = kotekan::type_total_bytes(_value_type);
     _array_shape = config.get_default<std::vector<int>>(
         unique_name, "array_shape", std::vector<int>({int(buf->frame_size) / type_size}));
     {
@@ -83,7 +93,7 @@ void testDataGenFloat::main_thread() {
 
     int frame_id = 0;
     int frame_id_abs = 0;
-    float* frame = nullptr;
+    void* frame = nullptr;
     uint64_t seq_num = _samples_per_data_set * _first_frame_index;
     bool finished_seeding_consant = false;
     static struct timeval now;
@@ -94,7 +104,7 @@ void testDataGenFloat::main_thread() {
     std::string telescope_type = telescope.get_name();
 
     while (!stop_thread) {
-        frame = (float*)buf->wait_for_empty_frame(unique_name, frame_id);
+        frame = (void*)buf->wait_for_empty_frame(unique_name, frame_id);
         if (frame == nullptr)
             break;
 
@@ -112,7 +122,7 @@ void testDataGenFloat::main_thread() {
             chordmeta->set_array_dimension(d, _array_shape[d], _dim_name[d], _dim_scaling[d]);
         chordmeta->set_strides_simple();
 
-        chordmeta->type = kotekan::float32;
+        chordmeta->type = _value_type;
 
         // Set frequency channel metadata
 
@@ -154,18 +164,36 @@ void testDataGenFloat::main_thread() {
         // std::uniform_int_distribution<> dis(0, 255);
         if (type == "random")
             srand(seed);
-        for (uint j = 0; j < buf->frame_size / sizeof(float); ++j) {
+        const uint type_size = kotekan::type_total_bytes(_value_type);
+        for (uint j = 0; j < buf->frame_size / type_size; ++j) {
+            float fvalue;
             if (type == "const") {
                 if (finished_seeding_consant)
                     break;
-                frame[j] = value;
+                fvalue = value;
             } else if (type == "ramp") {
-                frame[j] = fmod(j * value, 256 * value);
+                fvalue = fmod(j * value, 256 * value);
             } else if (type == "random") {
                 // Generate a random float between _rand_min and _rand_max
                 static std::mt19937 eng(seed);
                 static std::uniform_real_distribution<float> dis(_rand_min, _rand_max);
-                frame[j] = dis(eng);
+                fvalue = dis(eng);
+            } else {
+                throw std::runtime_error("Unexpected type " + type);
+            }
+            switch (_value_type) {
+                case kotekan::float16:
+                    static_cast<float16_t*>(frame)[j] = static_cast<float16_t>(fvalue);
+                    break;
+                case kotekan::float32:
+                    static_cast<float*>(frame)[j] = static_cast<float>(fvalue);
+                    break;
+                case kotekan::float64:
+                    static_cast<double*>(frame)[j] = static_cast<double>(fvalue);
+                    break;
+                default:
+                    throw std::runtime_error("Unexpected kotekan type: "
+                                             + kotekan::type_to_string(_value_type));
             }
         }
         usleep(83000);

--- a/lib/testing/testDataGenFloat.hpp
+++ b/lib/testing/testDataGenFloat.hpp
@@ -29,6 +29,14 @@ private:
     bool _gen_all_const_data;
     float _rand_min;
     float _rand_max;
+
+    std::string _name;
+    std::vector<int> _array_shape;
+    std::vector<std::string> _dim_name;
+    std::vector<ptrdiff_t> _dim_scaling;
+    size_t _num_freq_in_frame;
+    std::vector<uint32_t> _manual_freq_ids;
+    int _meta_time_downsample_factor;
 };
 
 #endif

--- a/lib/testing/testDataGenFloat.hpp
+++ b/lib/testing/testDataGenFloat.hpp
@@ -2,6 +2,7 @@
 #define TEST_DATA_GEN_FLOAT_H
 
 #include "Config.hpp"          // for Config
+#include "DataType.hpp"        // for datatype_t
 #include "Stage.hpp"           // for Stage
 #include "buffer.hpp"          // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
@@ -34,6 +35,7 @@ private:
     std::vector<int> _array_shape;
     std::vector<std::string> _dim_name;
     std::vector<ptrdiff_t> _dim_scaling;
+    kotekan::DataType _value_type;
     size_t _num_freq_in_frame;
     std::vector<uint32_t> _manual_freq_ids;
     int _meta_time_downsample_factor;


### PR DESCRIPTION
* corrects number of beams per FRB network packet in quantizers
* corrects documentation in L0_L1_packet file
* removes "custom" names from parseReorderDefault and uses the CHIMEfoo names introduced recently
* Python fixes
* float16 / float64 support in testDataGenFloat
* new float support in givenDataGen (at least support without having to provide integer values that have the correct bit-patterns when interpreted as a float...)