### PR TITLE
rfi: add option to disable first-stage RFI excision

### DIFF
--- a/config/chord_pathfinder.j2
+++ b/config/chord_pathfinder.j2
@@ -114,6 +114,10 @@ rfi_single_feed_min_good_frac: 0.25     # Wide open (0.25) so most feeds are goo
 rfi_feed_averaged_min_good_frac: {{ 0.25 * rfi_num_good_feeds / (2 * num_dishes) }}   # = 0.01171875 -> threshold 384
 rfi_mu_min: 2.0       # Minimum accepted average signal (|E|^2)  Kendrick's RFI Notes recommends 2.0
 rfi_mu_max: 50.0      # Maximum accepted average signal (|E|^2)  Kendrick's RFI Notes recommends 50.0
+# Disable first-stage (GPU, SK-based) RFI excision: cudaRFISKtilde produces an all-good RFImask,
+# so no samples are excised in the correlator. The SKtilde statistics are still computed, so
+# second-stage excision (RfiFrameMask -> N2Accumulate) keeps working.
+rfi_first_stage_excision_enabled: false
 
 num_times: samples_per_data_set  # New N2K needs this.
 num_polarizations: 2
@@ -287,27 +291,6 @@ packet_receipt_bitmap_buffers:
         kotekan_buffer: standard
         numa_node: 1
 
-# These are the dummy RFI masks produced by ProcessPacketMask (rfi_mask_buf).
-# uint1x8 "RFImask" [samples_per_data_set/1024, num_local_freq, 128] {T8hi128, F, T8lo128}.
-host_rfi_RFImask_dummy_buffer:
-    kotekan_buffer: ndarray
-    num_frames: host_side_buffer_depth
-    value_type: uint1x8
-    extents: [samples_per_data_set / 1024, num_local_freq, 128]
-    zero_new_frames: true
-    zero_value: 0xFF
-    metadata_pool: main_pool
-
-host_rfi_RFImask_dummy_buffer_1:
-    kotekan_buffer: ndarray
-    num_frames: host_side_buffer_depth
-    value_type: uint1x8
-    extents: [samples_per_data_set / 1024, num_local_freq, 128]
-    zero_new_frames: true
-    zero_value: 0xFF
-    numa_node: 1
-    metadata_pool: main_pool
-
 # Note this is the expanded version of the pl_mask, produced by ProcessPacketMask (pl_mask_buf).
 # It will be compressed to the normal PL mask before being sent to the GPU.
 # uint1x8 "pl_mask_exp" [samples_per_data_set/64, num_local_freq, 2, num_elements/8/2, 8]
@@ -365,7 +348,7 @@ host_rfi_sktilde_buffer_1:
     numa_node: 1
 
 # This is the RFI Mask recieved from the GPU, that was applied to produce n2k_correlation & n2k_counts.
-# It may contain either the dummy DPDK-generated mask or the real mask computed by SKtilde.
+# It contains the mask computed by SKtilde (all-good if rfi_first_stage_excision_enabled is false).
 # GPU output (cudaCopyFromRingbuffer of rfi_RFImask) and consumed by RfiMaskSum:
 # uint1x8 "RFImask" [samples_per_data_set/1024, num_local_freq, 128] {T8hi128, F, T8lo128}.
 host_rfi_RFImask_buffer:
@@ -622,18 +605,6 @@ host_rfi_sktilde_ringbuffer_1:
     metadata_pool: main_pool
     numa_node: 1
 
-host_rfi_RFImask_dummy_ringbuffer:
-    kotekan_buffer: ring
-    ring_buffer_size: buffer_depth * num_local_freq * samples_per_data_set / 8
-    metadata_pool: main_pool
-
-host_rfi_RFImask_dummy_ringbuffer_1:
-    kotekan_buffer: ring
-    ring_buffer_size: buffer_depth * num_local_freq * samples_per_data_set / 8
-    metadata_pool: main_pool
-    numa_node: 1
-
-
 # Stages
 
 ##  Packet capture from the F-engine ##
@@ -722,7 +693,6 @@ process_packet_mask_0:
         - packet_receipt_bitmap_buffer_1
     combined_receipt_bitmap_buf: combined_receipt_bitmap_buffer_0
     pl_mask_buf: host_pl_mask_exp_buffer
-    rfi_mask_buf: host_rfi_RFImask_dummy_buffer
     num_frequency: num_local_freq
     num_source_ids: num_crs_boards
     # Update this as we add more CRS (F-engine) boards 
@@ -737,7 +707,6 @@ process_packet_mask_1:
         - packet_receipt_bitmap_buffer_3
     combined_receipt_bitmap_buf: combined_receipt_bitmap_buffer_1
     pl_mask_buf: host_pl_mask_exp_buffer_1
-    rfi_mask_buf: host_rfi_RFImask_dummy_buffer_1
     num_frequency: num_local_freq
     num_source_ids: num_crs_boards
     # Update this as we add more CRS (F-engine) boards 
