### PR TITLE
cudaDeviceInterface: report the CUDA error when loading a kernel module fails

### DIFF
--- a/lib/cuda/cudaDeviceInterface.cpp
+++ b/lib/cuda/cudaDeviceInterface.cpp
@@ -352,7 +352,10 @@ void cudaDeviceInterface::build_ptx(const std::string& kernel_filename,
     // Extract kernels
     cu_res = cuModuleLoadDataEx(&module, elf, 0, nullptr, nullptr);
     if (cu_res != CUDA_SUCCESS) {
-        FATAL_ERROR("Could not load module data from elf");
+        const char* errStr = nullptr;
+        cuGetErrorString(cu_res, &errStr);
+        FATAL_ERROR("Could not load module data from elf for kernel file {:s}: {:s}",
+                    kernel_filename, errStr);
         return;
     }
 


### PR DESCRIPTION
`cuModuleLoadDataEx` failures printed a bare "Could not load module data from elf", with no error code and no indication of which kernel file was involved. Report `cuGetErrorString` and the file name instead, so that e.g. an architecture mismatch says "No kernel image is available for execution on the device" rather than nothing at all.