### PR TITLE
Improve DPDK startup for CHIME and NIC counter logging

### DIFF
--- a/config/chime_upgrade_frb.j2
+++ b/config/chime_upgrade_frb.j2
@@ -202,10 +202,11 @@ dpdk:
   tx_ring_size: 128
   num_mbufs: 512
   mbuf_cache_size: 128
-
   # Set to true when using a switch to replicate packets
   using_switch: true
-  alignment: samples_per_data_set * 4
+  alignment: samples_per_frame
+  alignment_startup_delay: 20.0
+  lcore_start_delay: 1.0
   # List of PCIe devices we don't want to attach too
   # Required to exclude the ConnectX 6 Lx output NICs.
   # Excluded devices are listed by their PCIe address. 

--- a/config/chime_upgrade_frb.j2
+++ b/config/chime_upgrade_frb.j2
@@ -204,7 +204,7 @@ dpdk:
   mbuf_cache_size: 128
   # Set to true when using a switch to replicate packets
   using_switch: true
-  alignment: samples_per_frame
+  alignment: samples_per_data_set
   alignment_startup_delay: 20.0
   lcore_start_delay: 1.0
   # List of PCIe devices we don't want to attach too

--- a/config/chime_upgrade_n2.j2
+++ b/config/chime_upgrade_n2.j2
@@ -193,11 +193,13 @@ dpdk:
   rx_ring_size: 192
   tx_ring_size: 128
   num_mbufs: 512
+  # Increase this value if ports are not synchronizing
+  alignment_startup_delay: 20.0
+  lcore_start_delay: 1.0
   mbuf_cache_size: 128
-
   # Set to true when using a switch to replicate packets
   using_switch: true
-  alignment: samples_per_data_set * 4
+  alignment: samples_per_data_set
   # List of PCIe devices we don't want to attach too
   # Required to exclude the ConnectX 6 Lx output NICs.
   # Excluded devices are listed by their PCIe address. 

--- a/config/chime_upgrade_network.j2
+++ b/config/chime_upgrade_network.j2
@@ -34,6 +34,14 @@ sizeof_float: 4
 sizeof_int: 4
 sizeof_short: 2
 
+{% set num_polarizations = 2 %}
+{% set num_dishes = 1024 %}
+{% set num_elements = num_polarizations * num_dishes %}
+
+num_polarizations: {{ num_polarizations }}
+num_dishes: {{ num_dishes }}
+num_elements: {{ num_elements }}
+
 use_hugepages: true
 
 # Single source of truth for the upstream FPGA controller's REST interface.
@@ -111,7 +119,9 @@ dpdk:
   max_rx_pkt_len: 5000
   # Set to true when using a switch to replicate packets
   using_switch: true
-  alignment: samples_per_frame * 4
+  alignment: samples_per_frame
+  alignment_startup_delay: 20.0
+  lcore_start_delay: 1.0
   # List of PCIe devices we don't want to attach too
   # Required to exclude the ConnectX 6 Lx output NICs.
   # Excluded devices are listed by their PCIe address. 

--- a/config/chime_upgrade_network.j2
+++ b/config/chime_upgrade_network.j2
@@ -20,7 +20,6 @@ type: config
 # OFF, ERROR, WARN, INFO, DEBUG, DEBUG2 (case insensitive)
 # Note DEBUG and DEBUG2 require a build with (-DCMAKE_BUILD_TYPE=Debug)
 log_level: info
-num_elements: 2048
 num_freq_host_buf: 1
 num_freq_gpu_buf: 16
 samples_per_frame: 16384

--- a/lib/dpdk/dpdkCore.cpp
+++ b/lib/dpdk/dpdkCore.cpp
@@ -1,42 +1,41 @@
 #include "dpdkCore.hpp"
 
