### PR TITLE
Include external gain interface in chime_upgrade_frb config

### DIFF
--- a/config/chime_upgrade_frb.j2
+++ b/config/chime_upgrade_frb.j2
@@ -952,13 +952,8 @@ rfi_broadcast:
     rfi_sktilde_buf: host_rfi_SKtilde_buffer
     rfi_skbar_buf: host_rfi_SKbar_buffer
     rfi_mask_buf: host_rfi_RFImask_buffer
-    # 3-sigma deviations seems reasonable for identifying outliers,
-    # and empirically produces vaguely comparable results to the
-    # old system
-    num_sigma_deviations: 3
-    # Simply selected from the old system, and accounted for by
-    # the receiver. Can be increased or decreased based on the rate
-    # at which we want to be sending packets
+    # Same value as legacy system. Can be increased or decreased based
+    # on the rate at which we want to be sending packets
     frames_per_packet: 10
     destination_port: "3000"
     # This is the IP of `vm-steelpan-recv1`. Needs to be updated when

--- a/config/chime_upgrade_frb.j2
+++ b/config/chime_upgrade_frb.j2
@@ -89,6 +89,10 @@ earth_rotation_data:
     - {t_inst_ns: 0, delta_UT1_inst: 0.0, xp_as: 0.0, yp_as: 0.0}
 
 updatable_config:
+  frb_gain:
+    0:
+      kotekan_update_endpoint: "json"
+      gain_directory: /mnt/frb-archiver/daily_gain_solutions/Latest_FRB
   # bad input mask, assumed to be in cylinder order
   bad_inputs:
       kotekan_update_endpoint: json
@@ -1322,16 +1326,26 @@ FRB:
         metadata_pool: main_pool
 
     # Beamforming Phases and interpolation weights
+    host_frb1_phase_buffer:
+        kotekan_buffer: ndarray
+        num_frames: 1
+        value_type: float32
+        extents: [num_freq_gpu_buf, num_elements, num_components]
+        quantity_name: "gain"
+        dimnames: ["F", "E", "C"]
+        dimscalings: [1, 1, 1]
+        metadata_pool: main_pool
 
     host_frb1_U16_phase_buffer:
         kotekan_buffer: ndarray
         num_frames: 1
-        # TODO: check what this "16" is
         value_type: float16
-        extents: [upchan_U16_max_num_channels * 16, num_polarizations, num_dishes_x, num_dishes_y, num_components]
+        # TODO: verify that the correct variables are being used for
+        # the upchannelized frequencies
+        extents: [1, num_freq_gpu_buf * factor_upchan_out, num_elements, num_components]
         quantity_name: "W"
-        dimnames: ["Fbar", "P", "dishN", "dishM", "C"]
-        dimscalings: [1, 1, 1, 1, 1]
+        dimnames: ["R", "Fbar", "E", "C"]
+        dimscalings: [1, factor_upchan_out, 1, 1]
         metadata_pool: main_pool
 
     host_frb2_weights_buffer:
@@ -1499,17 +1513,27 @@ FRB:
 
     # FRB 1
 
-    run_set_frb1_U16_phase:
-        kotekan_stage: setFRB1Phase
+    load_frb1_phase:
+        kotekan_stage: loadFeedGains
+        beamformer_type: "frb"
+        filename_template: "quick_gains_%04d_reordered.bin"
+        num_local_freq: num_freq_gpu_buf
+        default_gains: [1.0, 1.0]
+        gain_buffers:
+          - host_frb1_phase_buffer
+        in_buf: host_rfi_RFImask_buffer
+        updatable_config:
+          frb_gain: /updatable_config/frb_gain
+
+    process_frb1_U16_phase:
+        kotekan_stage: processFeedGains
+        num_local_freq: num_freq_gpu_buf
         upchan_factor: factor_upchan_out
