### PR TITLE
Patch up leaks valgrind found

### DIFF
--- a/lib/metadata/BasebandMetadata.cpp
+++ b/lib/metadata/BasebandMetadata.cpp
@@ -1,6 +1,7 @@
 #include "BasebandMetadata.hpp"
 
 #include <assert.h>     // for assert
+#include <cstring>      // for memset
 #include <json.hpp>     // for json
 #include <memory>       // for allocator, shared_ptr, dynamic_pointer_cast, __shared_ptr_access
 #include <string>       // for basic_string
@@ -57,6 +58,8 @@ size_t BasebandMetadata::set_from_bytes(const char* bytes, [[maybe_unused]] size
 size_t BasebandMetadata::serialize(char* bytes) {
     size_t sz = get_serialized_size();
     BasebandMetadataFormat* fmt = reinterpret_cast<BasebandMetadataFormat*>(bytes);
+    // Zero first so struct padding is not written out uninitialized
+    memset(bytes, 0, sz);
     fmt->event_id = event_id;
     fmt->freq_id = freq_id;
     fmt->event_start_fpga = event_start_fpga;

--- a/lib/metadata/BeamMetadata.cpp
+++ b/lib/metadata/BeamMetadata.cpp
@@ -1,6 +1,7 @@
 #include "BeamMetadata.hpp"
 
 #include <assert.h>           // for assert
+#include <cstring>            // for memset
 #include <json.hpp>           // for json
 #include <memory>             // for allocator, shared_ptr, dynamic_pointer_cast, __shared_ptr_a...
 #include <string>             // for basic_string
@@ -54,6 +55,8 @@ size_t BeamMetadata::set_from_bytes(const char* bytes, [[maybe_unused]] size_t l
 size_t BeamMetadata::serialize(char* bytes) {
     size_t sz = get_serialized_size();
     BeamMetadataFormat* fmt = reinterpret_cast<BeamMetadataFormat*>(bytes);
+    // Zero first so struct padding is not written out uninitialized
+    memset(bytes, 0, sz);
     fmt->fpga_seq_start = fpga_seq_start;
     fmt->ctime = ctime;
     fmt->nfreq = static_cast<int>(coarse_freq.size());

--- a/lib/metadata/HFBMetadata.cpp
+++ b/lib/metadata/HFBMetadata.cpp
@@ -1,6 +1,7 @@
 #include "HFBMetadata.hpp"
 
 #include <assert.h>     // for assert
+#include <cstring>      // for memset
 #include <json.hpp>     // for json
 #include <string>       // for basic_string
 
@@ -48,6 +49,8 @@ size_t HFBMetadata::set_from_bytes(const char* bytes, [[maybe_unused]] size_t le
 size_t HFBMetadata::serialize(char* bytes) {
     size_t sz = get_serialized_size();
     HFBMetadataFormat* fmt = reinterpret_cast<HFBMetadataFormat*>(bytes);
+    // Zero first so struct padding is not written out uninitialized
+    memset(bytes, 0, sz);
     fmt->fpga_seq_start = fpga_seq_start;
     fmt->ctime = ctime;
     fmt->freq_id = freq_id;

--- a/lib/metadata/N2Metadata.cpp
+++ b/lib/metadata/N2Metadata.cpp
@@ -1,5 +1,6 @@
 #include "N2Metadata.hpp"
 
+#include <cstring>          // for memset
 #include <json.hpp>         // for json
 
 #include "N2FrameDesc.hpp"  // for N2FrameDesc
@@ -54,6 +55,8 @@ size_t N2Metadata::set_from_bytes(const char* bytes, [[maybe_unused]] size_t len
 
 size_t N2Metadata::serialize(char* bytes) {
     N2MetadataFormat* fmt = reinterpret_cast<N2MetadataFormat*>(bytes);
+    // Zero first so struct padding is not written out uninitialized
+    memset(bytes, 0, sizeof(N2MetadataFormat));
 
     fmt->fpga_start_tick = fpga_start_tick;
     fmt->frame_start_time_ns = frame_start_time_ns;

--- a/lib/stages/bufferRecv.cpp
+++ b/lib/stages/bufferRecv.cpp
@@ -213,6 +213,11 @@ void bufferRecv::internal_accept_connection(evutil_socket_t listener, short even
     instance->event_read = event_read;
     instance->fd = fd;
 
+    {
+        std::lock_guard<mutex> lock(instance_list_lock);
+        instance_list.push_back(instance);
+    }
+
     event_add(instance->event_read, &read_timeout);
 }
 
@@ -253,6 +258,7 @@ void bufferRecv::main_thread() {
         return;
     }
     base = event_base_new_with_config(ev_config);
+    event_config_free(ev_config);
     if (!base) {
         FATAL_ERROR("Failed to create libevent base");
         return;
@@ -338,6 +344,25 @@ void bufferRecv::main_thread() {
             t.join();
         }
     }
+
+    // Delete connection instances still open; they are otherwise only
+    // deleted on connection close or errors.
+    while (true) {
+        connInstance* instance;
+        {
+            std::lock_guard<mutex> lock(instance_list_lock);
+            if (instance_list.empty())
+                break;
+            instance = instance_list.front();
+        }
+        // The destructor removes the instance from instance_list.
+        delete instance;
+    }
+
+    event_free(listener_event);
+    event_free(timer_event);
+    event_base_free(base);
+    close(listener);
 }
 
 int bufferRecv::get_next_frame() {
@@ -384,6 +409,14 @@ connInstance::connInstance(const std::string& producer_name, Buffer* buf, buffer
 
 connInstance::~connInstance() {
     DEBUG("Closing FD");
+    {
+        std::lock_guard<std::mutex> lock(buffer_recv->instance_list_lock);
+        auto it = std::find(buffer_recv->instance_list.begin(),
+                            buffer_recv->instance_list.end(), this);
+        if (it != buffer_recv->instance_list.end()) {
+            buffer_recv->instance_list.erase(it);
+        }
+    }
     close(fd);
     event_free(event_read);
     buffer_free(frame_space, buf->aligned_frame_size, buf->use_hugepages);

--- a/lib/stages/bufferRecv.hpp
+++ b/lib/stages/bufferRecv.hpp
@@ -197,6 +197,12 @@ private:
     /// Lock for the work queue
     std::mutex work_queue_lock;
 
+    /// All open connection instances, so they can be cleaned up on exit
+    std::deque<connInstance*> instance_list;
+
+    /// Lock for the instance list
+    std::mutex instance_list_lock;
+
     /// Condition variable for the state (empty or not) of the work queue
     std::condition_variable work_cv;
 

--- a/lib/utils/restClient.cpp
+++ b/lib/utils/restClient.cpp
@@ -94,6 +94,7 @@ void restClient::event_thread() {
         return;
     }
     _base = event_base_new_with_config(ev_config);
+    event_config_free(ev_config);
     if (!_base) {
         FATAL_ERROR_NON_OO("restClient: Failure creating new event_base.");
         return;

--- a/lib/utils/visBuffer.cpp
+++ b/lib/utils/visBuffer.cpp
@@ -71,6 +71,8 @@ size_t VisMetadata::set_from_bytes(const char* bytes, [[maybe_unused]] size_t le
 size_t VisMetadata::serialize(char* bytes) {
     size_t sz = get_serialized_size();
     VisMetadataFormat* fmt = reinterpret_cast<VisMetadataFormat*>(bytes);
+    // Zero first so struct padding is not written out uninitialized
+    memset(bytes, 0, sz);
     fmt->fpga_seq_start = fpga_seq_start;
     fmt->ctime = ctime;
     fmt->fpga_seq_length = fpga_seq_length;

--- a/lib/utils/visBuffer.hpp
+++ b/lib/utils/visBuffer.hpp
@@ -62,30 +62,30 @@ public:
     nlohmann::json to_json() override;
 
     /// The FPGA sequence number of the integration frame
-    uint64_t fpga_seq_start;
+    uint64_t fpga_seq_start = 0;
     /// The ctime of the integration frame
-    timespec ctime;
+    timespec ctime = {};
     /// Nominal length of the frame in FPGA ticks
-    uint64_t fpga_seq_length;
+    uint64_t fpga_seq_length = 0;
     /// Amount of data that actually went into the frame (in FPGA ticks)
-    uint64_t fpga_seq_total;
+    uint64_t fpga_seq_total = 0;
     /// The number of FPGA frames flagged as containing RFI. NOTE: This value
     /// might contain overlap with lost samples, as that counts missing samples
     /// as well as RFI. For renormalization this value should NOT be used, use
     /// lost samples (= @c fpga_seq_length - @c fpga_seq_total) instead.
-    uint64_t rfi_total;
+    uint64_t rfi_total = 0;
 
     /// ID of the frequency bin
-    freq_id_t freq_id;
+    freq_id_t freq_id = 0;
     /// ID of the dataset
     dset_id_t dataset_id;
 
     /// Number of elements for data in buffer
-    uint32_t num_elements;
+    uint32_t num_elements = 0;
     /// Number of products for data in buffer
-    uint32_t num_prod;
+    uint32_t num_prod = 0;
     /// Number of eigenvectors and values calculated
-    uint32_t num_ev;
+    uint32_t num_ev = 0;
 };
 
 /**


### PR DESCRIPTION
Just ran CI tests through valgrind and let Claude fix up the results. So this is not exhaustive, and does not test production pipelines. And should not actually have any effects, other than cleaner shutdown.

------

* metadata: zero serialization buffers and VisMetadata members

The field-assigning serialize() implementations (N2, Beam, HFB, Baseband, Vis) left struct padding bytes uninitialized in the output, which bufferSend then sent over the network and rawFileWrite wrote to disk (flagged by valgrind). Zero the output buffer first, as chordMetadata::serialize already does; VisMetadata's explicit trailing pad did not cover the implicit padding between freq_id and dataset_id.

Also give VisMetadata default member initializers so fields a producing stage does not set are deterministic.



* bufferRecv/restClient: free libevent objects and open connections

Fix memory leaks found by valgrind: neither stage freed its libevent event_config (and bufferRecv never freed its event base, listener and timer events, or listener socket). bufferRecv also only deleted connInstance objects on connection close or errors, so instances open at shutdown leaked their frame and metadata staging memory; track them in an instance list and delete any still open after the event loop exits.
