### PR TITLE
fixes to FRB quantizers for CHIME

### DIFF
--- a/lib/cuda/cudaQuantize8.cpp
+++ b/lib/cuda/cudaQuantize8.cpp
@@ -64,11 +64,11 @@ private:
     static constexpr int out_nfreqs_chunk = 16;
     // Chunks are combined into packets.
     static constexpr int out_nfreqs_packet = 4;
-    static constexpr int out_nbeams_packet = 8;
+    static constexpr int out_nbeams_packet = 4;
     // There are several packets.
     static constexpr int out_ntimes_outer = 16;
     static constexpr int out_nfreqs_outer = 4;
-    static constexpr int out_nbeams_outer = 128;
+    static constexpr int out_nbeams_outer = 256;
 
     static_assert(out_ntimes_chunk * out_ntimes_outer == in_ntimes);
     static_assert(out_nfreqs_chunk * out_nfreqs_packet * out_nfreqs_outer == in_nfreqs);
@@ -112,11 +112,11 @@ cudaQuantize8::cudaQuantize8(Config& config, const std::string& unique_name,
                                                          out_nfreqs_packet,
                                                          out_nfreqs_chunk,
                                                          out_ntimes_chunk};
-        const std::array<std::string, 8> beam_dimnames{"Ttilde256",     "R8",        "Fbar64",
-                                                       "Ttilde16_lo16", "Rlo8",      "Fbar16_lo4",
+        const std::array<std::string, 8> beam_dimnames{"Ttilde256",     "R4",        "Fbar64",
+                                                       "Ttilde16_lo16", "Rlo4",      "Fbar16_lo4",
                                                        "Fbarlo16",      "Ttildelo16"};
         const std::array<std::ptrdiff_t, 8> beam_dimscalings{
-            _frb_downsampling_factor * 256, 8, 64, _frb_downsampling_factor * 16, 1, 16, 1,
+            _frb_downsampling_factor * 256, 4, 64, _frb_downsampling_factor * 16, 1, 16, 1,
             _frb_downsampling_factor};
         return NDArrayBuffer<std::uint8_t, 8>(_gpu_mem_beams, "I3", beam_lengths, beam_dimnames,
                                               beam_dimscalings, *this);
@@ -130,9 +130,9 @@ cudaQuantize8::cudaQuantize8(Config& config, const std::string& unique_name,
                                                                 out_nfreqs_packet,
                                                                 2};
         const std::array<std::string, 7> offsetscale_dimnames{
-            "Ttilde256", "R8", "Fbar64", "Ttilde16_lo16", "Rlo8", "Fbar16_lo4", "offset/scale"};
+            "Ttilde256", "R4", "Fbar64", "Ttilde16_lo16", "Rlo4", "Fbar16_lo4", "offset/scale"};
         const std::array<std::ptrdiff_t, 7> offsetscale_dimscalings{
-            _frb_downsampling_factor * 256, 8, 64, _frb_downsampling_factor * 16, 1, 16, 1};
+            _frb_downsampling_factor * 256, 4, 64, _frb_downsampling_factor * 16, 1, 16, 1};
         return NDArrayBuffer<float16_t, 7>(_gpu_mem_beams_offsetscale, "I3_offsetscale",
                                            offsetscale_lengths, offsetscale_dimnames,
                                            offsetscale_dimscalings, *this);

--- a/lib/cuda/cudaQuantizeKernel8.cu
+++ b/lib/cuda/cudaQuantizeKernel8.cu
@@ -26,11 +26,11 @@ static constexpr int out_ntimes_chunk = 16;
 static constexpr int out_nfreqs_chunk = 16;
 // Chunks are combined into packets.
 static constexpr int out_nfreqs_packet = 4;
-static constexpr int out_nbeams_packet = 8;
+static constexpr int out_nbeams_packet = 4;
 // There are several packets.
 static constexpr int out_ntimes_outer = 16;
 static constexpr int out_nfreqs_outer = 4;
-static constexpr int out_nbeams_outer = 128;
+static constexpr int out_nbeams_outer = 256;
 
 static_assert(out_ntimes_chunk * out_ntimes_outer == in_ntimes);
 static_assert(out_nfreqs_chunk * out_nfreqs_packet * out_nfreqs_outer == in_nfreqs);

--- a/lib/cuda/testQuantizeKernel8.cpp
+++ b/lib/cuda/testQuantizeKernel8.cpp
@@ -1,30 +1,31 @@
 // Test 8-bit FRB beam quantizer for CHIME, using the float16 FRB beamformer and CHIME's
 // sending-to-Bonsai network format
 
-#include <algorithm>                // for fill, fill_n
-#include <cassert>                  // for assert
-#include <cfloat>                   // for FLT_MAX
-#include <cmath>                    // for fabs, isfinite, isnan, fmax, fmin
-#include <cstdint>                  // for uint8_t
-#include <cstdlib>                  // for abort
-#include <string>                   // for allocator, string
-#include <vector>                   // for vector
-#include <functional>               // for function
+#include "Config.hpp"              // for Config
+#include "DataType.hpp"            // for float16_t
+#include "Stage.hpp"               // for Stage
+#include "StageFactory.hpp"        // for REGISTER_KOTEKAN_STAGE
+#include "bufferContainer.hpp"     // for bufferContainer
+#include "cudaQuantizeKernel8.hpp" // for cpu_quantize8, gpu_quantize8
+#include "cudaUtils.hpp"           // for CHECK_CUDA_ERROR
+#include "cuda_fp16.h"             // for __half, __half::operator float
+#include "cuda_runtime.h"          // for cudaMalloc
+#include "cuda_runtime_api.h"      // for cudaMemcpy
+#include "driver_types.h"          // for cudaMemcpyKind
+#include "errors.h"                // for TEST_PASSED
+#include "kotekanLogging.hpp"      // for FATAL_ERROR, INFO
 