-        # TODO: replace the stage with one that actually takes the gains into account
-        # TODO: need to worry about over / underflow
-        frb1_input_scale: 1.0 / 32
-        frb1_swap_MN: true
-        upchan_min_channel: upchan_U16_min_channel
-        upchan_max_channel: upchan_U16_max_channel
-        upchan_max_num_channels: upchan_U16_max_num_channels
-        frb1_phase: host_frb1_U16_phase_buffer
+        scaling_factor: 1.0 / 32
+        gain_buffers:
+          - host_frb1_phase_buffer
+        in_mask_buf: host_bf_mask_buffer
+        out_buf: host_frb1_U16_phase_buffer
 
     run_frb1_U16:
         gpu_0:

--- a/config/chime_upgrade_n2.j2
+++ b/config/chime_upgrade_n2.j2
@@ -814,13 +814,8 @@ rfi_broadcast:
     rfi_sktilde_buf: host_rfi_SKtilde_buffer
     rfi_skbar_buf: host_rfi_SKbar_buffer
     rfi_mask_buf: host_rfi_RFImask_buffer
-    # 3-sigma deviations seems reasonable for identifying outliers,
-    # and empirically produces vaguely comparable results to the
-    # old system
-    num_sigma_deviations: 3
-    # Simply selected from the old system, and accounted for by
-    # the receiver. Can be increased or decreased based on the rate
-    # at which we want to be sending packets
+    # Same value as legacy system. Can be increased or decreased based
+    # on the rate at which we want to be sending packets
     frames_per_packet: 10
     destination_port: "3000"
     # This is the IP of `vm-steelpan-recv1`. Needs to be updated when

--- a/lib/stages/loadFeedGains.cpp
+++ b/lib/stages/loadFeedGains.cpp
@@ -89,7 +89,7 @@ loadFeedGains::loadFeedGains(Config& config, const std::string& unique_name,
             "gain",
             {static_cast<ptrdiff_t>(num_local_freq), static_cast<ptrdiff_t>(num_elements),
              static_cast<ptrdiff_t>(2)},
-            {"F", "E", "ReIm"}, {1, 1, 1}));
+            {"F", "E", "C"}, {1, 1, 1}));
     }
 
     // Set up callbacks for each beam_id

