### PR TITLE
Fixes bad feed mask reorder and optionally reorders feeds before sending in RFI broadcast

### DIFF
--- a/config/chime_upgrade_frb.j2
+++ b/config/chime_upgrade_frb.j2
@@ -449,8 +449,8 @@ baseband_merge:
 host_bf_mask_buffer:
     kotekan_buffer: ndarray
     num_frames: host_buffer_depth
-    value_type: int8
-    extents: [num_polarizations, num_dishes]
+    value_type: uint8
+    extents: [num_elements]
     metadata_pool: main_pool
 
 host_pl_mask_buffer:
@@ -1799,6 +1799,12 @@ FRB:
             input_order: CHIMEBeamformer # this makes no sense, but is required
             in_buf: host_frb1_U16_phase_buffer
             file_name: host_frb1_U16_phase_buffer
+        host_bad_input_mask:
+            kotekan_stage: hdf5FileWrite
+            base_dir: frb_weights
+            input_order: CHIMEBeamformer # this makes no sense, but is required
+            in_buf: host_bf_mask_buffer
+            file_name: host_bf_mask_buffer
 {% endif %}
 
 {% if False %}

--- a/lib/stages/bufferBadInputs.cpp
+++ b/lib/stages/bufferBadInputs.cpp
@@ -1,7 +1,8 @@
 #include "bufferBadInputs.hpp"
 
-#include "Config.hpp"         // for Config
-#include "N2Util.hpp"         // for frameID
+#include "Config.hpp" // for Config
+#include "N2Util.hpp" // for frameID
+#include "NDArray.hpp"
 #include "StageFactory.hpp"   // for REGISTER_KOTEKAN_STAGE
 #include "Telescope.hpp"      // for Telescope, station_id_t
 #include "buffer.hpp"         // for Buffer
