### PR TITLE
restServer: drain requests before taking kotekan_state_lock, bound th…

### DIFF
--- a/kotekan/kotekan.cpp
+++ b/kotekan/kotekan.cpp
@@ -707,6 +707,15 @@ int main(int argc, char** argv) {
 
         if (sig_value == SIGINT || sig_value == SIGTERM) {
             INFO_NON_OO("Got SIGINT or SIGTERM, shutting down kotekan...");
+            // Quiesce the REST server before destructing the stages: this
+            // teardown runs on the main thread while the server thread may
+            // still be handling a request that captured a stage's `this`
+            // (e.g. a monitor polling a stage's get_status endpoint), which
+            // would use-after-free once the stage is deleted below. Must
+            // happen before kotekan_state_lock is taken: the /start, /stop
+            // and /status handlers block on that lock, so draining while
+            // holding it would deadlock against any such handler in flight.
+            rest_server.stop_processing();
             std::lock_guard<std::mutex> lock(kotekan_state_lock);
             if (kotekan_mode != nullptr) {
                 INFO_NON_OO("Attempting to stop and join kotekan_stages...");
@@ -715,12 +724,6 @@ int main(int argc, char** argv) {
                 if (string(get_error_message()) != "not set") {
                     KotekanTrackers::instance().dump_trackers();
                 }
-                // Quiesce the REST server before destructing the stages: this
-                // teardown runs on the main thread while the server thread may
-                // still be handling a request that captured a stage's `this`
-                // (e.g. a monitor polling a stage's get_status endpoint), which
-                // would use-after-free once the stage is deleted below.
-                rest_server.stop_processing();
                 delete kotekan_mode;
             }
             break;

--- a/lib/core/restServer.cpp
+++ b/lib/core/restServer.cpp
@@ -7,6 +7,7 @@
 
 #include <arpa/inet.h>             // for inet_pton, ntohs
 #include <assert.h>                // for assert
+#include <chrono>                  // for seconds
 #include <cstring>                 // for memset
 #include <event2/buffer.h>         // for evbuffer_add, evbuffer_peek, iovec, evbuffer_iovec
 #include <event2/event.h>          // for event_add, event_base_dispatch, event_base_free, even...
@@ -234,20 +235,25 @@ void restServer::start(const std::string& bind_address, u_short port) {
 void restServer::stop_processing() {
     // Refuse further dispatch first, so any request that has not yet taken the
     // shared lock will see this and 503 instead of invoking a callback.
-    _accepting_requests = false;
+    accepting_requests = false;
 
-    // If we are already on the server thread (a /stop handler tearing the mode
-    // down), the single-threaded event loop guarantees no other handler is in
-    // flight, and taking the lock exclusively here would dead-lock against our
-    // own shared hold. The flag above is enough; skip the drain.
+    // If we are already on the server thread, the single-threaded event loop
+    // guarantees no other handler is in flight, and taking the lock
+    // exclusively here would dead-lock against our own shared hold. The flag
+    // above is enough; skip the drain.
     if (std::this_thread::get_id() == main_thread.get_id())
         return;
 
     // Otherwise (main-thread signal shutdown) wait out any handler currently
     // running on the server thread. Once we hold the lock exclusively, no
     // handler is executing and none can start, so the caller may destruct the
-    // stages those handlers reach into.
-    std::unique_lock<std::shared_timed_mutex> drain(request_lock);
+    // stages those handlers reach into. Bound the wait: a handler stuck past
+    // it means shutdown would hang forever, and proceeding with a loud error
+    // at least leaves a restartable process (kotekan runs under a daemon).
+    std::unique_lock<std::shared_timed_mutex> drain(request_lock, std::chrono::seconds(30));
+    if (!drain.owns_lock())
+        ERROR_NON_OO("restServer: a request handler is still running 30s into shutdown; "
+                     "proceeding with teardown anyway.");
 }
 
 void restServer::handle_request(struct evhttp_request* request, void* cb_data) {
@@ -260,7 +266,7 @@ void restServer::handle_request(struct evhttp_request* request, void* cb_data) {
     // is running. Distinct from callback_map_lock, which is dropped before the
     // callback runs (callbacks may re-register endpoints).
     std::shared_lock<std::shared_timed_mutex> request_guard(server->request_lock);
-    if (!server->_accepting_requests) {
+    if (!server->accepting_requests) {
         connectionInstance conn(request);
         conn.send_error("Server shutting down", HTTP_RESPONSE::SERVICE_UNAVAILABLE);
         return;

--- a/lib/core/restServer.hpp
+++ b/lib/core/restServer.hpp
@@ -196,7 +196,7 @@ public:
     void start(const std::string& bind_address = "0.0.0.0", u_short port = PORT_REST_SERVER);
 
     /**
-     * @brief Quiesce request handling ahead of tearing down the pipeline.
+     * @brief Quiesce request handling ahead of process teardown.
      *
      * Stop dispatching to registered endpoint callbacks and block until any
      * handler already running on the server thread has returned. After this
@@ -212,12 +212,19 @@ public:
      * map lock alone does not keep the stage alive across the call; this
      * barrier does.
      *
+     * One-way: requests are refused permanently, so this is only for process
+     * teardown -- not for the @c /stop path, which must leave the server
+     * usable for a later @c /start. The caller must not hold any lock that
+     * request handlers also take (e.g. the kotekan state lock in kotekan.cpp)
+     * while this drains, or drain and handler deadlock against each other.
+     * The drain is bounded: after 30 seconds an error is logged and teardown
+     * proceeds anyway. When called from the server thread itself the drain is
+     * skipped, since the single-threaded event loop guarantees no other
+     * handler is in flight.
+     *
      * The server thread is left running (endpoints stay resolvable, just
      * refused) so this composes with the framework's normal singleton
-     * teardown. Idempotent. Safe to call from the server thread itself (e.g. a
-     * @c /stop handler that deletes the mode): the single-threaded event loop
-     * guarantees no other handler is in flight, so the drain is skipped rather
-     * than dead-locking on the caller's own in-flight handler.
+     * teardown. Idempotent.
      */
     void stop_processing();
 
@@ -480,7 +487,7 @@ private:
 
     /// Cleared by @c stop_processing to refuse further callback dispatch. Once
     /// false, handle_request answers 503 without invoking any endpoint.
-    std::atomic<bool> _accepting_requests{true};
+    std::atomic<bool> accepting_requests{true};
 
     /// Cached value of /rest_server/enable_cors (legacy "*" mode); see
     /// @c set_cors_from_config.


### PR DESCRIPTION
Follow-ups to the request-quiesce barrier:

- kotekan.cpp: call stop_processing() before taking kotekan_state_lock in the signal path. The /start, /stop and /status handlers block on that lock while holding request_lock shared, so draining while holding it deadlocks the main thread against the server thread whenever a poller hits one of those endpoints during stop_stages()/join().

- Bound the drain at 30 seconds: a stuck handler otherwise hangs shutdown forever; log an error and proceed so the daemon gets a restartable process back.