### PR TITLE
Fix frame hand-off race in applyGains and visCompression

### DIFF
--- a/lib/stages/applyGains.cpp
+++ b/lib/stages/applyGains.cpp
@@ -34,7 +34,7 @@
 #include "prometheusMetrics.hpp"     // for Metrics, Counter, Gauge
 #include "restClient.hpp"            // for restClient
 #include "visBuffer.hpp"             // for VisFrameView, VisField
-#include "visUtil.hpp"               // for modulo, cfloat, double_to_ts, ts_to_double, frameID
+#include "visUtil.hpp"               // for cfloat, double_to_ts, ts_to_double
 #include "fmt.hpp"                   // for compile_string_to_view, format, fmt, format_string
 #include "gsl-lite.hpp"              // for span
 
@@ -57,9 +57,9 @@ REGISTER_KOTEKAN_STAGE(applyGains);
 applyGains::applyGains(Config& config, const std::string& unique_name,
                        bufferContainer& buffer_container) :
     Stage(config, unique_name, buffer_container, std::bind(&applyGains::main_thread, this)),
-    in_buf(get_buffer("in_buf")), out_buf(get_buffer("out_buf")), frame_id_in(in_buf),
-    frame_id_out(out_buf), update_age_metric(Metrics::instance().add_gauge(
-                               "kotekan_applygains_update_age_seconds", unique_name)),
+    in_buf(get_buffer("in_buf")), out_buf(get_buffer("out_buf")),
+    update_age_metric(Metrics::instance().add_gauge("kotekan_applygains_update_age_seconds",
+                                                    unique_name)),
     late_update_counter(
         Metrics::instance().add_counter("kotekan_applygains_late_update_count", unique_name)),
     late_frames_counter(
@@ -92,6 +92,11 @@ applyGains::applyGains(Config& config, const std::string& unique_name,
     num_threads = config.get_default<uint32_t>(unique_name, "num_threads", 1);
     if (num_threads == 0)
         throw std::invalid_argument("applyGains: num_threads has to be at least 1.");
+
+    // One "in use" flag per buffer slot, so two apply threads never process the
+    // same frame concurrently when the cursor wraps onto a slot still in use.
+    in_frame_busy.assign(in_buf->num_frames, false);
+    out_frame_busy.assign(out_buf->num_frames, false);
 
     // FIFO for gains and weights updates
     gains_fifo.resize(num_kept_updates);
@@ -214,19 +219,17 @@ void applyGains::main_thread() {
     fetch_thread.join();
 }
 
+void applyGains::release_frame(std::vector<bool>& busy, int frame_id) {
+    {
+        std::lock_guard<std::mutex> lock(m_frame_ids);
+        busy[frame_id] = false;
+    }
+    frame_cv.notify_all();
+}
+
 void applyGains::apply_thread() {
 
     auto& dm = datasetManager::instance();
-
-    int output_frame_id;
-    int input_frame_id;
-
-    // Get the current values of the shared frame IDs and increment them.
-    {
-        std::lock_guard<std::mutex> lock_frame_ids(m_frame_ids);
-        output_frame_id = frame_id_out++;
-        input_frame_id = frame_id_in++;
-    }
 
     // Vectors for storing gains computed on the fly, keep out here so they are
     // only allocated once
@@ -236,8 +239,25 @@ void applyGains::apply_thread() {
 
     while (!stop_thread) {
 
+        // Claim the next input frame in order, blocking while its slot is still
+        // in use by another thread (the cursor has wrapped onto it).
+        int input_frame_id;
+        int output_frame_id = -1;
+        uint64_t seq;
+        {
+            std::unique_lock<std::mutex> lock(m_frame_ids);
+            while (in_frame_busy[claim_seq % in_buf->num_frames] && !stop_thread)
+                frame_cv.wait_for(lock, std::chrono::milliseconds(100));
+            if (stop_thread)
+                break;
+            input_frame_id = claim_seq % in_buf->num_frames;
+            in_frame_busy[input_frame_id] = true;
+            seq = claim_seq++;
+        }
+
         // Wait for the input buffer to be filled with data
         if (in_buf->wait_for_full_frame(unique_name, input_frame_id) == nullptr) {
+            release_frame(in_frame_busy, input_frame_id);
             break;
         }
 
@@ -245,8 +265,10 @@ void applyGains::apply_thread() {
         auto input_frame = VisFrameView(in_buf, input_frame_id);
 
         // Check that the input frame has the right sizes
-        if (!validate_frame(input_frame))
+        if (!validate_frame(input_frame)) {
+            release_frame(in_frame_busy, input_frame_id);
             return;
+        }
 
         // get the frames timestamp
         ts_frame.store(std::get<1>(input_frame.time));
@@ -256,21 +278,53 @@ void applyGains::apply_thread() {
         auto freq_ind = freq_map.at(input_frame.freq_id);
         auto frame_time = ts_to_double(std::get<1>(input_frame.time));
 
-        // Calculate the gain factors we need to apply to this frame
+        // Calculate the gain factors we need to apply to this frame. This is the
+        // parallel part: different threads compute gains for different frames at
+        // the same time.
         auto [late, age, state_id] =
             calculate_gain(frame_time, freq_ind, gain, gain_conj, weight_factor);
 
-        // Report number of frames received late and skip the frame entirely
+        // Take this frame's turn to publish, in claim order, so the output stays
+        // in temporal order. A late frame is dropped here without taking an
+        // output slot, keeping the output dense.
+        {
+            std::unique_lock<std::mutex> lock(m_frame_ids);
+            while (emit_seq != seq && !stop_thread)
+                frame_cv.wait_for(lock, std::chrono::milliseconds(100));
+            // When not late, also wait for the output slot (only contended when
+            // the output buffer has fewer frames than there are threads).
+            if (!stop_thread && !late) {
+                while (out_frame_busy[out_count % out_buf->num_frames] && !stop_thread)
+                    frame_cv.wait_for(lock, std::chrono::milliseconds(100));
+            }
+            if (stop_thread) {
+                lock.unlock();
+                in_buf->mark_frame_empty(unique_name, input_frame_id);
+                release_frame(in_frame_busy, input_frame_id);
+                break;
+            }
+            if (!late) {
+                output_frame_id = out_count % out_buf->num_frames;
+                out_frame_busy[output_frame_id] = true;
+                out_count++;
+            }
+            emit_seq++;
+            frame_cv.notify_all();
+        }
+
+        // Report number of frames received late and skip the frame entirely.
         if (late) {
             late_frames_counter.inc();
-            std::lock_guard<std::mutex> lock_frame_ids(m_frame_ids);
             in_buf->mark_frame_empty(unique_name, input_frame_id);
-            input_frame_id = frame_id_in++;
+            release_frame(in_frame_busy, input_frame_id);
             continue;
         }
 
         // Wait for the output buffer to be empty of data
         if (out_buf->wait_for_empty_frame(unique_name, output_frame_id) == nullptr) {
+            in_buf->mark_frame_empty(unique_name, input_frame_id);
+            release_frame(in_frame_busy, input_frame_id);
+            release_frame(out_frame_busy, output_frame_id);
             break;
         }
         out_buf->allocate_new_metadata_object(output_frame_id);
@@ -327,16 +381,11 @@ void applyGains::apply_thread() {
         // Report how old the gains being applied to the current data are.
         update_age_metric.set(age);
 
-        // Mark the buffers and move on
+        // Mark the buffers and release the slots for reuse.
         out_buf->mark_frame_full(unique_name, output_frame_id);
         in_buf->mark_frame_empty(unique_name, input_frame_id);
-
-        // Get the current values of the shared frame IDs.
-        {
-            std::lock_guard<std::mutex> lock_frame_ids(m_frame_ids);
-            output_frame_id = frame_id_out++;
-            input_frame_id = frame_id_in++;
-        }
+        release_frame(out_frame_busy, output_frame_id);
+        release_frame(in_frame_busy, input_frame_id);
     }
 }
 

--- a/lib/stages/applyGains.hpp
+++ b/lib/stages/applyGains.hpp
@@ -11,12 +11,13 @@
 #include "restClient.hpp"        // for restClient
 #include "updateQueue.hpp"       // for updateQueue
 #include "visBuffer.hpp"         // for VisFrameView
-#include "visUtil.hpp"           // for cfloat, frameID
+#include "visUtil.hpp"           // for cfloat
 
 #include "json.hpp" // for json
 
-#include <atomic>       // for atomic
-#include <ctime>        // for timespec, size_t
+#include <atomic>             // for atomic
+#include <condition_variable> // for condition_variable
+#include <ctime>              // for timespec, size_t
 #include <map>          // for map
 #include <mutex>        // for mutex
 #include <optional>     // for optional
@@ -145,14 +146,23 @@ private:
     /// Number of parallel threads accessing the same buffers (default 1)
     uint32_t num_threads;
 
-    /// Input frame ID, shared by apply threads.
-    frameID frame_id_in;
-
-    /// Output frame ID, shared by apply threads.
-    frameID frame_id_out;
-
-    /// Mutex protecting shared frame IDs.
+    /// Ordered cursors shared by the apply threads: threads claim input frames
+    /// in order (claim_seq), compute gains in parallel, then publish strictly in
+    /// claim order (emit_seq, output slot out_count) so the output stays in
+    /// temporal order. A "late" frame is dropped without taking an output slot.
+    /// The per-slot "busy" flags stop two threads sharing a wrapped slot, even
+    /// when num_threads exceeds the buffer depth. frame_cv wakes threads waiting
+    /// to claim, to take their emit turn, or for a slot to be released.
+    uint64_t claim_seq = 0;
+    uint64_t emit_seq = 0;
+    uint64_t out_count = 0;
     std::mutex m_frame_ids;
+    std::condition_variable frame_cv;
+    std::vector<bool> in_frame_busy;
+    std::vector<bool> out_frame_busy;
+
+    /// Release a slot and wake any thread waiting for it.
+    void release_frame(std::vector<bool>& busy, int frame_id);
 
     // Prometheus metrics
     kotekan::prometheus::Gauge& update_age_metric;

--- a/lib/stages/visCompression.cpp
+++ b/lib/stages/visCompression.cpp
@@ -2,7 +2,8 @@
 
 #include <pthread.h>              // for pthread_setaffinity_np
 #include <sched.h>                // for cpu_set_t, CPU_SET, CPU_ZERO
-#include <algorithm>              // for fill, equal
+#include <algorithm>              // for fill, equal, min
+#include <chrono>                 // for milliseconds
 #include <complex>                // for complex, conj, norm
 #include <functional>             // for function, bind, placeholders
 #include <future>                 // for async, future
@@ -23,7 +24,7 @@
 #include "kotekanLogging.hpp"     // for INFO, DEBUG, ERROR, FATAL_ERROR
 #include "prometheusMetrics.hpp"  // for Gauge, Counter, Metrics, MetricFamily
 #include "visBuffer.hpp"          // for VisFrameView, VisField
-#include "visUtil.hpp"            // for modulo, current_time, rstack_ctype, frameID, prod_ctype
+#include "visUtil.hpp"            // for current_time, rstack_ctype, prod_ctype
 #include "fmt.hpp"                // for compile_string_to_view, format
 #include "gsl-lite.hpp"           // for span
 
@@ -42,9 +43,9 @@ baselineCompression::baselineCompression(Config& config, const std::string& uniq
                                          bufferContainer& buffer_container) :
     Stage(config, unique_name, buffer_container,
           std::bind(&baselineCompression::main_thread, this)),
-    in_buf(get_buffer("in_buf")), out_buf(get_buffer("out_buf")), frame_id_in(in_buf),
-    frame_id_out(out_buf), compression_residuals_metric(Metrics::instance().add_gauge(
-                               "kotekan_baselinecompression_residuals", unique_name, {"freq_id"})),
+    in_buf(get_buffer("in_buf")), out_buf(get_buffer("out_buf")),
+    compression_residuals_metric(Metrics::instance().add_gauge(
+        "kotekan_baselinecompression_residuals", unique_name, {"freq_id"})),
     compression_time_seconds_metric(Metrics::instance().add_gauge(
         "kotekan_baselinecompression_time_seconds", unique_name, {"thread_id"})),
     compression_frame_counter(Metrics::instance().add_counter(
@@ -139,24 +140,27 @@ void baselineCompression::change_dataset_state(dset_id_t input_ds_id) {
 
 void baselineCompression::compress_thread(uint32_t thread_id) {
 
-    int input_frame_id;
-    int output_frame_id;
-
-    // Get the current values of the shared frame IDs.
-    {
-        std::lock_guard<std::mutex> lock_frame_ids(m_frame_ids);
-        output_frame_id = frame_id_out++;
-        input_frame_id = frame_id_in++;
-    }
-
-    // Wait for the input buffer to be filled with data
-    // in order to get dataset ID
-    if (in_buf->wait_for_full_frame(unique_name, input_frame_id) == nullptr) {
-        return;
-    }
-    auto input_frame = VisFrameView(in_buf, input_frame_id);
+    const uint32_t in_frames = in_buf->num_frames;
+    const uint32_t out_frames = out_buf->num_frames;
+    // Never let the claim cursor run more than a ring's worth ahead of the
+    // oldest uncommitted frame, so every in-flight frame maps to a distinct
+    // input and output slot.
+    const uint64_t window = std::min(in_frames, out_frames);
 
     while (!stop_thread) {
+
+        // Claim the next frame in order (bounded window).
+        uint64_t seq;
+        {
+            std::unique_lock<std::mutex> lock_frame_ids(m_frame_ids);
+            while (claim - commit >= window && !stop_thread)
+                frame_cv.wait_for(lock_frame_ids, std::chrono::milliseconds(100));
+            if (stop_thread)
+                break;
+            seq = claim++;
+        }
+        int input_frame_id = seq % in_frames;
+        int output_frame_id = seq % out_frames;
 
         // Wait for the input buffer to be filled with data
         if (in_buf->wait_for_full_frame(unique_name, input_frame_id) == nullptr) {
@@ -272,10 +276,6 @@ void baselineCompression::compress_thread(uint32_t thread_id) {
             normt += norm;
         }
 
-        // Mark the buffers and move on
-        out_buf->mark_frame_full(unique_name, output_frame_id);
-        in_buf->mark_frame_empty(unique_name, input_frame_id);
-
         // Calculate residuals (return zero if no data for this freq)
         float residual = (normt != 0.0) ? (vart / normt) : 0.0;
 
@@ -285,11 +285,20 @@ void baselineCompression::compress_thread(uint32_t thread_id) {
         compression_time_seconds_metric.labels({std::to_string(thread_id)}).set(elapsed);
         compression_frame_counter.labels({std::to_string(thread_id)}).inc();
 
-        // Get the current values of the shared frame IDs and increment them.
+        // Publish strictly in claim order: mark the output full and release the
+        // input only when it is this frame's turn, so the output stream stays in
+        // input order and a slot is never reused by two threads at once.
+        {
+            std::unique_lock<std::mutex> lock_frame_ids(m_frame_ids);
+            while (commit != seq && !stop_thread)
+                frame_cv.wait_for(lock_frame_ids, std::chrono::milliseconds(100));
+        }
+        out_buf->mark_frame_full(unique_name, output_frame_id);
+        in_buf->mark_frame_empty(unique_name, input_frame_id);
         {
             std::lock_guard<std::mutex> lock_frame_ids(m_frame_ids);
-            output_frame_id = frame_id_out++;
-            input_frame_id = frame_id_in++;
+            commit++;
+            frame_cv.notify_all();
         }
 
         DEBUG("Compression time {:.4f}", elapsed);

--- a/lib/stages/visCompression.hpp
+++ b/lib/stages/visCompression.hpp
@@ -13,10 +13,11 @@
 #include "datasetManager.hpp"    // for dset_id_t, state_id_t, fingerprint_t
 #include "datasetState.hpp"      // for prodState, stackState
 #include "prometheusMetrics.hpp" // for MetricFamily, Gauge, Counter
-#include "visUtil.hpp"           // for frameID, rstack_ctype, input_ctype, prod_ctype
+#include "visUtil.hpp"           // for rstack_ctype, input_ctype, prod_ctype
 
-#include <cstdint>    // for uint32_t
-#include <functional> // for function
+#include <condition_variable> // for condition_variable
+#include <cstdint>            // for uint32_t, uint64_t
+#include <functional>         // for function
 #include <map>        // for map
 #include <mutex>      // for mutex
 #include <string>     // for string
@@ -103,10 +104,15 @@ private:
     Buffer* in_buf;
     Buffer* out_buf;
 
-    // Frame IDs, shared by compress threads and their mutex.
-    frameID frame_id_in;
-    frameID frame_id_out;
+    // Ordered ring cursors shared by the compress threads. `claim` hands out the
+    // next frame in order; `commit` is the next frame allowed to publish. The
+    // threads compute in parallel but publish strictly in claim order, so a
+    // frame is never handed to two threads and the output stays in input order.
+    // frame_cv wakes threads waiting to claim or to take their commit turn.
+    uint64_t claim = 0;
+    uint64_t commit = 0;
     std::mutex m_frame_ids;
+    std::condition_variable frame_cv;
     std::mutex m_dset_map;
 
     // Map the incoming ID to an outgoing one

--- a/tests/test_applygains.py
+++ b/tests/test_applygains.py
@@ -39,7 +39,10 @@ global_params = {
     },
     "wait": False,
     "sleep_before": 2.0,
-    "num_threads": 4,
+    # Run applyGains with many worker threads (more than the buffer depth) to
+    # reliably exercise the multi-threaded apply path; this is a regression
+    # guard against the frame hand-off race that duplicated output frames.
+    "num_threads": 16,
     "dataset_manager": {"use_dataset_broker": False},
 }
 

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -15,7 +15,10 @@ diag_global_params = {
     "dataset_manager": {"use_dataset_broker": False},
 }
 
-diag_stage_params = {"stack_type": "diagonal"}
+# Run with many compress threads (more than the buffer depth) to reliably
+# exercise the multi-threaded path; this guards against the frame hand-off race
+# that duplicated output frames.
+diag_stage_params = {"stack_type": "diagonal", "num_threads": 16}
 
 smallchime_global_params = {
     "num_elements": 128,


### PR DESCRIPTION
Fixes the intermittent `test_applygains` CI failure, root-caused to a frame hand-off race in `applyGains` (and the same bug in `baselineCompression`/`visCompression`) when run with `num_threads > 1`.

The worker threads share wrapping `frame_id` counters and a single buffer producer/consumer registration, so when a counter wraps onto a slot another thread is still using, the buffer hands the same frame to two threads — duplicating an output frame (occasionally uninitialized). Both stages run `num_threads: 3` in production (`chime_science_run_recv.yaml`).

Fix: each worker takes exclusive ownership of its input and output slot before processing; the gain/stack computation still runs concurrently on distinct frames. `test_applygains` and `test_compression` now run these stages with `num_threads: 16` as a regression guard (the bug surfaced in ~84% of runs at that thread count, 0% after).

🤖 Generated with [Claude Code](https://claude.com/claude-code)