### PR TITLE
Add NDArrayRingbuffer functions to return the current position

### DIFF
--- a/lib/cuda/NDArrayRingBuffer.hpp
+++ b/lib/cuda/NDArrayRingBuffer.hpp
@@ -366,6 +366,13 @@ public:
 
     // State
 
+    extent_t get_maybe_empty_write_valid() const {
+        return write_valid;
+    }
+    extent_t get_maybe_empty_read_valid() const {
+        return read_valid;
+    }
+
     extent_t get_write_valid() const {
 #ifdef DEBUGGING
         if (!(write_valid.size() > 0))


### PR DESCRIPTION
Add NDArrayRingBuffer functions to return the current position even when the currently valid region is empty, i.e. when no data may be accessed. This is useful to align ringbuffers with different dimscalings.