@@ -34,7 +35,7 @@ bufferBadInputs::bufferBadInputs(Config& config_, const std::string& unique_name
     out_buf->register_producer(unique_name);
 
     // Construct the cylinder -> beamformer reorder table.
-    // reorder[beamformer_idx] = cylinder_idx;
+    // want reorder[cylinder_idx] = beamformer_idx
     reorder.resize(num_elements);
 
     // initialize the mask (1 == good)
@@ -42,12 +43,15 @@ bufferBadInputs::bufferBadInputs(Config& config_, const std::string& unique_name
 
     const Telescope& tel = Telescope::instance();
 
-    for (size_t beamformer_idx = 0; beamformer_idx < num_elements; ++beamformer_idx) {
-        station_id_t st_id =
-            tel.element_index_to_station_id(beamformer_idx, ElementOrder::CHIMEBeamformer);
-        reorder.at(beamformer_idx) =
-            tel.station_id_to_element_index(st_id, ElementOrder::CHIMECylinder);
+    // cylinder order is already gives the station id
+    for (station_id_t cyl_idx = 0; cyl_idx < num_elements; ++cyl_idx) {
+        reorder.at(cyl_idx) =
+            tel.station_id_to_element_index(cyl_idx, ElementOrder::CHIMEBeamformer);
     }
+
+    // Set the frame description
+    out_buf->ensure_frame_desc(kotekan::NDArray<kotekan::GetType_t<kotekan::uint8>, 1>::describe(
+        "bad_inputs", {static_cast<ptrdiff_t>(num_elements)}, {"E"}, {1}));
 
     // Listen for bad input list updates
     std::string badInputs = config.get<std::string>(unique_name, "updatable_config/bad_inputs");
@@ -88,7 +92,8 @@ bool bufferBadInputs::update_bad_inputs_callback(nlohmann::json& json) {
     // Reset the mask (1 == good)
     std::fill(input_mask.begin(), input_mask.end(), 1);
 
-    // now update the mask
+    // now update the mask. Elements are in _cylinder_ order, but the
+    // output map should be in _beamformer_ order
     for (int element : bad_inputs) {
         input_mask.at(reorder[element]) = 0;
     }
@@ -119,7 +124,13 @@ void bufferBadInputs::main_thread() {
 
         // Set metadata and release
         out_buf->allocate_new_metadata_object(frame_id);
-        get_chord_metadata(out_buf, frame_id)->set_rfi_num_bad_inputs(nbad);
+        auto meta = get_chord_metadata(out_buf, frame_id);
+        meta->set_from_frame_desc(out_buf->get_frame_desc<kotekan::GenericNDArray>());
+        meta->set_name("bad_inputs");
+        meta->set_rfi_num_bad_inputs(nbad);
+        // Verify the frame desc and metadata match
+        meta->check_frame_desc(out_buf->get_frame_desc<kotekan::GenericNDArray>());
+
         out_buf->mark_frame_full(unique_name, frame_id);
         frame_id++;
     }

--- a/lib/stages/rfiBroadcast.cpp
+++ b/lib/stages/rfiBroadcast.cpp
@@ -1,8 +1,9 @@
 #include "rfiBroadcast.hpp"
 
-#include "Config.hpp"          // for Config
-#include "N2Util.hpp"          // for frameID, modulo
-#include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
+#include "Config.hpp"       // for Config
+#include "N2Util.hpp"       // for frameID, modulo
+#include "StageFactory.hpp" // for REGISTER_KOTEKAN_STAGE
+#include "Telescope.hpp"
 #include "buffer.hpp"          // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
 #include "chordMetadata.hpp"   // for chordMetadata, get_chord_metadata
@@ -99,6 +100,20 @@ rfiBroadcast::rfiBroadcast(Config& config, const std::string& unique_name,
         FATAL_ERROR(
             "`rfi_skbar_buf` does not have the expected frame size. Expected {:d}, got {:d}",
             _skbar_expected_frame_size, sk_bar_buf->frame_size);
+
+    // Construct the beamformer -> cylinder reorder table
+    // NB: the CHIME receiver system _always_ expects inputs to be in cylinder order
+    // reorder[beamformer_idx] = cylinder_idx
+    reorder.resize(num_elements);
+
+    const Telescope& tel = Telescope::instance();
+
+    for (size_t beamformer_idx = 0; beamformer_idx < num_elements; ++beamformer_idx) {
+        station_id_t st_id =
+            tel.element_index_to_station_id(beamformer_idx, ElementOrder::CHIMEBeamformer);
+        reorder.at(beamformer_idx) =
+            tel.station_id_to_element_index(st_id, ElementOrder::CHIMECylinder);
+    }
 
     // Set up the UDP socket params and validate the the provided ID is valid
     dest_addr.sin_family = AF_INET;
@@ -242,7 +257,7 @@ void rfiBroadcast::main_thread() {
                 float* dst_bar_t = dst_bar + f * num_elements;
 
                 for (size_t e = 0; e < num_elements; ++e) {
-                    dst_bar_t[e] += src[e];
+                    dst_bar_t[reorder[e]] += src[e];
                 }
             }
         }

--- a/lib/stages/rfiBroadcast.hpp
+++ b/lib/stages/rfiBroadcast.hpp
@@ -13,7 +13,6 @@
 
 #include <netinet/in.h> // for sockaddr_in
 #include <stddef.h>     // for size_t
-#include <stdint.h>     // for uint16_t
 #include <string>       // for string, basic_string
 
 /*
@@ -103,6 +102,10 @@ private:
     size_t samples_per_data_set;           // base number of FPGA time samples
     size_t rfi_downsampling_factor;        // Downsampling rate to high-cadence SK
     size_t rfi_second_downsampling_factor; // Additional downsampling factor for low-cadence SK
+
+    // The table to reorder from beamformer to cylinder order.
+    // reorder[beamformer_idx] = cylinder_idx;
+    std::vector<size_t> reorder;
 
     // Derived buffer shapes
     size_t _downsampled_samples_per_data_set;


### PR DESCRIPTION
Confirmed that this produces the expected mapping (compared to manually reordering the bad_inputs updatable_config list in python)