### PR TITLE
ConfigTracker updates & FPGA monitoring

### DIFF
--- a/config/chord_pathfinder.j2
+++ b/config/chord_pathfinder.j2
@@ -607,6 +607,16 @@ host_rfi_sktilde_ringbuffer_1:
 
 # Stages
 
+##  Monitor the F-engine for drift ##
+# The config tracker reads the F-engine controller once at startup and hands
+# that snapshot downstream; this re-reads it so a controller that is
+# reprogrammed or resynced mid-acquisition is caught rather than silently
+# invalidating every config already propagated.
+fpga_monitor:
+    kotekan_stage: FPGAMonitor
+    poll_interval_seconds: 5
+    fetch_timeout_seconds: 5
+
 ##  Packet capture from the F-engine ##
 dpdk:
     kotekan_stage: dpdkCore

--- a/config/chord_pathfinder_recv.j2
+++ b/config/chord_pathfinder_recv.j2
@@ -189,6 +189,19 @@ buffer_recv_full_n2:
 
 
 
+## Monitor the F-engine for drift
+
+# The config tracker reads the F-engine controller once at startup and hands
+# that snapshot downstream; this re-reads it so a controller that is
+# reprogrammed or resynced mid-acquisition is caught rather than silently
+# invalidating every config already propagated.
+fpga_monitor:
+    kotekan_stage: FPGAMonitor
+    poll_interval_seconds: 5
+    fetch_timeout_seconds: 5
+
+
+
 ## Write out the visibilities using HDF5
 
 # Subset visibilities

--- a/docs/sphinx/dev/dev_config_tracker.rst
+++ b/docs/sphinx/dev/dev_config_tracker.rst
@@ -168,9 +168,18 @@ Per-Connection REST Ports
 When receiving frames over the network, ``bufferRecv`` may need to pull upstream configurations
 from the sender's REST server (only when the config tracker is enabled).
 
-- Default: the receiver assumes the sender's REST server is on port ``12048`` (``PORT_REST_SERVER``).
-- Override: use the stage config key ``upstream_rest_endpoints`` to specify non‑standard ports
-  per client. Entries are matched against the client IP as seen by ``bufferRecv``.
+Nothing on the wire carries the sender's REST port, so it has to come from
+config on the receiving side.
+
+- Default: the port this instance's own REST server is bound to, i.e. whatever
+  ``--bind-address`` gave it. A fleet launched on one port therefore agrees with
+  no extra config.
+- ``upstream_rest_port``: states that port explicitly. Set it when the senders
+  bind a different port than this receiver does — the two are unrelated, and the
+  default only happens to be right when they match.
+- ``upstream_rest_endpoints``: per-client overrides as ``"host:port"`` entries,
+  matched against the client IP as seen by ``bufferRecv``. These win over
+  ``upstream_rest_port``.
 
 Example::
 
@@ -178,13 +187,19 @@ Example::
     type: bufferRecv
     listen_port: 11024
     use_config_tracker: true
+    upstream_rest_port: 12050
     upstream_rest_endpoints:
       - "10.1.2.3:13000"
       - "192.168.5.10:14080"
 
 Notes
-- This setting is only meaningful when ``use_config_tracker: true``.
-- If a client IP:port is not listed, the default port ``12048`` is used for the IP.
+
+- These settings are only meaningful when ``use_config_tracker: true``.
+- If a client IP is not listed in ``upstream_rest_endpoints``, ``upstream_rest_port``
+  is used for it.
+- The default changed: receivers previously always assumed ``12048``. A receiver
+  bound to another port while its senders stay on ``12048`` now needs
+  ``upstream_rest_port: 12048`` set explicitly.
 
 Enabling or disabling the tracker
 ---------------------------------

--- a/docs/sphinx/dev/dev_config_tracker.rst
+++ b/docs/sphinx/dev/dev_config_tracker.rst
@@ -22,10 +22,12 @@ regular upstream entry: a single combined ``{"config": ..., "timing": ...}``
 JSON, keyed by the controller's REST ``(host, port)``. The hostname is
 resolved to a canonical IPv4 string up front so downstream peers
 transitively land on the same key. Any change to either part after the
-initial fetch indicates a controller reset and is fatal. The FPGA snapshot
-rides along on the same propagation path as peer kotekan configs, so an
-HDF5 writer downstream of the FPGA-adjacent node sees it as an ordinary
-upstream entry.
+initial fetch indicates a controller reset. The startup fetch treats such a
+change as fatal; ``checkFpgaTracking()`` re-reads the controller without
+inserting or exiting, so a poller can decide what a deviation means. The
+FPGA snapshot rides along on the same propagation
+path as peer kotekan configs, so an HDF5 writer downstream of the
+FPGA-adjacent node sees it as an ordinary upstream entry.
 
 The tracker exposes four REST endpoints:
 
@@ -59,10 +61,11 @@ The tracker is enabled by default. Its behaviour is configured by an optional to
       upstream_fetch_retries: 2             # retries per HTTP request
       upstream_fetch_timeout_seconds: 10    # per-attempt HTTP timeout
 
