### PR TITLE
Fix spurious 5-sigma test failures in test_accumulate.py

### DIFF
--- a/tests/test_accumulate.py
+++ b/tests/test_accumulate.py
@@ -342,10 +342,13 @@ def test_gaussian(gaussian_data):
     vis_set = np.array([frame.vis for frame in gaussian_data])
     weight_set = np.array([frame.weight for frame in gaussian_data])
 
-    # These tests need a 5 sigma fluctuation to cause failure
-    assert np.allclose(vis_set.mean(axis=0), exp_vis, atol=7e-4, rtol=0)
-    assert np.allclose(vis_set.var(axis=0), frac_var, rtol=7e-2, atol=0)
-    assert np.allclose((1.0 / weight_set).mean(axis=0), frac_var, rtol=1e-2, atol=0)
+    # These tests need a 5 sigma fluctuation to cause failure. The diagonal
+    # (auto-correlation) entries are real-valued and so have ~sqrt(2) larger
+    # estimator spread than the complex off-diagonal entries; the tolerances
+    # below are sized for the noisier diagonal case.
+    assert np.allclose(vis_set.mean(axis=0), exp_vis, atol=1e-3, rtol=0)
+    assert np.allclose(vis_set.var(axis=0), frac_var, rtol=1.2e-1, atol=0)
+    assert np.allclose((1.0 / weight_set).mean(axis=0), frac_var, rtol=1.5e-2, atol=0)
 
 
 # Test that we can deal with whole frames being dropped
@@ -361,9 +364,10 @@ def test_missing_frames(drop_frame_data):
     vis_set = np.array([frame.vis for frame in drop_frame_data])
     weight_set = np.array([frame.weight for frame in drop_frame_data])
 
-    # These tests need a 5 sigma fluctuation to cause failure
-    assert np.allclose(vis_set.mean(axis=0), exp_vis, atol=7e-4, rtol=0)
-    assert np.allclose(vis_set.var(axis=0), frac_var, rtol=7e-2, atol=0)
+    # These tests need a 5 sigma fluctuation to cause failure. (See note in
+    # test_gaussian: real-valued diagonal entries dominate the tolerance.)
+    assert np.allclose(vis_set.mean(axis=0), exp_vis, atol=1e-3, rtol=0)
+    assert np.allclose(vis_set.var(axis=0), frac_var, rtol=1.2e-1, atol=0)
     assert np.allclose((1.0 / weight_set).mean(axis=0), frac_var, rtol=5e-2, atol=0)
 
 


### PR DESCRIPTION
## Problem

`tests/test_accumulate.py::test_gaussian` and `::test_missing_frames` fail spuriously in CI. Both carry the comment *"These tests need a 5 sigma fluctuation to cause failure"*, but several tolerances are only **~3.5σ**, so they flake at roughly **1 in 250 runs**.

## Root cause (not a code bug)

The realized statistics match the radiometer-equation expectations exactly — only the tolerances are miscalibrated.

With `num_elements=4` there are 10 visibility products: 4 **real-valued diagonal autocorrelations** and 6 **complex off-diagonal cross-correlations**. A complex `np.var` / inverse-weight estimate averages two independent components (real + imag), so its estimator spread is `∝ 1/√N`. The real-valued diagonal has a single component, giving spread `∝ √(2/N)` — a factor `√2` larger. The tolerances were sized for the complex case (≈5σ) but are only ≈3.5σ on the diagonal entries. (The author already loosened the one tolerance where this was noticed — `test_missing_frames` weight = `5e-2`; the rest were missed.)

## Fix

Recalibrate the under-sized tolerances so the diagonal entries also require a true ≥5σ fluctuation:

| Assert | Test | Before → After |
|---|---|---|
| mean | both | `atol 7e-4 → 1e-3` |
| variance | both | `rtol 7e-2 → 1.2e-1` |
| weight | `test_gaussian` | `rtol 1e-2 → 1.5e-2` |
| weight | `test_missing_frames` | `rtol 5e-2` (unchanged, already loose) |

`1.2e-1` rather than `1e-1` is needed because `test_missing_frames`'s variance estimate carries a small `+0.4%` Jensen bias from the random kept-frame count `K` (`E[1/K] > 1/E[K]`). Off-diagonal entries remain at ≈8σ, so sensitivity to a genuine systematic regression in the vis/weight computation is preserved — such a bug would appear as a constant offset far larger than these statistical bands.

No change to the accumulation/weight math (`lib/stages/visAccumulate.cpp`) or the fake-GPU data generation (`lib/testing/fakeGpuPattern.cpp`); this is purely a test-tolerance recalibration.

## Verification

A Monte-Carlo reproducing the exact test statistics (60k trials per scenario) confirms the per-assert failure rate collapses from `1.5–2.9e-3` to `0` (< the analytic ~1e-6 for a true 5σ test):

```
                  mean      var       weight
gaussian   OLD    0.0e+00   1.8e-03   1.6e-03
           NEW    0.0e+00   0.0e+00   0.0e+00
drop_frame OLD    1.5e-04   2.9e-03
           NEW    0.0e+00   0.0e+00
```

Note: the fake-GPU RNG is unseeded, so this statistical argument — not a few green runs — is the evidence; a handful of passing runs cannot distinguish 3.5σ from 5σ.
