### PR TITLE
Add optional config usage tracking

### DIFF
--- a/config/ci-tests/cpu_batch/run_n2accum.yaml
+++ b/config/ci-tests/cpu_batch/run_n2accum.yaml
@@ -7,9 +7,6 @@ log_level: INFO
 
 buffer_depth: 4
 cpu_affinity: [2]  # [2,3,4,5,8,9,10,11]
-sizeof_float: 4
-frame_arrival_period: 5.12e-6 * samples_per_data_set
-sizeof_int: 4
 
 # For faster CHORD testing, we're using...
 sub_integration_ntime: 2048
@@ -17,7 +14,6 @@ samples_per_data_set: 4096
 rfi_downsampling_factor: 256
 # sub_integration_ntime: 8192  # ~40 ms for chord
 # samples_per_data_set: 8192   # 
-num_times: samples_per_data_set
 num_polarizations: 2
 num_dishes: 64
 num_elements: num_polarizations * num_dishes
@@ -168,13 +164,10 @@ gen_fake_corr_counts:
     kotekan_stage: testN2kGen
     out_buf: fake_correlation_buffer
     out_counts_buf: fake_counts_buffer
-    in_rfimask_buf: fake_rfimask_buffer
     correlation_type: "f_times_ee"
     counts_type: "random_scalar"
     correlation_value: [1, -1]
     counts_value: sub_integration_ntime
-    counts_min: 0
-    counts_max: sub_integration_ntime
     mul_correlation_by_counts: true
     num_frames: frames_to_generate
     freq_ids: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
@@ -237,3 +230,4 @@ writers:
         file_name: n2_vis_posdef
         in_buf: n2_buffer
         max_frames: num_local_freq * n2_frames_to_write # Will trigger exit after writing this many frames
+log_config_usage: fatal_error

--- a/config/ci-tests/cpu_batch/run_n2accum_chime.yaml
+++ b/config/ci-tests/cpu_batch/run_n2accum_chime.yaml
@@ -7,15 +7,11 @@ log_level: INFO
 
 buffer_depth: 4
 cpu_affinity: [2]  # [2,3,4,5,8,9,10,11]
-sizeof_float: 4
-frame_arrival_period: 2.56e-6 * samples_per_data_set
-sizeof_int: 4
 
 # For faster CHIME testing, we're using...
 sub_integration_ntime: 2048
 samples_per_data_set: 4096
 rfi_downsampling_factor: 256
-num_times: samples_per_data_set
 num_polarizations: 2
 num_dishes: 64
 num_elements: num_polarizations * num_dishes
@@ -149,13 +145,10 @@ gen_fake_corr_counts:
     kotekan_stage: testN2kGen
     out_buf: fake_correlation_buffer
     out_counts_buf: fake_counts_buffer
-    in_rfimask_buf: fake_rfimask_buffer
     correlation_type: "f_times_ee"
     counts_type: "random_scalar"
     correlation_value: [1, -1]
     counts_value: sub_integration_ntime
-    counts_min: 0
-    counts_max: sub_integration_ntime
     mul_correlation_by_counts: true
     num_frames: frames_to_generate
     freq_ids: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
@@ -195,47 +188,41 @@ writers:
         kotekan_stage: hdf5FileWrite
         file_name: n2k_corr
         in_buf: fake_correlation_buffer
-        input_order: CHIMEBeamformer
 
     write_fake_counts:
         kotekan_stage: hdf5FileWrite
         file_name: n2k_counts
         in_buf: fake_counts_buffer
-        input_order: CHIMEBeamformer
 
     write_fake_rfimask:
         kotekan_stage: hdf5FileWrite
         file_name: n2k_rfimask
         in_buf: fake_rfimask_buffer
-        input_order: CHIMEBeamformer
 
     write_fake_rficounts:
         kotekan_stage: hdf5FileWrite
         file_name: n2k_rficounts
         in_buf: fake_rficounts_buffer
-        input_order: CHIMEBeamformer
 
     write_fake_plcounts:
         kotekan_stage: hdf5FileWrite
         file_name: n2k_plcounts
         in_buf: fake_plcounts_buffer
-        input_order: CHIMEBeamformer
 
     write_fake_rfi_frame_mask:
         kotekan_stage: hdf5FileWrite
         file_name: n2k_rfiframemask
         in_buf: fake_rfi_frame_mask_buffer
-        input_order: CHIMEBeamformer
 
     write_N2:
         kotekan_stage: hdf5FileWrite
         file_name: n2_vis_posdef
         in_buf: n2_buffer
         max_frames: num_local_freq * n2_frames_to_write # Will trigger exit after writing this many frames
-        input_order: CHIMEBeamformer
 
     write_vis:
         kotekan_stage: rawFileWrite
         file_name: vis
         in_buf: vis_buffer
         file_ext: raw
+log_config_usage: fatal_error

--- a/config/ci-tests/cpu_batch/test_lostSamplesToPLMask.yaml
+++ b/config/ci-tests/cpu_batch/test_lostSamplesToPLMask.yaml
@@ -10,7 +10,6 @@ cpu_affinity: [0, 1]
 
 num_dishes: 1024
 num_polarizations: 2
-num_elements: num_dishes * num_polarizations
 num_freq_bins: 3 # actual CHIME has 4, but then its 4 bins of 4 freqs each, which is a worse test case
 
 
@@ -94,24 +93,20 @@ writers:
         kotekan_stage: hdf5FileWrite
         file_name: lost_samples_buffer_0
         in_buf: lost_samples_buffer_0
-        input_order: CHIMEBeamformer
     lost_samples_1:
         kotekan_stage: hdf5FileWrite
         file_name: lost_samples_buffer_1
         in_buf: lost_samples_buffer_1
-        input_order: CHIMEBeamformer
     lost_samples_2:
         kotekan_stage: hdf5FileWrite
         file_name: lost_samples_buffer_2
         in_buf: lost_samples_buffer_2
-        input_order: CHIMEBeamformer
     out_pl_mask:
         kotekan_stage: hdf5FileWrite
         file_name: out_pl_mask_buffer
         in_buf: out_pl_mask_buffer
-        input_order: CHIMEBeamformer
     cmp_pl_mask:
         kotekan_stage: hdf5FileWrite
         file_name: cmp_pl_mask_buffer
         in_buf: cmp_pl_mask_buffer
-        input_order: CHIMEBeamformer
+log_config_usage: fatal_error

--- a/config/ci-tests/cpu_batch/test_send_recv.yaml
+++ b/config/ci-tests/cpu_batch/test_send_recv.yaml
@@ -142,7 +142,6 @@ buffer_send_standard:
     buf: send_buffer
     server_ip: 127.0.0.1
     server_port: 11024
-    retry_time: 1.0
     drop_frames: false
 
 buffer_recv_standard:
@@ -169,7 +168,6 @@ buffer_send_standard_noCT:
     buf: send_buffer_noCT
     server_ip: 127.0.0.1
     server_port: 11026
-    retry_time: 1.0
     drop_frames: false
 
 buffer_recv_standard_NoCT:
@@ -187,7 +185,6 @@ fake_n2:
     log_level: WARN
     kotekan_stage: FakeN2
     out_buf: send_N2_buffer
-    num_total_freq: 3
     cadence: 0.2
     wait: false
     mode: default
@@ -198,7 +195,6 @@ buffer_send_n2:
     buf: send_N2_buffer
     server_ip: 127.0.0.1
     server_port: 11025
