### PR TITLE
Support conjugation of FRB gains

### DIFF
--- a/config/chime_upgrade_frb.j2
+++ b/config/chime_upgrade_frb.j2
@@ -1522,7 +1522,7 @@ FRB:
         num_local_freq: num_freq_gpu_buf
         upchan_factor: factor_upchan_out
         frb1_swap_MN: true
-        conj: true
+        conjugate_gains: true
         scaling_factor: 1.0 / 128
         gain_buffers:
           - host_frb1_phase_buffer

--- a/config/chime_upgrade_frb.j2
+++ b/config/chime_upgrade_frb.j2
@@ -1522,7 +1522,8 @@ FRB:
         num_local_freq: num_freq_gpu_buf
         upchan_factor: factor_upchan_out
         frb1_swap_MN: true
-        scaling_factor: 1.0 / 32
+        conj: true
+        scaling_factor: 1.0 / 128
         gain_buffers:
           - host_frb1_phase_buffer
         in_mask_buf: host_bf_mask_buffer

--- a/lib/stages/processFeedGains.cpp
+++ b/lib/stages/processFeedGains.cpp
@@ -32,7 +32,7 @@ processFeedGains::processFeedGains(Config& config, const std::string& unique_nam
     upchan_factor = config.get_default<uint32_t>(unique_name, "upchan_factor", 1);
     num_components = config.get<uint32_t>(unique_name, "num_components");
     scaling_factor = config.get_default<float>(unique_name, "scaling_factor", 1.0);
-    conj = config.get_default<bool>(unique_name, "conj", false);
+    conjugate_gains = config.get_default<bool>(unique_name, "conjugate_gains", false);
 
     // Input gain buffers
     json in_buf_list = config.get_value(unique_name, "gain_buffers");
@@ -109,7 +109,7 @@ void processFeedGains::copy_upchannelize(float* frame, size_t beam_id) {
     }
 
     // conjugate if gains are complex
-    if (conj && num_components > 1) {
+    if (conjugate_gains && num_components > 1) {
         size_t num_beam_elements = num_elements * num_local_freq * upchan_factor * num_components;
 
         for (size_t i = 1; i < num_beam_elements; i += 2) {

--- a/lib/stages/processFeedGains.hpp
+++ b/lib/stages/processFeedGains.hpp
@@ -51,6 +51,8 @@ using std::vector;
  * @conf   upchan_factor                         Int. Frequency upchannelization factor.
  * @conf   num_components                        Int. Number of gain components. Should be either
  *                                                   1 (real) or 2 (real/imag).
+ * @conf conjugate_gains                         Bool. If true, save the conjugate of the input
+ *                                                   gains.
  *
  * @author Liam Gray
  *
@@ -105,7 +107,7 @@ private:
     uint32_t out_num_values;
 
     /// Whether or not to conjugate the gains
-    bool conj;
+    bool conjugate_gains;
 
     /// Fixed buffers used to hold gains separately from the kotekan buffers
     std::vector<float16_t> gain_store_buf;


### PR DESCRIPTION
Most of the diff here is related to merge conflicts rather than actual changes. This branch was branched off of `frbNetwork4`, but was then rebased against `develop` (with a few cherry-picked commits from other branches removed).

The only actual changes here should be a couple of minor updates to `chime_upgrade_frb.j2`, and options to conjugate and swap real/imaginary ordering in the `processFeedGains` and `loadFeedGains` stages.