### PR TITLE
Rhaas/upchan freq from voltage

### DIFF
--- a/config/ci-tests/gpu_batch/test_calc_frb2_weights.yaml
+++ b/config/ci-tests/gpu_batch/test_calc_frb2_weights.yaml
@@ -22,7 +22,7 @@ frb2_num_beams_y: 16
 frb2_num_beams: frb2_num_beams_x * frb2_num_beams_y
 
 # Upchannelization schedule: 4 coarse channels, each upchannelized by 8
-frequency_channels: [1000, 2000, 3000, 4000]
+frequency_channels: &frequency_channels_list [1000, 2000, 3000, 4000]
 upchan_factors: [8]
 # ranges are [min, max)
 upchan_channel_ranges:
@@ -214,6 +214,28 @@ host_frb2_weights_gpu_buffer:
     dimscalings: [1, 1, 1, 1]
     metadata_pool: main_pool
 
+# only used to get coarse frequencies from
+host_dummy_voltage_buffer:
+    kotekan_buffer: ndarray
+    num_frames: 1
+    value_type: int4x2_swapped_withoffset
+    extents: [1, 1, 1]
+    quantity_name: "E"
+    dimnames: ["F", "T", "E"]
+    dimscalings: [1, 1, 1]
+    metadata_pool: main_pool
+
+run_set_dummy_voltage:
+    kotekan_stage: testDataGen
+    type: const_offset
+    value: 0x88
+    array_shape: [1, 1, 1]
+    dim_scaling: [1, 1, 1]
+    dim_name: ["F", "T", "E"]
+    num_local_freq: 4 # len of frequency_channels
+    manual_freq_ids: *frequency_channels_list
+    out_buf: host_dummy_voltage_buffer
+
 # Stages
 run_set_frb_beams:
     kotekan_stage: setFRBBeams
@@ -233,11 +255,13 @@ run_calc_frb2_weights_cpu:
     frb2_beam_positions: host_frb2_beam_positions_buffer
     frb2_weights: host_frb2_weights_cpu_buffer
     num_threads: 4
+    metadata: host_dummy_voltage_buffer
 
 run_calc_frb2_weights_gpu:
     kotekan_stage: cudaCalcFRB2Weights
     frb2_beam_positions: host_frb2_beam_positions_buffer
     frb2_weights: host_frb2_weights_gpu_buffer
+    metadata: host_dummy_voltage_buffer
 
 run_test_calc_frb2_weights:
     kotekan_stage: testCalcFRB2Weights

--- a/config/fengine/include/frb_charts.j2
+++ b/config/fengine/include/frb_charts.j2
@@ -166,6 +166,7 @@ run_calc_frb2_weights:
     frb2_num_frequencies: upchan_all_max_output_channel - upchan_all_min_output_channel
     frb2_beam_positions: host_frb2_beam_positions_buffer
     frb2_weights: host_frb2_weights_buffer
+    metadata: host_voltage_buffer
 
 run_frb23:
     gpu_0:

--- a/config/fengine/include/frb_chime.j2
+++ b/config/fengine/include/frb_chime.j2
@@ -174,6 +174,7 @@ run_calc_frb2_weights:
     frb2_num_frequencies: upchan_U16_max_num_output_channels
     frb2_beam_positions: host_frb2_beam_positions_buffer
     frb2_weights: host_frb2_weights_buffer
+    metadata: host_rfi_RFImask_buffer # contains all frequencies
 
 run_frb23:
     gpu_0:

--- a/config/fengine/include/frb_chord.j2
+++ b/config/fengine/include/frb_chord.j2
@@ -207,6 +207,7 @@ run_calc_frb2_weights:
     frb2_num_frequencies: upchan_all_max_output_channel - upchan_all_min_output_channel
     frb2_beam_positions: host_frb2_beam_positions_buffer
     frb2_weights: host_frb2_weights_buffer
+    metadata: host_voltage_buffer
 
 run_frb23:
     gpu_0:

--- a/config/fengine/include/frb_hirax.j2
+++ b/config/fengine/include/frb_hirax.j2
@@ -182,6 +182,7 @@ run_calc_frb2_weights:
     frb2_num_frequencies: upchan_all_max_output_channel - upchan_all_min_output_channel
     frb2_beam_positions: host_frb2_beam_positions_buffer
     frb2_weights: host_frb2_weights_buffer
+    metadata: host_voltage_buffer
 
 run_frb23:
     gpu_0:

--- a/config/fengine/include/frb_pathfinder.j2
+++ b/config/fengine/include/frb_pathfinder.j2
@@ -207,6 +207,7 @@ run_calc_frb2_weights:
     frb2_num_frequencies: upchan_all_max_output_channel - upchan_all_min_output_channel
     frb2_beam_positions: host_frb2_beam_positions_buffer
     frb2_weights: host_frb2_weights_buffer