-    retry_time: 1.0
     drop_frames: false
 
 buffer_recv_n2:
@@ -224,7 +220,6 @@ buffer_send_ndarray:
     buf: send_ndarray_buffer
     server_ip: 127.0.0.1
     server_port: 11027
-    retry_time: 1.0
     drop_frames: false
 
 buffer_recv_ndarray:
@@ -250,7 +245,6 @@ buffer_send_ndarray_nolabel:
     buf: send_ndarray_nolabel_buffer
     server_ip: 127.0.0.1
     server_port: 11028
-    retry_time: 1.0
     drop_frames: false
 
 buffer_recv_ndarray_nolabel:
@@ -314,3 +308,4 @@ buffer_monitor:
         - recv_ndarray_buffer
         - recv_ndarray_nolabel_buffer
     clean_exit_after_frames: 6 # Trigger success after this many frames have been seen
+log_config_usage: fatal_error

--- a/config/ci-tests/cpu_batch/verify_lost_samples_n2k_counts.yaml
+++ b/config/ci-tests/cpu_batch/verify_lost_samples_n2k_counts.yaml
@@ -10,10 +10,7 @@ type: config
 log_level: INFO
 
 cpu_affinity: [0, 1]
-num_gpus: 1
 
-frame_arrival_period: 5.12e-6 * samples_per_data_set
-sizeof_int: 4
 
 num_dishes: 64   # Needs to be CHORD/Pathfinder compatible.
 num_polarizations: 2
@@ -21,7 +18,6 @@ num_elements: num_polarizations * num_dishes
 num_freq_bins: 3 # actual CHIME has 4, but then its 4 bins of 4 freqs each, which is a worse test case
 num_local_freq: 4 *  num_freq_bins
 
-input_order: CHIMEBeamformer
 
 pl_mask_downsampling_factor: 2
 pl_mask_dishes_per_bin: 8
@@ -34,7 +30,6 @@ counts_num_blocks: (counts_num_blocks_lin * (counts_num_blocks_lin + 1)) / 2
 buffer_depth: 5
 samples_per_data_set: 2048
 sub_integration_ntime: 1024
-num_times: samples_per_data_set
   # num_frame_samples: pl_mask_hilo_split * pl_mask_downsampling_factor * 2  # 2 pl_mask tiles worth of samples
 
 # Pools
@@ -298,3 +293,4 @@ writers:
         file_name: ls_counts
         in_buf: host_ls_counts_buffer
 
+log_config_usage: fatal_error

--- a/config/ci-tests/gpu_batch/test_n2k_writeHDF5.yaml
+++ b/config/ci-tests/gpu_batch/test_n2k_writeHDF5.yaml
@@ -16,13 +16,9 @@ log_level: INFO
 #timesamples_per_packet: 2
 
 #num_data_sets: 1
-num_gpus: 1
 buffer_depth: 4
-num_gpu_frames: 4
 cpu_affinity: [2, 3, 4, 5, 8, 9, 10, 11]
-sizeof_float: 4
 frame_arrival_period: 0.00000256 * samples_per_data_set
-sizeof_int: 4
 
 # For faster CHORD testing, we're using...
 sub_integration_ntime: 1024
@@ -35,7 +31,6 @@ num_dishes: 64
 num_elements: 128
 num_local_freq: 16
 
-input_order: CHIMEBeamformer
 
 # vis matrix size
 vis_blocks_tr_root: (num_elements + 1) / 16
@@ -168,3 +163,4 @@ write_n2k_correlation:
     skip_writing: false
     in_buf: host_correlation_buffer
 
+log_config_usage: fatal_error

--- a/config/ci-tests/gpu_batch/test_pl_mask_upchannelizer.yaml
+++ b/config/ci-tests/gpu_batch/test_pl_mask_upchannelizer.yaml
@@ -16,3 +16,4 @@ test_pl_mask_upchannelizer:
     kotekan_stage: testPLMaskUpchannelizer
     # Safety cap for the GPU-vs-CPU sweep in debug builds (the test runs in a few seconds).
     join_timeout: 60
+log_config_usage: fatal_error

--- a/config/ci-tests/gpu_batch/test_quantize4.yaml
+++ b/config/ci-tests/gpu_batch/test_quantize4.yaml
@@ -11,3 +11,4 @@ num_dishes: 512
 
 test_quantize_kernel_4:
     kotekan_stage: testQuantizeKernel4
+log_config_usage: fatal_error

--- a/config/ci-tests/gpu_batch/test_quantize8.yaml
+++ b/config/ci-tests/gpu_batch/test_quantize8.yaml
@@ -11,3 +11,4 @@ num_dishes: 512
 
 test_quantize_kernel_8:
     kotekan_stage: testQuantizeKernel8
+log_config_usage: fatal_error

--- a/config/ci-tests/gpu_batch/test_quantize8chime.yaml
+++ b/config/ci-tests/gpu_batch/test_quantize8chime.yaml
@@ -11,3 +11,4 @@ num_dishes: 512
 
 test_quantize_kernel_8_chime:
     kotekan_stage: testQuantizeKernel8Chime
+log_config_usage: fatal_error

--- a/config/ci-tests/gpu_batch/verify_cuda_n2k.yaml
+++ b/config/ci-tests/gpu_batch/verify_cuda_n2k.yaml
@@ -12,12 +12,9 @@ type: config
 # Note DEBUG and DEBUG2 require a build with (-DCMAKE_BUILD_TYPE=Debug)
 log_level: INFO
 
-num_gpus: 1
 buffer_depth: 4
 cpu_affinity: [2, 3, 4, 5, 8, 9, 10, 11]
-sizeof_float: 4
 frame_arrival_period: 5.12e-6 * samples_per_data_set
-sizeof_int: 4
 
 # For faster CHORD testing, we're using...
 sub_integration_ntime: 512
@@ -290,3 +287,4 @@ check_counts_data:
     num_frames_to_test: 2*buffer_depth
     trigger_exit_on_pass: false
     check_metadata: true
+log_config_usage: fatal_error

--- a/config/ci-tests/gpu_batch/verify_cuda_n2k_corr.yaml
+++ b/config/ci-tests/gpu_batch/verify_cuda_n2k_corr.yaml
@@ -12,12 +12,9 @@ type: config
 # Note DEBUG and DEBUG2 require a build with (-DCMAKE_BUILD_TYPE=Debug)
 log_level: INFO
 
-num_gpus: 1
 buffer_depth: 4
 cpu_affinity: [2, 3, 4, 5, 8, 9, 10, 11]
-sizeof_float: 4
 frame_arrival_period: 5.12e-6 * samples_per_data_set
-sizeof_int: 4
 
 # For faster CHORD testing, we're using...
 sub_integration_ntime: 512
@@ -31,9 +28,6 @@ num_elements: num_polarizations * num_dishes
 num_local_freq: 8
 
 #counts matrix size
-counts_blocksize: 8
-counts_num_blocks_lin: (num_elements / 8) / counts_blocksize
-counts_num_blocks: (counts_num_blocks_lin * (counts_num_blocks_lin + 1)) / 2
 
 # vis matrix size
 vis_blocksize: 16
@@ -171,3 +165,4 @@ check_data:
     second_buf: simulated_correlation_buffer
     num_frames_to_test: buffer_depth
     check_metadata: true
+log_config_usage: fatal_error