-The retry/timeout policy applies to every upstream fetch — both the one-shot
-FPGA controller fetch at startup and the per-frame peer fetches triggered by
-``bufferRecv``'s wire flag. After retries are exhausted on any fetch, the call
-is fatal (no silent skip).
+The retry/timeout policy applies to every upstream fetch — the one-shot FPGA
+controller fetch at startup, the per-frame peer fetches triggered by
+``bufferRecv``'s wire flag, and the repeat reads made by ``checkFpgaTracking()``.
+After retries are exhausted, the first two are fatal (no silent skip);
+``checkFpgaTracking()`` reports the failure to its caller instead.
 
 The controller's two endpoint paths live on the controller block itself so the
 Telescope (which reads ``timing_endpoint`` from the same block via

--- a/docs/sphinx/dev/dev_config_tracker.rst
+++ b/docs/sphinx/dev/dev_config_tracker.rst
@@ -24,7 +24,8 @@ resolved to a canonical IPv4 string up front so downstream peers
 transitively land on the same key. Any change to either part after the
 initial fetch indicates a controller reset. The startup fetch treats such a
 change as fatal; ``checkFpgaTracking()`` re-reads the controller without
-inserting or exiting, so a poller can decide what a deviation means. The
+inserting or exiting, so a poller can decide what a deviation means (see
+:ref:`fpga-monitor`). The
 FPGA snapshot rides along on the same propagation
 path as peer kotekan configs, so an HDF5 writer downstream of the
 FPGA-adjacent node sees it as an ordinary upstream entry.
@@ -130,6 +131,37 @@ Threading & Safety
 - The tracker is process-local; network exchange happens via the REST client/servers under the hood.
 - Hash collisions are unlikely in practice. If a different hash is found at the same endpoint,
   execution aborts to avoid state contamination.
+
+.. _fpga-monitor:
+
+Monitoring the FPGA controller
+------------------------------
+The tracker reads the FPGA controller once, at startup, and hands that snapshot
+to every downstream node. Nothing re-reads it afterwards, so a controller that
+is reprogrammed or resynced mid-acquisition leaves the pipeline describing data
+it no longer produced.
+
+The ``FPGAMonitor`` stage closes that gap. It re-reads the two endpoints the
+tracker registered, at the address the tracker resolved, and compares them
+against the record. It requires ``/config_tracker/fpga_host_info`` to be set on
+the same instance::
+
+  fpga_monitor:
+      kotekan_stage: FPGAMonitor
+      poll_interval_seconds: 5     # default
+      fetch_timeout_seconds: 5     # default; keep below poll_interval_seconds
+      fatal_on_change: true        # default
+      fatal_on_unreachable: false  # default
+      max_consecutive_failures: 3  # default
+
+A deviation from the record is fatal by default: every config the tracker has
+already propagated downstream is wrong from that point on. A controller that
+cannot be read is tolerated instead, escalating from a warning to an error after
+``max_consecutive_failures`` polls in a row, so a REST restart does not end an
+acquisition.
+
+Nothing is ever written back to the tracker by a poll — the record stays the
+snapshot taken at startup.
 
 Per-Connection REST Ports
 -------------------------

--- a/lib/core/configTracker.hpp
+++ b/lib/core/configTracker.hpp
@@ -13,7 +13,10 @@
  * An upstream FPGA controller, if present, is registered as a regular
  * upstream entry: a single combined ``{"config": ..., "timing": ...}`` JSON,
  * keyed by the controller's REST (host, port). Any change to either part
- * after the initial fetch indicates a controller reset and is fatal.
+ * after the initial fetch indicates a controller reset. The startup fetch
+ * treats a change as fatal; @c checkFpgaTracking re-reads the controller
+ * without inserting or exiting, so a poller (the FPGAMonitor stage) can decide
+ * what a deviation means.
  *
  * - kotekan::ConfigTracker
  *   -- instance
@@ -23,8 +26,10 @@
  *   -- setLocalConfig
  *   -- insertUpstreamConfig
  *   -- fetchAndRegisterFpgaTracking
+ *   -- getFpgaEndpoint / checkFpgaTracking
  *   -- applyConfig
  *   -- hasLocalConfig / hasUpstreamConfig
+ *   -- getUpstreamConfigInfo
  *   -- getLocalConfigInfo / getLocalConfigHash
  *   -- trackers_local_callback
  *   -- trackers_local_hash_callback
@@ -179,6 +184,38 @@ public:
                                   {"kotekan_git_commit_hash", kotekan_git_commit_hash},
                                   {"kotekan_cmake_options", kotekan_cmake_options}};
         }