--- a/lib/stages/processFeedGains.cpp
+++ b/lib/stages/processFeedGains.cpp
@@ -102,13 +102,14 @@ processFeedGains::~processFeedGains() {}
 
 void processFeedGains::set_frame_desc(Buffer* buf) {
     buf->ensure_frame_desc(kotekan::NDArray<kotekan::GetType_t<kotekan::float32>, 4>::describe(
-        "processed_gain",
+        "W",
         {static_cast<ptrdiff_t>(num_beams), static_cast<ptrdiff_t>(num_local_freq * upchan_factor),
          static_cast<ptrdiff_t>(num_elements), static_cast<ptrdiff_t>(num_components)},
         {"R", "Fbar", "E", "C"}, {1, 1, 1, 1}));
 
     freq_upchan_factor = std::vector<int>(num_local_freq * upchan_factor, 1);
     freq_upchan_index = std::vector<int>(num_local_freq * upchan_factor);
+    coarse_freq = std::vector<int>(num_local_freq * upchan_factor);
 
     // set the actual frequency upchan indices. Assume increasing index
     // TODO: verify that this is correct
@@ -119,12 +120,13 @@ void processFeedGains::set_frame_desc(Buffer* buf) {
 
 void processFeedGains::copy_upchannelize_f(const float* src_f, float* dst_f, size_t fid) {
     (void)fid; // not used in the default implementation
+    auto scaling_factor = this->scaling_factor;
     for (size_t u = 0; u < upchan_factor; ++u) {
         // copy ell elements from the source into each fine channel
         float* u_ptr = dst_f + u * num_elements * num_components;
         // apply the constant scaling factor
         std::transform(src_f, src_f + num_components * num_elements, u_ptr,
-                       [this](float v) { return v * this->scaling_factor; });
+                       [scaling_factor](float v) { return v * scaling_factor; });
     }
 }
 
@@ -154,6 +156,8 @@ void processFeedGains::main_thread() {
     for (size_t iter = 0; iter < gain_buffers.size(); iter++) {
         gain_buffer_frame_ids.emplace_back(gain_buffers.at(iter));
     }
+
+    bool set_coarse_freqs = false;
 
     while (!stop_thread) {
         // Poll all possible producing buffers
@@ -208,10 +212,22 @@ void processFeedGains::main_thread() {
         out_buf->allocate_new_metadata_object(out_buf_frame_id);
         auto meta = get_chord_metadata(out_buf, out_buf_frame_id);
         meta->set_from_frame_desc(out_buf->get_frame_desc<kotekan::GenericNDArray>());
-        meta->set_name("processed_gain");
+        meta->set_name("W");
         // Set the frequency upchannelization metadata
         meta->set_freq_upchan_factor(freq_upchan_factor);
         meta->set_freq_upchan_index(freq_upchan_index);
+        // Also need to set coarse frequencies, which requires metadata
+        // from the input frame
+        if (set_coarse_freqs) {
+            auto meta_in = get_chord_metadata(in_mask_buf, in_mask_frame_id);
+            auto coarse_freqs_in = meta_in->get_coarse_freq();
+
+            for (uint64_t f = 0; f < num_local_freq * upchan_factor; ++f) {
+                int idx = f / upchan_factor;
+                coarse_freq[f] = coarse_freqs_in[idx];
+            }
+        }
+        meta->set_coarse_freq(coarse_freq);
         // Verify that frame desc and metadata match
         meta->check_frame_desc(out_buf->get_frame_desc<kotekan::GenericNDArray>());
 

--- a/lib/stages/processFeedGains.cpp
+++ b/lib/stages/processFeedGains.cpp
@@ -32,6 +32,7 @@ processFeedGains::processFeedGains(Config& config, const std::string& unique_nam
     num_local_freq = config.get<uint32_t>(unique_name, "num_local_freq");
     num_beams = config.get_default<uint32_t>(unique_name, "num_beams", 1);
     upchan_factor = config.get_default<uint32_t>(unique_name, "upchan_factor", 1);
+    num_components = config.get<uint32_t>(unique_name, "num_components");
 
     // Input gain buffers
     json in_buf_list = config.get_value(unique_name, "gain_buffers");
@@ -52,9 +53,10 @@ processFeedGains::processFeedGains(Config& config, const std::string& unique_nam
                         gain_buffers.at(0)->frame_size);
         }
 
-        if (buf->frame_size != num_local_freq * num_elements * 2 * sizeof(float)) {
+        if (buf->frame_size != num_local_freq * num_elements * num_components * sizeof(float)) {
             FATAL_ERROR("Input buffer does not have the expected size. Expected {:d}, got {:d}",
-                        num_local_freq * num_elements * 2 * sizeof(float), buf->frame_size);
+                        num_local_freq * num_elements * num_components * sizeof(float),
+                        buf->frame_size);
         }
     }
 
@@ -73,7 +75,7 @@ processFeedGains::processFeedGains(Config& config, const std::string& unique_nam
                     in_mask_size, in_mask_buf->frame_size);
     }
 
-    out_num_values = num_beams * num_elements * num_local_freq * upchan_factor * 2;
+    out_num_values = num_beams * num_elements * num_local_freq * upchan_factor * num_components;
     auto out_buf_size = out_num_values * sizeof(float);
     if (out_buf->frame_size != out_buf_size) {
         FATAL_ERROR("Output buffer does not have the expected shape. Expected {:d}, got {:d}",
@@ -101,8 +103,8 @@ void processFeedGains::set_frame_desc(Buffer* buf) {
     buf->ensure_frame_desc(kotekan::NDArray<kotekan::GetType_t<kotekan::float32>, 4>::describe(
         "processed_gain",
         {static_cast<ptrdiff_t>(num_beams), static_cast<ptrdiff_t>(num_local_freq * upchan_factor),
-         static_cast<ptrdiff_t>(num_elements), static_cast<ptrdiff_t>(2)},
-        {"R", "Fbar", "E", "ReIm"}, {1, 1, 1, 1}));
+         static_cast<ptrdiff_t>(num_elements), static_cast<ptrdiff_t>(num_components)},
+        {"R", "Fbar", "E", "C"}, {1, 1, 1, 1}));
 
     freq_upchan_factor = std::vector<int>(num_local_freq * upchan_factor, 1);
     freq_upchan_index = std::vector<int>(num_local_freq * upchan_factor);
@@ -118,15 +120,15 @@ void processFeedGains::copy_upchannelize_f(const float* src_f, float* dst_f, siz
     (void)fid; // not used in the default implementation
     for (size_t u = 0; u < upchan_factor; ++u) {
         // copy ell elements from the source into each fine channel
-        float* u_ptr = dst_f + u * num_elements * 2;
-        std::copy_n(src_f, 2 * num_elements, u_ptr);
+        float* u_ptr = dst_f + u * num_elements * num_components;
+        std::copy_n(src_f, num_components * num_elements, u_ptr);
     }
 }
 
 void processFeedGains::copy_upchannelize(float* frame, size_t beam_id) {
-    size_t in_fstride = num_elements * 2;
+    size_t in_fstride = num_elements * num_components;
     // duplicate the gains at each upchan = 0 bin for each freq
-    size_t out_fstride = upchan_factor * num_elements * 2;
+    size_t out_fstride = upchan_factor * num_elements * num_components;
 
     // data starting at this beam_id
     float* out_ptr = gain_store_buf.data() + beam_id * num_local_freq * out_fstride;
@@ -220,9 +222,11 @@ void processFeedGains::main_thread() {
         for (size_t e = 0; e < num_elements; e++) {
             if (mask_store_buf[e] == 0) {
                 // zero out this element for all other indices
-                for (size_t k = 2 * e; k < out_num_values; k += 2 * num_elements) {
-                    out_frame[k] = 0.0;
-                    out_frame[k + 1] = 0.0;
+                for (size_t k = num_components * e; k < out_num_values;
+                     k += num_components * num_elements) {
+                    for (size_t j = 0; j < num_components; ++j) {
+                        out_frame[k + j] = 0.0;
+                    }
                 }
             }
         }

--- a/lib/stages/processFeedGains.cpp
+++ b/lib/stages/processFeedGains.cpp
@@ -33,6 +33,7 @@ processFeedGains::processFeedGains(Config& config, const std::string& unique_nam
     num_beams = config.get_default<uint32_t>(unique_name, "num_beams", 1);
     upchan_factor = config.get_default<uint32_t>(unique_name, "upchan_factor", 1);
     num_components = config.get<uint32_t>(unique_name, "num_components");
+    scaling_factor = config.get_default<float>(unique_name, "scaling_factor", 1.0);
 
     // Input gain buffers
     json in_buf_list = config.get_value(unique_name, "gain_buffers");
@@ -93,7 +94,7 @@ processFeedGains::processFeedGains(Config& config, const std::string& unique_nam
     // Allocate permanent buffers to hold the loaded gains in memory. These will only
     // be updated whenever the gains are updated, and get repeatedly copied
     // into received kotekan buffers
-    gain_store_buf = std::vector<float>(out_num_values, 0.0f);
+    gain_store_buf = std::vector<float>(out_num_values, std::numeric_limits<float>::quiet_NaN());
     mask_store_buf = std::vector<uint8_t>(num_elements, 1u);
 }
 
@@ -121,7 +122,9 @@ void processFeedGains::copy_upchannelize_f(const float* src_f, float* dst_f, siz
     for (size_t u = 0; u < upchan_factor; ++u) {
         // copy ell elements from the source into each fine channel
         float* u_ptr = dst_f + u * num_elements * num_components;
-        std::copy_n(src_f, num_components * num_elements, u_ptr);
+        // apply the constant scaling factor
+        std::transform(src_f, src_f + num_components * num_elements, u_ptr,
+                       [this](float v) { return v * this->scaling_factor; });
     }
 }
 

--- a/lib/stages/processFeedGains.cpp
+++ b/lib/stages/processFeedGains.cpp
@@ -86,7 +86,7 @@ processFeedGains::processFeedGains(Config& config, const std::string& unique_nam
     // via ensure_frame_desc. This works equally if out_buf is later declared
     // ndarray, in which case ensure_frame_desc validates against the config
     // descriptor instead of attaching one.
-    ensure_frame_desc(out_buf);
+    set_frame_desc(out_buf);
 
     // Allocate permanent buffers to hold the loaded gains in memory. These will only
     // be updated whenever the gains are updated, and get repeatedly copied
@@ -97,13 +97,21 @@ processFeedGains::processFeedGains(Config& config, const std::string& unique_nam
 
 processFeedGains::~processFeedGains() {}
 
-void processFeedGains::ensure_frame_desc(Buffer* buf) {
-    buf->ensure_frame_desc(kotekan::NDArray<kotekan::GetType_t<kotekan::float32>, 5>::describe(
+void processFeedGains::set_frame_desc(Buffer* buf) {
+    buf->ensure_frame_desc(kotekan::NDArray<kotekan::GetType_t<kotekan::float32>, 4>::describe(
         "processed_gain",
-        {static_cast<ptrdiff_t>(num_beams), static_cast<ptrdiff_t>(num_local_freq),
-         static_cast<ptrdiff_t>(upchan_factor), static_cast<ptrdiff_t>(num_elements),
-         static_cast<ptrdiff_t>(2)},
-        {"R", "F", "U", "E", "ReIm"}, {1, 1, 1, 1, 1}));
+        {static_cast<ptrdiff_t>(num_beams), static_cast<ptrdiff_t>(num_local_freq * upchan_factor),
+         static_cast<ptrdiff_t>(num_elements), static_cast<ptrdiff_t>(2)},
+        {"R", "Fbar", "E", "ReIm"}, {1, 1, 1, 1}));
+
+    freq_upchan_factor = std::vector<int>(num_local_freq * upchan_factor, 1);
+    freq_upchan_index = std::vector<int>(num_local_freq * upchan_factor);
+
+    // set the actual frequency upchan indices. Assume increasing index
+    // TODO: verify that this is correct
+    for (uint64_t f = 0; f < num_local_freq * upchan_factor; ++f) {
+        freq_upchan_index[f] = static_cast<int>(f % upchan_factor);
+    }
 }
 
 void processFeedGains::copy_upchannelize_f(const float* src_f, float* dst_f, size_t fid) {
@@ -196,6 +204,9 @@ void processFeedGains::main_thread() {
         auto meta = get_chord_metadata(out_buf, out_buf_frame_id);
         meta->set_from_frame_desc(out_buf->get_frame_desc<kotekan::GenericNDArray>());
         meta->set_name("processed_gain");
+        // Set the frequency upchannelization metadata
+        meta->set_freq_upchan_factor(freq_upchan_factor);
+        meta->set_freq_upchan_index(freq_upchan_index);
         // Verify that frame desc and metadata match
         meta->check_frame_desc(out_buf->get_frame_desc<kotekan::GenericNDArray>());
 

--- a/lib/stages/processFeedGains.cpp
+++ b/lib/stages/processFeedGains.cpp
@@ -1,6 +1,7 @@
 #include "processFeedGains.hpp"
 
 #include "Config.hpp"         // for Config
+#include "DataType.hpp"       // for float16_t
 #include "N2Util.hpp"         // for frameID
 #include "StageFactory.hpp"   // for REGISTER_KOTEKAN_STAGE
 #include "buffer.hpp"         // for Buffer
@@ -77,7 +78,7 @@ processFeedGains::processFeedGains(Config& config, const std::string& unique_nam
     }
 
     out_num_values = num_beams * num_elements * num_local_freq * upchan_factor * num_components;
-    auto out_buf_size = out_num_values * sizeof(float);
+    auto out_buf_size = out_num_values * sizeof(float16_t);
     if (out_buf->frame_size != out_buf_size) {
         FATAL_ERROR("Output buffer does not have the expected shape. Expected {:d}, got {:d}",
                     out_buf_size, out_buf->frame_size);
@@ -94,39 +95,42 @@ processFeedGains::processFeedGains(Config& config, const std::string& unique_nam
     // Allocate permanent buffers to hold the loaded gains in memory. These will only
     // be updated whenever the gains are updated, and get repeatedly copied
     // into received kotekan buffers
-    gain_store_buf = std::vector<float>(out_num_values, std::numeric_limits<float>::quiet_NaN());
+    gain_store_buf =
+        std::vector<float16_t>(out_num_values, std::numeric_limits<float16_t>::quiet_NaN());
     mask_store_buf = std::vector<uint8_t>(num_elements, 1u);
 }
 
 processFeedGains::~processFeedGains() {}
 
 void processFeedGains::set_frame_desc(Buffer* buf) {
-    buf->ensure_frame_desc(kotekan::NDArray<kotekan::GetType_t<kotekan::float32>, 4>::describe(
+    buf->ensure_frame_desc(kotekan::NDArray<kotekan::GetType_t<kotekan::float16>, 4>::describe(
         "W",
         {static_cast<ptrdiff_t>(num_beams), static_cast<ptrdiff_t>(num_local_freq * upchan_factor),
          static_cast<ptrdiff_t>(num_elements), static_cast<ptrdiff_t>(num_components)},
         {"R", "Fbar", "E", "C"}, {1, 1, 1, 1}));
 
-    freq_upchan_factor = std::vector<int>(num_local_freq * upchan_factor, 1);
+    freq_upchan_factor = std::vector<int>(num_local_freq * upchan_factor, upchan_factor);
     freq_upchan_index = std::vector<int>(num_local_freq * upchan_factor);
-    coarse_freq = std::vector<int>(num_local_freq * upchan_factor);
+    coarse_freq = std::vector<int>(num_local_freq * upchan_factor, -1);
 
-    // set the actual frequency upchan indices. Assume increasing index
-    // TODO: verify that this is correct
+    // set the actual frequency upchan indices. Assume increasing
+    // upchannelized index
+    // TODO: this needs to be consistent with the upchannelizer, and
+    // potentially configurable
     for (uint64_t f = 0; f < num_local_freq * upchan_factor; ++f) {
         freq_upchan_index[f] = static_cast<int>(f % upchan_factor);
     }
 }
 
-void processFeedGains::copy_upchannelize_f(const float* src_f, float* dst_f, size_t fid) {
+void processFeedGains::copy_upchannelize_f(const float* src_f, float16_t* dst_f, size_t fid) {
     (void)fid; // not used in the default implementation
     auto scaling_factor = this->scaling_factor;
     for (size_t u = 0; u < upchan_factor; ++u) {
         // copy ell elements from the source into each fine channel
-        float* u_ptr = dst_f + u * num_elements * num_components;
+        float16_t* u_ptr = dst_f + u * num_elements * num_components;
         // apply the constant scaling factor
         std::transform(src_f, src_f + num_components * num_elements, u_ptr,
-                       [scaling_factor](float v) { return v * scaling_factor; });
+                       [scaling_factor](float v) { return float16_t(v * scaling_factor); });
     }
 }
 
@@ -136,13 +140,13 @@ void processFeedGains::copy_upchannelize(float* frame, size_t beam_id) {
     size_t out_fstride = upchan_factor * num_elements * num_components;
 
     // data starting at this beam_id
-    float* out_ptr = gain_store_buf.data() + beam_id * num_local_freq * out_fstride;
+    float16_t* out_ptr = gain_store_buf.data() + beam_id * num_local_freq * out_fstride;
 
     for (size_t f = 0; f < num_local_freq; ++f) {
         // pointer to this frequency in the input frame
         const float* src = frame + f * in_fstride;
         // pointer to the first fine channel of each coarse freq
-        float* dst = out_ptr + f * out_fstride;
+        float16_t* dst = out_ptr + f * out_fstride;
         // upchannelize and copy
         copy_upchannelize_f(src, dst, f);
     }
@@ -157,7 +161,7 @@ void processFeedGains::main_thread() {
         gain_buffer_frame_ids.emplace_back(gain_buffers.at(iter));
     }
 
-    bool set_coarse_freqs = false;
+    bool set_coarse_freqs_once = true;
 
     while (!stop_thread) {
         // Poll all possible producing buffers
@@ -177,6 +181,18 @@ void processFeedGains::main_thread() {
                 // copy gains into the permanent buffer and upchannelize
                 copy_upchannelize(frame, beam_id);
                 DEBUG("Copied upchannelized gains for beam {:d}", beam_id);
+
+                // set coarse freq metadata once
+                if (set_coarse_freqs_once) {
+                    auto meta_in = get_chord_metadata(buf, frame_id);
+                    auto coarse_freq_in = meta_in->get_coarse_freq();
+
+                    for (uint64_t f = 0; f < num_local_freq * upchan_factor; ++f) {
+                        int idx = f / upchan_factor;
+                        coarse_freq[f] = coarse_freq_in[idx];
+                    }
+                    set_coarse_freqs_once = false;
+                }
 
                 buf->mark_frame_empty(unique_name, frame_id);
                 frame_id++;
@@ -203,7 +219,8 @@ void processFeedGains::main_thread() {
         }
 
         // Get an output buffer
-        float* out_frame = (float*)out_buf->wait_for_empty_frame(unique_name, out_buf_frame_id);
+        float16_t* out_frame =
+            (float16_t*)out_buf->wait_for_empty_frame(unique_name, out_buf_frame_id);
         if (out_frame == nullptr) {
             return;
         }
@@ -216,17 +233,6 @@ void processFeedGains::main_thread() {
         // Set the frequency upchannelization metadata
         meta->set_freq_upchan_factor(freq_upchan_factor);
         meta->set_freq_upchan_index(freq_upchan_index);
-        // Also need to set coarse frequencies, which requires metadata
-        // from the input frame
-        if (set_coarse_freqs) {
-            auto meta_in = get_chord_metadata(in_mask_buf, in_mask_frame_id);
-            auto coarse_freqs_in = meta_in->get_coarse_freq();
-
-            for (uint64_t f = 0; f < num_local_freq * upchan_factor; ++f) {
-                int idx = f / upchan_factor;
-                coarse_freq[f] = coarse_freqs_in[idx];
-            }
-        }
         meta->set_coarse_freq(coarse_freq);
         // Verify that frame desc and metadata match
         meta->check_frame_desc(out_buf->get_frame_desc<kotekan::GenericNDArray>());
@@ -244,7 +250,7 @@ void processFeedGains::main_thread() {
                 for (size_t k = num_components * e; k < out_num_values;
                      k += num_components * num_elements) {
                     for (size_t j = 0; j < num_components; ++j) {
-                        out_frame[k + j] = 0.0;
+                        out_frame[k + j] = float16_t(0.0);
                     }
                 }
             }

--- a/lib/stages/processFeedGains.hpp
+++ b/lib/stages/processFeedGains.hpp
@@ -96,6 +96,9 @@ private:
     /// Number of elements in the output buffer
     uint32_t out_num_values;
 
+    /// Fixed scaling factor
+    float scaling_factor;
+
     /// Fixed buffers used to hold gains separately from the kotekan buffers
     std::vector<float> gain_store_buf;
     std::vector<uint8_t> mask_store_buf;

--- a/lib/stages/processFeedGains.hpp
+++ b/lib/stages/processFeedGains.hpp
@@ -48,6 +48,8 @@ using std::vector;
  * @conf   num_beams                             Int. Number of beams with unique gain files
  * @conf   num_local_freq                        Int. Number of frequencies per node
  * @conf   upchan_factor                         Int. Frequency upchannelization factor.
+ * @conf   num_components                        Int. Number of gain components. Should be either
+ *                                                   1 (real) or 2 (real/imag).
  *
  * @author Liam Gray
  *
@@ -88,6 +90,8 @@ private:
     uint32_t num_local_freq;
     /// Frequency upchannelization factor
     uint32_t upchan_factor;
+    /// Number of components
+    uint32_t num_components;
 
     /// Number of elements in the output buffer
     uint32_t out_num_values;

--- a/lib/stages/processFeedGains.hpp
+++ b/lib/stages/processFeedGains.hpp
@@ -74,7 +74,7 @@ private:
 
     /// Create a frame desc for the output buffer. Default creates a frame desc
     /// containing [beam, freq, subfreq, element, ReIm] axes.
-    virtual void ensure_frame_desc(Buffer* buf);
+    virtual void set_frame_desc(Buffer* buf);
 
     std::vector<Buffer*> gain_buffers;
     Buffer* in_mask_buf;
@@ -95,6 +95,10 @@ private:
     /// Fixed buffers used to hold gains separately from the kotekan buffers
     std::vector<float> gain_store_buf;
     std::vector<uint8_t> mask_store_buf;
+
+    /// Store gain upchannelization factors
+    std::vector<int> freq_upchan_factor;
+    std::vector<int> freq_upchan_index;
 };
 
 

--- a/lib/stages/processFeedGains.hpp
+++ b/lib/stages/processFeedGains.hpp
@@ -106,6 +106,7 @@ private:
     /// Store gain upchannelization factors
     std::vector<int> freq_upchan_factor;
     std::vector<int> freq_upchan_index;
+    std::vector<int> coarse_freq;
 };
 
 

--- a/lib/stages/processFeedGains.hpp
+++ b/lib/stages/processFeedGains.hpp
@@ -8,6 +8,7 @@
 #define PROCESS_FEED_GAINS_HPP
 
 #include "Config.hpp"          // for Config
+#include "DataType.hpp"        // for float16_t
 #include "Stage.hpp"           // for Stage
 #include "buffer.hpp"          // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
@@ -72,10 +73,10 @@ private:
 
     /// Implement logic to upchannelize a single fine frequency, given a coarse frequency.
     /// Default will just duplicate the coarse frequency gain `N` times.
-    virtual void copy_upchannelize_f(const float* src_f, float* dst_f, size_t fid);
+    virtual void copy_upchannelize_f(const float* src_f, float16_t* dst_f, size_t fid);
 
     /// Create a frame desc for the output buffer. Default creates a frame desc
-    /// containing [beam, freq, subfreq, element, ReIm] axes.
+    /// containing [beam, freq, element, ReIm] axes.
     virtual void set_frame_desc(Buffer* buf);
 
     std::vector<Buffer*> gain_buffers;
@@ -100,7 +101,7 @@ private:
     float scaling_factor;
 
     /// Fixed buffers used to hold gains separately from the kotekan buffers
-    std::vector<float> gain_store_buf;
+    std::vector<float16_t> gain_store_buf;
     std::vector<uint8_t> mask_store_buf;
 
     /// Store gain upchannelization factors


### PR DESCRIPTION
Mechanically, this works (requires a few cherry-picked commits from `rhaas/frbNetwork4` in order to use the `FewHot` test stage). How it affects the data will require additional tests.

There are two sets of "gains" discussed in the context of the FRB beamformer - first, those produced by `setUpchanGain`. These are just a single, real value for each upchannelized frequency, applied to the frequency after upchannelizing (assuming my reading of the kernels is correct). For CHIME's sake, I think we just leave these all to be 1.

Then, there are the FRB1 phases, which were previously produced by `setFRB1Phase`. As far as I can tell (again, from reading the kernels), these are effectively the complex per-element calibration gains (times some scaling factor?). `setFRB1Phase` just produces some constant value (equal to the scaling factor), so I've updated `processFeedGains` to include a fixed, real scaling factor as well.

The one potential _TODO_ here involves the `upchan_min_channel` and `upchan_max_channel` parameters in `setFRB1Phase`, but I don't think these are really used here for CHIME in a way that matters (they're just set to the range [0, 16) for an upchan factor of 16).

This PR also only includes gains for the FRB beamformer stage - full config (including HFB and tracking beams as well) is still demonstrated in the `chime_upgrade_test_gains` config file (which I'll keep around for now).