### PR TITLE
Optional fatal on EOP requests outside the table range

### DIFF
--- a/config/chord_pathfinder.j2
+++ b/config/chord_pathfinder.j2
@@ -185,6 +185,7 @@ telescope:
     auto_correct_gps_week_rollover: true
 
     eop_updatable_config: /earth_rotation_data
+    fatal_eop_out_of_range: true  # Shut down rather than clamp to the ends of the EOP table
 
 earth_rotation_data:
     kotekan_update_endpoint: json

--- a/config/chord_pathfinder_recv.j2
+++ b/config/chord_pathfinder_recv.j2
@@ -141,6 +141,7 @@ telescope:
     auto_correct_gps_week_rollover: True
 
     eop_updatable_config: /earth_rotation_data
+    fatal_eop_out_of_range: true  # Shut down rather than clamp to the ends of the EOP table
 
 earth_rotation_data:
     kotekan_update_endpoint: json

--- a/lib/testing/fakeGpu.cpp
+++ b/lib/testing/fakeGpu.cpp
@@ -179,6 +179,7 @@ void FakeGpu::main_thread() {
 FakeTelescope::FakeTelescope(const kotekan::Config& config, const std::string& path) :
     Telescope(path, config.get<std::string>(path, "log_level"),
               config.get_default<bool>(path, "require_eop", false),
+              config.get_default<bool>(path, "fatal_eop_out_of_range", false),
               config.get_default<std::string>(path, "eop_updatable_config", ""),
               GeoFrame(config.get<std::string>(path, "log_level"), "grid", 0.0, 0.0, {0, 0, 0},
                        {1, 0, 0}, {0, 1, 0}, {0, 0, 1})) {

--- a/lib/utils/CHIMETelescope.cpp
+++ b/lib/utils/CHIMETelescope.cpp
@@ -24,6 +24,7 @@ CHIMETelescope::CHIMETelescope(const kotekan::Config& config, const std::string&
                  config.get_default<double>(path, "feed_sep_NS", 0.3048), path,
                  config.get<std::string>(path, "log_level"),
                  config.get_default<bool>(path, "require_eop", false),
+                 config.get_default<bool>(path, "fatal_eop_out_of_range", false),
                  config.get_default<std::string>(path, "eop_updatable_config", ""),
                  grid_frame_from_config(config, path)) {
     INFO("Building CHIMETelescope");

--- a/lib/utils/CHORDTelescope.cpp
+++ b/lib/utils/CHORDTelescope.cpp
@@ -406,6 +406,7 @@ bool GPSTimeParams::get_gps_time0_ns_from_remote(const GPSTimeParams& gps, uint6
 CHORDTelescope::CHORDTelescope(const kotekan::Config& config, const std::string& path) :
     Telescope(path, config.get<std::string>(path, "log_level"),
               config.get_default<bool>(path, "require_eop", false),
+              config.get_default<bool>(path, "fatal_eop_out_of_range", false),
               config.get_default<std::string>(path, "eop_updatable_config", ""),
               grid_frame_from_config(config, path)),
     // Frequency sampling parameters

--- a/lib/utils/CHORDTelescope.hpp
+++ b/lib/utils/CHORDTelescope.hpp
@@ -338,6 +338,8 @@ private:
  *
  * @conf    eop_updatable_config    string. ConfigUpdater path for dynamic EOP updates. For more
  *information see Telescope.hpp
+ * @conf    fatal_eop_out_of_range  bool. Optional, default false. Fail fatally when an EOP is
+ *requested for a time outside the range of the EOP table. For more information see Telescope.hpp
  * @conf    log_level           string. Optional log level for this telescope instance.
  *
  * @author Geoffrey Ryan

--- a/lib/utils/ICETelescope.cpp
+++ b/lib/utils/ICETelescope.cpp
@@ -20,6 +20,7 @@ REGISTER_TELESCOPE(ICETelescope, "ICETelescope");
 ICETelescope::ICETelescope(const kotekan::Config& config, const std::string& path) :
     Telescope(path, config.get<std::string>(path, "log_level"),
               config.get_default<bool>(path, "require_eop", false),
+              config.get_default<bool>(path, "fatal_eop_out_of_range", false),
               config.get_default<std::string>(path, "eop_updatable_config", ""),
               grid_frame_from_config(config, path)),
     _num_polarizations(config.get<uint64_t>(path, "num_polarizations")),

--- a/lib/utils/Telescope.cpp
+++ b/lib/utils/Telescope.cpp
@@ -5,7 +5,7 @@
 #include "restServer.hpp"    // for restServer, connectionInstance
 #include "timeUtil.hpp"      // for EOP, BareEOP, get_ERA_from_UT1, EOP_comp_time, eop_null
 
-#include "fmt.hpp" // for compile_string_to_view
+#include "fmt.hpp" // for compile_string_to_view, format
 
 #include <algorithm>    // for copy, lower_bound, sort
 #include <functional>   // for bind, _1, function
@@ -31,8 +31,10 @@ static constexpr BareEOP dummy_bare_eop_last = {.t_inst_ns = std::numeric_limits
                                                 .yp_as = 0.0};
 
 Telescope::Telescope(const std::string& tel_path, const std::string& log_level, bool require_eop,
-                     const std::string& eop_updatable_config_path, const GeoFrame& frame) :
-    _unique_name(tel_path), _frame(frame), _require_eop(require_eop) {
+                     bool fatal_eop_out_of_range, const std::string& eop_updatable_config_path,
+                     const GeoFrame& frame) :
+    _unique_name(tel_path), _frame(frame), _require_eop(require_eop),
+    _fatal_eop_out_of_range(fatal_eop_out_of_range) {
     set_log_level(log_level);
     set_log_prefix("/telescope");
 
@@ -189,6 +191,13 @@ void Telescope::send_time0_ns(connectionInstance& conn) {
     conn.send_json_reply(reply);
 }
 
+void Telescope::report_eop_out_of_range(const std::string& msg) const {
+    if (_fatal_eop_out_of_range)
+        FATAL_ERROR("{:s}", msg);
+
+    WARN("{:s}", msg);
+}
+
 std::vector<EOP> Telescope::get_current_EOP_table() const {
 
     std::vector<EOP> tab_copy;
@@ -216,8 +225,9 @@ EOP Telescope::get_EOP_at_time_ns(int64_t t_target_ns) const {
         std::shared_lock lock(_eop_lock);
 
         if (_eop_table.empty()) {
-            WARN("EOP table is empty, cannot interpolate EOP at instrument time {:d} s + {:d} ns.",
-                 t_target_ns / GIGA, t_target_ns % GIGA);
+            report_eop_out_of_range(fmt::format(
+                "EOP table is empty, cannot interpolate EOP at instrument time {:d} s + {:d} ns.",
+                t_target_ns / GIGA, t_target_ns % GIGA));
             return eop_null;
         }
 
@@ -234,11 +244,11 @@ EOP Telescope::get_EOP_at_time_ns(int64_t t_target_ns) const {
             eop.xp_as = eop_b->xp_as;
             eop.yp_as = eop_b->yp_as;
             if (t_target_ns < eop_b->t_inst_ns) {
-                WARN("Requesting EOP earlier than in table. Requested time = {:d} s + {:d} ns. "
-                     "Earliest "
-                     "time = {:d} s + {:d} ns.",
-                     t_target_ns / GIGA, t_target_ns % GIGA, eop_b->t_inst_ns / GIGA,
-                     eop_b->t_inst_ns % GIGA);
+                report_eop_out_of_range(fmt::format(
+                    "Requesting EOP earlier than in table. Requested time = {:d} s + {:d} ns. "
+                    "Earliest time = {:d} s + {:d} ns.",
+                    t_target_ns / GIGA, t_target_ns % GIGA, eop_b->t_inst_ns / GIGA,
+                    eop_b->t_inst_ns % GIGA));
             }
         } else if (eop_b == _eop_table.end()) {
             // Time is later than covered by the table, use the last value.
@@ -247,12 +257,11 @@ EOP Telescope::get_EOP_at_time_ns(int64_t t_target_ns) const {
             eop.xp_as = eop_last->xp_as;
             eop.yp_as = eop_last->yp_as;
             if (t_target_ns > eop_last->t_inst_ns) {
-                WARN(
-                    "Requesting EOP later than in table. Requested time = {:d} s + {:d} ns. Latest "
-                    "time = "
-                    "{:d} s + {:d} ns.",
+                report_eop_out_of_range(fmt::format(
+                    "Requesting EOP later than in table. Requested time = {:d} s + {:d} ns. "
+                    "Latest time = {:d} s + {:d} ns.",
                     t_target_ns / GIGA, t_target_ns % GIGA, eop_last->t_inst_ns / GIGA,
-                    eop_last->t_inst_ns % GIGA);
+                    eop_last->t_inst_ns % GIGA));
             }
         } else {
             // Interpolate!
@@ -296,8 +305,9 @@ EOP Telescope::get_EOP_at_UT1(int64_t t_ut1_ns) const {
         std::shared_lock lock(_eop_lock);
 
         if (_eop_table.empty()) {
-            WARN("EOP table is empty, cannot interpolate EOP at UT1 time {:d} s + {:d} ns.",
-                 t_ut1_ns / GIGA, t_ut1_ns % GIGA);
+            report_eop_out_of_range(fmt::format(
+                "EOP table is empty, cannot interpolate EOP at UT1 time {:d} s + {:d} ns.",
+                t_ut1_ns / GIGA, t_ut1_ns % GIGA));
             return eop_null;
         }
 
@@ -315,21 +325,24 @@ EOP Telescope::get_EOP_at_UT1(int64_t t_ut1_ns) const {
             eop.delta_UT1_inst = eop_b->delta_UT1_inst;
             eop.xp_as = eop_b->xp_as;
             eop.yp_as = eop_b->yp_as;
-            WARN("Requesting EOP earlier than in table. Requested UT1 = {:d} s + {:d} ns. Earliest "
-                 "UT1 "
-                 "= {:d} s + {:d} ns.",
-                 t_ut1_ns / GIGA, t_ut1_ns % GIGA, eop_b->t_ut1_ns / GIGA, eop_b->t_ut1_ns % GIGA);
+            if (t_ut1_ns < eop_b->t_ut1_ns) {
+                report_eop_out_of_range(fmt::format(
+                    "Requesting EOP earlier than in table. Requested UT1 = {:d} s + {:d} ns. "
+                    "Earliest UT1 = {:d} s + {:d} ns.",
+                    t_ut1_ns / GIGA, t_ut1_ns % GIGA, eop_b->t_ut1_ns / GIGA,
+                    eop_b->t_ut1_ns % GIGA));
+            }
         } else if (eop_b == _eop_table.end()) {
             // Time is later than covered by the table, use the last value.
             auto eop_last = eop_b - 1;
             eop.delta_UT1_inst = eop_last->delta_UT1_inst;
             eop.xp_as = eop_last->xp_as;
             eop.yp_as = eop_last->yp_as;
-            WARN("Requesting EOP later than in table. Requested UT1 = {:d} s + {:d} ns. Latest UT1 "
-                 "= "
-                 "{:d} s + {:d} ns.",
-                 t_ut1_ns / GIGA, t_ut1_ns % GIGA, eop_last->t_ut1_ns / GIGA,
-                 eop_last->t_ut1_ns % GIGA);
+            report_eop_out_of_range(
+                fmt::format("Requesting EOP later than in table. Requested UT1 = {:d} s + {:d} ns. "
+                            "Latest UT1 = {:d} s + {:d} ns.",
+                            t_ut1_ns / GIGA, t_ut1_ns % GIGA, eop_last->t_ut1_ns / GIGA,
+                            eop_last->t_ut1_ns % GIGA));
         } else {
             // Interpolate! Target time = t, in table interval [ta, tb]
             auto eop_a = eop_b - 1;

--- a/lib/utils/Telescope.hpp
+++ b/lib/utils/Telescope.hpp
@@ -185,6 +185,13 @@ struct stream_t {
  *                                  - xp_as             double  Polar Motion x', arcseconds.
  *                                  - yp_as             double  Polar Motion y', arcseconds.
  *
+ * Config
+ *
+ * @conf    fatal_eop_out_of_range  Optional. Bool, default false. If true, requesting an EOP for a
+ *                                  time outside the range covered by the EOP table is a fatal
+ *                                  error. If false, the first or last table entry is used and a
+ *                                  warning is logged.
+ *
  * Updatable Config
  *
  * @conf    eop_updatable_config    Optional. If not present, EOP table will be a dummy and only
@@ -499,7 +506,7 @@ public:
     /**
      * @brief   Return the EOP at the desired instrument time. Will interpolate
      *          over table, use first or last entry if target time is out of
-     *          table range.
+     *          table range, or fail fatally if `fatal_eop_out_of_range` is set.
      *
      * @param   ts  Target instrument time, as a timespec.
      **/
@@ -508,7 +515,7 @@ public:
     /**
      * @brief   Return the EOP at the desired instrument time. Will interpolate
      *          over table, use first or last entry if target time is out of
-     *          table range.
+     *          table range, or fail fatally if `fatal_eop_out_of_range` is set.
      *
      * @param   t_ns  Target instrument time in nanoseconds.
      **/
@@ -517,7 +524,8 @@ public:
     /**
      * @brief   Return the EOP at the desired UT1 time. Will interpolate
      *          over table, using the first or last entry if target time is
-     *          out of table range.
+     *          out of table range, or fail fatally if `fatal_eop_out_of_range`
+     *          is set.
      *
      * @param   ts  Target UT1 time, in nanoseconds since J2000(UT1) int64_t
      **/
@@ -688,6 +696,8 @@ protected:
      * @param   tel_path    Path to the telescope in the Config (e.g. /telescope)
      * @param   log_level   The level to set logging at.
      * @param   require_eop Whether to require a valid EOP table.
+     * @param   fatal_eop_out_of_range  Whether requesting an EOP outside the range
+     *          covered by the EOP table is a fatal error.
      * @param   eop_updatable_config_path   The value of "eop_updatable_config" in
      *          the telescope Config, pointing to the updatable field which
      *          contains "earth_orientation_parameter_table"
@@ -695,7 +705,15 @@ protected:
      *                      and the orientation of the feed grid axes.
      **/
     Telescope(const std::string& tel_path, const std::string& log_level, bool require_eop,
-              const std::string& eop_updatable_config_path, const GeoFrame& frame);
+              bool fatal_eop_out_of_range, const std::string& eop_updatable_config_path,
+              const GeoFrame& frame);
+
+    /**
+     * @brief   Report an EOP request the table cannot cover, fatally if configured to.
+     *
+     * @param   msg     Description of the request and the table range.
+     */
+    void report_eop_out_of_range(const std::string& msg) const;
 
     /**
      * @brief Callback to update EOP data
@@ -734,6 +752,12 @@ protected:
      * is provided, the telescope will return a 0 EOP when queried.
      */
     const bool _require_eop;
+
+    /**
+     * Whether to treat a request for an EOP outside the range of the EOP table
+     * as a fatal error, rather than clamping to the first or last table entry.
+     */
+    const bool _fatal_eop_out_of_range;
 
     /**
      * This is the Earth Orientation Parameter (EOP) table used to determine

--- a/tests/boost/test_Telescope.cpp
+++ b/tests/boost/test_Telescope.cpp
@@ -15,6 +15,7 @@
 #include <boost/test/included/unit_test.hpp>
 #include <boost/test/tools/output_test_stream.hpp>
 #include <complex>
+#include <csignal>
 #include <filesystem>
 #include <inttypes.h>
 #include <iostream>
@@ -51,6 +52,7 @@ public:
     TestTelescope(const Config& config, const std::string& path) :
         Telescope(path, config.get<std::string>(path, "log_level"),
                   config.get<bool>(path, "require_eop"),
+                  config.get_default<bool>(path, "fatal_eop_out_of_range", false),
                   config.get<std::string>(path, "eop_updatable_config"),
                   GeoFrame(config.get<std::string>(path, "log_level"), "grid",
                            config.get_default<double>(path, "inst_lat", 0.0),
@@ -192,7 +194,7 @@ struct TelescopeFixture {
 };
 
 struct TelescopeEOPFixture {
-    TelescopeEOPFixture() {
+    TelescopeEOPFixture(bool fatal_eop_out_of_range = false) {
         json json_config = json::parse(default_tel_config_str);
 
         N = 5;
@@ -221,6 +223,7 @@ struct TelescopeEOPFixture {
         }
 
         json_config["telescope"]["require_eop"] = true;
+        json_config["telescope"]["fatal_eop_out_of_range"] = fatal_eop_out_of_range;
         json_config["telescope"]["eop_updatable_config"] = "/eop_update";
         json_config["eop_update"] = {{"kotekan_update_endpoint", "json"},
                                      {"earth_orientation_parameter_table", fix_bare_eop_table}};
@@ -241,9 +244,23 @@ struct TelescopeEOPFixture {
     std::vector<BareEOP> fix_bare_eop_table;
 };
 
+// The same EOP table, but out-of-range requests are fatal.
+struct TelescopeFatalEOPFixture : public TelescopeEOPFixture {
+    TelescopeFatalEOPFixture() : TelescopeEOPFixture(true) {}
+};
+
+// FATAL_ERROR raises SIGTERM to shut kotekan down before throwing FatalError.
+// Ignore the signal so the tests observe the throw instead of being terminated.
+struct IgnoreSigtermFixture {
+    IgnoreSigtermFixture() {
+        std::signal(SIGTERM, SIG_IGN);
+    }
+};
+
 // Uncomment to show kotekan logs to stdout during test run.
 // BOOST_TEST_GLOBAL_FIXTURE(LoggingFixture);
 BOOST_TEST_GLOBAL_FIXTURE(RestServerFixture);
+BOOST_TEST_GLOBAL_FIXTURE(IgnoreSigtermFixture);
 
 /******************
  *
@@ -429,4 +446,34 @@ BOOST_FIXTURE_TEST_CASE(_get_eop_at_ut1, TelescopeEOPFixture) {
             check_eop_close(tel_eop, test_eop);
         }
     }
+}
+
+/*
+ * @brief   With `fatal_eop_out_of_range` set, requests off the ends of the EOP
+ *          table are fatal, while requests within it behave as usual.
+ */
+BOOST_FIXTURE_TEST_CASE(_get_eop_out_of_range_fatal, TelescopeFatalEOPFixture) {
+    const Telescope& tel = Telescope::instance();
+
+    int64_t giga = 1'000'000'000;
+
+    std::vector<EOP> eop_table = tel.get_current_EOP_table();
+
+    const EOP& eop_first = eop_table.front();
+    const EOP& eop_last = eop_table.back();
+
+    // Times within the table, including both end points, are fine.
+    BOOST_CHECK_NO_THROW(tel.get_EOP_at_time_ns(eop_first.t_inst_ns));
+    BOOST_CHECK_NO_THROW(tel.get_EOP_at_time_ns(eop_last.t_inst_ns));
+    BOOST_CHECK_NO_THROW(tel.get_EOP_at_time(nanosec_i64_to_timespec(eop_first.t_inst_ns + giga)));
+    BOOST_CHECK_NO_THROW(tel.get_EOP_at_UT1(eop_first.t_ut1_ns));
+    BOOST_CHECK_NO_THROW(tel.get_EOP_at_UT1(eop_last.t_ut1_ns));
+
+    // Times off either end of the table are not.
+    BOOST_CHECK_THROW(tel.get_EOP_at_time_ns(eop_first.t_inst_ns - giga), FatalError);
+    BOOST_CHECK_THROW(tel.get_EOP_at_time_ns(eop_last.t_inst_ns + giga), FatalError);
+    BOOST_CHECK_THROW(tel.get_EOP_at_time(nanosec_i64_to_timespec(eop_first.t_inst_ns - giga)),
+                      FatalError);
+    BOOST_CHECK_THROW(tel.get_EOP_at_UT1(eop_first.t_ut1_ns - giga), FatalError);
+    BOOST_CHECK_THROW(tel.get_EOP_at_UT1(eop_last.t_ut1_ns + giga), FatalError);
 }


### PR DESCRIPTION
Also guard the "earlier than in table" report in get_EOP_at_UT1() with the same bounds check the instrument-time version uses, so a request for exactly the first table entry is not reported as out of range.