### PR TITLE
Fix out-of-bounds frame access when a host buffer is shallower than the GPU pipeline

### DIFF
--- a/lib/cuda/cudaCommand.cpp
+++ b/lib/cuda/cudaCommand.cpp
@@ -98,6 +98,28 @@ cudaCommand::~cudaCommand() {
     DEBUG("post_events Freed: {:s}", unique_name.c_str());
 }
 
+void cudaCommand::register_host_buffer(Buffer* buf) {
+    if (instance_num != 0 || !buf->frame_size)
+        return;
+    for (int i = 0; i < buf->num_frames; i++) {
+        uint flags;
+        // only register the memory if it isn't already...
+        if (cudaErrorInvalidValue == cudaHostGetFlags(&flags, buf->frames[i]))
+            CHECK_CUDA_ERROR(cudaHostRegister(buf->frames[i], buf->frame_size, 0));
+    }
+}
+
+void cudaCommand::unregister_host_buffer(Buffer* buf) {
+    if (instance_num != 0 || !buf->frame_size)
+        return;
+    for (int i = 0; i < buf->num_frames; i++) {
+        uint flags;
+        // only unregister if it's actually been registered
+        if (cudaSuccess == cudaHostGetFlags(&flags, buf->frames[i]))
+            CHECK_CUDA_ERROR(cudaHostUnregister(buf->frames[i]));
+    }
+}
+
 cudaEvent_t cudaCommand::execute_base(cudaPipelineState& pipestate,
                                       const std::vector<cudaEvent_t>& pre_events) {
     if (!should_execute(pipestate, pre_events))

--- a/lib/cuda/cudaCommand.hpp
+++ b/lib/cuda/cudaCommand.hpp
@@ -121,6 +121,19 @@ public:
 protected:
     void set_command_type(const gpuCommandType& type);
 
+    /**
+     * @brief Page-locks (registers) every frame of a host buffer with the CUDA runtime.
+     *
+     * The frames belong to the buffer as a whole, and a buffer's frame count is
+     * independent of the number of command instances (@c _gpu_buffer_depth), so
+     * this is a no-op for instances other than 0.  Frames that are already
+     * registered are left alone.
+     */
+    void register_host_buffer(Buffer* buf);
+
+    /// Counterpart to @c register_host_buffer; unregisters every frame of @c buf.
+    void unregister_host_buffer(Buffer* buf);
+
     // For subclassers to call to create & record a GPU starting event, IFF profiling is on.
     void record_start_event();
 

--- a/lib/cuda/cudaCopyFromRingbuffer.cpp
+++ b/lib/cuda/cudaCopyFromRingbuffer.cpp
@@ -48,15 +48,7 @@ cudaCopyFromRingbuffer::cudaCopyFromRingbuffer(Config& config, const std::string
         if (instance_num == 0)
             out_buffer->register_producer(unique_name);
 
-        if (out_buffer->frame_size) {
-            uint flags;
-            // only register the memory if it isn't already...
-            if (cudaErrorInvalidValue
-                == cudaHostGetFlags(&flags, out_buffer->frames[instance_num])) {
-                CHECK_CUDA_ERROR(
-                    cudaHostRegister(out_buffer->frames[instance_num], out_buffer->frame_size, 0));
-            }
-        }
+        register_host_buffer(out_buffer);
     } else {
         out_buffer = nullptr;
         gpu_buffers_used.push_back(std::make_tuple(_gpu_mem_output, true, false, true));
@@ -77,13 +69,8 @@ cudaCopyFromRingbuffer::cudaCopyFromRingbuffer(Config& config, const std::string
 }
 
 cudaCopyFromRingbuffer::~cudaCopyFromRingbuffer() {
-    if (out_buffer && out_buffer->frame_size) {
-        uint flags;
-        // only unregister if it's already been registered
-        if (cudaSuccess == cudaHostGetFlags(&flags, out_buffer->frames[instance_num])) {
-            CHECK_CUDA_ERROR(cudaHostUnregister(out_buffer->frames[instance_num]));
-        }
-    }
+    if (out_buffer)
+        unregister_host_buffer(out_buffer);
 }
 
 int cudaCopyFromRingbuffer::wait_on_precondition() {

--- a/lib/cuda/cudaCopyNToRingbuffer.cpp
+++ b/lib/cuda/cudaCopyNToRingbuffer.cpp
@@ -64,12 +64,7 @@ cudaCopyNToRingbuffer::cudaCopyNToRingbuffer(Config& config, const std::string& 
 cudaCopyNToRingbuffer::~cudaCopyNToRingbuffer() {
     for (auto buf : in_buffers) {
         assert(buf);
-        if (buf->frame_size) {
-            uint flags;
-            if (cudaSuccess == cudaHostGetFlags(&flags, buf->frames[instance_num])) {
-                CHECK_CUDA_ERROR(cudaHostUnregister(buf->frames[instance_num]));
-            }
-        }
+        unregister_host_buffer(buf);
     }
 }
 

--- a/lib/cuda/cudaCopyToRingbuffer.cpp
+++ b/lib/cuda/cudaCopyToRingbuffer.cpp
@@ -64,13 +64,8 @@ cudaCopyToRingbuffer::cudaCopyToRingbuffer(Config& config, const std::string& un
 }
 
 cudaCopyToRingbuffer::~cudaCopyToRingbuffer() {
-    if (in_buffer && in_buffer->frame_size) {
-        uint flags;
-        // only unregister if it's already been registered
-        if (cudaSuccess == cudaHostGetFlags(&flags, in_buffer->frames[instance_num])) {
-            CHECK_CUDA_ERROR(cudaHostUnregister(in_buffer->frames[instance_num]));
-        }
-    }
+    if (in_buffer)
+        unregister_host_buffer(in_buffer);
 }
 
 int cudaCopyToRingbuffer::wait_on_precondition() {

--- a/lib/cuda/cudaInputData.cpp
+++ b/lib/cuda/cudaInputData.cpp
@@ -30,11 +30,7 @@ cudaInputData::cudaInputData(Config& config, const std::string& unique_name,
         in_buf->register_consumer(unique_name);
 
     if (in_buf->frame_size) {
-        uint flags;
-        // only register the memory if it isn't already...
-        if (cudaErrorInvalidValue == cudaHostGetFlags(&flags, in_buf->frames[instance_num])) {
-            CHECK_CUDA_ERROR(cudaHostRegister(in_buf->frames[instance_num], in_buf->frame_size, 0));
-        }
+        register_host_buffer(in_buf);
         _gpu_mem = config.get<std::string>(unique_name, "gpu_mem");
         gpu_buffers_used.push_back(std::make_tuple(_gpu_mem, true, false, true));
     } else {
@@ -49,13 +45,7 @@ cudaInputData::~cudaInputData() {
     if (do_once && instance_num > 0)
         return;
 
-    if (in_buf->frame_size) {
-        uint flags;
-        // only unregister if it's actually been registered
-        if (cudaSuccess == cudaHostGetFlags(&flags, in_buf->frames[instance_num])) {
-            CHECK_CUDA_ERROR(cudaHostUnregister(in_buf->frames[instance_num]));
-        }
-    }
+    unregister_host_buffer(in_buf);
 }
 
 int cudaInputData::wait_on_precondition() {

--- a/lib/cuda/cudaOutputData.cpp
+++ b/lib/cuda/cudaOutputData.cpp
@@ -46,15 +46,7 @@ cudaOutputData::cudaOutputData(Config& config, const std::string& unique_name,
     if (instance_num == 0)
         output_buffer->register_producer(unique_name);
 
-    if (output_buffer->frame_size) {
-        uint flags;
-        // only register the memory if it isn't already...
-        if (cudaErrorInvalidValue
-            == cudaHostGetFlags(&flags, output_buffer->frames[instance_num])) {
-            CHECK_CUDA_ERROR(cudaHostRegister(output_buffer->frames[instance_num],
-                                              output_buffer->frame_size, 0));
-        }
-    }
+    register_host_buffer(output_buffer);
 
     if (output_buffer->frame_size == 0) {
         _gpu_mem = "";
@@ -68,13 +60,7 @@ cudaOutputData::cudaOutputData(Config& config, const std::string& unique_name,
 }
 
 cudaOutputData::~cudaOutputData() {
-    if (output_buffer->frame_size) {
-        uint flags;
-        // only unregister if it's already been registered
-        if (cudaSuccess == cudaHostGetFlags(&flags, output_buffer->frames[instance_num])) {
-            CHECK_CUDA_ERROR(cudaHostUnregister(output_buffer->frames[instance_num]));
-        }
-    }
+    unregister_host_buffer(output_buffer);
 }
 
 int cudaOutputData::wait_on_precondition() {


### PR DESCRIPTION
Fix out-of-bounds frame access when a host buffer is shallower than the GPU pipeline

The CUDA commands that page-lock host buffer frames indexed the frame array by command instance number:

    in_buffer->frames[instance_num]

with instance_num in [0, gpu_buffer_depth).  That only holds when the buffer happens to have exactly gpu_buffer_depth frames.  A buffer with fewer frames reads past the end of the vector; with a shallower buffer than the pipeline, this aborted during shutdown in a debug build (where _GLIBCXX_ASSERTIONS catches it) and silently corrupted the unregister call in a release build.

It was also asymmetric with registration: gpuProcess::init() registers every frame of every host buffer it uses, so frames beyond the pipeline depth were never unregistered.

Replace the per-instance indexing with register_host_buffer() and unregister_host_buffer() helpers on cudaCommand, which walk all frames of the buffer once, from instance 0 — matching what gpuProcess::init() does.