-#include <numa.h>                       // for numa_node_of_cpu, numa_num_configured_nodes
-#include <rte_branch_prediction.h>      // for unlikely
-#include <rte_config.h>                 // for RTE_PKTMBUF_HEADROOM
-#include <rte_eal.h>                    // for rte_eal_init
-#include <rte_errno.h>                  // for rte_strerror, per_lcore__rte_errno, rte_errno
-#include <rte_ether.h>                  // for rte_ether_addr
-#include <rte_launch.h>                 // for rte_eal_mp_remote_launch, rte_eal_mp_wait_lcore
-#include <rte_lcore.h>                  // for rte_lcore_count, rte_lcore_id
-#include <rte_mbuf.h>                   // for rte_pktmbuf_free, rte_pktmbuf_init, rte_pktmbuf_p...
-#include <rte_mbuf_core.h>              // for rte_mbuf
-#include <rte_mempool.h>                // for rte_mempool_create, rte_mempool_free
-#include <rte_memzone.h>                // for rte_memzone_max_set
-#include <stdio.h>                      // for fprintf, NULL, size_t, stderr
-#include <stdlib.h>                     // for free, malloc
-#include <string.h>                     // for memset
-#include <sys/types.h>                  // for uint
-#include <unistd.h>                     // for sleep
-#include <rte_ring.h>                   // for rte_ring_create, rte_ring_dequeue_burst
-#include <cinttypes>                    // for uint32_t, uint16_t, int32_t, uint8_t
-#include <functional>                   // for bind, function
-#include <set>                          // for set
-#include <stdexcept>                    // for runtime_error
-#include <vector>                       // for vector
+#include <functional>              // for bind, function
+#include <numa.h>                  // for numa_node_of_cpu, numa_num_configured_nodes
+#include <rte_branch_prediction.h> // for unlikely
+#include <rte_config.h>            // for RTE_PKTMBUF_HEADROOM
+#include <rte_eal.h>               // for rte_eal_init
+#include <rte_errno.h>             // for rte_strerror, per_lcore__rte_errno, rte_errno
+#include <rte_ether.h>             // for rte_ether_addr
+#include <rte_launch.h>            // for rte_eal_mp_remote_launch, rte_eal_mp_wait_lcore
+#include <rte_lcore.h>             // for rte_lcore_count, rte_lcore_id
+#include <rte_mbuf.h>              // for rte_pktmbuf_free, rte_pktmbuf_init, rte_pktmbuf_p...
+#include <rte_mbuf_core.h>         // for rte_mbuf
+#include <rte_mempool.h>           // for rte_mempool_create, rte_mempool_free
+#include <rte_memzone.h>           // for rte_memzone_max_set
+#include <rte_ring.h>              // for rte_ring_create, rte_ring_dequeue_burst
+#include <set>                     // for set
+#include <stdexcept>               // for runtime_error
+#include <stdio.h>                 // for fprintf, NULL, size_t, stderr
+#include <stdlib.h>                // for free, malloc
+#include <string.h>                // for memset
+#include <sys/types.h>             // for uint
+#include <unistd.h>                // for sleep
+#include <vector>                  // for vector
 
-// cinttypes needed by some CentOS systems.
-#include "Config.hpp"                   // for Config
-#include "StageFactory.hpp"             // for REGISTER_KOTEKAN_STAGE
-#include "captureHandler.hpp"           // for captureHandler
-#include "crs16BoardCaptureWorker.hpp"  // for crs16BoardCaptureWorker
-#include "crs16BoardDistributor.hpp"    // for crs16BoardDistributor
-#include "crs1BoardCaptureWorker.hpp"   // for crs1BoardCaptureWorker
-#include "crs1BoardDistributor.hpp"     // for crs1BoardDistributor
-#include "iceBoardShuffle.hpp"          // for iceBoardShuffle
-#include "iceBoardStandard.hpp"         // for iceBoardStandard
-#include "iceBoardVDIF.hpp"             // for iceBoardVDIF
-#include "fmt.hpp"                      // for format, compile_string_to_view, fmt, format_string
-#include "json.hpp"                     // for basic_json, json, iter_impl
+#include "Config.hpp"                  // for Config
+#include "StageFactory.hpp"            // for REGISTER_KOTEKAN_STAGE
+#include "captureHandler.hpp"          // for captureHandler
+#include "crs16BoardCaptureWorker.hpp" // for crs16BoardCaptureWorker
+#include "crs16BoardDistributor.hpp"   // for crs16BoardDistributor
+#include "crs1BoardCaptureWorker.hpp"  // for crs1BoardCaptureWorker
+#include "crs1BoardDistributor.hpp"    // for crs1BoardDistributor
+#include "iceBoardShuffle.hpp"         // for iceBoardShuffle
+#include "iceBoardStandard.hpp"        // for iceBoardStandard
+#include "iceBoardVDIF.hpp"            // for iceBoardVDIF
+
+#include "fmt.hpp"  // for format, compile_string_to_view, fmt, format_string
+#include "json.hpp" // for basic_json, json, iter_impl
 
 using nlohmann::json;
 using std::string;