@@ -838,41 +807,6 @@ run_send_voltage:
           signal_buf: host_voltage_ringbuffer_out
           gpu_mem_output: voltage_buffer
 
-# Copy the dummy RFI mask to the RFI mask on the GPU
-# To activate the 1st stage RFI excision, do not run this stage! Instead make sure the
-# SKtilde stage produces the RFI mask and places it in the host_rfi_RFImask_buffer
-# run_send_rfi_RFImask_dummy:
-#     gpu_0:
-#         kotekan_stage: cudaProcess
-#         gpu_id: 0
-#         cpu_affinity: [12, 13, 14]
-#         in_buffers:
-#             host_rfi_RFImask_buffer_in: host_rfi_RFImask_dummy_buffer
-#         out_buffers:
-#             host_rfi_RFImask_ringbuffer_out: host_rfi_RFImask_ringbuffer
-#         commands:
-#         - name: cudaCopyToRingbuffer
-#           input_size: num_local_freq * samples_per_data_set / 8
-#           ring_buffer_size: buffer_depth * input_size
-#           in_buf: host_rfi_RFImask_buffer_in
-#           signal_buf: host_rfi_RFImask_ringbuffer_out
-#           gpu_mem_output: rfi_RFImask_buffer
-#     gpu_1:
-#         kotekan_stage: cudaProcess
-#         gpu_id: 1
-#         cpu_affinity: [25, 26, 27]
-#         in_buffers:
-#             host_rfi_RFImask_buffer_in: host_rfi_RFImask_dummy_buffer_1
-#         out_buffers:
-#             host_rfi_RFImask_ringbuffer_out: host_rfi_RFImask_ringbuffer_1
-#         commands:
-#         - name: cudaCopyToRingbuffer
-#           input_size: num_local_freq * samples_per_data_set / 8
-#           ring_buffer_size: buffer_depth * input_size
-#           in_buf: host_rfi_RFImask_buffer_in
-#           signal_buf: host_rfi_RFImask_ringbuffer_out
-#           gpu_mem_output: rfi_RFImask_buffer
-
 run_send_pl_mask:
     gpu_0:
         kotekan_stage: cudaProcess
@@ -940,9 +874,8 @@ run_rfi_s012:
           rfi_num_times: samples_per_data_set / rfi_downsampling_factor
 
 # This stage produces SK statistics averaged over all input elements and the RFI mask.
-# If the pipeline is using the dummy DPDK-produced RFI mask, then this stage needs to direct its
-# mask to "_dummy" buffers.  If the pipeline is using this RFI mask, then the buffers should
-# *not* contain "_dummy", and the DPDK-produced mask should not be sent to the GPU.
+# When rfi_first_stage_excision_enabled is false, the mask is written as all-good (no excision)
+# but the SK statistics are still computed for second-stage excision.
 run_rfi_sktilde:
     gpu_0:
         kotekan_stage: cudaProcess
@@ -1022,8 +955,8 @@ run_recv_rfi_sktilde:
           out_buf: host_rfi_sktilde_buffer_out
 
 # This copies the RFI Mask that was used in N2K kernels back out to the CPU into the
-# host_rfi_RFImask_buffer. It may contain either the DPDK-produced dummy mask or the
-# SKtilde-produced real mask.
+# host_rfi_RFImask_buffer. It contains the SKtilde-produced mask (all-good if
+# rfi_first_stage_excision_enabled is false).
 run_recv_rfi_RFImask:
     gpu_0:
         kotekan_stage: cudaProcess