+    };
+
+    /**
+     * @brief The upstream FPGA controller this node registered at startup.
+     *
+     * Kept so a monitor can re-poll exactly what was registered: the same
+     * canonical IPv4 the snapshot is keyed under, and the same endpoint paths.
+     */
+    struct FpgaEndpoint {
+        std::string host; ///< Canonical IPv4 the controller was reached at.
+        uint16_t port = 0;
+        std::string config_endpoint;
+        std::string timing_endpoint;
+    };
+
+    /// Outcome of one @c checkFpgaTracking poll.
+    enum class FpgaCheckStatus {
+        not_tracked, ///< No FPGA controller was registered; nothing to check.
+        unreachable, ///< The controller did not answer, or its answer did not parse.
+        changed,     ///< The controller answered, but no longer matches the record.
+        ok,          ///< The controller matches the record.
+    };
+
+    /// Result of one @c checkFpgaTracking poll: status plus enough to log it.
+    struct FpgaCheckResult {
+        FpgaCheckStatus status = FpgaCheckStatus::not_tracked;
+        /// Why, for @c unreachable and @c changed. Empty otherwise.
+        std::string detail;
+        /// Hash the tracker holds for the controller ("" if it holds none).
+        std::string recorded_hash;
+        /// Hash of what the controller just returned ("" if unreachable).
+        std::string observed_hash;
     };
 
     /**
@@ -383,10 +420,118 @@ public:
         nlohmann::json combined = {{"config", cfg_json}, {"timing", tim_json}};
         insertUpstreamConfig(ip, port, combined, "", "", "", "");
 
+        {
+            std::lock_guard<std::mutex> lock(_lock);
+            _fpga_endpoint = FpgaEndpoint{ip, port, config_endpoint, timing_endpoint};
+        }
+
         INFO_NON_OO(
             "ConfigTracker: registered FPGA controller config and timing from {}:{} (config {}, "
             "timing {})",
             ip, port, config_endpoint, timing_endpoint);
+    }
+
+    /// The FPGA controller registered at startup, or std::nullopt if none.
+    std::optional<FpgaEndpoint> getFpgaEndpoint() const {
+        std::lock_guard<std::mutex> lock(_lock);
+        return _fpga_endpoint;
+    }
+
+    /// Copy of the upstream ConfigInfo held for (host, port), or std::nullopt.
+    std::optional<ConfigInfo> getUpstreamConfigInfo(const std::string& host, uint16_t port) const {
+        std::lock_guard<std::mutex> lock(_lock);
+        auto it = _upstream_configs.find({host, port});
+        if (it == _upstream_configs.end())
+            return std::nullopt;
+        return it->second;
+    }
+
+    /**
+     * @brief Re-fetch the registered FPGA controller and compare it against
+     * the snapshot the tracker recorded at startup.
+     *
+     * Unlike @c fetchAndRegisterFpgaTracking, neither a failed fetch nor a
+     * changed payload is fatal here, and nothing is inserted: a poller has to
+     * be able to survive a controller that is briefly unreachable, and
+     * deciding what a deviation means is the caller's job (see the FPGAMonitor
+     * stage). Note that @c restClient::make_request_blocking is still fatal if
+     * libevent never calls back at all (at twice @p timeout_seconds), which is
+     * a restClient failure rather than a controller one. The comparison is
+     * made over the same combined ``{"config": ..., "timing": ...}`` JSON and
+     * the same (host, port)-keyed hash the startup fetch stored, so a match
+     * here means the tracker's record is still accurate.
+     *
+     * @param retries          Retries per request; -1 uses the tracker's policy.
+     * @param timeout_seconds  HTTP timeout per attempt; -1 uses the tracker's policy.
+     */
+    FpgaCheckResult checkFpgaTracking(int retries = -1, int timeout_seconds = -1) const {
+        FpgaCheckResult result;
+
+        FpgaEndpoint endpoint;
+        std::optional<ConfigInfo> recorded;
+        {
+            std::lock_guard<std::mutex> lock(_lock);
+            if (!_fpga_endpoint.has_value()) {
+                result.status = FpgaCheckStatus::not_tracked;
+                return result;
+            }
+            endpoint = *_fpga_endpoint;
+            if (retries < 0)
+                retries = _upstream_fetch_retries;
+            if (timeout_seconds < 0)
+                timeout_seconds = _upstream_fetch_timeout_seconds;
+            auto it = _upstream_configs.find({endpoint.host, endpoint.port});
+            if (it != _upstream_configs.end())
+                recorded = it->second;
+        }
+        if (recorded.has_value())
+            result.recorded_hash = recorded->json_hash;
+
+        // Fetch outside the lock: these are blocking HTTP round trips.
+        std::string error;
+        auto cfg_json = _fpga_try_get(endpoint.host, endpoint.port, endpoint.config_endpoint,
+                                      timeout_seconds, retries, error);
+        if (!cfg_json.has_value()) {
+            result.status = FpgaCheckStatus::unreachable;
+            result.detail = error;
+            return result;
+        }
+        auto tim_json = _fpga_try_get(endpoint.host, endpoint.port, endpoint.timing_endpoint,
+                                      timeout_seconds, retries, error);
+        if (!tim_json.has_value()) {
+            result.status = FpgaCheckStatus::unreachable;
+            result.detail = error;
+            return result;
+        }
+
+        nlohmann::json combined = {{"config", *cfg_json}, {"timing", *tim_json}};
+        nlohmann::json filtered = _strip_update_endpoints(combined);
+        result.observed_hash = _jsonHashWithEndpoint(filtered, endpoint.host, endpoint.port);
+
+        if (!recorded.has_value()) {
+            result.status = FpgaCheckStatus::changed;
+            result.detail = fmt::format(fmt("the tracker holds no snapshot for {}:{}"),
+                                        endpoint.host, endpoint.port);
+            return result;
+        }
+        if (result.observed_hash == result.recorded_hash) {
+            result.status = FpgaCheckStatus::ok;
+            return result;
+        }
+
+        // Name the part that moved: "config" is the controller's setup, and
+        // "timing" its frame-0 reference, and the two mean different things
+        // (a reprogram versus a resync).
+        result.status = FpgaCheckStatus::changed;
+        std::vector<std::string> parts;
+        for (const char* key : {"config", "timing"}) {
+            if (recorded->config.value(key, nlohmann::json())
+                != filtered.value(key, nlohmann::json()))
+                parts.push_back(key);
+        }
+        result.detail = parts.empty() ? std::string("content differs")
+                                      : fmt::format(fmt("{} changed"), fmt::join(parts, " and "));
+        return result;
     }
 
     /**
@@ -787,6 +932,7 @@ public:
             _upstream_configs.clear();
             _upstream_config_hashes.clear();
             _local_config.reset();
+            _fpga_endpoint.reset();
             _tracker_hash.clear();
             _configs_total_metric().set(0.0);
         }
@@ -818,6 +964,11 @@ private:
     /// node observed for the upstream. Hash includes (host, port).
     std::map<HostPort, ConfigInfo> _upstream_configs;
     std::map<std::string, HostPort> _upstream_config_hashes;
+
+    /// The FPGA controller registered by @c fetchAndRegisterFpgaTracking, if
+    /// any. Its snapshot lives in @c _upstream_configs like any other upstream
+    /// entry; this only remembers where it came from so it can be re-polled.
+    std::optional<FpgaEndpoint> _fpga_endpoint;
 
     /// Combined hash of all configurations (local first if present, then
     /// upstream hashes in sorted order).
@@ -1010,6 +1161,32 @@ private:
         }
         // Unreachable; FATAL_ERROR_NON_OO throws.
         return nlohmann::json{};
+    }
+
+    /**
+     * @brief GET a single FPGA controller endpoint, returning std::nullopt
+     * (and a reason in @p error) instead of exiting kotekan on failure.
+     * Used by @c checkFpgaTracking, where one missed poll is not on its own a
+     * reason to bring the pipeline down.
+     */
+    static std::optional<nlohmann::json> _fpga_try_get(const std::string& ip, uint16_t port,
+                                                       const std::string& endpoint,
+                                                       int request_timeout_seconds,
+                                                       int request_retries, std::string& error) {
+        auto reply = restClient::instance().make_request_blocking(
+            endpoint, {}, ip, port, request_retries, request_timeout_seconds);
+        if (!reply.first) {
+            error = fmt::format(fmt("GET {}:{}{} failed (after {} retries, {}s timeout)"), ip, port,
+                                endpoint, request_retries, request_timeout_seconds);
+            return std::nullopt;
+        }
+        try {
+            return nlohmann::json::parse(reply.second);
+        } catch (const nlohmann::json::parse_error& e) {
+            error = fmt::format(fmt("GET {}:{}{} returned unparseable JSON: {}"), ip, port,
+                                endpoint, e.what());
+            return std::nullopt;
+        }
     }
 
     /// MD5 of a string, returned as a 32-char lowercase hex string.