-#include "Config.hpp"               // for Config
-#include "DataType.hpp"             // for float16_t
-#include "Stage.hpp"                // for Stage
-#include "StageFactory.hpp"         // for REGISTER_KOTEKAN_STAGE
-#include "bufferContainer.hpp"      // for bufferContainer
-#include "cudaQuantizeKernel8.hpp"  // for cpu_quantize8, gpu_quantize8
-#include "cudaUtils.hpp"            // for CHECK_CUDA_ERROR
-#include "cuda_fp16.h"              // for __half, __half::operator float
-#include "cuda_runtime.h"           // for cudaMalloc
-#include "cuda_runtime_api.h"       // for cudaMemcpy
-#include "driver_types.h"           // for cudaMemcpyKind
-#include "errors.h"                 // for TEST_PASSED
-#include "fmt.hpp"                  // for compile_string_to_view
-#include "kotekanLogging.hpp"       // for FATAL_ERROR, INFO
+#include "fmt.hpp" // for compile_string_to_view
+
+#include <algorithm>  // for fill, fill_n
+#include <cassert>    // for assert
+#include <cfloat>     // for FLT_MAX
+#include <cmath>      // for fabs, isfinite, isnan, fmax, fmin
+#include <cstdint>    // for uint8_t
+#include <cstdlib>    // for abort
+#include <functional> // for function
+#include <string>     // for allocator, string
+#include <vector>     // for vector
 
 class testQuantizeKernel8 : public kotekan::Stage {
 public:
@@ -53,11 +54,11 @@ public:
         const int out_nfreqs_chunk = 16;
         // Chunks are combined into packets.
         const int out_nfreqs_packet = 4;
-        const int out_nbeams_packet = 8;
+        const int out_nbeams_packet = 4;
         // There are several packets.
         const int out_ntimes_outer = 16;
         const int out_nfreqs_outer = 4;
-        const int out_nbeams_outer = 128;
+        const int out_nbeams_outer = 256;
 
         static_assert(out_ntimes_chunk * out_ntimes_outer == in_ntimes);
         static_assert(out_nfreqs_chunk * out_nfreqs_packet * out_nfreqs_outer == in_nfreqs);

--- a/lib/cuda/testQuantizeKernel8.cpp
+++ b/lib/cuda/testQuantizeKernel8.cpp
@@ -277,10 +277,8 @@ public:
                                     FATAL_ERROR("Found non-finite offset {}", offset);
 
                                 // Check relative error of offset
-                                bool offset_is_good =
-                                    fabs(offset - expected_offset)
-                                    <= epsilon
-                                           * fmax(1.0f, fmax(fabs(offset), fabs(expected_offset)));
+                                bool offset_is_good = fabs(offset - expected_offset)
+                                                      <= epsilon * fabs(expected_offset);
                                 // If we think an overflow is allowed, and if the other
                                 // implementation might have detected one (offset=0), then
                                 // all is fine as well
@@ -291,8 +289,9 @@ public:
                                                 "{}, scale_may_collapse={}",
                                                 beam, expected_offset, offset, scale_may_collapse);
 
-                                // Check absolute error of scale
-                                bool scale_is_good = fabs(scale - expected_scale) <= epsilon;
+                                // Check relative error of scale
+                                bool scale_is_good =
+                                    fabs(scale - expected_scale) <= epsilon * fabs(expected_scale);
                                 // If the scale is close to zero then don't worry about the
                                 // scale at all
                                 if (scale_may_collapse)

--- a/lib/cuda/testQuantizeKernel8Chime.cpp
+++ b/lib/cuda/testQuantizeKernel8Chime.cpp
@@ -265,10 +265,8 @@ public:
                                     FATAL_ERROR("Found non-finite offset {}", offset);
 
                                 // Check relative error of offset
-                                bool offset_is_good =
-                                    fabs(offset - expected_offset)
-                                    <= epsilon
-                                           * fmax(1.0f, fmax(fabs(offset), fabs(expected_offset)));
+                                bool offset_is_good = fabs(offset - expected_offset)
+                                                      <= epsilon * fabs(expected_offset);
                                 // If we think an overflow is allowed, and if the other
                                 // implementation might have detected one (offset=0), then
                                 // all is fine as well
@@ -286,8 +284,9 @@ public:
                                         scale_may_collapse);
                                 }
 
-                                // Check absolute error of scale
-                                bool scale_is_good = fabs(scale - expected_scale) <= epsilon;
+                                // Check relative error of scale
+                                bool scale_is_good =
+                                    fabs(scale - expected_scale) <= epsilon * fabs(expected_scale);
                                 // If the scale is close to zero then don't worry about the
                                 // scale at all
                                 if (scale_may_collapse)


### PR DESCRIPTION
This pull request contains fixes (handling metadata, some incorrect size of arrays) for the quantizers for CHIME, both for the achromatic beamformer (in `cudaQuantize8`) and for the chromatic (legacy CHIME look-alike) beamformer (testQuantizeKernel8Chime).