--- a/config/ci-tests/gpu_batch/verify_cuda_rfi_sktilde_disabled.yaml
+++ b/config/ci-tests/gpu_batch/verify_cuda_rfi_sktilde_disabled.yaml
@@ -1,0 +1,259 @@
+---
+##########################################
+#
+# verify_cuda_rfi_sktilde_disabled.yaml
+#
+# Config to test the cuda RFI SKtilde kernel & wrapper with first-stage RFI
+# excision disabled: the SKtilde statistics must still match the CPU
+# simulation, while the produced RFI mask must be all-good (all bits 1).
+#
+##########################################
+type: config
+# Logging level can be one of:
+# OFF, ERROR, WARN, INFO, DEBUG, DEBUG2 (case insensitive)
+# Note DEBUG and DEBUG2 require a build with (-DCMAKE_BUILD_TYPE=Debug)
+log_level: INFO
+
+buffer_depth: 4
+cpu_affinity: [0]
+sizeof_float: 4
+sizeof_long: 8
+
+# For faster CHORD testing, we're using...
+samples_per_data_set: 8192
+frame_arrival_period: 5.12e-6 * samples_per_data_set
+num_polarizations: 2
+num_dishes: 64
+num_elements: num_polarizations * num_dishes
+num_local_freq: 4
+
+rfi_downsampling_factor: 256
+
+# For random data (as used here) the sk-sigma is ~1.0e-3 but sk~[10, 50].
+# To get a non-trivial (not all true or false) RFI mask, need the 
+# RFI mask sigmas to be enormous, 2000 is good.
+#
+# The other thresholds are also set wide, because their effect is multiplicative.
+# A mu range of [2, 80] and min_good_frac of 0.25 only gives 60% good SK, the
+# rest are 0'd.
+rfi_sk_rfimask_sigmas: 2000.0
+rfi_first_stage_excision_enabled: false
+rfi_single_feed_min_good_frac: 0.25     # Wide open (0.25) so most feeds are good
+rfi_feed_averaged_min_good_frac: 0.25   # Wide open (0.25) so most averaged feeds are good
+rfi_mu_min: 2.0       # Should be small (2) to let in many samples.
+rfi_mu_max: 80.0      # Should be big (80) to let in many samples.
+
+# Pool
+main_pool:
+    kotekan_metadata_pool: chordMetadata
+    num_metadata_objects: 20 * buffer_depth
+
+# Buffers
+
+host_bf_mask_buffer:
+    kotekan_buffer: ndarray
+    num_frames: 1
+    value_type: int8
+    extents: [num_polarizations, num_dishes]
+    metadata_pool: main_pool
+
+host_rfi_s012_buffer:
+    kotekan_buffer: ndarray
+    num_frames: buffer_depth
+    value_type: uint64
+    extents: [samples_per_data_set / rfi_downsampling_factor, num_local_freq, 3, num_polarizations, num_dishes]
+    metadata_pool: main_pool
+
+host_rfi_sktilde_buffer:
+    kotekan_buffer: ndarray
+    num_frames: buffer_depth
+    value_type: float32
+    extents: [samples_per_data_set / rfi_downsampling_factor, num_local_freq, 3]
+    metadata_pool: main_pool
+
+host_rfi_mask_buffer:
+    kotekan_buffer: ndarray
+    num_frames: buffer_depth
+    value_type: uint1x8
+    extents: [samples_per_data_set / 1024, num_local_freq, 128]
+    metadata_pool: main_pool
+
+simulated_rfi_sk_buffer:
+    kotekan_buffer: ndarray
+    num_frames: buffer_depth
+    value_type: float32
+    extents: [samples_per_data_set / rfi_downsampling_factor, num_local_freq, 3, num_polarizations, num_dishes]
+    metadata_pool: main_pool
+
+simulated_rfi_sktilde_buffer:
+    kotekan_buffer: ndarray
+    num_frames: buffer_depth
+    value_type: float32
+    extents: [samples_per_data_set / rfi_downsampling_factor, num_local_freq, 3]
+    metadata_pool: main_pool
+
+simulated_rfi_mask_buffer:
+    kotekan_buffer: ndarray
+    num_frames: buffer_depth
+    value_type: uint1x8
+    extents: [samples_per_data_set / 1024, num_local_freq, 128]
+    metadata_pool: main_pool
+
+# All-good mask (all bits 1) the GPU-produced RFI mask is compared against.
+allgood_rfi_mask_buffer:
+    kotekan_buffer: ndarray
+    num_frames: buffer_depth
+    value_type: uint1x8
+    extents: [samples_per_data_set / 1024, num_local_freq, 128]
+    metadata_pool: main_pool
+
+
+# Ringbuffer signalling buffer
+host_rfi_s012_ringbuffer:
+    kotekan_buffer: ring
+    ring_buffer_size: buffer_depth * (samples_per_data_set / rfi_downsampling_factor) * num_local_freq * 3 * num_elements * sizeof_long
+    metadata_pool: main_pool
+
+host_rfi_sktilde_ringbuffer:
+    kotekan_buffer: ring
+    ring_buffer_size: buffer_depth * (samples_per_data_set / rfi_downsampling_factor) * num_local_freq * 3 * sizeof_float
+    metadata_pool: main_pool
+
+host_rfi_mask_ringbuffer:
+    kotekan_buffer: ring
+    ring_buffer_size: buffer_depth * samples_per_data_set * num_local_freq / 8
+    metadata_pool: main_pool
+
+gen_rfi_s012:
+    log_level: DEBUG
+    kotekan_stage: testRFIS012Gen
+    out_buf: host_rfi_s012_buffer
+    type: random
+    bar_mode: false
+    downsampling_factor: rfi_downsampling_factor
+    num_frames: 2 * buffer_depth
+
+gen_allgood_mask:
+    type: const1x8
+    value: 255
+    kotekan_stage: testDataGen
+    out_buf: allgood_rfi_mask_buffer
+    name: "RFImask"
+    array_shape: [8, 4, 128]
+    dim_name: ["T8hi128", "F", "T8lo128"]
+    dim_scaling: [1024, 1, 8]
+    num_frames: 2 * buffer_depth
+
+gen_bf_mask:
+    type: random8
+    kotekan_stage: testDataGen
+    out_buf: host_bf_mask_buffer
+    name: "bf_mask"
+    array_shape: [2, 64]
+    dim_name: ["P", "D"]
+    dim_scaling: [1, 1]
+    num_frames: 1
+
+run_send_rfi_s012:
+    gpu_0:
+        kotekan_stage: cudaProcess
+        gpu_id: 0
+        in_buffers:
+            host_rfi_s012_buffer_in: host_rfi_s012_buffer
+        out_buffers:
+            host_rfi_s012_ringbuffer_out: host_rfi_s012_ringbuffer
+        commands:
+            - name: cudaCopyToRingbuffer
+              input_size: samples_per_data_set / rfi_downsampling_factor * num_local_freq * 3 * num_elements * sizeof_long
+              ring_buffer_size: buffer_depth * input_size
+              in_buf: host_rfi_s012_buffer_in
+              signal_buf: host_rfi_s012_ringbuffer_out
+              gpu_mem_output: rfi_s012_buffer
+
+run_rfi_sktilde:
+    log_level: DEBUG
+    gpu_0:
+        kotekan_stage: cudaProcess
+        gpu_id: 0
+        in_buffers:
+            host_bf_mask_buffer: host_bf_mask_buffer
+            host_rfi_s012_ringbuffer: host_rfi_s012_ringbuffer
+        out_buffers:
+            host_rfi_sktilde_ringbuffer: host_rfi_sktilde_ringbuffer
+            host_rfi_mask_ringbuffer: host_rfi_mask_ringbuffer
+        commands:
+            - name: cudaInputData
+              do_once: true
+              in_buf: host_bf_mask_buffer
+              gpu_mem: bf_mask_buffer
+            - name: cudaSyncInput
+            - name: cudaRFISKtilde
+              rfi_S012_name: rfi_s012
+              bf_mask_name: bf_mask
+              rfi_SKtilde_name: rfi_sktilde
+              rfi_RFImask_name: rfi_mask
+              num_times: samples_per_data_set
+              num_frequencies: num_local_freq
+              rfi_num_times: samples_per_data_set / rfi_downsampling_factor
+
+run_recv_rfi_sktilde:
+    gpu_0:
+        kotekan_stage: cudaProcess
+        gpu_id: 0
+        in_buffers:
+            host_rfi_sktilde_ringbuffer_in: host_rfi_sktilde_ringbuffer
+        out_buffers:
+            host_rfi_sktilde_buffer_out: host_rfi_sktilde_buffer
+        commands:
+            - name: cudaCopyFromRingbuffer
+              host_signal: host_rfi_sktilde_ringbuffer_in
+              gpu_mem_input: rfi_sktilde_buffer
+              output_size: (samples_per_data_set / rfi_downsampling_factor) * num_local_freq * 3 * sizeof_float
+              ring_buffer_size: buffer_depth * output_size
+              out_buf: host_rfi_sktilde_buffer_out
+
+run_recv_rfi_mask:
+    gpu_0:
+        kotekan_stage: cudaProcess
+        gpu_id: 0
+        in_buffers:
+            host_rfi_mask_ringbuffer_in: host_rfi_mask_ringbuffer
+        out_buffers:
+            host_rfi_mask_buffer_out: host_rfi_mask_buffer
+        commands:
+            - name: cudaCopyFromRingbuffer
+              host_signal: host_rfi_mask_ringbuffer_in
+              gpu_mem_input: rfi_mask_buffer
+              output_size: samples_per_data_set * num_local_freq / 8
+              ring_buffer_size: buffer_depth * output_size
+              out_buf: host_rfi_mask_buffer_out
+
+
+cpu_rfi_sktilde:
+    kotekan_stage: gpuSimulateRFISK
+    in_rfi_s012_buf: host_rfi_s012_buffer
+    in_bf_mask_buf: host_bf_mask_buffer
+    out_rfi_sk_buf: simulated_rfi_sk_buffer
+    out_rfi_sktilde_buf: simulated_rfi_sktilde_buffer
+    out_rfi_mask_buf: simulated_rfi_mask_buffer
+    bar_mode: false
+    rfi_total_downsampling_factor: rfi_downsampling_factor
+
+
+check_rfi_sktilde_data:
+    kotekan_stage: testDataCheckFloat
+    first_buf: host_rfi_sktilde_buffer
+    second_buf: simulated_rfi_sktilde_buffer
+    max_num_errors_logged: 64
+    epsilon: 1.0e-6
+    num_frames_to_test: 2 * buffer_depth
+    check_metadata: true
+
+check_rfi_rfimask_data:
+    kotekan_stage: testDataCheckUchar
+    first_buf: host_rfi_mask_buffer
+    second_buf: allgood_rfi_mask_buffer
+    max_num_errors_logged: 64
+    num_frames_to_test: 2 * buffer_depth
+    check_metadata: false
+log_config_usage: fatal_error

