### PR TITLE
minor updates and fixes

### DIFF
--- a/lib/stages/parseReorderDefault.cpp
+++ b/lib/stages/parseReorderDefault.cpp
@@ -30,34 +30,18 @@ using kotekan::Stage;
 
 REGISTER_KOTEKAN_STAGE(parseReorderDefault);
 
-#define CHIME_ORDER_CORRELATOR "correlator" // not regular
-#define CHIME_ORDER_CYLINDER "cylinder"     // cyl-pol-dish
-#define CHIME_ORDER_BEAMFORMER "beamformer" // pol-dish
-
 parseReorderDefault::parseReorderDefault(Config& config, const std::string& unique_name,
                                          bufferContainer& buffer_container) :
     Stage(config, unique_name, buffer_container,
           std::bind(&parseReorderDefault::main_thread, this)),
     _out_buf(get_buffer("out_buf")), _name(config.get<std::string>(unique_name, "name")),
-    _input_order_str(
-        config.get_default<std::string>(unique_name, "input_order", CHIME_ORDER_CORRELATOR)),
-    _output_order_str(
-        config.get_default<std::string>(unique_name, "output_order", CHIME_ORDER_CYLINDER)),
-    _input_order(parseOrderStr(_input_order_str)), _output_order(parseOrderStr(_output_order_str)),
+    _input_order(config.get_default<ElementOrder>(unique_name, "input_order",
+                                                  ElementOrder::CHIMECorrelator)),
+    _output_order(
+        config.get_default<ElementOrder>(unique_name, "output_order", ElementOrder::CHIMECylinder)),
     _num_polarizations(config.get<int>(unique_name, "num_polarizations")),
     _num_dishes(config.get<int>(unique_name, "num_dishes")) {
     _out_buf->register_producer(unique_name);
-
-    if (_input_order_str != CHIME_ORDER_CORRELATOR && _input_order_str != CHIME_ORDER_CYLINDER
-        && _input_order_str != CHIME_ORDER_BEAMFORMER) {
-        FATAL_ERROR("Input element order {} is not a CHIME order.", _input_order);
-    }
-
-    if (_output_order_str != CHIME_ORDER_CORRELATOR && _output_order_str != CHIME_ORDER_CYLINDER
-        && _output_order_str != CHIME_ORDER_BEAMFORMER) {
-        FATAL_ERROR("Output element order {} is not a CHIME order.", _output_order);
-    }
-
 
 #if 0 // this is what it should be
     if (_input_order == ElementOrder::CHIMECorrelator) {
@@ -79,19 +63,6 @@ parseReorderDefault::parseReorderDefault(Config& config, const std::string& uniq
     _out_buf->require_frame_desc(kotekan::GenericNDArray::describe(
         kotekan::int32, _name, {_num_polarizations, _num_dishes}, {"P", "D"}, {1, 1}));
 #endif
-}
-
-ElementOrder parseReorderDefault::parseOrderStr(const std::string& ord_str) {
-    if (ord_str == CHIME_ORDER_CORRELATOR)
-        return ElementOrder::CHIMECorrelator;
-    else if (ord_str == CHIME_ORDER_CYLINDER)
-        return ElementOrder::CHIMECylinder;
-    else if (ord_str == CHIME_ORDER_BEAMFORMER)
-        return ElementOrder::CHIMEBeamformer;
-
-    FATAL_ERROR_NON_OO("parseReorderDefault: Order string {:s} was not {:s}, {:s}, or {:s}",
-                       ord_str, CHIME_ORDER_CORRELATOR, CHIME_ORDER_CYLINDER,
-                       CHIME_ORDER_BEAMFORMER);
 }
 
 void parseReorderDefault::main_thread() {

--- a/lib/stages/parseReorderDefault.hpp
+++ b/lib/stages/parseReorderDefault.hpp
@@ -1,15 +1,15 @@
 #ifndef GIVEN_DATA_GEN_H
 #define GIVEN_DATA_GEN_H
 
-#include <stdint.h>             // for uint32_t
-#include <string>               // for string, basic_string
-#include <vector>               // for vector
+#include "Config.hpp"          // for Config
+#include "Stage.hpp"           // for Stage
+#include "Telescope.hpp"       // for ElementOrder
+#include "buffer.hpp"          // for Buffer
+#include "bufferContainer.hpp" // for bufferContainer
 
-#include "Config.hpp"           // for Config
-#include "Stage.hpp"            // for Stage
-#include "Telescope.hpp"        // for ElementOrder
-#include "buffer.hpp"           // for Buffer
-#include "bufferContainer.hpp"  // for bufferContainer
+#include <stdint.h> // for uint32_t
+#include <string>   // for string, basic_string
+#include <vector>   // for vector
 
 /**
  * @class parseReorderDefault
@@ -21,8 +21,10 @@
  *         @buffer_metadata chordMetadata
  *
  * @conf  name                  String. Name of the quantity being set.
- * @conf  input_order           ElementOrder. Default: CHIMECorrelator. Must be one of CHIMECorrelator, CHIMECylinder, CHIMEBeamformer.
- * @conf  output_order          ElementOrder. Default: CHIMECylinder. Must be one of CHIMECorrelator, CHIMECylinder, CHIMEBeamformer.
+ * @conf  input_order           ElementOrder. Default: CHIMECorrelator. Must be one of
+ * CHIMECorrelator, CHIMECylinder, CHIMEBeamformer.
+ * @conf  output_order          ElementOrder. Default: CHIMECylinder. Must be one of
+ * CHIMECorrelator, CHIMECylinder, CHIMEBeamformer.
  * @conf  num_polarizations     Int. Number of polarizations. Used only to
  *                              compute number of elements.
  * @conf  num_dishes            Int. Number of dishes in telescope. Used only to
@@ -38,13 +40,8 @@ public:
     void main_thread() override;
 
 private:
-
-    static ElementOrder parseOrderStr(const std::string &ord_str);
-
     Buffer* const _out_buf;
     const std::string _name;
-    const std::string _input_order_str;
-    const std::string _output_order_str;
     const ElementOrder _input_order;
     const ElementOrder _output_order;
     const int _num_polarizations;

--- a/lib/utils/CHIMETelescope.cpp
+++ b/lib/utils/CHIMETelescope.cpp
@@ -1,30 +1,31 @@
 #include "CHIMETelescope.hpp"
 
-#include <exception>           // for exception
-#include <stdexcept>           // for runtime_error
-#include <utility>             // for pair
-#include <vector>              // for vector
+#include "ICETelescope.hpp"   // for ice_stream_id_t, ice_encode_stream_id, ice_extract_stream_id
+#include "Telescope.hpp"      // for stream_t, Telescope, REGISTER_TELESCOPE, _factory_aliasTel...
+#include "geoUtil.hpp"        // for GeoFrame
+#include "kotekanLogging.hpp" // for ERROR, INFO, WARN, DEBUG2, FATAL_ERROR_NON_OO
+#include "restClient.hpp"     // for restClient
 
-#include "ICETelescope.hpp"    // for ice_stream_id_t, ice_encode_stream_id, ice_extract_stream_id
-#include "Telescope.hpp"       // for stream_t, Telescope, REGISTER_TELESCOPE, _factory_aliasTel...
-#include "geoUtil.hpp"         // for GeoFrame
-#include "kotekanLogging.hpp"  // for ERROR, INFO, WARN, DEBUG2, FATAL_ERROR_NON_OO
-#include "restClient.hpp"      // for restClient
-#include "fmt.hpp"             // for compile_string_to_view, format, format_string
-#include "json.hpp"            // for json, json_ref, basic_json, input_adapter
+#include "fmt.hpp"  // for compile_string_to_view, format, format_string
+#include "json.hpp" // for json, json_ref, basic_json, input_adapter
+
+#include <exception> // for exception
+#include <stdexcept> // for runtime_error
+#include <utility>   // for pair
+#include <vector>    // for vector
 
 REGISTER_TELESCOPE(CHIMETelescope, "CHIMETelescope");
 
 CHIMETelescope::CHIMETelescope(const kotekan::Config& config, const std::string& path) :
     ICETelescope(config.get<uint64_t>(path, "num_polarizations"),
-            config.get<uint64_t>(path, "num_dishes"),
-            config.get_default<uint64_t>(path, "num_cylinders", 4),
-            config.get_default<double>(path, "feed_sep_EW", 22.0),
-            config.get_default<double>(path, "feed_sep_NS", 0.3048),
-            path, config.get<std::string>(path, "log_level"),
-             config.get_default<bool>(path, "require_eop", false),
-             config.get_default<std::string>(path, "eop_updatable_config", ""),
-             grid_frame_from_config(config, path)) {
+                 config.get<uint64_t>(path, "num_dishes"),
+                 config.get_default<uint64_t>(path, "num_cylinders", 4),
+                 config.get_default<double>(path, "feed_sep_EW", 22.0),
+                 config.get_default<double>(path, "feed_sep_NS", 0.3048), path,
+                 config.get<std::string>(path, "log_level"),
+                 config.get_default<bool>(path, "require_eop", false),
+                 config.get_default<std::string>(path, "eop_updatable_config", ""),
+                 grid_frame_from_config(config, path)) {
     INFO("Building CHIMETelescope");
 
     // This is always 1 for CHIME
@@ -81,18 +82,19 @@ CHIMETelescope::CHIMETelescope(const kotekan::Config& config, const std::string&
     }
 
     if (_num_dishes % _num_cylinders != 0)
-        FATAL_ERROR("num_cylinders {:d} does not divide num_dishes {:d}", _num_cylinders, _num_dishes);
+        FATAL_ERROR("num_cylinders {:d} does not divide num_dishes {:d}", _num_cylinders,
+                    _num_dishes);
 
     const auto input_tuple = ICETelescope::parse_reorder_default(config, path, _num_elements);
     _input_reorder = std::get<0>(input_tuple);
     _input_map = std::get<1>(input_tuple);
     if (_input_reorder.size() != _num_elements) {
         FATAL_ERROR("input_reorder has size {:d}, should be num_elements = {:d}",
-                _input_reorder.size(), _num_elements);
+                    _input_reorder.size(), _num_elements);
     }
     if (_input_reorder.size() != _num_elements) {
         FATAL_ERROR("input_map (from input_reorder) has size {:d}, should be num_elements = {:d}",
-                _input_map.size(), _num_elements);
+                    _input_map.size(), _num_elements);
     }
 
     _correlator_stations = invert_reorder_table(_input_reorder);
@@ -100,7 +102,8 @@ CHIMETelescope::CHIMETelescope(const kotekan::Config& config, const std::string&
     _feed_positions_2d = config.get_default<std::vector<vec2d_t>>(path, "feed_positions", {});
 
     if (_feed_positions_2d.size() > 0 && _feed_positions_2d.size() != _num_dishes)
-        FATAL_ERROR("feed_positions has size {:d}, should be num_dishes {:d}", _feed_positions_2d.size(), _num_dishes);
+        FATAL_ERROR("feed_positions has size {:d}, should be num_dishes {:d}",
+                    _feed_positions_2d.size(), _num_dishes);
 }
 
 nlohmann::json CHIMETelescope::fetch_frequency_map(const std::string& host, const uint32_t port,
@@ -111,7 +114,7 @@ nlohmann::json CHIMETelescope::fetch_frequency_map(const std::string& host, cons
         restClient::instance().make_request_blocking(path, {{"format", "s:b"}}, host, port, 0, 30);
 
     if (!reply.first) {
-        WARN("Failed to get frequency map from {:s}:{:d}{:s}");
+        WARN("Failed to get frequency map from {:s}:{:d}{:s}", host, port, path);
         return nlohmann::json();
     }
 

--- a/lib/utils/L0_L1_packet.hpp
+++ b/lib/utils/L0_L1_packet.hpp
@@ -45,7 +45,7 @@
 // The packet header size in bytes is currently
 //    32 + 2*nbeam + 2*nfreq_coarse + 8*nbeam*nfreq
 //
-// For full CHIME, we expect to use (nbeam, nfreq_coarse, nupfreq, ntsamp) = (8, 4, 16, 16)
+// For full CHIME, we expect to use (nbeam, nfreq_coarse, nupfreq, ntsamp) = (4, 4, 16, 16)
 // which gives a 304-byte header and an 8192-byte data segment.
 //
 // For the pathfinder, I'm currently using  (nbeam, nfreq_coarse, nupfreq, ntsamp) = (1, 32, 1, 256) 
@@ -110,12 +110,12 @@ struct L0_L1_header {
     //
     // Thus in full chime, the uncompressed data array has shape
     //
-    //  uint8 data[8][4][16][16]
+    //  uint8 data[4][4][16][16]
     //             |  |   |   |
     //             |  |   |   +-- 16x 1-ms time samples
     //             |  |   +------ 16x 24 kHz frequency channels 
     //             |  +---------- 4x frequency bands (may not be consecutive in frequency)
-    //             +------------- 8x on-sky beams
+    //             +------------- 4x on-sky beams
     //
     // We need a sentinel value to indicate "this entry in the array is invalid".
     // We currently take both endpoint values to be sentinels, i.e. if a byte is either

--- a/python/kotekan/frbbuffer.py
+++ b/python/kotekan/frbbuffer.py
@@ -42,7 +42,7 @@ class FrbPacket(ctypes.Structure):
         with io.FileIO(filename, "rb") as fh:
             fh.readinto(buf)
 
-        return from_buffer(cls, buf[4:], max_packets, filename)
+        return cls.from_buffer(buf[4:], max_packets, filename)
 
     @classmethod
     def from_buffer(cls, buffer, max_packets=None, name=None):

--- a/tests/test_parseReorderDefault.py
+++ b/tests/test_parseReorderDefault.py
@@ -10,8 +10,8 @@ if not runner.has_hdf5():
 
 parseReorderDefault_params = {
     "out_buf": "reorder_buffer",
-    "input_order": "correlator",
-    "output_order": "beamformer",
+    "input_order": "CHIMECorrelator",
+    "output_order": "CHIMEBeamformer",
     "name": "scatter_indices",
 }
 


### PR DESCRIPTION
* 5107f3560 - CHIMETelescope: correct error reporting code getting frequency map
* 0905a6429 - L0_L1_packet: correct number of beams per stream
* 6a28fb2c0 - parseReorderDefault: use "common" order names rather legacy ones
* e0573924e - frbbuffer: corect calling class method when constructing from file

the `parseReorderDefault` will cause failures if an explicit order had been used using the "old" names (eg beamformer instead of CHIMEBeamformer) 