--- a/config/ci-tests/gpu_batch/verify_cuda_n2k_pl1bitcorr.yaml
+++ b/config/ci-tests/gpu_batch/verify_cuda_n2k_pl1bitcorr.yaml
@@ -12,12 +12,9 @@ type: config
 # Note DEBUG and DEBUG2 require a build with (-DCMAKE_BUILD_TYPE=Debug)
 log_level: INFO
 
-num_gpus: 1
 buffer_depth: 4
 cpu_affinity: [2, 3, 4, 5, 8, 9, 10, 11]
-sizeof_float: 4
 frame_arrival_period: 5.12e-6 * samples_per_data_set
-sizeof_int: 4
 
 # For faster CHORD testing, we're using...
 sub_integration_ntime: 2048
@@ -168,3 +165,4 @@ check_data:
     second_buf: simulated_counts_buffer
     num_frames_to_test: buffer_depth
     check_metadata: true
+log_config_usage: fatal_error

--- a/config/ci-tests/gpu_batch/verify_cuda_n2k_plexp.yaml
+++ b/config/ci-tests/gpu_batch/verify_cuda_n2k_plexp.yaml
@@ -12,15 +12,11 @@ type: config
 # Note DEBUG and DEBUG2 require a build with (-DCMAKE_BUILD_TYPE=Debug)
 log_level: INFO
 
-num_gpus: 1
 buffer_depth: 4
 cpu_affinity: [2, 3, 4, 5, 8, 9, 10, 11]
-sizeof_float: 4
 frame_arrival_period: 5.12e-6 * samples_per_data_set
-sizeof_int: 4
 
 # For faster CHORD testing, we're using...
-sub_integration_ntime: 2048
 samples_per_data_set: 4096
 # sub_integration_ntime: 8192  # ~40 ms for chord
 # samples_per_data_set: 8192   # 
@@ -137,3 +133,4 @@ check_data:
     second_buf: simulated_pl_mask_exp_buffer
     num_frames_to_test: buffer_depth
     check_metadata: true
+log_config_usage: fatal_error

--- a/config/ci-tests/gpu_batch/verify_cuda_pl_accum.yaml
+++ b/config/ci-tests/gpu_batch/verify_cuda_pl_accum.yaml
@@ -12,12 +12,9 @@ type: config
 # Note DEBUG and DEBUG2 require a build with (-DCMAKE_BUILD_TYPE=Debug)
 log_level: INFO
 
-num_gpus: 1
 buffer_depth: 4
 cpu_affinity: [0]
-sizeof_float: 4
 sizeof_int: 4
-sizeof_long: 8
 
 # For faster CHORD testing, we're using...
 samples_per_data_set: 1024
@@ -126,3 +123,4 @@ check_pl_counts_data:
     max_num_errors_logged: 384
     num_frames_to_test: 2*buffer_depth
     check_metadata: true
+log_config_usage: fatal_error

--- a/config/ci-tests/gpu_batch/verify_cuda_rfi_s012.yaml
+++ b/config/ci-tests/gpu_batch/verify_cuda_rfi_s012.yaml
@@ -12,11 +12,8 @@ type: config
 # Note DEBUG and DEBUG2 require a build with (-DCMAKE_BUILD_TYPE=Debug)
 log_level: INFO
 
-num_gpus: 1
 buffer_depth: 4
 cpu_affinity: [0]
-sizeof_float: 4
-sizeof_int: 4
 sizeof_long: 8
 
 # For faster CHORD testing, we're using...
@@ -195,3 +192,4 @@ check_rfi_data:
     max_num_errors_logged: 384
     num_frames_to_test: 2*buffer_depth
     check_metadata: true
+log_config_usage: fatal_error

--- a/config/ci-tests/gpu_batch/verify_cuda_rfi_s012bar.yaml
+++ b/config/ci-tests/gpu_batch/verify_cuda_rfi_s012bar.yaml
@@ -12,11 +12,8 @@ type: config
 # Note DEBUG and DEBUG2 require a build with (-DCMAKE_BUILD_TYPE=Debug)
 log_level: INFO
 
-num_gpus: 1
 buffer_depth: 4
 cpu_affinity: [0]
-sizeof_float: 4
-sizeof_int: 4
 sizeof_long: 8
 
 # For faster CHORD testing, we're using...
@@ -144,3 +141,4 @@ check_rfi_data:
     max_num_errors_logged: 384
     num_frames_to_test: 2*buffer_depth
     check_metadata: true
+log_config_usage: fatal_error

--- a/config/ci-tests/gpu_batch/verify_cuda_rfi_s012tilde.yaml
+++ b/config/ci-tests/gpu_batch/verify_cuda_rfi_s012tilde.yaml
@@ -12,11 +12,8 @@ type: config
 # Note DEBUG and DEBUG2 require a build with (-DCMAKE_BUILD_TYPE=Debug)
 log_level: INFO
 
-num_gpus: 1
 buffer_depth: 4
 cpu_affinity: [0]
-sizeof_float: 4
-sizeof_int: 4
 sizeof_long: 8
 
 # For faster CHORD testing, we're using...
@@ -168,3 +165,4 @@ check_rfi_data:
     max_num_errors_logged: 64
     num_frames_to_test: 2 * buffer_depth
     check_metadata: true
+log_config_usage: fatal_error

--- a/config/ci-tests/gpu_batch/verify_cuda_rfi_skbar.yaml
+++ b/config/ci-tests/gpu_batch/verify_cuda_rfi_skbar.yaml
@@ -12,11 +12,9 @@ type: config
 # Note DEBUG and DEBUG2 require a build with (-DCMAKE_BUILD_TYPE=Debug)
 log_level: INFO
 
-num_gpus: 1
 buffer_depth: 4
 cpu_affinity: [0]
 sizeof_float: 4
-sizeof_int: 4
 sizeof_long: 8
 
 # For faster CHORD testing, we're using...
@@ -242,3 +240,4 @@ check_rfi_skbartilde_data:
 #   max_num_errors_logged: 64
 #   num_frames_to_test: 2 * buffer_depth
 #   check_metadata: True
+log_config_usage: fatal_error

--- a/config/ci-tests/gpu_batch/verify_cuda_rfi_sktilde.yaml
+++ b/config/ci-tests/gpu_batch/verify_cuda_rfi_sktilde.yaml
@@ -12,11 +12,9 @@ type: config
 # Note DEBUG and DEBUG2 require a build with (-DCMAKE_BUILD_TYPE=Debug)
 log_level: INFO
 
-num_gpus: 1
 buffer_depth: 4
 cpu_affinity: [0]
 sizeof_float: 4
-sizeof_int: 4
 sizeof_long: 8
 
 # For faster CHORD testing, we're using...
@@ -236,3 +234,4 @@ check_rfi_rfimask_data:
     max_num_errors_logged: 64
     num_frames_to_test: 2 * buffer_depth
     check_metadata: true
+log_config_usage: fatal_error

--- a/config/ci-tests/gpu_batch/verify_fake_n2k.yaml
+++ b/config/ci-tests/gpu_batch/verify_fake_n2k.yaml
@@ -5,12 +5,9 @@ type: config
 # Note DEBUG and DEBUG2 require a build with (-DCMAKE_BUILD_TYPE=Debug)
 log_level: INFO
 
-num_gpus: 1
 buffer_depth: 4
 cpu_affinity: [2]  # [2,3,4,5,8,9,10,11]
