### PR TITLE
Fix chime_upgrade_n2 config

### DIFF
--- a/config/chime_upgrade_n2.j2
+++ b/config/chime_upgrade_n2.j2
@@ -151,7 +151,7 @@ host_voltage_buffers:
   num_frames: baseband_buffer_depth
   value_type: int4x2_swapped_withoffset
   extents: [1, samples_per_data_set * num_elements * num_freq_host_buf / 2048, 2048]
-  dimnames: [F, T, E]
+  dimnames: ["F", "T", "E"]
   metadata_pool: main_pool
   use_hugepages: true
   numa_0:
@@ -524,7 +524,7 @@ host_rfi_S012_ringbuffer:
     ring_buffer_size: gpu_buffer_depth * sizeof_uint64 * num_dishes * num_polarizations * 3 * num_freq_gpu_buf * rfi_num_times
     type: uint64
     dimnames: ["Trfi", "F", "S", "P", "D"]
-    shape: [gpu_buffer_depth * rfi_num_times, num_freq_gpu_buf, 3, num_polarizations, num_dishes]
+    extents: [gpu_buffer_depth * rfi_num_times, num_freq_gpu_buf, 3, num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 host_rfi_S012bar_ringbuffer:
@@ -533,7 +533,7 @@ host_rfi_S012bar_ringbuffer:
     ring_buffer_size: gpu_buffer_depth * sizeof_uint64 * num_dishes * num_polarizations * 3 * num_freq_gpu_buf * rfi_num_times_bar
     type: uint64
     dimnames: ["Trfibar", "F", "S", "P", "D"]
-    shape: [gpu_buffer_depth * rfi_num_times_bar, num_freq_gpu_buf, 3, num_polarizations, num_dishes]
+    extents: [gpu_buffer_depth * rfi_num_times_bar, num_freq_gpu_buf, 3, num_polarizations, num_dishes]
     metadata_pool: main_pool
 
 host_rfi_S012tilde_ringbuffer:
@@ -542,7 +542,7 @@ host_rfi_S012tilde_ringbuffer:
     ring_buffer_size: gpu_buffer_depth * sizeof_uint64 * 3 * num_freq_gpu_buf * rfi_num_times
     type: uint64
     dimnames: ["Trfi", "F", "S"]
-    shape: [gpu_buffer_depth * rfi_num_times, num_freq_gpu_buf, 3]
+    extents: [gpu_buffer_depth * rfi_num_times, num_freq_gpu_buf, 3]
     metadata_pool: main_pool
 
 host_rfi_SKtilde_buffer:
@@ -559,7 +559,7 @@ host_rfi_SKtilde_ringbuffer:
     ring_buffer_size: gpu_buffer_depth * sizeof_float32 * 3 * num_freq_gpu_buf * rfi_num_times
     type: float32
     dimnames: ["Trfi", "F", "S"]
-    shape: [gpu_buffer_depth * rfi_num_times, num_freq_gpu_buf, 3]
+    extents: [gpu_buffer_depth * rfi_num_times, num_freq_gpu_buf, 3]
     metadata_pool: main_pool
 
 host_rfi_RFImask_buffer:
@@ -576,7 +576,7 @@ host_rfi_RFImask_ringbuffer:
     ring_buffer_size: gpu_buffer_depth * num_freq_gpu_buf * samples_per_data_set / 8
     type: uint1x8
     dimnames: ["T8hi128", "F", "T8lo128"]
-    shape: [gpu_buffer_depth * samples_per_data_set / 8 / 128, num_freq_gpu_buf, 128]
+    extents: [gpu_buffer_depth * samples_per_data_set / 8 / 128, num_freq_gpu_buf, 128]
     metadata_pool: main_pool
 
 host_rfi_SKbar_buffer:
@@ -592,7 +592,7 @@ host_rfi_SKbar_ringbuffer:
     ring_buffer_size: gpu_buffer_depth * sizeof_float32 * num_dishes * num_polarizations * 3 * num_freq_gpu_buf * rfi_num_times_bar
     type: float32
     dimnames: ["Trfi", "F", "S", "P", "D"]
-    shape: [gpu_buffer_depth * rfi_num_times_bar, num_freq_gpu_buf, 3, num_polarizaions, num_dishes]
+    extents: [gpu_buffer_depth * rfi_num_times_bar, num_freq_gpu_buf, 3, num_polarizaions, num_dishes]
     metadata_pool: main_pool
 
 host_rfi_SKbartilde_buffer:
@@ -608,7 +608,7 @@ host_rfi_SKbartilde_ringbuffer:
     ring_buffer_size: gpu_buffer_depth * sizeof_float32 * 3 * num_freq_gpu_buf * rfi_num_times_bar
     type: float32
     dimnames: ["Trfi", "F", "S"]
-    shape: [gpu_buffer_depth * rfi_num_times_bar, num_freq_gpu_buf, 3]
+    extents: [gpu_buffer_depth * rfi_num_times_bar, num_freq_gpu_buf, 3]
     metadata_pool: main_pool
 
 # The mask for second stage RFI excision.
@@ -1127,30 +1127,15 @@ write_failed_vis:
     in_buf: failed_vis_buffer_post
 
 # System to optionally dump sk statistics data
-host_rfi_SKtilde_buffer:
-    kotekan_buffer: standard
-    num_frames: host_buffer_depth
-    frame_size: sizeof_float32 * 3 * num_freq_gpu_buf * rfi_num_times
-    type: float32
-    dimnames: ["Trfi", "F", "S"]
-    shape: [rfi_num_times, num_freq_gpu_buf, 3]
-    metadata_pool: main_pool
 host_rfi_SKtilde_buffer_post:
-    kotekan_buffer: standard
+    kotekan_buffer: ndarray
     num_frames: host_buffer_depth
     frame_size: sizeof_float32 * 3 * num_freq_gpu_buf * rfi_num_times
-    type: float32
+    value_type: float32
     dimnames: ["Trfi", "F", "S"]
-    shape: [rfi_num_times, num_freq_gpu_buf, 3]
+    extents: [rfi_num_times, num_freq_gpu_buf, 3]
     metadata_pool: main_pool
-host_rfi_SKtilde_ringbuffer:
-    kotekan_buffer: ring
-    num_frames: gpu_buffer_depth
-    ring_buffer_size: gpu_buffer_depth * sizeof_float32 * 3 * num_freq_gpu_buf * rfi_num_times
-    type: float32
-    dimnames: ["Trfi", "F", "S"]
-    shape: [gpu_buffer_depth * rfi_num_times, num_freq_gpu_buf, 3]
-    metadata_pool: main_pool
+
 run_recv_rfi_SKtilde:
     gpu_0:
         kotekan_stage: cudaProcess
@@ -1169,12 +1154,14 @@ run_recv_rfi_SKtilde:
           output_size: sizeof_float32 * 3 * num_freq_gpu_buf * rfi_num_times
           ring_buffer_size: gpu_buffer_depth * output_size
           out_buf: host_rfi_SKtilde_buffer
+
 switch_sk_out:
     kotekan_stage: bufferSwitch
     in_bufs:
       - enabled: host_rfi_SKtilde_buffer
     out_buf: host_rfi_SKtilde_buffer_post
     updatable_config: /updatable_config/enable_sk_out
+
 dump_rfi_SKtilde:
     kotekan_stage: hdf5FileWrite
     log_level: warn

--- a/lib/dpdk/iceBoardShuffle.hpp
+++ b/lib/dpdk/iceBoardShuffle.hpp
@@ -489,6 +489,9 @@ inline bool iceBoardShuffle::advance_frames(uint64_t new_seq, bool first_time) {
         meta->dim[0] = 1;
         meta->dim[1] = out_bufs[i]->frame_size / sample_size;
         meta->dim[2] = sample_size;
+        meta->dim_scaling[0] = 1;
+        meta->dim_scaling[1] = 1;
+        meta->dim_scaling[2] = 1;
         meta->set_strides_simple();
         // frame_desc set in constructor
         /* test that things are consistent */
@@ -540,6 +543,7 @@ inline bool iceBoardShuffle::advance_frames(uint64_t new_seq, bool first_time) {
 
     std::strncpy(meta->dim_name[0], "T", sizeof meta->dim_name[0]);
     meta->dim[0] = lost_samples_buf->frame_size; // One byte per time sample
+    meta->dim_scaling[0] = 1;
     meta->dims = 1;
     std::strncpy(meta->name, "lost_samples", sizeof meta->name);
     meta->set_strides_simple();

--- a/lib/stages/lostSamplesToN2Counts.cpp
+++ b/lib/stages/lostSamplesToN2Counts.cpp
@@ -1,28 +1,16 @@
 #include "lostSamplesToN2Counts.hpp"
 
 #include "Config.hpp"          // for Config
-#include "Config.hpp"          // for Config
 #include "DataType.hpp"        // for DataType, GetType_t
-#include "DataType.hpp"        // for DataType, GetType_t
-#include "N2Util.hpp"          // for frameID, modulo
 #include "N2Util.hpp"          // for frameID, modulo
 #include "NDArray.hpp"         // for NDArray, GenericNDArray, Config
 #include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
-#include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
-#include "buffer.hpp"          // for Buffer
 #include "buffer.hpp"          // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
-#include "bufferContainer.hpp" // for bufferContainer
-#include "chordMetadata.hpp"   // for chordMetadata, get_chord_metadata
 #include "chordMetadata.hpp"   // for chordMetadata, get_chord_metadata
 #include "div.hpp"             // for num_triangle_blocks
-#include "div.hpp"             // for num_triangle_blocks
-#include "kotekanLogging.hpp"  // for FATAL_ERROR, DEBUG
 #include "kotekanLogging.hpp"  // for FATAL_ERROR, DEBUG
 
-#include "fmt.hpp"  // for compile_string_to_view, format
-#include "fmt.hpp"  // for compile_string_to_view, format
-#include "json.hpp" // for basic_json, json, iter_impl
 #include "json.hpp" // for basic_json, json, iter_impl
 
 #include <functional> // for bind, function
@@ -104,10 +92,6 @@ lostSamplesToN2Counts::lostSamplesToN2Counts(Config& config, const std::string& 
             "Number of lost_samples buffers ({:d}) does not evenly divide total frequencies ({:d})",
             _nbufs, num_n2k_freq);
 
-    // rfi_mask's shape is established and validated by its producer; this stage
-    // works from frame_size and config (checked above), so it only requires that
-    // a descriptor was declared rather than re-asserting the full shape.
-    rfi_mask_buf->require_frame_desc();
 
     // This is a bit of a misnomer - the lost_samples buffer does not _include_
     // multiple frequencies, but information may be shared by multiple frequencies
@@ -130,6 +114,12 @@ lostSamplesToN2Counts::lostSamplesToN2Counts(Config& config, const std::string& 
                     n2k_counts_buf->frame_size, _expected_counts_frame_size);
 
     // Set the frame description
+    rfi_mask_buf->require_frame_desc(
+        kotekan::NDArray<kotekan::GetType_t<kotekan::uint1x8>, 3>::describe(
+            "RFImask",
+            {static_cast<ptrdiff_t>(samples_per_data_set) / 1024,
+             static_cast<ptrdiff_t>(num_n2k_freq), 1024 / 8},
+            {"T8hi128", "F", "T8lo128"}, {1024, 1, 8}));
     // The buffer name and axis names are the same as those set in
     // cudaPL1butCorrelator
     n2k_counts_buf->require_frame_desc(


### PR DESCRIPTION
- Use `extents` instead of 'shape' parameter
- Remove duplicate definitions of `host_rfi_SKtilde_buffer` and `host_rfi_SKtilde_ringbuffer`