--- a/lib/cuda/cudaRFISKtilde.cpp
+++ b/lib/cuda/cudaRFISKtilde.cpp
@@ -10,7 +10,7 @@
 #include "cudaUtils.hpp"           // for CHECK_CUDA_ERROR
 #include "div.hpp"                 // for div_noremainder, round_down
 #include "gpuCommand.hpp"          // for gpuCommandType
-#include "kotekanLogging.hpp"      // for DEBUG
+#include "kotekanLogging.hpp"      // for DEBUG, INFO
 #include "n2k/rfi_kernels.hpp"     // for SkKernel
 
 #include "fmt.hpp" // for compile_string_to_view
@@ -72,6 +72,10 @@ private:
     const int rfi_downsampling_factor;
     const int rfi_num_times;
     const bool poison_buffers;
+    // If false, the SK kernel skips the RFI mask computation and an all-good mask is
+    // produced instead, so no samples are excised in the correlator. The SKtilde
+    // statistics are still computed for second-stage excision (RfiFrameMask).
+    const bool first_stage_excision_enabled;
 
     // Kotekan buffer names
     const std::string bf_mask_name;
@@ -105,6 +109,8 @@ cudaRFISKtilde::cudaRFISKtilde(kotekan::Config& config, const std::string& uniqu
     rfi_downsampling_factor(config.get<int>(unique_name, "rfi_downsampling_factor")),
     rfi_num_times(config.get<int>(unique_name, "rfi_num_times")),
     poison_buffers(config.get_default<bool>(unique_name, "poison_buffers", false)),
+    first_stage_excision_enabled(
+        config.get_default<bool>(unique_name, "rfi_first_stage_excision_enabled", true)),
     // Buffer names
     bf_mask_name(config.get<std::string>(unique_name, "bf_mask_name")),
     rfi_S012_name(config.get<std::string>(unique_name, "rfi_S012_name")),
@@ -142,6 +148,10 @@ cudaRFISKtilde::cudaRFISKtilde(kotekan::Config& config, const std::string& uniqu
     rfi_S012.register_consumer();
     rfi_SKtilde.register_producer();
     rfi_RFImask.register_producer();
+
+    if (!first_stage_excision_enabled && get_instance_num() == 0)
+        INFO("First-stage RFI excision disabled: producing an all-good RFI mask. "
+             "SK statistics are still computed.");
 
     set_command_type(gpuCommandType::KERNEL);
 }
@@ -215,7 +225,8 @@ cudaEvent_t cudaRFISKtilde::execute(cudaPipelineState& /*pipestate*/,
 
     float* const out_sk_feed_averaged = rfi_SKtilde_memory;
     float* const out_sk_single_feed = nullptr;
-    uint* const out_rfimask = (uint*)rfi_RFImask_memory;
+    // The SK kernel skips the mask computation when out_rfimask is NULL.
+    uint* const out_rfimask = first_stage_excision_enabled ? (uint*)rfi_RFImask_memory : nullptr;
     const ulong* const in_S012 = rfi_S012_memory;
     const uint8_t* const in_bf_mask = (const uint8_t*)bf_mask_memory;
     const long T = rfi_S012.get_read_valid().size();
@@ -239,6 +250,21 @@ cudaEvent_t cudaRFISKtilde::execute(cudaPipelineState& /*pipestate*/,
                     F, S, S012_Tmin, S012_Tsize, sk_feed_averaged_Tmin, sk_feed_averaged_Tsize,
                     sk_single_feed_Tmin, sk_single_feed_Tsize, rfimask_T512min, rfimask_T512size,
                     stream);
+
+    if (!first_stage_excision_enabled) {
+        // The kernel skipped the mask, so fill the claimed region with 1s (all samples
+        // good). The claimed region may wrap around the end of the ring buffer.
+        const long mask_row_len =
+            rfi_RFImask.get_ndarray().get_extent(1) * rfi_RFImask.get_ndarray().get_extent(2);
+        const long mask_row_bytes = mask_row_len * sizeof(kotekan::uint1x8_t);
+        const long mask_rows = rfi_RFImask.get_write_valid().size();
+        const long mask_rows_to_end = std::min(mask_rows, rfimask_T512size - rfimask_T512min);
+        CHECK_CUDA_ERROR(cudaMemsetAsync(rfi_RFImask_memory + rfimask_T512min * mask_row_len, 0xff,
+                                         mask_rows_to_end * mask_row_bytes, stream));
+        if (mask_rows > mask_rows_to_end)
+            CHECK_CUDA_ERROR(cudaMemsetAsync(
+                rfi_RFImask_memory, 0xff, (mask_rows - mask_rows_to_end) * mask_row_bytes, stream));
+    }
 #ifdef DEBUGGING
     CHECK_CUDA_ERROR(cudaStreamSynchronize(device.getStream(cuda_stream_id)));
 #endif

--- a/lib/stages/N2Accumulate.cpp
+++ b/lib/stages/N2Accumulate.cpp
@@ -533,7 +533,7 @@ void N2Accumulate::main_thread() {
                     continue;
                 }
 
-                // Third: accum RFI samples
+                // Third: accum RFI sampes
                 _n_rfi_samples_in_vis[f] += rficounts_t0[f] + rficounts_t1[f];
 
                 // Fourth: Normalization - accum the remaining good ticks.

--- a/lib/stages/N2Accumulate.cpp
+++ b/lib/stages/N2Accumulate.cpp
@@ -533,7 +533,7 @@ void N2Accumulate::main_thread() {
                     continue;
                 }
 
-                // Third: accum RFI sampes
+                // Third: accum RFI samples
                 _n_rfi_samples_in_vis[f] += rficounts_t0[f] + rficounts_t1[f];
 
                 // Fourth: Normalization - accum the remaining good ticks.

--- a/lib/stages/ProcessPacketMask.cpp
+++ b/lib/stages/ProcessPacketMask.cpp
@@ -37,8 +37,11 @@ STAGE_CONSTRUCTOR(ProcessPacketMask) {
     // The RFI mask here is just a hack to avoid running the actual RFI kernels
     // It just replays a mask of whatever is in the frames at startup
     // (This should be set to 0xff as the "zeroing" value.)
-    rfi_mask_buf = get_buffer("rfi_mask_buf");
-    rfi_mask_buf->register_producer(unique_name);
+    // Optional: pipelines using the GPU-computed RFI mask can omit this buffer.
+    rfi_mask_buf =
+        config.exists(unique_name, "rfi_mask_buf") ? get_buffer("rfi_mask_buf") : nullptr;
+    if (rfi_mask_buf)
+        rfi_mask_buf->register_producer(unique_name);
 
     // Get the array of receipt bitmap buffer names and register as consumer on each
     std::vector<std::string> receipt_bitmap_buf_names =
@@ -139,17 +142,19 @@ STAGE_CONSTRUCTOR(ProcessPacketMask) {
 
     // Validate rfi_mask buffer size
     // rfi_mask shape: uint8_t [T/1024][F][128] where T = time_long * time_short
-    size_t expected_rfi_mask_size = (T / 1024) * num_frequency * 128 * sizeof(uint8_t);
-    if (rfi_mask_buf->frame_size != expected_rfi_mask_size) {
-        throw std::runtime_error(
-            fmt::format(fmt("ProcessPacketMask: rfi_mask_buf frame size ({:d}) does not match "
-                            "expected size ({:d}) for shape [T/1024={:d}][F={:d}][128]"),
-                        rfi_mask_buf->frame_size, expected_rfi_mask_size, T / 1024, num_frequency));
-    }
+    if (rfi_mask_buf) {
+        size_t expected_rfi_mask_size = (T / 1024) * num_frequency * 128 * sizeof(uint8_t);
+        if (rfi_mask_buf->frame_size != expected_rfi_mask_size) {
+            throw std::runtime_error(fmt::format(
+                fmt("ProcessPacketMask: rfi_mask_buf frame size ({:d}) does not match "
+                    "expected size ({:d}) for shape [T/1024={:d}][F={:d}][128]"),
+                rfi_mask_buf->frame_size, expected_rfi_mask_size, T / 1024, num_frequency));
+        }
 
-    rfi_mask_buf->require_frame_desc(kotekan::GenericNDArray::describe(
-        kotekan::uint1x8, "RFImask", {time_long * time_short / 1024, num_frequency, 128},
-        {"T8hi128", "F", "T8lo128"}, {1024, 1, 8}));
+        rfi_mask_buf->require_frame_desc(kotekan::GenericNDArray::describe(
+            kotekan::uint1x8, "RFImask", {time_long * time_short / 1024, num_frequency, 128},
+            {"T8hi128", "F", "T8lo128"}, {1024, 1, 8}));
+    }
 
     INFO("ProcessPacketMask: Initialized with {:d} receipt bitmap buffers",
          receipt_bitmap_bufs.size());
@@ -166,7 +171,8 @@ void ProcessPacketMask::main_thread() {
     frameID voltage_frame_id(voltage_buf);
     frameID combined_bitmap_frame_id(combined_receipt_bitmap_buf);
     frameID pl_mask_frame_id(pl_mask_buf);
-    frameID rfi_mask_frame_id(rfi_mask_buf);
+    // frameID needs a valid buffer even if rfi_mask_frame_id is never used.
+    frameID rfi_mask_frame_id(rfi_mask_buf != nullptr ? rfi_mask_buf : pl_mask_buf);
     std::vector<frameID> bitmap_frame_ids;
     for (auto* buf : receipt_bitmap_bufs) {
         bitmap_frame_ids.emplace_back(buf);
@@ -194,10 +200,12 @@ void ProcessPacketMask::main_thread() {
             break;
 
         // Wait for rfi_mask frame
-        uint8_t* rfi_mask_frame =
-            rfi_mask_buf->wait_for_empty_frame(unique_name, rfi_mask_frame_id);
-        if (rfi_mask_frame == nullptr)
-            break;
+        if (rfi_mask_buf) {
+            uint8_t* rfi_mask_frame =
+                rfi_mask_buf->wait_for_empty_frame(unique_name, rfi_mask_frame_id);
+            if (rfi_mask_frame == nullptr)
+                break;
+        }
 
         // Wait for all receipt bitmap frames
         std::vector<uint8_t*> bitmap_frames;
@@ -368,25 +376,27 @@ void ProcessPacketMask::main_thread() {
         pl_mask_meta->set_time_downsampling_fpga(64);
 
         // Set metadata for rfi_mask_buf
-        rfi_mask_buf->allocate_new_metadata_object(rfi_mask_frame_id);
-        auto rfi_mask_meta = get_chord_metadata(rfi_mask_buf, rfi_mask_frame_id);
+        if (rfi_mask_buf) {
+            rfi_mask_buf->allocate_new_metadata_object(rfi_mask_frame_id);
+            auto rfi_mask_meta = get_chord_metadata(rfi_mask_buf, rfi_mask_frame_id);
 
-        rfi_mask_meta->set_fpga_seq_num(
-            get_chord_metadata(voltage_buf, voltage_frame_id)->get_fpga_seq_num());
-        rfi_mask_meta->type = kotekan::uint1x8;
-        rfi_mask_meta->dims = 3;
-        rfi_mask_meta->set_array_dimension(0, time_long * time_short / 1024, "T8hi128", 1024);
-        rfi_mask_meta->set_array_dimension(1, num_frequency, "F", 1);
-        rfi_mask_meta->set_array_dimension(2, 128, "T8lo128", 8);
-        rfi_mask_meta->set_name("RFImask");
+            rfi_mask_meta->set_fpga_seq_num(
+                get_chord_metadata(voltage_buf, voltage_frame_id)->get_fpga_seq_num());
+            rfi_mask_meta->type = kotekan::uint1x8;
+            rfi_mask_meta->dims = 3;
+            rfi_mask_meta->set_array_dimension(0, time_long * time_short / 1024, "T8hi128", 1024);
+            rfi_mask_meta->set_array_dimension(1, num_frequency, "F", 1);
+            rfi_mask_meta->set_array_dimension(2, 128, "T8lo128", 8);
+            rfi_mask_meta->set_name("RFImask");
 
-        rfi_mask_meta->set_strides_simple();
+            rfi_mask_meta->set_strides_simple();
 
-        rfi_mask_meta->set_coarse_freq(
-            get_chord_metadata(voltage_buf, voltage_frame_id)->get_coarse_freq());
-        rfi_mask_meta->set_freq_upchan_factor(
-            get_chord_metadata(voltage_buf, voltage_frame_id)->get_freq_upchan_factor());
-        rfi_mask_meta->set_time_downsampling_fpga(1024);
+            rfi_mask_meta->set_coarse_freq(
+                get_chord_metadata(voltage_buf, voltage_frame_id)->get_coarse_freq());
+            rfi_mask_meta->set_freq_upchan_factor(
+                get_chord_metadata(voltage_buf, voltage_frame_id)->get_freq_upchan_factor());
+            rfi_mask_meta->set_time_downsampling_fpga(1024);
+        }
 
         // Mark frames as empty
         voltage_buf->mark_frame_empty(unique_name, voltage_frame_id);
@@ -398,8 +408,10 @@ void ProcessPacketMask::main_thread() {
         pl_mask_buf->mark_frame_full(unique_name, pl_mask_frame_id);
         pl_mask_frame_id++;
 
-        rfi_mask_buf->mark_frame_full(unique_name, rfi_mask_frame_id);
-        rfi_mask_frame_id++;
+        if (rfi_mask_buf) {
+            rfi_mask_buf->mark_frame_full(unique_name, rfi_mask_frame_id);
+            rfi_mask_frame_id++;
+        }
 
         for (size_t i = 0; i < receipt_bitmap_bufs.size(); i++) {
             receipt_bitmap_bufs[i]->mark_frame_empty(unique_name, bitmap_frame_ids[i]);

--- a/lib/stages/ProcessPacketMask.cpp
+++ b/lib/stages/ProcessPacketMask.cpp
@@ -14,6 +14,7 @@
 #include <assert.h>    // for assert
 #include <cstring>     // for size_t, memset
 #include <memory>      // for __shared_ptr_access, shared_ptr
+#include <optional>    // for optional
 #include <stdexcept>   // for runtime_error
 #include <visUtil.hpp> // for frameID, modulo
 
@@ -171,8 +172,10 @@ void ProcessPacketMask::main_thread() {
     frameID voltage_frame_id(voltage_buf);
     frameID combined_bitmap_frame_id(combined_receipt_bitmap_buf);
     frameID pl_mask_frame_id(pl_mask_buf);
-    // frameID needs a valid buffer even if rfi_mask_frame_id is never used.
-    frameID rfi_mask_frame_id(rfi_mask_buf != nullptr ? rfi_mask_buf : pl_mask_buf);
+    // Only tracked when the optional rfi_mask_buf is configured.
+    std::optional<frameID> rfi_mask_frame_id;
+    if (rfi_mask_buf)
+        rfi_mask_frame_id.emplace(rfi_mask_buf);
     std::vector<frameID> bitmap_frame_ids;
     for (auto* buf : receipt_bitmap_bufs) {
         bitmap_frame_ids.emplace_back(buf);
@@ -202,7 +205,7 @@ void ProcessPacketMask::main_thread() {
         // Wait for rfi_mask frame
         if (rfi_mask_buf) {
             uint8_t* rfi_mask_frame =
-                rfi_mask_buf->wait_for_empty_frame(unique_name, rfi_mask_frame_id);
+                rfi_mask_buf->wait_for_empty_frame(unique_name, *rfi_mask_frame_id);
             if (rfi_mask_frame == nullptr)
                 break;
         }
@@ -377,8 +380,8 @@ void ProcessPacketMask::main_thread() {
 
         // Set metadata for rfi_mask_buf
         if (rfi_mask_buf) {
-            rfi_mask_buf->allocate_new_metadata_object(rfi_mask_frame_id);
-            auto rfi_mask_meta = get_chord_metadata(rfi_mask_buf, rfi_mask_frame_id);
+            rfi_mask_buf->allocate_new_metadata_object(*rfi_mask_frame_id);
+            auto rfi_mask_meta = get_chord_metadata(rfi_mask_buf, *rfi_mask_frame_id);
 
             rfi_mask_meta->set_fpga_seq_num(
                 get_chord_metadata(voltage_buf, voltage_frame_id)->get_fpga_seq_num());
@@ -409,8 +412,8 @@ void ProcessPacketMask::main_thread() {
         pl_mask_frame_id++;
 
         if (rfi_mask_buf) {
-            rfi_mask_buf->mark_frame_full(unique_name, rfi_mask_frame_id);
-            rfi_mask_frame_id++;
+            rfi_mask_buf->mark_frame_full(unique_name, *rfi_mask_frame_id);
+            (*rfi_mask_frame_id)++;
         }
 
         for (size_t i = 0; i < receipt_bitmap_bufs.size(); i++) {

--- a/lib/stages/ProcessPacketMask.hpp
+++ b/lib/stages/ProcessPacketMask.hpp
@@ -1,14 +1,14 @@
 #ifndef PROCESS_PACKET_MASK_HPP
 #define PROCESS_PACKET_MASK_HPP
 
-#include "Config.hpp"          // for Config
-#include "Stage.hpp"           // for Stage
-#include "buffer.hpp"          // for Buffer
-#include "bufferContainer.hpp" // for bufferContainer
+#include <cstdint>              // for uint32_t, uint64_t
+#include <string>               // for string
+#include <vector>               // for vector
 
-#include <cstdint> // for uint32_t, uint64_t
-#include <string>  // for string
-#include <vector>  // for vector
+#include "Config.hpp"           // for Config
+#include "Stage.hpp"            // for Stage
+#include "buffer.hpp"           // for Buffer
+#include "bufferContainer.hpp"  // for bufferContainer
 
 /**
  * @class ProcessPacketMask

--- a/lib/stages/ProcessPacketMask.hpp
+++ b/lib/stages/ProcessPacketMask.hpp
@@ -1,14 +1,14 @@
 #ifndef PROCESS_PACKET_MASK_HPP
 #define PROCESS_PACKET_MASK_HPP
 
-#include <cstdint>              // for uint32_t, uint64_t
-#include <string>               // for string
-#include <vector>               // for vector
+#include "Config.hpp"          // for Config
+#include "Stage.hpp"           // for Stage
+#include "buffer.hpp"          // for Buffer
+#include "bufferContainer.hpp" // for bufferContainer
 
-#include "Config.hpp"           // for Config
-#include "Stage.hpp"            // for Stage
-#include "buffer.hpp"           // for Buffer
-#include "bufferContainer.hpp"  // for bufferContainer
+#include <cstdint> // for uint32_t, uint64_t
+#include <string>  // for string
+#include <vector>  // for vector
 
 /**
  * @class ProcessPacketMask
@@ -30,6 +30,11 @@
  * @buffer pl_mask_buf Output buffer for packet loss mask
  *    @buffer_format uint64_t pl_mask[T/64][F][E/8] where T=time_long*time_short, F=num_frequency,
  * E=element_long*element_short
+ *    @buffer_metadata chordMetadata
+ * @buffer rfi_mask_buf Optional output buffer for a dummy RFI mask. The frame data is
+ * not written, only metadata is set; frames replay whatever they contain at startup.
+ * Omit to skip producing the mask (e.g. when the GPU-computed RFI mask is used).
+ *    @buffer_format uint1x8 RFImask[T/1024][F][128]
  *    @buffer_metadata chordMetadata
  *
  * @conf time_long      Int. Number of long time samples per frame.


### PR DESCRIPTION
Add a rfi_first_stage_excision_enabled config option (default true) to cudaRFISKtilde. When false, the SK kernel skips the RFI mask computation. The SKtilde statistics are still computed, so second-stage excision and bad feed flagging is unaffected. This avoids using a "dummy buffer" to turn off RFI flagging.

(Note about motivation: this change is so the relevant GPU stages can run on chord pathfinder, without actually doing anything, as most feeds/dishes are not connected and so the SK statistic just flags everything.)