-sizeof_float: 4
 frame_arrival_period: 5.12e-6 * samples_per_data_set
-sizeof_int: 4
 
 # For faster CHORD testing, we're using...
 sub_integration_ntime: 2048
@@ -39,8 +36,6 @@ frames_to_test: 2 * buffer_depth
 # test values
 E_re: 3
 E_im: -5
-corr_re: (E_re * E_re + E_im * E_im) * sub_integration_ntime
-corr_im: 0
 
 # Pool
 main_pool:
@@ -155,7 +150,6 @@ gen_pl_mask:
 
 gen_fake_corr_counts:
     kotekan_stage: testN2kGen
-    in_rfimask_buf: host_rfi_RFImask_buffer
     out_buf: fake_correlation_buffer
     out_counts_buf: fake_counts_buffer
     correlation_type: "const"
@@ -281,3 +275,4 @@ check_counts_data:
     num_frames_to_test: frames_to_test
     trigger_exit_on_pass: false
     check_metadata: true
+log_config_usage: fatal_error

--- a/docs/sphinx/user/user_config.rst
+++ b/docs/sphinx/user/user_config.rst
@@ -194,12 +194,21 @@ and referenced by name in child blocks.
 Config usage tracking
 ---------------------
 
-Set the top-level ``log_config_usage: true`` to have kotekan record which config leaf items (scalar
+Set the top-level ``log_config_usage`` to have kotekan record which config leaf items (scalar
 values, strings, and lists -- not the object blocks that contain them) are actually read while a
-pipeline runs, and by which path. At shutdown an ``INFO`` summary is logged listing the accessed
-items (with the requesting base paths, typically stage ``unique_name``\ s) and the items that were
-never accessed. This is useful for spotting stale or misspelled config keys that no stage consumes.
-The feature is off by default and adds no overhead unless enabled.
+pipeline runs, and by which path. At shutdown a summary is logged listing the accessed items (with
+the requesting base paths, typically stage ``unique_name``\ s) and the items that were never
+accessed. This is useful for spotting stale or misspelled config keys that no stage consumes. The
+feature is off by default and adds no overhead unless enabled.
+
+The value selects how unused items are reported:
+
+- ``false`` (default) -- disabled.
+- ``true`` / ``info`` -- log the summary at ``INFO``.
+- ``warn`` / ``error`` -- log the summary at that severity when one or more items went unused
+  (otherwise ``INFO``).
+- ``fatal_error`` -- additionally fail kotekan with a non-zero exit when any item went unused. Useful
+  in CI to reject configs that carry stale parameters.
 
 Framework dispatch markers (``kotekan_buffer``, ``kotekan_stage``, ``kotekan_metadata_pool``,
 ``kotekan_update_endpoint``) are excluded from the summary: the factories and config updater consume

--- a/docs/sphinx/user/user_config.rst
+++ b/docs/sphinx/user/user_config.rst
@@ -191,6 +191,21 @@ parent scopes, then the root. Jinja2 templating can be used in ``.j2`` configs; 
 ``-e '{"key": "value"}'`` when invoking kotekan. Shared constants can be defined at higher levels
 and referenced by name in child blocks.
 
+Config usage tracking
+---------------------
+
+Set the top-level ``log_config_usage: true`` to have kotekan record which config leaf items (scalar
+values, strings, and lists -- not the object blocks that contain them) are actually read while a
+pipeline runs, and by which path. At shutdown an ``INFO`` summary is logged listing the accessed
+items (with the requesting base paths, typically stage ``unique_name``\ s) and the items that were
+never accessed. This is useful for spotting stale or misspelled config keys that no stage consumes.
+The feature is off by default and adds no overhead unless enabled.
+
+Framework dispatch markers (``kotekan_buffer``, ``kotekan_stage``, ``kotekan_metadata_pool``,
+``kotekan_update_endpoint``) are excluded from the summary: the factories and config updater consume
+those by walking the config tree directly rather than through a value lookup, so they would otherwise
+always appear as unused.
+
 REST server
 -----------
 

--- a/kotekan/kotekan.cpp
+++ b/kotekan/kotekan.cpp
@@ -418,9 +418,12 @@ void start_new_kotekan_mode(Config& config, bool dump_config) {
 
     // When enabled, record which config leaf items get read (and by which
     // path) so a usage summary can be logged at shutdown (see ~kotekanMode).
-    // Turned on here, before any values are read, so the summary is complete.
-    if (config.get_default<bool>("/", "log_config_usage", false))
-        config.set_track_access(true);
+    // The level (bool or "info"/"warn"/"error"/"fatal_error") sets the report
+    // severity; "fatal_error" fails kotekan if anything went unused. Turned on
+    // here, before any values are read, so the summary is complete.
+    if (config.exists("/", "log_config_usage"))
+        config.set_usage_report_level(
+            Config::parse_usage_report_level(config.get_value("/", "log_config_usage")));
 
     update_log_levels(config);
 

--- a/kotekan/kotekan.cpp
+++ b/kotekan/kotekan.cpp
@@ -415,6 +415,13 @@ void start_new_kotekan_mode(Config& config, bool dump_config) {
 
     if (dump_config)
         config.dump_config();
+
+    // When enabled, record which config leaf items get read (and by which
+    // path) so a usage summary can be logged at shutdown (see ~kotekanMode).
+    // Turned on here, before any values are read, so the summary is complete.
+    if (config.get_default<bool>("/", "log_config_usage", false))
+        config.set_track_access(true);
+
     update_log_levels(config);
 
     request_backtraces(config.get_default<std::vector<std::string>>("/", "trap_signals", {}));

--- a/lib/core/Config.cpp
+++ b/lib/core/Config.cpp
@@ -3,6 +3,7 @@
 #include "fmt.hpp"  // for compile_string_to_view, format, fmt
 #include "json.hpp" // for json, basic_json, iter_impl, operator>>
 
+#include <cctype>    // for tolower
 #include <cstddef>   // for size_t
 #include <cstdint>   // for int32_t, uint8_t
 #include <fstream>   // for basic_ifstream, basic_istream, ifstream
@@ -124,10 +125,10 @@ json Config::get_value(const std::string& base_path, const std::string& name) co
 
         json::json_pointer value_pointer(value_path);
         const json& value = _json.at(value_pointer);
-        // Note the access of a leaf value (not a branch/object) when tracking
-        // is enabled, attributed to the requesting base path.
-        if (_track_access && !value.is_object())
-            record_access(value_path, base_path);
+        // Note the access when tracking is enabled, attributed to the
+        // requesting base path. A whole-object fetch records all its leaves.
+        if (_usage_report_level != UsageReportLevel::off)
+            record_access(value_path, value, base_path);
         return value;
     }
     throw std::runtime_error(
@@ -172,13 +173,51 @@ void Config::dump_config() const {
     INFO_NON_OO("Config: {:s}", _json.dump(4));
 }
 
-void Config::set_track_access(bool enable) {
-    _track_access = enable;
+void Config::set_usage_report_level(UsageReportLevel level) {
+    _usage_report_level = level;
 }
 
-void Config::record_access(const std::string& leaf_path, const std::string& base_path) const {
+Config::UsageReportLevel Config::parse_usage_report_level(const json& value) {
+    if (value.is_boolean())
+        return value.get<bool>() ? UsageReportLevel::info : UsageReportLevel::off;
+    if (value.is_string()) {
+        std::string s = value.get<std::string>();
+        for (char& c : s)
+            c = std::tolower(static_cast<unsigned char>(c));
+        if (s == "off" || s == "none" || s == "false")
+            return UsageReportLevel::off;
+        if (s == "info" || s == "true" || s == "on")
+            return UsageReportLevel::info;
+        if (s == "warn" || s == "warning")
+            return UsageReportLevel::warn;
+        if (s == "error")
+            return UsageReportLevel::error;
+        if (s == "fatal" || s == "fatal_error")
+            return UsageReportLevel::fatal;
+    }
+    throw std::runtime_error(
+        fmt::format(fmt("Invalid log_config_usage value {:s}; expected a boolean or one of "
+                        "'off', 'info', 'warn', 'error', 'fatal_error'."),
+                    value.dump()));
+}
+
+void Config::record_access(const std::string& path, const json& value,
+                           const std::string& base_path) const {
     std::lock_guard<std::mutex> lock(access_lock);
-    _accessed[leaf_path].insert(base_path);
+    record_access_locked(path, value, base_path);
+}
+
+void Config::record_access_locked(const std::string& path, const json& value,
+                                  const std::string& base_path) const {
+    if (value.is_object()) {
+        // The caller fetched a whole block (e.g. gpuProcess reading its
+        // in_buffers/out_buffers map) and consumes every entry, so mark them all.
+        for (auto it = value.begin(); it != value.end(); ++it)
+            record_access_locked(fmt::format(fmt("{:s}/{:s}"), path, it.key()), it.value(),
+                                 base_path);
+    } else {
+        _accessed[path].insert(base_path);
+    }
 }
 
 // Leaves that are never read through get(): the framework dispatch markers
@@ -197,6 +236,11 @@ static bool is_framework_key(const std::string& path) {
 void Config::collect_leaf_paths(const json& j, const std::string& path,
                                 vector<std::string>& leaves) const {
     if (j.is_object()) {
+        // configUpdater-managed blocks are consumed via the update endpoint
+        // (a get_full_config_json() tree walk), not through get(), so their
+        // values never register as accessed -- don't count them.
+        if (j.contains("kotekan_update_endpoint"))
+            return;
         for (auto it = j.begin(); it != j.end(); ++it)
             collect_leaf_paths(it.value(), fmt::format(fmt("{:s}/{:s}"), path, it.key()), leaves);
     } else if (!is_framework_key(path)) {
@@ -205,7 +249,7 @@ void Config::collect_leaf_paths(const json& j, const std::string& path,
 }
 
 void Config::log_access_summary() const {
-    if (!_track_access)
+    if (_usage_report_level == UsageReportLevel::off)
         return;
 
     // Enumerate every leaf in the config, then split into accessed vs. not,
@@ -217,27 +261,60 @@ void Config::log_access_summary() const {
     std::string not_accessed;
     std::size_t n_accessed = 0;
 
-    std::lock_guard<std::mutex> lock(access_lock);
-    for (const std::string& leaf : leaves) {
-        auto it = _accessed.find(leaf);
-        if (it == _accessed.end()) {
-            not_accessed += fmt::format(fmt("\n    {:s}"), leaf);
-            continue;
+    {
+        std::lock_guard<std::mutex> lock(access_lock);
+        for (const std::string& leaf : leaves) {
+            auto it = _accessed.find(leaf);
+            if (it == _accessed.end()) {
+                not_accessed += fmt::format(fmt("\n    {:s}"), leaf);
+                continue;
+            }
+            n_accessed++;
+            std::string base_paths;
+            for (const std::string& base_path : it->second) {
+                if (!base_paths.empty())
+                    base_paths += ", ";
+                base_paths += base_path;
+            }
+            accessed += fmt::format(fmt("\n    {:s}  <- {:s}"), leaf, base_paths);
         }
-        n_accessed++;
-        std::string base_paths;
-        for (const std::string& base_path : it->second) {
-            if (!base_paths.empty())
-                base_paths += ", ";
-            base_paths += base_path;
-        }
-        accessed += fmt::format(fmt("\n    {:s}  <- {:s}"), leaf, base_paths);
     }
 
-    INFO_NON_OO("Config usage summary: {:d} of {:d} leaf items accessed.\n"
-                "  Accessed (item <- requesting paths):{:s}\n"
-                "  Not accessed:{:s}",
-                n_accessed, leaves.size(), accessed, not_accessed);
+    const std::size_t n_unused = leaves.size() - n_accessed;
+    const std::string summary =
+        fmt::format(fmt("Config usage summary: {:d} of {:d} leaf items accessed.\n"
+                        "  Accessed (item <- requesting paths):{:s}\n"
+                        "  Not accessed:{:s}"),
+                    n_accessed, leaves.size(), accessed, not_accessed);
+
+    // With nothing unused there is nothing to flag, regardless of level.
+    if (n_unused == 0) {
+        INFO_NON_OO("{:s}", summary);
+        return;
+    }
+
+    switch (_usage_report_level) {
+        case UsageReportLevel::warn:
+            WARN_NON_OO("{:s}", summary);
+            break;
+        case UsageReportLevel::error:
+            ERROR_NON_OO("{:s}", summary);
+            break;
+        case UsageReportLevel::fatal:
+            ERROR_NON_OO("{:s}", summary);
+            // Note: not FATAL_ERROR_NON_OO, which throws -- this runs from
+            // ~kotekanMode (a noexcept destructor). Set the error message and
+            // exit code directly so kotekan exits non-zero after teardown.
+            kotekanLogging::set_error_message(
+                fmt("Config usage: {:d} config item(s) were not accessed."), n_unused);
+            exit_kotekan(ReturnCode::FATAL_ERROR);
+            break;
+        case UsageReportLevel::info:
+        case UsageReportLevel::off:
+        default:
+            INFO_NON_OO("{:s}", summary);
+            break;
+    }
 }
 
 const json& Config::get_full_config_json() const {

--- a/lib/core/Config.cpp
+++ b/lib/core/Config.cpp
@@ -10,6 +10,7 @@
 #include <map>       // for map
 #include <mutex>     // for mutex, lock_guard
 #include <set>       // for set
+#include <sstream>   // for ostringstream
 #include <stdexcept> // for runtime_error
 #include <stdio.h>   // for sprintf
 #include <string>    // for string
@@ -257,8 +258,8 @@ void Config::log_access_summary() const {
     vector<std::string> leaves;
     collect_leaf_paths(_json, "", leaves);
 
-    std::string accessed;
-    std::string not_accessed;
+    std::ostringstream accessed;
+    std::ostringstream not_accessed;
     std::size_t n_accessed = 0;
 
     {
@@ -266,17 +267,19 @@ void Config::log_access_summary() const {
         for (const std::string& leaf : leaves) {
             auto it = _accessed.find(leaf);
             if (it == _accessed.end()) {
-                not_accessed += fmt::format(fmt("\n    {:s}"), leaf);
+                not_accessed << fmt::format(fmt("\n    {:s}"), leaf);
                 continue;
             }
             n_accessed++;
-            std::string base_paths;
+            std::ostringstream base_paths;
+            bool first = true;
             for (const std::string& base_path : it->second) {
-                if (!base_paths.empty())
-                    base_paths += ", ";
-                base_paths += base_path;
+                if (!first)
+                    base_paths << ", ";
+                first = false;
+                base_paths << base_path;
             }
-            accessed += fmt::format(fmt("\n    {:s}  <- {:s}"), leaf, base_paths);
+            accessed << fmt::format(fmt("\n    {:s}  <- {:s}"), leaf, base_paths.str());
         }
     }
 
@@ -285,7 +288,7 @@ void Config::log_access_summary() const {
         fmt::format(fmt("Config usage summary: {:d} of {:d} leaf items accessed.\n"
                         "  Accessed (item <- requesting paths):{:s}\n"
                         "  Not accessed:{:s}"),
-                    n_accessed, leaves.size(), accessed, not_accessed);
+                    n_accessed, leaves.size(), accessed.str(), not_accessed.str());
 
     // With nothing unused there is nothing to flag, regardless of level.
     if (n_unused == 0) {

--- a/lib/core/Config.cpp
+++ b/lib/core/Config.cpp
@@ -6,8 +6,12 @@
 #include <cstddef>   // for size_t
 #include <cstdint>   // for int32_t, uint8_t
 #include <fstream>   // for basic_ifstream, basic_istream, ifstream
+#include <map>       // for map
+#include <mutex>     // for mutex, lock_guard
+#include <set>       // for set
 #include <stdexcept> // for runtime_error
 #include <stdio.h>   // for sprintf
+#include <string>    // for string
 #include <vector>    // for vector
 
 #ifdef WITH_SSL
@@ -18,6 +22,11 @@ using nlohmann::json;
 using std::vector;
 
 namespace kotekan {
+
+// Guards Config::_accessed for all instances. Access tracking is an opt-in
+// diagnostic feature, so a single shared lock (rather than a per-instance
+// mutex, which would make Config non-copyable) is sufficient.
+static std::mutex access_lock;
 
 // Instantiation of the most common types to prevent them being built inline
 // everywhere used.
@@ -95,26 +104,31 @@ json Config::get_value(const std::string& base_path, const std::string& name) co
     std::string search_path = base_path;
     for (;;) {
 
+        // Resolve the value's full JSON pointer at the current search scope,
+        // walking up the tree until found. Behaviour matches the original
+        // chain of guards, but with a single exit so accesses can be recorded.
+        std::string value_path;
         if (search_path == "" && exists("/", name)) {
-            json::json_pointer value_pointer(fmt::format(fmt("/{:s}"), name));
-            return _json.at(value_pointer);
-        }
-
-        if (search_path == "")
+            value_path = fmt::format(fmt("/{:s}"), name);
+        } else if (search_path == "") {
             break;
-
-        if (search_path == "/" && exists(search_path, name)) {
-            json::json_pointer value_pointer(search_path + name);
-            return _json.at(value_pointer);
+        } else if (search_path == "/" && exists(search_path, name)) {
+            value_path = search_path + name;
+        } else if (exists(search_path, name)) {
+            value_path = fmt::format(fmt("{:s}/{:s}"), search_path, name);
+        } else {
+            std::size_t last_slash = search_path.find_last_of("/");
+            search_path = search_path.substr(0, last_slash);
+            continue;
         }
 
-        if (exists(search_path, name)) {
-            json::json_pointer value_pointer(fmt::format(fmt("{:s}/{:s}"), search_path, name));
-            return _json.at(value_pointer);
-        }
-
-        std::size_t last_slash = search_path.find_last_of("/");
-        search_path = search_path.substr(0, last_slash);
+        json::json_pointer value_pointer(value_path);
+        const json& value = _json.at(value_pointer);
+        // Note the access of a leaf value (not a branch/object) when tracking
+        // is enabled, attributed to the requesting base path.
+        if (_track_access && !value.is_object())
+            record_access(value_path, base_path);
+        return value;
     }
     throw std::runtime_error(
         fmt::format(fmt("The config option: {:s} is required, but was not found in the path: {:s}"),
@@ -156,6 +170,74 @@ void Config::get_value_recursive(const json& j, const std::string& name,
 
 void Config::dump_config() const {
     INFO_NON_OO("Config: {:s}", _json.dump(4));
+}
+
+void Config::set_track_access(bool enable) {
+    _track_access = enable;
+}
+
+void Config::record_access(const std::string& leaf_path, const std::string& base_path) const {
+    std::lock_guard<std::mutex> lock(access_lock);
+    _accessed[leaf_path].insert(base_path);
+}
+
+// Leaves that are never read through get(): the framework dispatch markers
+// (kotekan_buffer/kotekan_stage/kotekan_metadata_pool/kotekan_update_endpoint),
+// which the factories and configUpdater consume by walking get_full_config_json()
+// directly, plus the top-level meta keys. These are not tunable config values,
+// so excluding them keeps the usage summary focused on real settings.
+static bool is_framework_key(const std::string& path) {
+    const std::size_t slash = path.find_last_of('/');
+    const std::string key = (slash == std::string::npos) ? path : path.substr(slash + 1);
+    if (key.rfind("kotekan_", 0) == 0)
+        return true;
+    return path == "/type" || path == "/log_config_usage";
+}
+
+void Config::collect_leaf_paths(const json& j, const std::string& path,
+                                vector<std::string>& leaves) const {
+    if (j.is_object()) {
+        for (auto it = j.begin(); it != j.end(); ++it)
+            collect_leaf_paths(it.value(), fmt::format(fmt("{:s}/{:s}"), path, it.key()), leaves);
+    } else if (!is_framework_key(path)) {
+        leaves.push_back(path);
+    }
+}
+
+void Config::log_access_summary() const {
+    if (!_track_access)
+        return;
+
+    // Enumerate every leaf in the config, then split into accessed vs. not,
+    // using the paths recorded by get_value().
+    vector<std::string> leaves;
+    collect_leaf_paths(_json, "", leaves);
+
+    std::string accessed;
+    std::string not_accessed;
+    std::size_t n_accessed = 0;
+
+    std::lock_guard<std::mutex> lock(access_lock);
+    for (const std::string& leaf : leaves) {
+        auto it = _accessed.find(leaf);
+        if (it == _accessed.end()) {
+            not_accessed += fmt::format(fmt("\n    {:s}"), leaf);
+            continue;
+        }
+        n_accessed++;
+        std::string base_paths;
+        for (const std::string& base_path : it->second) {
+            if (!base_paths.empty())
+                base_paths += ", ";
+            base_paths += base_path;
+        }
+        accessed += fmt::format(fmt("\n    {:s}  <- {:s}"), leaf, base_paths);
+    }
+
+    INFO_NON_OO("Config usage summary: {:d} of {:d} leaf items accessed.\n"
+                "  Accessed (item <- requesting paths):{:s}\n"
+                "  Not accessed:{:s}",
+                n_accessed, leaves.size(), accessed, not_accessed);
 }
 
 const json& Config::get_full_config_json() const {

--- a/lib/core/Config.hpp
+++ b/lib/core/Config.hpp
@@ -15,7 +15,9 @@
 #include <exception>           // for exception
 #include <limits>              // for numeric_limits
 #include <list>                // for list
+#include <map>                 // for map
 #include <regex>               // for regex, regex_match, cmatch, sregex_token_iterator
+#include <set>                 // for set
 #include <stdexcept>           // for runtime_error
 #include <string>              // for basic_string, operator==, string, char_traits, allocator
 #include <type_traits>         // for is_arithmetic, is_integral, enable_if, is_same, conditional
@@ -265,9 +267,51 @@ public:
      */
     void dump_config() const;
 
+    /**
+     * @brief Enable or disable recording of config value accesses.
+     *
+     * When enabled, every leaf value returned by @c get_value() is recorded,
+     * together with the base path (typically a stage's unique name) that
+     * requested it. Branch (object) reads are not recorded; only leaf values
+     * count as "used". A summary of which leaf items were and were not used
+     * can then be logged with @c log_access_summary().
+     *
+     * Intended to be set once at startup, before any values are read, so the
+     * summary covers all framework and stage accesses.
+     *
+     * @param enable Whether to record accesses.
+     */
+    void set_track_access(bool enable);
+
+    /**
+     * @brief Log (at INFO) a summary of which config leaf items were accessed
+     *        and which were not, listing for each used item the base paths
+     *        (stages) that accessed it.
+     *
+     * Does nothing if access tracking was never enabled.
+     */
+    void log_access_summary() const;
+
 private:
     /// Internal json object
     nlohmann::json _json;
+
+    /// Whether to record config leaf accesses (see @c set_track_access()). Set
+    /// once at startup before stages run, so reads of it need no locking.
+    bool _track_access = false;
+
+    /// Resolved JSON pointer of each accessed leaf -> the base paths (stages)
+    /// that requested it. Only populated while @c _track_access is set.
+    mutable std::map<std::string, std::set<std::string>> _accessed;
+
+    /// Record one leaf access at resolved @c leaf_path requested from
+    /// @c base_path. Called by @c get_value() when tracking is enabled.
+    void record_access(const std::string& leaf_path, const std::string& base_path) const;
+
+    /// Append the JSON pointer of every leaf (non-object) node reachable from
+    /// @c j (built under @c path) to @c leaves. Helper for @c log_access_summary().
+    void collect_leaf_paths(const nlohmann::json& j, const std::string& path,
+                            std::vector<std::string>& leaves) const;
 
     /**
      * @brief Finds all values with key "name". Searches the given json.

--- a/lib/core/Config.hpp
+++ b/lib/core/Config.hpp
@@ -268,27 +268,56 @@ public:
     void dump_config() const;
 
     /**
-     * @brief Enable or disable recording of config value accesses.
+     * @brief Severity of the config-usage report logged at shutdown, and
+     *        whether unused items are treated as an error.
      *
-     * When enabled, every leaf value returned by @c get_value() is recorded,
-     * together with the base path (typically a stage's unique name) that
-     * requested it. Branch (object) reads are not recorded; only leaf values
-     * count as "used". A summary of which leaf items were and were not used
-     * can then be logged with @c log_access_summary().
+     * Selected from the top-level @c log_config_usage config value (see
+     * @c parse_usage_report_level()).
+     */
+    enum class UsageReportLevel {
+        off,   ///< Disabled (default): no tracking, no report.
+        info,  ///< Track; log the summary at INFO.
+        warn,  ///< Track; log the summary at WARN if any item was unused.
+        error, ///< Track; log the summary at ERROR if any item was unused.
+        fatal, ///< Track; fail kotekan (non-zero exit) if any item was unused.
+    };
+
+    /**
+     * @brief Set the config-usage report level (and thereby enable or disable
+     *        access tracking).
+     *
+     * Any level other than @c off records every leaf value returned by
+     * @c get_value(), together with the base path (typically a stage's unique
+     * name) that requested it. Branch (object) reads are not recorded; only
+     * leaf values count as "used". @c log_access_summary() then reports which
+     * items were and were not used, at the severity given here.
      *
      * Intended to be set once at startup, before any values are read, so the
      * summary covers all framework and stage accesses.
-     *
-     * @param enable Whether to record accesses.
      */
-    void set_track_access(bool enable);
+    void set_usage_report_level(UsageReportLevel level);
 
     /**
-     * @brief Log (at INFO) a summary of which config leaf items were accessed
-     *        and which were not, listing for each used item the base paths
-     *        (stages) that accessed it.
+     * @brief Parse a @c log_config_usage config value into a UsageReportLevel.
      *
-     * Does nothing if access tracking was never enabled.
+     * Accepts a boolean (@c false -> off, @c true -> info) or a string
+     * ("off"/"none", "info"/"true", "warn", "error", "fatal"/"fatal_error",
+     * case-insensitive).
+     *
+     * @throws std::runtime_error on any other value.
+     */
+    static UsageReportLevel parse_usage_report_level(const nlohmann::json& value);
+
+    /**
+     * @brief Log a summary of which config leaf items were accessed and which
+     *        were not, listing for each used item the base paths (stages) that
+     *        accessed it.
+     *
+     * The summary is logged at the level set via @c set_usage_report_level():
+     * @c info always logs at INFO; @c warn / @c error escalate to that
+     * severity when any item went unused; @c fatal additionally fails kotekan
+     * (non-zero exit) when any item went unused. Does nothing if tracking is
+     * @c off.
      */
     void log_access_summary() const;
 
@@ -296,20 +325,31 @@ private:
     /// Internal json object
     nlohmann::json _json;
 
-    /// Whether to record config leaf accesses (see @c set_track_access()). Set
-    /// once at startup before stages run, so reads of it need no locking.
-    bool _track_access = false;
+    /// Config-usage report level (see @c set_usage_report_level()). Tracking is
+    /// active for any level other than @c off. Set once at startup before
+    /// stages run, so reads of it need no locking.
+    UsageReportLevel _usage_report_level = UsageReportLevel::off;
 
     /// Resolved JSON pointer of each accessed leaf -> the base paths (stages)
-    /// that requested it. Only populated while @c _track_access is set.
+    /// that requested it. Only populated while tracking is active.
     mutable std::map<std::string, std::set<std::string>> _accessed;
 
-    /// Record one leaf access at resolved @c leaf_path requested from
-    /// @c base_path. Called by @c get_value() when tracking is enabled.
-    void record_access(const std::string& leaf_path, const std::string& base_path) const;
+    /// Record an access of the value at resolved @c path, requested from
+    /// @c base_path. If @c value is an object the caller fetched a whole block
+    /// (e.g. gpuProcess reading its @c in_buffers map), so every descendant
+    /// leaf is recorded; otherwise @c path itself is recorded. Called by
+    /// @c get_value() when tracking is enabled.
+    void record_access(const std::string& path, const nlohmann::json& value,
+                       const std::string& base_path) const;
+
+    /// Recursive worker for @c record_access(); caller must hold the access lock.
+    void record_access_locked(const std::string& path, const nlohmann::json& value,
+                              const std::string& base_path) const;
 
     /// Append the JSON pointer of every leaf (non-object) node reachable from
-    /// @c j (built under @c path) to @c leaves. Helper for @c log_access_summary().
+    /// @c j (built under @c path) to @c leaves. Skips framework markers and
+    /// configUpdater-managed (@c kotekan_update_endpoint) blocks, which are not
+    /// read through get(). Helper for @c log_access_summary().
     void collect_leaf_paths(const nlohmann::json& j, const std::string& path,
                             std::vector<std::string>& leaves) const;
 

--- a/lib/core/kotekanMode.cpp
+++ b/lib/core/kotekanMode.cpp
@@ -48,6 +48,10 @@ kotekanMode::kotekanMode(Config& config_) : config(config_) {
 
 kotekanMode::~kotekanMode() {
 
+    // Log which config items were used (and by which stage) if usage tracking
+    // was enabled. Done before tearing down stages, while config is intact.
+    config.log_access_summary();
+
     configUpdater::instance().reset();
     restServer::instance().remove_get_callback("/config");
     restServer::instance().remove_get_callback("/buffers");

--- a/tests/boost/test_config.cpp
+++ b/tests/boost/test_config.cpp
@@ -131,3 +131,33 @@ BOOST_AUTO_TEST_CASE(_get_value_recursive) {
     BOOST_CHECK(config.get_value(" ").empty());
     BOOST_CHECK(config.get_value("/").empty());
 }
+
+BOOST_AUTO_TEST_CASE(_access_tracking) {
+    json json_config = {
+        {"pi", 3.141},
+        {"unused_top", 7},
+        {"stage_a", {{"value", 10}, {"expr", "2 * pi"}}},
+        {"stage_b", {{"value", 20}, {"unused_b", 99}}},
+    };
+    Config config;
+    config.update_config(json_config);
+
+    // With tracking enabled, get() must still resolve values normally, while
+    // recording the resolved leaf paths and the requesting base paths.
+    config.set_track_access(true);
+
+    BOOST_CHECK_EQUAL(config.get<int>("/stage_a", "value"), 10);
+    BOOST_CHECK_EQUAL(config.get<int>("/stage_b", "value"), 20);
+    // stage_a/value reachable from a deeper scope (walks up the tree).
+    BOOST_CHECK_EQUAL(config.get_default<int>("/stage_a/child", "value", -1), 10);
+    // Expression evaluation reads "pi" via the top-level scope; that access is
+    // recorded too, attributed to the requesting stage path.
+    BOOST_CHECK_EQUAL(config.get<double>("/stage_a", "expr"), 2 * 3.141);
+
+    // Should run cleanly whether or not every item was touched; "unused_top"
+    // and "stage_b/unused_b" remain unaccessed and appear in the summary log.
+    config.log_access_summary();
+
+    // Tracking does not perturb subsequent reads.
+    BOOST_CHECK_EQUAL(config.get<int>("/stage_b", "value"), 20);
+}

--- a/tests/boost/test_config.cpp
+++ b/tests/boost/test_config.cpp
@@ -144,7 +144,7 @@ BOOST_AUTO_TEST_CASE(_access_tracking) {
 
     // With tracking enabled, get() must still resolve values normally, while
     // recording the resolved leaf paths and the requesting base paths.
-    config.set_track_access(true);
+    config.set_usage_report_level(Config::UsageReportLevel::info);
 
     BOOST_CHECK_EQUAL(config.get<int>("/stage_a", "value"), 10);
     BOOST_CHECK_EQUAL(config.get<int>("/stage_b", "value"), 20);
@@ -160,4 +160,24 @@ BOOST_AUTO_TEST_CASE(_access_tracking) {
 
     // Tracking does not perturb subsequent reads.
     BOOST_CHECK_EQUAL(config.get<int>("/stage_b", "value"), 20);
+}
+
+BOOST_AUTO_TEST_CASE(_parse_usage_report_level) {
+    using L = Config::UsageReportLevel;
+
+    // Boolean forms.
+    BOOST_CHECK(Config::parse_usage_report_level(json(false)) == L::off);
+    BOOST_CHECK(Config::parse_usage_report_level(json(true)) == L::info);
+
+    // String forms (case-insensitive), including aliases.
+    BOOST_CHECK(Config::parse_usage_report_level(json("off")) == L::off);
+    BOOST_CHECK(Config::parse_usage_report_level(json("info")) == L::info);
+    BOOST_CHECK(Config::parse_usage_report_level(json("WARN")) == L::warn);
+    BOOST_CHECK(Config::parse_usage_report_level(json("error")) == L::error);
+    BOOST_CHECK(Config::parse_usage_report_level(json("fatal_error")) == L::fatal);
+    BOOST_CHECK(Config::parse_usage_report_level(json("fatal")) == L::fatal);
+
+    // Anything else is a hard error so config typos are caught at startup.
+    BOOST_CHECK_THROW(Config::parse_usage_report_level(json("loud")), std::runtime_error);
+    BOOST_CHECK_THROW(Config::parse_usage_report_level(json(3)), std::runtime_error);
 }


### PR DESCRIPTION
## Summary

Adds an opt-in feature to track which config leaf items are actually read while a pipeline runs, and by which stage, plus the ability to **fail the run** when a config carries parameters no stage consumes. The `config/ci-tests` configs are cleaned of dead parameters and set to enforce this, so `run_tests.sh` rejects stale config going forward.

Set the top-level `log_config_usage`; at shutdown a summary lists the accessed items (with the requesting base paths, typically stage `unique_name`s) and the items never accessed. Off by default; no overhead unless enabled.

| value | behavior |
|---|---|
| `false` (default) | disabled |
| `true` / `info` | summary at INFO |
| `warn` / `error` | summary at that severity when any item went unused |
| `fatal_error` | **non-zero exit** when any item went unused (for CI) |

## Design

- **Single choke point.** All typed reads (`get<T>`, `get_default`, expression-variable lookups via `eval`) funnel through `Config::get_value(base_path, name)`, refactored to a single exit where accesses are recorded. Existing scope-walking resolution is unchanged (covered by the existing `test_config` cases).
- **Leaf, not branch**, attributed to the requesting `base_path`. A value resolved by walking up the tree is stored at its resolved leaf path.
- **Whole-block reads.** When `get_value` returns an *object* (e.g. `gpuProcess` reading its `in_buffers`/`out_buffers` map), every descendant leaf is recorded — the caller consumes the whole block.
- **Exclusions.** Framework dispatch markers (`kotekan_buffer`/`kotekan_stage`/`kotekan_metadata_pool`/`kotekan_update_endpoint`) and configUpdater-managed (`kotekan_update_endpoint`) blocks are excluded, since the factories and config updater consume those via a `get_full_config_json()` tree walk rather than `get()`.
- **Levels** parsed by `Config::parse_usage_report_level` (bool or string, case-insensitive; invalid value fails startup). The fatal path uses `exit_kotekan(FATAL_ERROR)` directly — `FATAL_ERROR_NON_OO` throws, and the summary runs from `~kotekanMode`, a `noexcept` destructor.

A `std::mutex` is intentionally not a `Config` member (would break the by-value `make_config` test helpers); the tracking map is guarded by a file-scope mutex.

## CI-test cleanup + enforcement

Removed parameters no stage reads in each pipeline — boilerplate `sizeof_*` constants, and genuinely-dead params verified against source: `retry_time` on `bufferSend`, `counts_max`/`counts_min` on `testN2kGen`, `input_order` on `hdf5FileWrite` writers, etc. (per-config: e.g. `frame_arrival_period` is dead in CPU configs but kept in GPU configs where `gpuProcess` reads it). Each config now sets `log_config_usage: fatal_error`.

## Testing

- `test_config` boost cases for access tracking and `parse_usage_report_level`.
- Ran all 21 `config/ci-tests/{cpu,gpu}_batch/*.yaml` on the real binary (2× A40): every config reports **N of N leaf items accessed** and exits 0. A negative test (injecting a bogus param) exits non-zero, and the level matrix behaves as specified (`info`/`warn`/`error`→exit 0, `fatal_error`→exit 1).

## Caveat

The summary reflects *runtime* accesses through `get()`. "Unused" means "not read in this execution" — a parameter read only on an untaken branch shows as unused. (This is the basis for the per-config cleanup above.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)