### PR TITLE
CI test script improvements

### DIFF
--- a/config/ci-tests/README.md
+++ b/config/ci-tests/README.md
@@ -4,10 +4,10 @@ Config files in this directory are intended to be run as part of CI. The `run_te
 
 ## Usage
 
-Any mix of directories and individual YAML configs can be given:
+Any mix of directories and individual configs can be given. Directories are searched for `.yaml`, `.yml` and `.j2` configs; an individual config can be given regardless of its extension.
 
 ```bash
-./run_tests.sh <kotekan_binary> <timeout_duration> <test_config_dir|test_config.yaml>...
+./run_tests.sh <kotekan_binary> <timeout_duration> <test_config_dir|test_config>...
 ```
 
 **Examples:**

--- a/config/ci-tests/README.md
+++ b/config/ci-tests/README.md
@@ -4,13 +4,17 @@ Config files in this directory are intended to be run as part of CI. The `run_te
 
 ## Usage
 
+Any mix of directories and individual YAML configs can be given:
+
 ```bash
-./run_tests.sh <kotekan_binary> <timeout_duration> <test_config_dir>
+./run_tests.sh <kotekan_binary> <timeout_duration> <test_config_dir|test_config.yaml>...
 ```
 
-**Example:**
+**Examples:**
 ```bash
 ./run_tests.sh ./build-2404/kotekan/kotekan 2m config/ci-tests/cpu_batch
+./run_tests.sh ./build-2404/kotekan/kotekan 2m config/ci-tests/cpu_batch/run_n2accum.yaml
+./run_tests.sh ./build-2404/kotekan/kotekan 2m config/ci-tests/gpu_batch config/ci-tests/cpu_batch/run_n2accum.yaml
 ```
 
 ## Output Exampe

--- a/config/ci-tests/run_tests.sh
+++ b/config/ci-tests/run_tests.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-# Runs Kotekan tests from directories of YAML configs and/or individual YAML
-# configs, with timeout protection.
+# Runs Kotekan tests from directories of configs and/or individual configs, with
+# timeout protection. Directories are searched for .yaml, .yml and .j2 configs.
 # Tracks pass/fail/timeout status and provides a summary at the end.
-# Usage: ./run_tests.sh <kotekan_binary> <timeout_duration> <test_config_dir|test_config.yaml>...
+# Usage: ./run_tests.sh <kotekan_binary> <timeout_duration> <test_config_dir|test_config>...
 
 # Check if required arguments are provided
 if [ $# -lt 3 ]; then
-  echo "Usage: $0 <kotekan_binary> <timeout_duration> <test_config_dir|test_config.yaml>..."
+  echo "Usage: $0 <kotekan_binary> <timeout_duration> <test_config_dir|test_config>..."
   echo "Example: $0 ./build-2404/kotekan/kotekan 2m config/ci-tests"
   echo "Example: $0 ./build-2404/kotekan/kotekan 2m config/ci-tests/cpu_batch/foo.yaml"
   exit 1
@@ -37,11 +37,11 @@ if [ ! -f "$KOTEKAN_BINARY" ]; then
   exit 1
 fi
 
-# Collect the configs to run: every *.yaml in a directory argument, or the file itself
+# Collect the configs to run: every config in a directory argument, or the file itself
 CONFIG_FILES=()
 for target in "$@"; do
   if [ -d "$target" ]; then
-    for config_file in "$target"/*.yaml; do
+    for config_file in "$target"/*.yaml "$target"/*.yml "$target"/*.j2; do
       [ -f "$config_file" ] && CONFIG_FILES+=("$config_file")
     done
   elif [ -f "$target" ]; then
@@ -53,7 +53,7 @@ for target in "$@"; do
 done
 
 if [ ${#CONFIG_FILES[@]} -eq 0 ]; then
-  echo "Error: No YAML configs found in $*"
+  echo "Error: No .yaml, .yml or .j2 configs found in $*"
   exit 1
 fi
 

--- a/config/ci-tests/run_tests.sh
+++ b/config/ci-tests/run_tests.sh
@@ -1,18 +1,20 @@
 #!/usr/bin/env bash
-# Runs Kotekan tests from a directory of YAML configs with timeout protection.
+# Runs Kotekan tests from directories of YAML configs and/or individual YAML
+# configs, with timeout protection.
 # Tracks pass/fail/timeout status and provides a summary at the end.
-# Usage: ./run_tests.sh <kotekan_binary> <timeout_duration> <test_config_dir>
+# Usage: ./run_tests.sh <kotekan_binary> <timeout_duration> <test_config_dir|test_config.yaml>...
 
 # Check if required arguments are provided
 if [ $# -lt 3 ]; then
-  echo "Usage: $0 <kotekan_binary> <timeout_duration> <test_config_dir>"
+  echo "Usage: $0 <kotekan_binary> <timeout_duration> <test_config_dir|test_config.yaml>..."
   echo "Example: $0 ./build-2404/kotekan/kotekan 2m config/ci-tests"
+  echo "Example: $0 ./build-2404/kotekan/kotekan 2m config/ci-tests/cpu_batch/foo.yaml"
   exit 1
 fi
 
 KOTEKAN_BINARY="$1"
 TIMEOUT_DURATION="$2"
-TEST_CONFIG_DIR="$3"
+shift 2
 
 format_duration() {
   local total_seconds=$1
@@ -35,9 +37,23 @@ if [ ! -f "$KOTEKAN_BINARY" ]; then
   exit 1
 fi
 
-# Verify test config directory exists
-if [ ! -d "$TEST_CONFIG_DIR" ]; then
-  echo "Error: Test config directory not found at $TEST_CONFIG_DIR"
+# Collect the configs to run: every *.yaml in a directory argument, or the file itself
+CONFIG_FILES=()
+for target in "$@"; do
+  if [ -d "$target" ]; then
+    for config_file in "$target"/*.yaml; do
+      [ -f "$config_file" ] && CONFIG_FILES+=("$config_file")
+    done
+  elif [ -f "$target" ]; then
+    CONFIG_FILES+=("$target")
+  else
+    echo "Error: Test config not found at $target"
+    exit 1
+  fi
+done
+
+if [ ${#CONFIG_FILES[@]} -eq 0 ]; then
+  echo "Error: No YAML configs found in $*"
   exit 1
 fi
 
@@ -52,7 +68,7 @@ TIMED_OUT_TEST_TIMES=()
 TIMED_OUT_TEST_EXIT_CODES=()
 
 # Run tests
-for config_file in "$TEST_CONFIG_DIR"/*.yaml; do
+for config_file in "${CONFIG_FILES[@]}"; do
   echo "Running test with config: $config_file"
   
   # Run the test with timeout


### PR DESCRIPTION
Invoke the script with individual files is now allowed.
Also looks for .yml and .j2 files (adds the test_xpose2048.j2 test, which wasn't running...)