@@ -52,7 +51,17 @@ REGISTER_KOTEKAN_STAGE(dpdkCore);
 static bool __eal_initalized = false;
 
 dpdkCore::dpdkCore(Config& config, const string& unique_name, bufferContainer& buffer_container) :
-    Stage(config, unique_name, buffer_container, std::bind(&dpdkCore::main_thread, this)) {
+    Stage(config, unique_name, buffer_container, std::bind(&dpdkCore::main_thread, this)),
+    nic_rx_packets_total_metric(kotekan::prometheus::Metrics::instance().add_gauge(
+        "kotekan_dpdk_nic_rx_packets_total", unique_name, {"port"})),
+    nic_rx_missed_total_metric(kotekan::prometheus::Metrics::instance().add_gauge(
+        "kotekan_dpdk_nic_rx_missed_total", unique_name, {"port"})),
+    nic_rx_errors_total_metric(kotekan::prometheus::Metrics::instance().add_gauge(
+        "kotekan_dpdk_nic_rx_errors_total", unique_name, {"port"})),
+    nic_rx_nombuf_total_metric(kotekan::prometheus::Metrics::instance().add_gauge(
+        "kotekan_dpdk_nic_rx_nombuf_total", unique_name, {"port"})),
+    nic_link_up_metric(kotekan::prometheus::Metrics::instance().add_gauge(
+        "kotekan_dpdk_nic_link_up", unique_name, {"port"})) {
 
     uint32_t num_mbufs = config.get_default<uint32_t>(unique_name, "num_mbufs", 1024);
     const uint32_t mbuf_cache_size =
@@ -76,6 +85,10 @@ dpdkCore::dpdkCore(Config& config, const string& unique_name, bufferContainer& b
     dpdk_init(lcore_cpu_map, main_lcore_cpu);
 
     num_system_ports = rte_eth_dev_count_avail();
+
+    // Storage for the per-port NIC hardware stats and link state polling.
+    last_eth_stats.resize(num_system_ports);
+    link_is_up.resize(num_system_ports, false);
 
     // This default works well for ICE boards,
     // but we might change this to something more genertic
@@ -367,11 +380,72 @@ void dpdkCore::main_thread() {
                 handlers[i]->update_stats();
         }
 
-        // TODO Check port status
+        // Poll the NIC hardware counters and link state for each port.
+        update_port_stats();
     }
 
     // Wait for the lcores to join
     rte_eal_mp_wait_lcore();
+}
+
+void dpdkCore::update_port_stats() {
+
+    for (uint32_t port = 0; port < num_system_ports; ++port) {
+        if (handlers[port] == nullptr)
+            continue;
+
+        // Check the link state (without blocking on the PHY).
+        struct rte_eth_link link;
+        if (rte_eth_link_get_nowait(port, &link) == 0) {
+            const bool up = (link.link_status == RTE_ETH_LINK_UP);
+            if (up != link_is_up[port]) {
+                if (up) {
+                    INFO("Port {:d}: link is UP at {:d} Mbps", port, link.link_speed);
+                } else {
+                    ERROR("Port {:d}: link went DOWN! The NIC, cable, or switch port may have "
+                          "reset.",
+                          port);
+                }
+                link_is_up[port] = up;
+            }
+        }
+
+        // Read the NIC hardware counters.
+        struct rte_eth_stats stats;
+        if (rte_eth_stats_get(port, &stats) != 0)
+            continue;
+
+        // imissed counts packets that arrived at the NIC but were dropped because
+        // the rx ring was full, i.e. the lcore didn't service this port fast enough.
+        const uint64_t missed_delta = stats.imissed - last_eth_stats[port].imissed;
+        if (missed_delta > 0) {
+            WARN("Port {:d}: NIC dropped {:d} packets since the last poll (~1s) because the rx "
+                 "ring was full (lcore stalled or too slow); total missed: {:d}",
+                 port, missed_delta, stats.imissed);
+        }
+
+        const uint64_t error_delta = stats.ierrors - last_eth_stats[port].ierrors;
+        if (error_delta > 0) {
+            WARN("Port {:d}: NIC reported {:d} rx errors since the last poll (~1s); total: {:d}",
+                 port, error_delta, stats.ierrors);
+        }
+
+        const uint64_t nombuf_delta = stats.rx_nombuf - last_eth_stats[port].rx_nombuf;
+        if (nombuf_delta > 0) {
+            WARN("Port {:d}: {:d} rx mbuf allocation failures since the last poll (~1s); "
+                 "increase num_mbufs; total: {:d}",
+                 port, nombuf_delta, stats.rx_nombuf);
+        }
+
+        std::vector<std::string> port_label = {to_string(port)};
+        nic_rx_packets_total_metric.labels(port_label).set(stats.ipackets);
+        nic_rx_missed_total_metric.labels(port_label).set(stats.imissed);
+        nic_rx_errors_total_metric.labels(port_label).set(stats.ierrors);
+        nic_rx_nombuf_total_metric.labels(port_label).set(stats.rx_nombuf);
+        nic_link_up_metric.labels(port_label).set(link_is_up[port] ? 1 : 0);
+
+        last_eth_stats[port] = stats;
+    }
 }
 
 dpdkCore::~dpdkCore() {

--- a/lib/dpdk/dpdkCore.cpp
+++ b/lib/dpdk/dpdkCore.cpp
@@ -417,20 +417,28 @@ void dpdkCore::update_port_stats() {
 
         // imissed counts packets that arrived at the NIC but were dropped because
         // the rx ring was full, i.e. the lcore didn't service this port fast enough.
-        const uint64_t missed_delta = stats.imissed - last_eth_stats[port].imissed;
+        // Guard against counter resets (e.g. a link/NIC reset), which would
+        // otherwise underflow the unsigned delta into a bogus WARN.
+        const uint64_t missed_delta = stats.imissed >= last_eth_stats[port].imissed
+                                          ? stats.imissed - last_eth_stats[port].imissed
+                                          : 0;
         if (missed_delta > 0) {
             WARN("Port {:d}: NIC dropped {:d} packets since the last poll (~1s) because the rx "
                  "ring was full (lcore stalled or too slow); total missed: {:d}",
                  port, missed_delta, stats.imissed);
         }
 
-        const uint64_t error_delta = stats.ierrors - last_eth_stats[port].ierrors;
+        const uint64_t error_delta = stats.ierrors >= last_eth_stats[port].ierrors
+                                         ? stats.ierrors - last_eth_stats[port].ierrors
+                                         : 0;
         if (error_delta > 0) {
             WARN("Port {:d}: NIC reported {:d} rx errors since the last poll (~1s); total: {:d}",
                  port, error_delta, stats.ierrors);
         }
 
-        const uint64_t nombuf_delta = stats.rx_nombuf - last_eth_stats[port].rx_nombuf;
+        const uint64_t nombuf_delta = stats.rx_nombuf >= last_eth_stats[port].rx_nombuf
+                                          ? stats.rx_nombuf - last_eth_stats[port].rx_nombuf
+                                          : 0;
         if (nombuf_delta > 0) {
             WARN("Port {:d}: {:d} rx mbuf allocation failures since the last poll (~1s); "
                  "increase num_mbufs; total: {:d}",
@@ -506,6 +514,12 @@ int32_t dpdkCore::port_init(uint8_t port, uint32_t lcore_id) {
         ERROR("Failed to start port: {:d}", port);
         return retval;
     }
+
+    // Prime the stats baseline so the first poll in update_port_stats() reports
+    // deltas relative to now rather than the port's cumulative pre-start counters.
+    if (rte_eth_stats_get(port, &last_eth_stats[port]) != 0)
+        WARN("Port {:d}: could not read initial NIC stats; first stats poll may over-report deltas",
+             port);
 
     // Report the port MAC address.
     // TODO record the MAC address for export to JSON

--- a/lib/dpdk/dpdkCore.hpp
+++ b/lib/dpdk/dpdkCore.hpp
@@ -14,22 +14,22 @@
 // break with "templates must have C++ linkage".
 extern "C" {
 // IWYU pragma: begin_keep
-#include <rte_ethdev.h>         // for rte_eth_conf
-#include <rte_ring_core.h>      // for rte_ring
-// cinttypes needed by some CentOS systems.
-#include <cinttypes>            // for uint32_t, int32_t, uint8_t
+#include <rte_ethdev.h>    // for rte_eth_conf
+#include <rte_ring_core.h> // for rte_ring
 // IWYU pragma: end_keep
 }
 
-#include <atomic>               // for atomic
-#include <string>               // for string, allocator, basic_string
-#include <vector>               // for vector
+#include "Config.hpp"            // for Config
+#include "Stage.hpp"             // for Stage
+#include "bufferContainer.hpp"   // for bufferContainer
+#include "kotekanLogging.hpp"    // for kotekanLogging
+#include "prometheusMetrics.hpp" // for Metrics, MetricFamily, Gauge
 
-#include "Config.hpp"           // for Config
-#include "Stage.hpp"            // for Stage
-#include "bufferContainer.hpp"  // for bufferContainer
-#include "kotekanLogging.hpp"   // for kotekanLogging
-#include "fmt.hpp"              // for format
+#include "fmt.hpp" // for format
+
+#include <atomic> // for atomic
+#include <string> // for string, allocator, basic_string
+#include <vector> // for vector
 
 /**
  * @brief Abstract object for processing packets that come from a given NIC port
@@ -212,6 +212,28 @@ private:
     void create_handlers(kotekan::bufferContainer& buffer_container);
 
     void create_workers(kotekan::bufferContainer& buffer_container);
+
+    /**
+     * @brief Polls the per-port NIC hardware counters and link state.
+     *
+     * Logs link state changes and NIC-level packet drops (e.g. rx ring overflows
+     * when an lcore stalls), and exports them as prometheus metrics. Runs on the
+     * main thread, so it keeps working even if the rx lcores are stuck.
+     */
+    void update_port_stats();
+
+    /// The NIC hardware stats at the last poll, per port, for computing deltas.
+    std::vector<struct rte_eth_stats> last_eth_stats;
+
+    /// The link state at the last poll, per port.
+    std::vector<bool> link_is_up;
+
+    /// Prometheus metrics for NIC-level (hardware) counters
+    kotekan::prometheus::MetricFamily<kotekan::prometheus::Gauge>& nic_rx_packets_total_metric;
+    kotekan::prometheus::MetricFamily<kotekan::prometheus::Gauge>& nic_rx_missed_total_metric;
+    kotekan::prometheus::MetricFamily<kotekan::prometheus::Gauge>& nic_rx_errors_total_metric;
+    kotekan::prometheus::MetricFamily<kotekan::prometheus::Gauge>& nic_rx_nombuf_total_metric;
+    kotekan::prometheus::MetricFamily<kotekan::prometheus::Gauge>& nic_link_up_metric;
 
     /// The pool of DPDK mbufs, one per numa node
     std::vector<struct rte_mempool*> mbuf_pools;

--- a/lib/dpdk/dpdkCore.hpp
+++ b/lib/dpdk/dpdkCore.hpp
@@ -16,6 +16,7 @@ extern "C" {
 // IWYU pragma: begin_keep
 #include <rte_ethdev.h>    // for rte_eth_conf
 #include <rte_ring_core.h> // for rte_ring
+#include <cinttypes> // for uint32_t, int32_t, uint8_t
 // IWYU pragma: end_keep
 }
 

--- a/lib/dpdk/iceBoardHandler.hpp
+++ b/lib/dpdk/iceBoardHandler.hpp
@@ -16,7 +16,7 @@
 
 #include "json.hpp"
 
-#include <mutex>
+#include <atomic>
 
 /**
  * @brief Abstract class which contains things which are common to processing
@@ -34,6 +34,12 @@
  *                                                 payload, FPGA footer flags, and any padding
  *                                                 (but not the Ethernet CRC).
  * @conf   samples_per_packet Int. Default 2.    The number of time samples per FPGA packet
+ * @conf   alignment_startup_delay Float. Default 1.0. The minimum time (in seconds) between the
+ *                                                 first packet seen (on any port) and the
+ *                                                 alignment edge (FPGA seq number) at which all
+ *                                                 ports will start processing data. Increase
+ *                                                 this if ports fail to start within one frame
+ *                                                 of each other.
  * @conf   status_cadence    Int  Default 0      The time (in seconds between printing port
  *                                                 status) Default 0 == don't print.
  *
@@ -77,46 +83,62 @@ protected:
     /**
      * @brief Aligns the first packet.
      *
-     * This function should only be used at startup to find the first packet to start processing
+     * This function should only be used at startup to find the first packet to start processing.
+     *
+     * The first handler (on any port) to see a packet sets a shared target alignment edge
+     * which is at least @c alignment_startup_delay seconds in the future, rounded up to the
+     * next @c alignment boundary. All handlers then drop packets until they reach that edge,
+     * so every port starts processing at exactly the same FPGA seq number.
+     *
+     * Any gap between the target edge and the first packet a port sees after it is filled
+     * in by the lost packet system. If that gap is one full frame (@c alignment) or more,
+     * kotekan is stopped with a fatal error, since that indicates the port started too far
+     * behind the others (see @c alignment_startup_delay).
      *
      * Should be called by every handler.
      *
      * @param mbuf The packet to check for alignment
-     * @return True if the packet is within 100 of the alignment edge,
+     * @return True if the packet is at or past the shared target alignment edge,
      *         False otherwise.
      */
     bool align_first_packet(struct rte_mbuf* mbuf) {
         uint64_t seq = iceBoardHandler::get_mbuf_seq_num(mbuf);
+
+        // Get (or set, if we are the first handler to see a packet) the shared target edge.
+        uint64_t target_seq = get_alignment_target(seq);
+
+        // Wait for the target alignment edge to be reached.
+        if (seq < target_seq)
+            return false;
+
+        // Check that this port didn't start more than one frame past the target edge,
+        // otherwise the lost packet fill system would need to back-fill one or more
+        // entire frames to catch up.
+        if (unlikely(seq >= target_seq + alignment)) {
+            const double late_seconds =
+                (double)(seq - target_seq) * Telescope::instance().seq_length_nsec() * 1e-9;
+            FATAL_ERROR("Port {:d}: first packet (seq num {:d}) arrived {:d} frame(s) "
+                        "({:.3f} s) after the target alignment edge {:d}. Try increasing "
+                        "alignment_startup_delay (currently {:.3f} s), closing kotekan!",
+                        port, seq, (seq - target_seq) / alignment, late_seconds, target_seq,
+                        alignment_startup_delay);
+            return false;
+        }
+
         ice_stream_id_t stream_id =
             ice_extract_stream_id(iceBoardHandler::get_mbuf_stream_id(mbuf));
 
-        // We allow for the fact we might miss the first packet by upto 100 FPGA frames,
-        // if this happens then the missing frames at the start of the buffer frame are filled
-        // in as lost packets.
-        // TODO This seems to happen more on the new CHIME hardware with extra links, this needs
-        // some optimization, likely requires moving buffer handling out of the critial packet loop.
-        if ((seq % alignment) <= 1000) {
+        last_seq = target_seq;
+        cur_seq = seq;
+        port_stream_id = stream_id;
+        got_first_packet = true;
 
-            last_seq = seq - seq % alignment;
-            cur_seq = seq;
-            port_stream_id = stream_id;
+        INFO("Port {:d}; Got StreamID: crate: {:d}, slot: {:d}, link: {:d}, unused: {:d}, "
+             "start seq num: {:d} current seq num: {:d}",
+             port, stream_id.crate_id, stream_id.slot_id, stream_id.link_id, stream_id.unused,
+             last_seq, seq);
 
-            INFO("Port {:d}; Got StreamID: crate: {:d}, slot: {:d}, link: {:d}, unused: {:d}, "
-                 "start seq num: {:d} current seq num: {:d}",
-                 port, stream_id.crate_id, stream_id.slot_id, stream_id.link_id, stream_id.unused,
-                 last_seq, seq);
-
-            if (!check_cross_handler_alignment(last_seq)) {
-                FATAL_ERROR("DPDK failed to align packets between handlers, closing kotekan!");
-                return false;
-            }
-
-            got_first_packet = true;
-
-            return true;
-        }
-
-        return false;
+        return true;
     }
 
     /**
@@ -181,10 +203,6 @@ protected:
             return false;
         }
 
-        // Add to common stats
-        rx_packets_total += 1;
-        rx_bytes_total += cur_mbuf->pkt_len;
-
         return true;
     }
 
@@ -244,53 +262,56 @@ protected:
     }
 
     /**
-     * @brief Function to ensure all handlers align to the same FPGA seq number
+     * @brief Gets the target FPGA seq number all handlers will align their first frame to.
+     *
+     * The first handler to call this function with the seq number of a received packet
+     * sets the shared target alignment edge: at least @c alignment_startup_delay seconds
+     * past the given seq number, rounded up to the next @c alignment boundary. All later
+     * calls simply return that shared target.
      *
      * This function must be called at least once with
-     * @c check_cross_handler_alignment(std::numeric_limits<uint64_t>::max());
-     * In order to initalize the alignment seq number
+     * @c get_alignment_target(std::numeric_limits<uint64_t>::max());
+     * in order to reset the shared target before packets are processed.
      *
-     * @param seq_num The seq number which should be aligned too.
-     * @return true if the alignment is good, or this is the first handler to call this function
-     *         false if the alignment fails.
+     * @param seq_num The FPGA seq number of the packet being processed,
+     *                or uint64_t max to reset the shared target.
+     * @return The shared target alignment seq number.
      */
-    inline bool check_cross_handler_alignment(uint64_t seq_num) {
+    inline uint64_t get_alignment_target(uint64_t seq_num) {
 
-        /// Alignment mutex
-        static std::mutex alignment_mutex;
+        /// The target seq number all handlers align to.
+        static std::atomic<uint64_t> alignment_target_seq{std::numeric_limits<uint64_t>::max()};
 
-        /// The first seq number seen by each handler
-        static uint64_t alignment_first_seq;
-
-        std::lock_guard<std::mutex> alignment_lock(alignment_mutex);
-
-        // This provides a way to init the alignment_first_seq to a fixed constand before we start
-        // getting packets.
+        // This provides a way to reset the alignment_target_seq to a fixed constant before
+        // we start getting packets.
         if (seq_num == std::numeric_limits<uint64_t>::max()) {
-            alignment_first_seq = std::numeric_limits<uint64_t>::max();
-            DEBUG("Setting alignment value to MAX={:d}", alignment_first_seq);
-            return true;
+            alignment_target_seq.store(std::numeric_limits<uint64_t>::max());
+            DEBUG("Setting alignment target to MAX={:d}", std::numeric_limits<uint64_t>::max());
+            return std::numeric_limits<uint64_t>::max();
         }
 
-        // This case deals with the first handler setting it's seq number.
-        if (seq_num != alignment_first_seq
-            && alignment_first_seq == std::numeric_limits<uint64_t>::max()) {
-            DEBUG("Port {:d}: Got first alignemnt value of {:d}", port, seq_num);
-            alignment_first_seq = seq_num;
-            return true;
+        // Fast path: the shared target has already been set by the first handler.
+        uint64_t target = alignment_target_seq.load();
+        if (target != std::numeric_limits<uint64_t>::max())
+            return target;
+
+        // The shared target isn't set yet, so compute a candidate and try to publish it.
+        // Only the first handler to succeed at the compare-exchange sets the target for
+        // everyone; any others discard their candidate and use the published value.
+        const uint64_t delay_samples =
+            (uint64_t)(alignment_startup_delay * 1e9 / Telescope::instance().seq_length_nsec());
+        const uint64_t candidate = ((seq_num + delay_samples) / alignment + 1) * alignment;
+
+        uint64_t expected = std::numeric_limits<uint64_t>::max();
+        if (alignment_target_seq.compare_exchange_strong(expected, candidate)) {
+            INFO("Port {:d}: Got first packet with seq num {:d}, set the target alignment "
+                 "seq num for all ports to {:d} ({:.3f} s startup delay)",
+                 port, seq_num, candidate, alignment_startup_delay);
+            return candidate;
         }
 
-        // This case deals with each addational handler checking if it has the same
-        // first seq number.
-        if (seq_num != alignment_first_seq) {
-            ERROR("Port {:d}: Got alignemnt value of {:d}, but expected {:d}", port, seq_num,
-                  alignment_first_seq);
-            return false;
-        }
-
-        // Additional handler(s) got the same first seq number.
-        DEBUG("Port {:d}: Got alignemnt value of {:d}", port, seq_num);
-        return true;
+        // Another handler won the race; expected now holds the published target.
+        return expected;
     }
 
     /**
@@ -324,6 +345,10 @@ protected:
 
     /// This is the value that we will align the first frame too.
     uint64_t alignment;
+
+    /// The minimum time (in seconds) between the first packet seen and the target
+    /// alignment edge all ports will start processing at.
+    double alignment_startup_delay;
 
     /// Offset into the first byte of data after the Ethernet/UP/UDP/FPGA packet headers
     /// this shouldn't change, so we don't expose this to the config.
@@ -396,9 +421,11 @@ inline iceBoardHandler::iceBoardHandler(kotekan::Config& config, const std::stri
 
     num_local_freq = config.get_default<int32_t>(unique_name, "num_local_freq", 1);
     alignment = config.get<uint64_t>(unique_name, "alignment");
+    alignment_startup_delay =
+        config.get_default<double>(unique_name, "alignment_startup_delay", 1.0);
     using_switch = config.get_default<bool>(unique_name, "using_switch", false);
 
-    check_cross_handler_alignment(std::numeric_limits<uint64_t>::max());
+    get_alignment_target(std::numeric_limits<uint64_t>::max());
 
     // Don't print anything for the first 30 seconds
     last_status_message_time = e_time() + 30;

--- a/lib/dpdk/iceBoardShuffle.hpp
+++ b/lib/dpdk/iceBoardShuffle.hpp
@@ -355,6 +355,10 @@ inline int iceBoardShuffle::handle_packet(struct rte_mbuf* mbuf) {
     if (unlikely(!iceBoardHandler::check_order(diff)))
         return 0;
 
+    // Accepting the packet, add to stats
+    rx_packets_total += 1;
+    rx_bytes_total += mbuf->pkt_len;
+
     // Handle lost packets
     // Note this handles packets for all loss reasons,
     // because we don't update the last_seq number value if the
@@ -559,6 +563,23 @@ inline bool iceBoardShuffle::advance_frames(uint64_t new_seq, bool first_time) {
 }
 
 inline bool iceBoardShuffle::handle_lost_samples(int64_t lost_samples) {
+
+    // A single gap (nearly) as large as the whole lost samples ringbuffer can never be
+    // back-filled: reusing those frames requires the other producers in this link group to
+    // catch up first, but they may share an lcore with this handler and so would never be
+    // serviced again while we block in advance_frames(). Fail with a clear error instead of
+    // deadlocking all the DPDK lcores.
+    // Note: one byte per time sample in the lost samples frames.
+    if (unlikely(lost_samples >= (int64_t)(lost_samples_buf->num_frames - 1)
+                                     * (int64_t)lost_samples_buf->frame_size)) {
+        FATAL_ERROR("Port {:d}: gap of {:d} lost samples exceeds the lost samples buffer "
+                    "capacity ({:d} frames of {:d} samples). Back-filling it would deadlock "
+                    "the DPDK handlers. Check for major packet loss on this port and/or "
+                    "increase the number of frames in the lost samples buffer, closing "
+                    "kotekan!",
+                    port, lost_samples, lost_samples_buf->num_frames, lost_samples_buf->frame_size);
+        return false;
+    }
 
     // By design all the seq numbers for all frames should be the same here.
     int64_t lost_sample_location;

--- a/lib/dpdk/iceBoardStandard.hpp
+++ b/lib/dpdk/iceBoardStandard.hpp
@@ -147,6 +147,10 @@ inline int iceBoardStandard::handle_packet(struct rte_mbuf* mbuf) {
     if (unlikely(!iceBoardHandler::check_order(diff)))
         return 0; // For not we just disgard any dublicate/out-of-order packets.
 
+    // Accepting the packet, add to stats
+    rx_packets_total += 1;
+    rx_bytes_total += mbuf->pkt_len;
+
     // Handle lost packets
     if (unlikely(diff > samples_per_packet))
         if (unlikely(!iceBoardStandard::handle_lost_samples(diff - samples_per_packet)))

--- a/lib/dpdk/iceBoardVDIF.hpp
+++ b/lib/dpdk/iceBoardVDIF.hpp
@@ -165,6 +165,10 @@ int iceBoardVDIF::handle_packet(struct rte_mbuf* mbuf) {
     if (unlikely(!iceBoardHandler::check_order(diff)))
         return 0; // For not we just disgard any dublicate/out-of-order packets.
 
+    // Accepting the packet, add to stats
+    rx_packets_total += 1;
+    rx_bytes_total += mbuf->pkt_len;
+
     // Handle lost packets
     if (unlikely(diff > samples_per_packet))
         iceBoardVDIF::handle_lost_samples(diff - samples_per_packet);


### PR DESCRIPTION
Changes the CHIME packet capture alignment process to avoid the random startup failures the result from the NIC startup delays.

Also adds a number of new NIC counter status to the metrics, and warnings about NIC drops related to mbuf starvation.