+    metadata: host_voltage_buffer
 
 run_frb23:
     gpu_0:

--- a/config/fengine/include/hfb_chime.j2
+++ b/config/fengine/include/hfb_chime.j2
@@ -193,7 +193,7 @@ run_calc_hfb2_weights:
     frb2_num_frequencies: upchan_hfb_upchan_U128_max_num_output_channels
     frb2_beam_positions: host_hfb2_beam_positions_buffer
     frb2_weights: host_hfb2_weights_buffer
-    num_threads: 32
+    metadata: host_rfi_RFImask_buffer # contains all frequencies
 
 run_hfb23:
     gpu_0:

--- a/lib/cuda/cudaCalcFRB2Weights.cpp
+++ b/lib/cuda/cudaCalcFRB2Weights.cpp
@@ -68,6 +68,7 @@ class cudaCalcFRB2Weights : public kotekan::Stage {
 
     Buffer* const frb2_beam_positions_buffer;
     Buffer* const W2_buffer;
+    Buffer* const metadata_buffer;
 
 public:
     cudaCalcFRB2Weights(kotekan::Config& config, const std::string& unique_name,
@@ -77,7 +78,7 @@ public:
                   return const_cast<kotekan::Stage&>(stage).main_thread();
               }),
         frb2_beam_positions_buffer(get_buffer("frb2_beam_positions")),