--- a/lib/stages/CMakeLists.txt
+++ b/lib/stages/CMakeLists.txt
@@ -100,6 +100,7 @@ add_library(
     BeamExtract.cpp
     BeamInspect.cpp
     configTrackerWriter.cpp
+    FPGAMonitor.cpp
     givenDataGen.cpp
     testDataGen.cpp
     DPDKShuffleSimulate.cpp

--- a/lib/stages/FPGAMonitor.cpp
+++ b/lib/stages/FPGAMonitor.cpp
@@ -1,0 +1,164 @@
+#include "FPGAMonitor.hpp"
+
+#include "StageFactory.hpp"   // for REGISTER_KOTEKAN_STAGE
+#include "configTracker.hpp"  // for ConfigTracker
+#include "kotekanLogging.hpp" // for FATAL_ERROR, INFO, WARN, ERROR, DEBUG
+
+#include "fmt.hpp" // for compile_string_to_view
+
+#include <chrono>     // for duration, steady_clock, milliseconds
+#include <functional> // for bind
+#include <thread>     // for sleep_for
+
+using kotekan::Config;
+using kotekan::ConfigTracker;
+using kotekan::Stage;
+using kotekan::prometheus::Metrics;
+
+REGISTER_KOTEKAN_STAGE(FPGAMonitor);
+
+FPGAMonitor::FPGAMonitor(Config& config, const std::string& unique_name,
+                         kotekan::bufferContainer& buffer_container) :
+    Stage(config, unique_name, buffer_container, std::bind(&FPGAMonitor::main_thread, this)),
+    _matches_record_metric(
+        Metrics::instance().add_gauge("kotekan_fpga_monitor_matches_record", unique_name)),
+    _polls_metric(Metrics::instance().add_counter("kotekan_fpga_monitor_polls_total", unique_name,
+                                                  {"result"})),
+    _last_ok_metric(Metrics::instance().add_gauge("kotekan_fpga_monitor_last_ok_timestamp_seconds",
+                                                  unique_name)) {
+
+    _poll_interval_seconds = config.get_default<double>(unique_name, "poll_interval_seconds", 5.0);
+    if (_poll_interval_seconds <= 0.0)
+        FATAL_ERROR("poll_interval_seconds must be positive, got {}", _poll_interval_seconds);
+
+    _fetch_timeout_seconds = config.get_default<int>(unique_name, "fetch_timeout_seconds", 5);
+    _fetch_retries = config.get_default<int>(unique_name, "fetch_retries", 0);
+    _fatal_on_change = config.get_default<bool>(unique_name, "fatal_on_change", true);
+    _fatal_on_unreachable = config.get_default<bool>(unique_name, "fatal_on_unreachable", false);
+    _max_consecutive_failures = config.get_default<int>(unique_name, "max_consecutive_failures", 3);
+    if (_max_consecutive_failures < 1)
+        FATAL_ERROR("max_consecutive_failures must be at least 1, got {}",
+                    _max_consecutive_failures);
+
+    if (!ConfigTracker::instance().is_enabled())
+        FATAL_ERROR("FPGAMonitor needs the config tracker: add a /config_tracker block naming the "
+                    "controller with `fpga_host_info`.");
+
+    // Registered by ConfigTracker::applyConfig, which kotekanMode runs before
+    // it builds any stage, so the endpoint is already known here.
+    auto endpoint = ConfigTracker::instance().getFpgaEndpoint();
+    if (!endpoint.has_value())
+        FATAL_ERROR("FPGAMonitor has no FPGA controller to poll: set "
+                    "/config_tracker/fpga_host_info to the controller's host block.");
+    _endpoint = *endpoint;
+
+    INFO("Monitoring FPGA controller {}:{} ({} and {}) every {}s", _endpoint.host, _endpoint.port,
+         _endpoint.config_endpoint, _endpoint.timing_endpoint, _poll_interval_seconds);
+
+    // Start out matching: the startup fetch is what defines the record.
+    _matches_record_metric.set(1.0);
+}
+
+FPGAMonitor::~FPGAMonitor() {}
+
+bool FPGAMonitor::poll_once() {
+    const ConfigTracker::FpgaCheckResult result =
+        ConfigTracker::instance().checkFpgaTracking(_fetch_retries, _fetch_timeout_seconds);
+
+    switch (result.status) {
+        case ConfigTracker::FpgaCheckStatus::ok:
+            _polls_metric.labels({"ok"}).inc();
+            _last_ok_metric.set(
+                std::chrono::duration<double>(std::chrono::steady_clock::now().time_since_epoch())
+                    .count());
+            if (_consecutive_failures > 0) {
+                INFO("FPGA controller {}:{} readable again after {} failed poll(s); still matches "
+                     "the tracker record ({})",
+                     _endpoint.host, _endpoint.port, _consecutive_failures, result.recorded_hash);
+                _consecutive_failures = 0;
+            }
+            DEBUG("FPGA controller {}:{} matches the tracker record ({})", _endpoint.host,
+                  _endpoint.port, result.recorded_hash);
+            return true;
+
+        case ConfigTracker::FpgaCheckStatus::unreachable: {
+            _polls_metric.labels({"unreachable"}).inc();
+            _consecutive_failures++;
+            if (_consecutive_failures < _max_consecutive_failures) {
+                WARN("Could not read FPGA controller {}:{} ({} in a row): {}", _endpoint.host,
+                     _endpoint.port, _consecutive_failures, result.detail);
+                return true;
+            }
+            // Past the threshold: the controller has been unreadable long
+            // enough that the tracker's record is no longer being confirmed
+            // by anything.
+            if (_fatal_on_unreachable) {
+                FATAL_ERROR("FPGA controller {}:{} unreadable for {} consecutive polls: {}",
+                            _endpoint.host, _endpoint.port, _consecutive_failures, result.detail);
+                return false;
+            }
+            ERROR("FPGA controller {:s}:{:d} unreadable for {:d} consecutive polls: {:s}",
+                  _endpoint.host, _endpoint.port, _consecutive_failures, result.detail);
+            return true;
+        }
+
+        case ConfigTracker::FpgaCheckStatus::changed:
+            _polls_metric.labels({"changed"}).inc();
+            _consecutive_failures = 0;
+            _matches_record_metric.set(0.0);
+            if (_fatal_on_change) {
+                FATAL_ERROR("FPGA controller {}:{} no longer matches the config tracker record "
+                            "({}): recorded hash {}, now {}. Every config already handed "
+                            "downstream describes the old controller state.",
+                            _endpoint.host, _endpoint.port, result.detail, result.recorded_hash,
+                            result.observed_hash);
+                return false;
+            }
+            // Report the deviation once. It will not clear on its own: the
+            // tracker's record is fixed at startup, so every later poll would
+            // repeat this.
+            if (!_deviation_reported) {
+                _deviation_reported = true;
+                ERROR("FPGA controller {:s}:{:d} no longer matches the config tracker record "
+                      "({:s}): recorded hash {:s}, now {:s}. Continuing because fatal_on_change is "
+                      "false; tracked configs are now stale.",
+                      _endpoint.host, _endpoint.port, result.detail, result.recorded_hash,
+                      result.observed_hash);
+            }
+            return true;
+
+        case ConfigTracker::FpgaCheckStatus::not_tracked:
+            // The constructor established that an endpoint exists, and nothing
+            // clears it while the pipeline runs.
+            FATAL_ERROR("FPGA controller registration disappeared from the config tracker.");
+            return false;
+    }
+    return true;
+}
+
+void FPGAMonitor::main_thread() {
+    using namespace std::chrono;
+    using namespace std::chrono_literals;
+
+    const auto interval =
+        duration_cast<steady_clock::duration>(duration<double>(_poll_interval_seconds));
+
+    // First poll one interval in, so a controller that is still settling at
+    // pipeline start isn't read the instant after the tracker read it.
+    auto next_poll = steady_clock::now() + interval;
+
+    while (!stop_thread) {
+        // Sleep in slices rather than for the whole interval, so shutdown does
+        // not have to wait out a poll period.
+        if (steady_clock::now() < next_poll) {
+            std::this_thread::sleep_for(100ms);
+            continue;
+        }
+        next_poll = steady_clock::now() + interval;
+
+        if (!poll_once())
+            break;
+    }
+
+    INFO("FPGAMonitor: exiting main thread");
+}

--- a/lib/stages/FPGAMonitor.hpp
+++ b/lib/stages/FPGAMonitor.hpp
@@ -1,0 +1,112 @@
+/**
+ * @file
+ * @brief Stage that polls the upstream FPGA controller for drift.
+ *
+ * The ConfigTracker fetches the FPGA controller's config and timing once at
+ * startup and treats them as fixed for the life of the pipeline: every
+ * downstream node is handed that snapshot, and data written to disk is
+ * labelled with it. Nothing re-reads the controller after that, so a
+ * controller that is reprogrammed or resynced mid-acquisition leaves the whole
+ * pipeline quietly describing data it no longer produced.
+ *
+ * This stage closes that gap: it re-reads the same two endpoints on an
+ * interval and compares them against the tracker's record.
+ *
+ * - FPGAMonitor : public kotekan::Stage
+ */
+#ifndef FPGA_MONITOR_HPP
+#define FPGA_MONITOR_HPP
+
+#include "Config.hpp"
+#include "Stage.hpp"
+#include "bufferContainer.hpp"
+#include "configTracker.hpp"
+#include "prometheusMetrics.hpp"
+
+#include <stdint.h>
+#include <string>
+
+/**
+ * @class FPGAMonitor
+ * @brief Periodically checks that the FPGA controller still matches what the
+ *        ConfigTracker recorded at startup.
+ *
+ * Requires the config tracker to be enabled and to have registered an FPGA
+ * controller (i.e. ``/config_tracker/fpga_host_info`` is set); it polls the
+ * controller registered there, at the address the tracker resolved, using the
+ * same ``config_endpoint`` and ``timing_endpoint``.
+ *
+ * A poll has three outcomes. It matches; the controller could not be read; or
+ * the controller answered with something other than what was recorded. Only
+ * the last is a real deviation, and by default it is fatal, because every
+ * config the tracker has already handed downstream is now wrong. Failing to
+ * read the controller is tolerated by default (a REST server restart or a
+ * blip should not take down an acquisition), but is escalated to an error
+ * after `max_consecutive_failures` polls in a row.
+ *
+ * @par Metrics
+ * @metric kotekan_fpga_monitor_matches_record  1 while the controller matches
+ *         the tracker's record, 0 once a deviation has been seen.
+ * @metric kotekan_fpga_monitor_polls_total     Polls, labelled by `result`
+ *         (`ok`, `changed`, `unreachable`).
+ * @metric kotekan_fpga_monitor_last_ok_timestamp_seconds
+ *         Monotonic time of the last poll that matched, on the same clock as
+ *         kotekan_config_tracker_last_change_timestamp_seconds.
+ *
+ * @conf poll_interval_seconds     Double. Default 5. Seconds between polls.
+ * @conf fetch_timeout_seconds     Int. Default 5. HTTP timeout per request.
+ *                                 Keep it below poll_interval_seconds.
+ * @conf fetch_retries             Int. Default 0. Retries per request. A poll
+ *                                 that misses is retried on the next tick
+ *                                 anyway, so retrying inside one is rarely
+ *                                 what you want.
+ * @conf fatal_on_change           Bool. Default true. Exit kotekan when the
+ *                                 controller no longer matches the record.
+ * @conf fatal_on_unreachable      Bool. Default false. Exit kotekan once the
+ *                                 controller has been unreadable for
+ *                                 `max_consecutive_failures` polls.
+ * @conf max_consecutive_failures  Int. Default 3. Failed polls in a row before
+ *                                 the stage escalates from a warning to an
+ *                                 error (and, if `fatal_on_unreachable`, exits).
+ *
+ * @author James Mertens
+ */
+class FPGAMonitor : public kotekan::Stage {
+public:
+    FPGAMonitor(kotekan::Config& config, const std::string& unique_name,
+                kotekan::bufferContainer& buffer_container);
+    ~FPGAMonitor() override;
+
+    void main_thread() override;
+
+private:
+    /// Run one poll and act on the outcome. Returns false if the stage should stop.
+    bool poll_once();
+
+    /// Seconds between polls.
+    double _poll_interval_seconds;
+    /// Per-request HTTP timeout, in seconds.
+    int _fetch_timeout_seconds;
+    /// Per-request retry count.
+    int _fetch_retries;
+    /// Whether a deviation from the record is fatal.
+    bool _fatal_on_change;
+    /// Whether a persistently unreachable controller is fatal.
+    bool _fatal_on_unreachable;
+    /// Consecutive failed polls tolerated before escalating.
+    int _max_consecutive_failures;
+
+    /// The controller being polled, as the tracker resolved it.
+    kotekan::ConfigTracker::FpgaEndpoint _endpoint;
+
+    /// Consecutive polls that failed to read the controller.
+    int _consecutive_failures = 0;
+    /// Set once a deviation has been reported, so it is logged once, not every poll.
+    bool _deviation_reported = false;
+
+    kotekan::prometheus::Gauge& _matches_record_metric;
+    kotekan::prometheus::MetricFamily<kotekan::prometheus::Counter>& _polls_metric;
+    kotekan::prometheus::Gauge& _last_ok_metric;
+};
+
+#endif // FPGA_MONITOR_HPP

--- a/lib/stages/bufferRecv.cpp
+++ b/lib/stages/bufferRecv.cpp
@@ -10,7 +10,7 @@
 #include "configTracker.hpp"     // for ConfigTracker
 #include "metadata.hpp"          // for metadataObject, metadataPool
 #include "prometheusMetrics.hpp" // for Gauge, Metrics, Counter, MetricFamily
-#include "restServer.hpp"        // for PORT_REST_SERVER, connectionInstance
+#include "restServer.hpp"        // for restServer, PORT_REST_SERVER, connectionInstance
 #include "util.h"                // for string_tail
 #include "visUtil.hpp"           // for current_time, regex_split
 
@@ -45,6 +45,7 @@ using kotekan::bufferContainer;
 using kotekan::Config;
 using kotekan::ConfigTracker;
 using kotekan::connectionInstance;
+using kotekan::restServer;
 using kotekan::Stage;
 using kotekan::prometheus::Metrics;
 
@@ -70,6 +71,20 @@ bufferRecv::bufferRecv(Config& config, const std::string& unique_name,
     num_threads = config.get_default<uint32_t>(unique_name, "num_threads", 1);
     connection_timeout = config.get_default<int>(unique_name, "connection_timeout", 60);
     drop_frames = config.get_default<bool>(unique_name, "drop_frames", true);
+
+    // Which REST port to reach a sender on for config-tracker fetches. The
+    // local configTracker does not have this information, so we need to know the
+    // port the instances were launched with (--bind-address). The REST server
+    // reports 0 before it is started, so fall back to the compile-time port
+    // rather than failing.
+    const uint16_t local_rest_port = restServer::instance().port();
+    const int upstream_rest_port_int =
+        config.get_default<int>(unique_name, "upstream_rest_port",
+                                local_rest_port != 0 ? local_rest_port : PORT_REST_SERVER);
+    if (upstream_rest_port_int <= 0 || upstream_rest_port_int > 65535) {
+        FATAL_ERROR("Invalid upstream_rest_port: {:d}", upstream_rest_port_int);
+    }
+    default_upstream_rest_port = static_cast<uint16_t>(upstream_rest_port_int);
 
     // Optional per-connection upstream REST port overrides for a given host (list of "host:port"
     // strings)
@@ -118,11 +133,16 @@ void bufferRecv::read_callback(evutil_socket_t fd, short what, void* arg) {
 void bufferRecv::worker_thread() {
     connInstance* instance;
     DEBUG2("Starting worker thread");
-    while (!stop_thread) {
+    // Two stop flags, and both matter: `stop_thread` is the pipeline shutting
+    // down, `worker_stop_thread` is this pool being torn down on its own (a
+    // failed main_thread setup), which happens while the stage is still
+    // nominally running.
+    while (!stop_thread && !worker_stop_thread) {
         {
             std::unique_lock<mutex> lock(work_queue_lock);
-            work_cv.wait(lock, [&] { return (!work_queue.empty() || stop_thread); });
-            if (stop_thread)
+            work_cv.wait(
+                lock, [&] { return (!work_queue.empty() || stop_thread || worker_stop_thread); });
+            if (stop_thread || worker_stop_thread)
                 return;
             instance = work_queue.front();
             work_queue.pop_front();
@@ -199,7 +219,7 @@ void bufferRecv::internal_accept_connection(evutil_socket_t listener, short even
 
     // New connection instance
     // Resolve per-connection upstream REST port (override by client IP if configured)
-    uint16_t conn_upstream_rest_port = PORT_REST_SERVER;
+    uint16_t conn_upstream_rest_port = default_upstream_rest_port;
     auto it_override = upstream_rest_port_overrides.find(std::string(ip_str));
     if (it_override != upstream_rest_port_overrides.end()) {
         conn_upstream_rest_port = it_override->second;
@@ -272,22 +292,6 @@ void bufferRecv::main_thread() {
         return;
     }
 
-    // Create worker threads:
-    cpu_set_t cpuset;
-    CPU_ZERO(&cpuset);
-    for (auto& i : config.get<std::vector<int>>(unique_name, "cpu_affinity"))
-        CPU_SET(i, &cpuset);
-
-    for (uint32_t i = 0; i < num_threads; ++i) {
-        thread_pool.push_back(thread(&bufferRecv::worker_thread, std::ref(*this)));
-        pthread_setaffinity_np(thread_pool.back().native_handle(), sizeof(cpu_set_t), &cpuset);
-#ifndef MAC_OSX
-        std::string short_name =
-            string_tail(fmt::format(fmt("{:s}/worker_thread/{:d}"), unique_name, i), 15);
-        pthread_setname_np(thread_pool.back().native_handle(), short_name.c_str());
-#endif
-    }
-
     server_addr.sin_family = AF_INET;
     // Bind to every address (might want to change this later)
     server_addr.sin_addr.s_addr = 0;
@@ -296,9 +300,11 @@ void bufferRecv::main_thread() {
     listener = socket(AF_INET, SOCK_STREAM, 0);
     evutil_make_socket_nonblocking(listener);
 
-    // This makes is possible to reuse the same socket even if it goes into TIME_WAIT
-    // Used by gossec
-    if (!drop_frames) {
+    // Bind even when connections from a previous run are still in TIME_WAIT.
+    // Without this, a restart within the TIME_WAIT window (a couple of minutes)
+    // fails with EADDRINUSE on a port nothing is listening on any more, which
+    // is exactly the window a supervisor restarts kotekan in.
+    {
         int reuse = 1;
         if (setsockopt(listener, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(int)) < 0) {
             ERROR("Could not set SO_REUSEADDR on socket");
@@ -308,13 +314,17 @@ void bufferRecv::main_thread() {
     }
 
     if (bind(listener, (struct sockaddr*)&server_addr, sizeof(server_addr)) < 0) {
-        FATAL_ERROR("Failed to bind to socket 0.0.0.0:{:d}, error: {:d} ({:s})", listen_port, errno,
-                    strerror(errno));
+        const int bind_errno = errno;
+        close(listener);
+        FATAL_ERROR("Failed to bind to socket 0.0.0.0:{:d}, error: {:d} ({:s})", listen_port,
+                    bind_errno, strerror(bind_errno));
         return;
     }
 
     if (listen(listener, 256) < 0) {
-        FATAL_ERROR("Failed to open listener {:d} ({:s})", errno, strerror(errno));
+        const int listen_errno = errno;
+        close(listener);
+        FATAL_ERROR("Failed to open listener {:d} ({:s})", listen_errno, strerror(listen_errno));
         return;
     }
 
@@ -341,11 +351,34 @@ void bufferRecv::main_thread() {
     interval.tv_usec = 100000;
     event_add(timer_event, &interval);
 
+    // Create the worker threads last, once nothing between here and the loop
+    // can throw, leaving the workers stuck waiting. Nothing reaches the workers
+    // until the loop runs anyway.
+    cpu_set_t cpuset;
+    CPU_ZERO(&cpuset);
+    for (auto& i : config.get<std::vector<int>>(unique_name, "cpu_affinity"))
+        CPU_SET(i, &cpuset);
+
+    for (uint32_t i = 0; i < num_threads; ++i) {
+        thread_pool.push_back(thread(&bufferRecv::worker_thread, std::ref(*this)));
+        pthread_setaffinity_np(thread_pool.back().native_handle(), sizeof(cpu_set_t), &cpuset);
+#ifndef MAC_OSX
+        std::string short_name =
+            string_tail(fmt::format(fmt("{:s}/worker_thread/{:d}"), unique_name, i), 15);
+        pthread_setname_np(thread_pool.back().native_handle(), short_name.c_str());
+#endif
+    }
+
     // The libevent main loop.
     event_base_dispatch(base);
 
-    // Join all the worker threads
-    worker_stop_thread = true;
+    // Join all the worker threads before touching the connection instances they
+    // read from. Setting the flag under the queue lock keeps a worker on its
+    // way into work_cv.wait() from missing the notify.
+    {
+        std::lock_guard<mutex> lock(work_queue_lock);
+        worker_stop_thread = true;
+    }
     work_cv.notify_all();
     for (thread& t : thread_pool) {
         if (t.joinable()) {

--- a/lib/stages/bufferRecv.hpp
+++ b/lib/stages/bufferRecv.hpp
@@ -19,6 +19,7 @@
 
 #include "fmt.hpp" // for compile_string_to_view
 
+#include <atomic>             // for atomic
 #include <condition_variable> // for condition_variable
 #include <deque>              // for deque
 #include <errno.h>            // for EAGAIN, EDEADLK
@@ -61,10 +62,17 @@ class connInstance;
  * @conf num_threads         Int, default 1.  The number of worker threads to use
  * @conf connection_timeout  Int, default 60.  Number of seconds before timeout on transfer
  * @conf drop_frames         Bool, default true.  Whether to drop frames when buffer fills.
+ * @conf upstream_rest_port  Int, default: this instance's own REST port. The
+ *        REST port to reach a sender on when fetching config-tracker state.
+ *        Nothing on the wire carries the sender's REST port, so it has to be
+ *        stated here; the default assumes the fleet runs on one port, which
+ *        holds when every instance is launched with the same --bind-address.
+ *        Set it explicitly when the senders bind a different port than this
+ *        receiver does.
  * @conf upstream_rest_endpoints  List[str], default empty. Optional list of
  *        "host:port" entries specifying non-standard upstream REST ports to use for
  *        particular senders. If the client IP (as seen by bufferRecv) matches a host in this
- *        list, that port overrides the default REST port (PORT_REST_SERVER) for that connection.
+ *        list, that port overrides @c upstream_rest_port for that connection.
  *
  * @par Metrics
  * @metric kotekan_buffer_recv_transfer_time_seconds
@@ -133,6 +141,9 @@ private:
 
     /// Whether to drop frames when buffer starts filling up
     bool drop_frames;
+
+    /// REST port used to reach a sender that has no per-host override
+    uint16_t default_upstream_rest_port;
 
     /// Optional per-host overrides for upstream REST ports
     std::map<std::string, uint16_t> upstream_rest_port_overrides;
@@ -215,8 +226,9 @@ private:
     /// Condition variable for the state (empty or not) of the work queue
     std::condition_variable work_cv;
 
-    /// Set to true to stop the worker threads
-    bool worker_stop_thread = false;
+    /// Set to true to stop the worker threads. Read by the workers and by the
+    /// read callbacks, which do not hold @c work_queue_lock.
+    std::atomic<bool> worker_stop_thread = false;
 
     /**
      * @brief The worker thread for handing read callbacks.

--- a/tests/boost/test_configTracker.cpp
+++ b/tests/boost/test_configTracker.cpp
@@ -1,7 +1,7 @@
 #define BOOST_TEST_MODULE "test_configTracker"
 
 #include "configTracker.hpp" // for ConfigTracker
-#include "restServer.hpp"    // for restServer
+#include "restServer.hpp"    // for restServer, connectionInstance
 
 #include "json.hpp" // for json_ref, basic_json<>::object_t, json
 
@@ -211,6 +211,94 @@ BOOST_AUTO_TEST_CASE(insert_upstream_with_combined_payload) {
     // Different content under same (host, port) -> conflict.
     BOOST_CHECK_THROW(tracker.insertUpstreamConfig("10.6.0.1", 54321, combined_v2, "", "", "", ""),
                       std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(upstream_config_info_lookup) {
+    auto& tracker = ConfigTracker::instance();
+
+    tracker.insertUpstreamConfig("10.6.0.1", 54321, kSampleJson1, "", "", "", "");
+
+    const auto found = tracker.getUpstreamConfigInfo("10.6.0.1", 54321);
+    BOOST_REQUIRE(found.has_value());
+    BOOST_CHECK_EQUAL(found->config, kSampleJson1);
+    BOOST_CHECK_EQUAL(found->json_hash.size(), 32u);
+
+    // Same host, different port is a different entry.
+    BOOST_CHECK(!tracker.getUpstreamConfigInfo("10.6.0.1", 54322).has_value());
+}
+
+BOOST_AUTO_TEST_CASE(fpga_check_without_registration) {
+    // Nothing registered: the check reports that rather than trying to talk to
+    // anything, so a monitor can tell "no controller" from "controller moved".
+    auto& tracker = ConfigTracker::instance();
+    BOOST_CHECK(!tracker.getFpgaEndpoint().has_value());
+
+    const auto result = tracker.checkFpgaTracking();
+    BOOST_CHECK(result.status == ConfigTracker::FpgaCheckStatus::not_tracked);
+    BOOST_CHECK(result.observed_hash.empty());
+}
+
+BOOST_AUTO_TEST_CASE(fpga_check_against_live_controller) {
+    // Stand up a fake controller on a kotekan REST server, register it the way
+    // startup does, then poll it: unchanged reads back as ok, and moving
+    // either half is reported as a change naming that half.
+    auto& tracker = ConfigTracker::instance();
+    auto& server = restServer::instance();
+
+    // Port 0 lets the OS pick; restServer::start() binds before returning, so
+    // port() is final here.
+    server.start("127.0.0.1", 0);
+    const uint16_t port = server.port();
+    BOOST_REQUIRE(port != 0);
+
+    json fpga_config = {{"fpga_serial", "0xdeadbeef"}, {"clock_mhz", 800}};
+    json fpga_timing = {{"frame_zero_unix_ns", 1700000000000000000LL}};
+
+    server.register_get_callback(
+        "/fake_fpga_config", [&](connectionInstance& conn) { conn.send_json_reply(fpga_config); });
+    server.register_get_callback(
+        "/fake_fpga_timing", [&](connectionInstance& conn) { conn.send_json_reply(fpga_timing); });
+
+    tracker.fetchAndRegisterFpgaTracking("127.0.0.1", port, "/fake_fpga_config",
+                                         "/fake_fpga_timing");
+
+    const auto endpoint = tracker.getFpgaEndpoint();
+    BOOST_REQUIRE(endpoint.has_value());
+    BOOST_CHECK_EQUAL(endpoint->host, "127.0.0.1");
+    BOOST_CHECK_EQUAL(endpoint->port, port);
+    BOOST_CHECK_EQUAL(endpoint->config_endpoint, "/fake_fpga_config");
+    BOOST_CHECK(tracker.hasUpstreamConfig("127.0.0.1", port));
+
+    {
+        const auto result = tracker.checkFpgaTracking(0, 5);
+        BOOST_CHECK(result.status == ConfigTracker::FpgaCheckStatus::ok);
+        BOOST_CHECK_EQUAL(result.observed_hash, result.recorded_hash);
+    }
+
+    // A resync moves the timing half only.
+    fpga_timing["frame_zero_unix_ns"] = 1800000000000000000LL;
+    {
+        const auto result = tracker.checkFpgaTracking(0, 5);
+        BOOST_CHECK(result.status == ConfigTracker::FpgaCheckStatus::changed);
+        BOOST_CHECK(result.observed_hash != result.recorded_hash);
+        BOOST_CHECK(result.detail.find("timing") != std::string::npos);
+        BOOST_CHECK(result.detail.find("config") == std::string::npos);
+    }
+
+    // A reprogram moves the config half as well.
+    fpga_config["clock_mhz"] = 1200;
+    {
+        const auto result = tracker.checkFpgaTracking(0, 5);
+        BOOST_CHECK(result.status == ConfigTracker::FpgaCheckStatus::changed);
+        BOOST_CHECK(result.detail.find("config") != std::string::npos);
+        BOOST_CHECK(result.detail.find("timing") != std::string::npos);
+    }
+
+    // Polling never writes back: the record still describes the startup state.
+    BOOST_CHECK_EQUAL(tracker.n_configs(), 1u);
+
+    server.remove_get_callback("/fake_fpga_config");
+    server.remove_get_callback("/fake_fpga_timing");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/ci-scripts/push_pull/test_configTracker.sh
+++ b/tests/ci-scripts/push_pull/test_configTracker.sh
@@ -44,6 +44,11 @@ CONFIG_OUT_DIR="${KOTEKAN_BUILD_DIR}/config_writes"
 rm -rf "${CONFIG_OUT_DIR}"
 mkdir -p "${CONFIG_OUT_DIR}"
 
+# configTrackerWriter's base_dir below is relative, so it lands in whatever
+# directory the instances are launched from. Launch from the build directory,
+# which is where CONFIG_OUT_DIR is checked.
+cd "${KOTEKAN_BUILD_DIR}" || exit 1
+
 # Run three instances of kotekan in an A -> B -> C chain. This exercises both
 # steps of getUpstreamConfigs on instance 3:
 #   - step 1: fetches B's local config via /config_tracker_local
@@ -143,20 +148,20 @@ check_file_hash() {
 }
 
 # Instance 3's own (local) config
-EXPECTED_LOCAL_HASH="92d32f5195eaeb8f9354a3a8eb860115"
+EXPECTED_LOCAL_HASH="0ea7c33c609614b8dc414d6270fcb241"
 if ! check_file_hash "${CONFIG_OUT_DIR}/local.json" "$EXPECTED_LOCAL_HASH"; then
     ERROR=1
 fi
 
 # B's local config as seen by C (step 1, re-keyed under 127.0.0.1:12748)
-EXPECTED_B_HASH="3cf1d34c37eb9179cf078dedd9ba0a68"
+EXPECTED_B_HASH="7f4de78da3e74a9c31e0ba312b8d4844"
 if ! check_file_hash "${CONFIG_OUT_DIR}/127.0.0.1_12748.json" "$EXPECTED_B_HASH"; then
     ERROR=1
 fi
 
 # A's config, discovered via B's upstream-hashes (step 2; B already had A
 # stored under 127.0.0.1:12048, and C trusts that key transitively).
-EXPECTED_A_HASH="7a4f644e999a4c6789d187b2c385406e"
+EXPECTED_A_HASH="998b28f455d99bfde5f4eb57ad5b1b2b"
 if ! check_file_hash "${CONFIG_OUT_DIR}/127.0.0.1_12048.json" "$EXPECTED_A_HASH"; then
     ERROR=1
 fi

--- a/tests/ci-scripts/push_pull/test_configTracker_1.yaml
+++ b/tests/ci-scripts/push_pull/test_configTracker_1.yaml
@@ -1,10 +1,21 @@
 ---
 # configTracker test 1
 
+# Participate in config tracking. The block must be a mapping; the older
+# bare-bool `config_tracker: true` form is no longer accepted.
+config_tracker:
+    enabled: true
+
 type: config
 log_level: debug
 
 cpu_affinity: [1, 2, 3, 4]
+
+# Every kotekan mode instantiates the Telescope singleton, so even a test that
+# only moves opaque frames needs a minimal one.
+telescope:
+    num_polarizations: 2
+    num_dishes: 2
 
 num_frame_samples: 2048
 buffer_depth: 2

--- a/tests/ci-scripts/push_pull/test_configTracker_2.yaml
+++ b/tests/ci-scripts/push_pull/test_configTracker_2.yaml
@@ -8,13 +8,21 @@
 #   - step 2: discovers and fetches A's config via B's
 #             /config_tracker_upstream_hashes + /config_tracker_upstream_configs
 
-# use the config tracker
-config_tracker: true
+# Participate in config tracking. The block must be a mapping; the older
+# bare-bool `config_tracker: true` form is no longer accepted.
+config_tracker:
+    enabled: true
 
 type: config
 log_level: debug
 
 cpu_affinity: [1, 2, 3, 4]
+
+# Every kotekan mode instantiates the Telescope singleton, so even a test that
+# only moves opaque frames needs a minimal one.
+telescope:
+    num_polarizations: 2
+    num_dishes: 2
 
 num_frame_samples: 2048
 buffer_depth: 2
@@ -39,6 +47,10 @@ buffer_recv:
         listen_port: 11024
         cpu_affinity: [5, 6]
         num_threads: 2
+        # A's REST server is on 12048 while this instance binds 12748, so the
+        # default (this instance's own REST port) is not the right place to
+        # fetch A's tracker state from.
+        upstream_rest_port: 12048
 
 # Forward received frames to instance 3
 buffer_send:

--- a/tests/ci-scripts/push_pull/test_configTracker_3.yaml
+++ b/tests/ci-scripts/push_pull/test_configTracker_3.yaml
@@ -9,10 +9,21 @@
 #   - upstream(127.0.0.1, 12048): A's config, discovered via B's upstream
 #                                  hashes (via step 2)
 
+# Participate in config tracking. The block must be a mapping; the older
+# bare-bool `config_tracker: true` form is no longer accepted.
+config_tracker:
+    enabled: true
+
 type: config
 log_level: debug
 
 cpu_affinity: [1, 2, 3, 4]
+
+# Every kotekan mode instantiates the Telescope singleton, so even a test that
+# only moves opaque frames needs a minimal one.
+telescope:
+    num_polarizations: 2
+    num_dishes: 2
 
 num_frame_samples: 2048
 buffer_depth: 2


### PR DESCRIPTION
 - The configTracker should support kotekan instances running on other ports.
 - Kotekan should poll the FPGA occasionally to verify consistency (otherwise, new acquisition).
 - Hopefully also fixes some daemon restart issues...
 