-        W2_buffer(get_buffer("frb2_weights"))
+        W2_buffer(get_buffer("frb2_weights")), metadata_buffer(get_buffer("metadata"))
     //
     {
         assert(frb2_beam_positions_buffer);
@@ -86,6 +87,7 @@ public:
             FATAL_ERROR("gpu_max_chunk_bytes {:d} must be positive", gpu_max_chunk_bytes);
         frb2_beam_positions_buffer->register_consumer(unique_name);
         W2_buffer->register_producer(unique_name);
+        metadata_buffer->register_consumer(unique_name);
 
         frb2_beam_positions_buffer->require_frame_desc(kotekan::NDArray<float, 2>::describe(
             "frb2_beam_positions", {frb2_num_beams, 2}, {"R", "X/Y"}, {1, 1}));
@@ -108,8 +110,16 @@ public:
         const Telescope& telescope = Telescope::instance();
 
         // Upchannelization schedule
-        const auto& upchan_schedule =
-            UpchannelizationSchedule::instance(config, upchannelization_schedule_name);
+        uint8_t const* const metadata_frame = metadata_buffer->wait_for_full_frame(unique_name, 0);
+        if (metadata_frame == nullptr)
+            return;
+        const auto& upchan_schedule = *[&]() {
+            const auto coarse_freq = get_chord_metadata(metadata_buffer, 0)->get_coarse_freq();
+            return &UpchannelizationSchedule::instance(config, upchannelization_schedule_name,
+                                                       coarse_freq);
+        }();
+        metadata_buffer->mark_frame_empty(unique_name, 0);
+        metadata_buffer->unregister_consumer(unique_name);
 
         // Calculate frequencies
         const auto& frequency_channels = upchan_schedule.get_frequency_channels();

--- a/lib/stages/UpchannelizationSchedule.cpp
+++ b/lib/stages/UpchannelizationSchedule.cpp
@@ -8,11 +8,6 @@
 #include <mutex>
 #include <sstream> // for basic_ostream, basic_ostringstream, operator<<, basic_ostream::...
 
-std::vector<int> UpchannelizationSchedule::make_frequency_channels() const {
-    const auto frequency_channels = config.get<std::vector<int>>(unique_name, "frequency_channels");
-    return frequency_channels;
-}
-
 std::map<int, int> UpchannelizationSchedule::make_frequency_channels_to_indices() const {
     std::map<int, int> channels_to_indices;
     for (std::size_t index = 0; index < frequency_channels.size(); ++index)
@@ -176,7 +171,7 @@ UpchannelizationSchedule::UpchannelizationSchedule(kotekan::Config& config,
     //
     unique_name(unique_name), config(config),
     //
-    frequency_channels(coarse_freq.size() ? coarse_freq : make_frequency_channels()),
+    frequency_channels(coarse_freq),
     frequency_channels_to_indices(make_frequency_channels_to_indices()),
     //
     upchan_factors(make_upchan_factors()),

--- a/lib/stages/UpchannelizationSchedule.cpp
+++ b/lib/stages/UpchannelizationSchedule.cpp
@@ -170,12 +170,13 @@ bool UpchannelizationSchedule::invariant() const {
 }
 
 UpchannelizationSchedule::UpchannelizationSchedule(kotekan::Config& config,
-                                                   const std::string& unique_name) :
+                                                   const std::string& unique_name,
+                                                   const std::vector<int>& coarse_freq) :
     kotekan::kotekanLogging(),
     //
     unique_name(unique_name), config(config),
     //
-    frequency_channels(make_frequency_channels()),
+    frequency_channels(coarse_freq.size() ? coarse_freq : make_frequency_channels()),
     frequency_channels_to_indices(make_frequency_channels_to_indices()),
     //
     upchan_factors(make_upchan_factors()),
@@ -188,14 +189,16 @@ UpchannelizationSchedule::UpchannelizationSchedule(kotekan::Config& config,
     assert(invariant());
 }
 
-const UpchannelizationSchedule& UpchannelizationSchedule::instance(kotekan::Config& config,
-                                                                   const std::string& unique_name) {
+const UpchannelizationSchedule&
+UpchannelizationSchedule::instance(kotekan::Config& config, const std::string& unique_name,
+                                   const std::vector<int>& coarse_freq) {
     static std::map<std::string, UpchannelizationSchedule> the_instances;
     static std::mutex the_mutex;
 
     std::lock_guard<std::mutex> lock(the_mutex);
     const UpchannelizationSchedule& the_instance =
-        the_instances.try_emplace(unique_name, config, unique_name).first->second;
+        the_instances.try_emplace(unique_name, config, unique_name, coarse_freq).first->second;
+    assert(coarse_freq.size() && the_instance.frequency_channels == coarse_freq);
     return the_instance;
 }
 

--- a/lib/stages/UpchannelizationSchedule.cpp
+++ b/lib/stages/UpchannelizationSchedule.cpp
@@ -198,7 +198,13 @@ UpchannelizationSchedule::instance(kotekan::Config& config, const std::string& u
     std::lock_guard<std::mutex> lock(the_mutex);
     const UpchannelizationSchedule& the_instance =
         the_instances.try_emplace(unique_name, config, unique_name, coarse_freq).first->second;
-    assert(coarse_freq.size() && the_instance.frequency_channels == coarse_freq);
+    if (!(the_instance.frequency_channels == coarse_freq)) {
+        const std::string coarse_freq_str = fmt::format("{:s}", fmt::join(coarse_freq, ","));
+        const std::string frequency_channels_str =
+            fmt::format("{:s}", fmt::join(the_instance.frequency_channels, ","));
+        FATAL_ERROR_NON_OO("Frequency channels [{:s}] and [{:s}] do not match", coarse_freq_str,
+                           frequency_channels_str);
+    }
     return the_instance;
 }
 

--- a/lib/stages/UpchannelizationSchedule.hpp
+++ b/lib/stages/UpchannelizationSchedule.hpp
@@ -51,7 +51,6 @@ class UpchannelizationSchedule : kotekan::kotekanLogging {
 
     ////////////////////////////////////////////////////////////////////////////////
 
-    std::vector<int> make_frequency_channels() const;
     std::map<int, int> make_frequency_channels_to_indices() const;
 
     std::vector<int> make_upchan_factors() const;
@@ -68,8 +67,8 @@ public:
     UpchannelizationSchedule& operator=(const UpchannelizationSchedule&) = delete;
     UpchannelizationSchedule& operator=(UpchannelizationSchedule&&) = delete;
 
-    UpchannelizationSchedule(kotekan::Config& config, const std::string& unique_name = "",
-                             const std::vector<int>& coarse_freq = std::vector<int>());
+    UpchannelizationSchedule(kotekan::Config& config, const std::string& unique_name,
+                             const std::vector<int>& coarse_freq);
 
     // Get the singleton instance
     static const UpchannelizationSchedule&

--- a/lib/stages/UpchannelizationSchedule.hpp
+++ b/lib/stages/UpchannelizationSchedule.hpp
@@ -68,11 +68,13 @@ public:
     UpchannelizationSchedule& operator=(const UpchannelizationSchedule&) = delete;
     UpchannelizationSchedule& operator=(UpchannelizationSchedule&&) = delete;
 
-    UpchannelizationSchedule(kotekan::Config& config, const std::string& unique_name = "");
+    UpchannelizationSchedule(kotekan::Config& config, const std::string& unique_name = "",
+                             const std::vector<int>& coarse_freq = std::vector<int>());
 
     // Get the singleton instance
-    static const UpchannelizationSchedule& instance(kotekan::Config& config,
-                                                    const std::string& unique_name = "");
+    static const UpchannelizationSchedule&
+    instance(kotekan::Config& config, const std::string& unique_name = "",
+             const std::vector<int>& coarse_freq = std::vector<int>());
 
     // The coarse frequency channels handled by this X-Engine
     // instance. This maps "channel index" to "channel".

--- a/lib/stages/calcFRB2Weights.cpp
+++ b/lib/stages/calcFRB2Weights.cpp
@@ -83,6 +83,7 @@ class calcFRB2Weights : public kotekan::Stage {
 
     Buffer* const frb2_beam_positions_buffer;
     Buffer* const W2_buffer;
+    Buffer* const metadata_buffer;
 
 public:
     calcFRB2Weights(kotekan::Config& config, const std::string& unique_name,
@@ -92,7 +93,7 @@ public:
                   return const_cast<kotekan::Stage&>(stage).main_thread();
               }),
         frb2_beam_positions_buffer(get_buffer("frb2_beam_positions")),
-        W2_buffer(get_buffer("frb2_weights"))
+        W2_buffer(get_buffer("frb2_weights")), metadata_buffer(get_buffer("metadata"))
     //
     {
         assert(frb2_beam_positions_buffer);
@@ -101,6 +102,7 @@ public:
             FATAL_ERROR("num_threads %d must be positive", num_threads);
         frb2_beam_positions_buffer->register_consumer(unique_name);
         W2_buffer->register_producer(unique_name);
+        metadata_buffer->register_consumer(unique_name);
 
         frb2_beam_positions_buffer->require_frame_desc(kotekan::NDArray<float, 2>::describe(
             "frb2_beam_positions", {frb2_num_beams, 2}, {"R", "X/Y"}, {1, 1}));
@@ -123,8 +125,16 @@ public:
         const Telescope& telescope = Telescope::instance();
 
         // Upchannelization schedule
-        const auto& upchan_schedule =
-            UpchannelizationSchedule::instance(config, upchannelization_schedule_name);
+        uint8_t const* const metadata_frame = metadata_buffer->wait_for_full_frame(unique_name, 0);
+        if (metadata_frame == nullptr)
+            return;
+        const auto& upchan_schedule = *[&]() {
+            const auto coarse_freq = get_chord_metadata(metadata_buffer, 0)->get_coarse_freq();
+            return &UpchannelizationSchedule::instance(config, upchannelization_schedule_name,
+                                                       coarse_freq);
+        }();
+        metadata_buffer->mark_frame_empty(unique_name, 0);
+        metadata_buffer->unregister_consumer(unique_name);
 
         // Calculate frequencies
         const auto& frequency_channels = upchan_schedule.get_frequency_channels();

--- a/lib/stages/setUpchanGain.cpp
+++ b/lib/stages/setUpchanGain.cpp
@@ -29,6 +29,7 @@ class setUpchanGain : public kotekan::Stage {
         config.get<std::vector<double>>(unique_name, "upchan_gain");
 
     Buffer* const upchan_gain_buffer;
+    Buffer* const metadata_buffer;
 
 public:
     setUpchanGain(kotekan::Config& config, const std::string& unique_name,
@@ -37,7 +38,8 @@ public:
               [](const kotekan::Stage& stage) {
                   return const_cast<kotekan::Stage&>(stage).main_thread();
               }),
-        upchan_gain_buffer(get_buffer("upchan_gain_buffer"))
+        upchan_gain_buffer(get_buffer("upchan_gain_buffer")),
+        metadata_buffer(get_buffer("metadata_buffer"))
     //
     {
         // We use the same gain for all channels
@@ -49,6 +51,7 @@ public:
                == sizeof(float16_t) * upchan_max_num_channels * upchan_factor);
 
         upchan_gain_buffer->register_producer(unique_name);
+        metadata_buffer->register_consumer(unique_name);
     }
 
     virtual ~setUpchanGain() {}
@@ -62,8 +65,16 @@ public:
             return;
 
         // Upchannelization schedule
-        const auto& upchan_schedule =
-            UpchannelizationSchedule::instance(config, upchannelization_schedule_name);
+        uint8_t const* const metadata_frame = metadata_buffer->wait_for_full_frame(unique_name, 0);
+        if (metadata_frame == nullptr)
+            return;
+        const auto& upchan_schedule = *[&]() {
+            const auto coarse_freq = get_chord_metadata(metadata_buffer, 0)->get_coarse_freq();
+            return &UpchannelizationSchedule::instance(config, upchannelization_schedule_name,
+                                                       coarse_freq);
+        }();
+        metadata_buffer->mark_frame_empty(unique_name, 0);
+        metadata_buffer->unregister_consumer(unique_name);
 
         // Wait for buffer
         DEBUG("[{:s}/{:d}] Waiting for buffer...", upchan_gain_buffer->buffer_name, frame_index);


### PR DESCRIPTION
set list of frequencies in upchan schedule based on frequencies from dpdk, instead of hard-coding in input files. Input files are identical on all nodes while no two nodes handle the same frequencies.