### PR TITLE
build_ptx: compile kernels for the GPU that is present

### DIFF
--- a/lib/cuda/cudaDeviceInterface.cpp
+++ b/lib/cuda/cudaDeviceInterface.cpp
@@ -276,10 +276,32 @@ void cudaDeviceInterface::build_ptx(const std::string& kernel_filename,
         return;
     }
 
+    // Compile for the compute capability of the GPU that is actually present. Callers
+    // pass the --gpu-name their kernel was generated for, but SASS is only compatible
+    // within a major architecture (an sm_89 cubin fails to load on an sm_86 device with
+    // "no kernel image is available for execution on the device"), so kernels would
+    // otherwise only run on the specific GPU model they were generated for.
+    cudaDeviceProp prop;
+    CHECK_CUDA_ERROR(cudaGetDeviceProperties(&prop, gpu_id));
+    const std::string gpu_name = fmt::format("--gpu-name=sm_{:d}{:d}", prop.major, prop.minor);
+    std::vector<std::string> compile_opts;
+    compile_opts.reserve(opts.size() + 1);
+    for (const std::string& opt : opts) {
+        if (opt.rfind("--gpu-name", 0) == 0) {
+            if (opt != gpu_name)
+                INFO("Kernel file {:s} was generated for {:s}; compiling for the local GPU with "
+                     "{:s} instead",
+                     kernel_filename, opt, gpu_name);
+        } else {
+            compile_opts.push_back(opt);
+        }
+    }
+    compile_opts.push_back(gpu_name);
+
     // Convert compiler options to a c-style array.
     std::vector<const char*> cstring_opts;
-    cstring_opts.reserve(opts.size());
-    for (auto& s : opts)
+    cstring_opts.reserve(compile_opts.size());
+    for (auto& s : compile_opts)
         cstring_opts.push_back(s.c_str());
 
     // Compile the code

--- a/lib/cuda/cudaDeviceInterface.hpp
+++ b/lib/cuda/cudaDeviceInterface.hpp
@@ -92,6 +92,16 @@ public:
     void build(const std::string& kernel_filename, const std::vector<std::string>& kernel_names,
                const std::vector<std::string>& opts);
 
+    /**
+     * @brief Builds a list of kernels from the PTX file with name: @c kernel_file_name
+     *
+     * Any @c --gpu-name option in @c opts is replaced with the compute capability of
+     * the local GPU, so PTX generated for one GPU model runs on others as well.
+     *
+     * @param kernel_names       Vector list of kernel names in the kernel file
+     * @param opts               List of options to pass to the PTX compiler
+     * @param kernel_name_prefix Prefix to add to the kernel names in @c runtime_kernels
+     **/
     void build_ptx(const std::string& kernel_filename, const std::vector<std::string>& kernel_names,
                    const std::vector<std::string>& opts,
                    const std::string& kernel_name_prefix = "");


### PR DESCRIPTION
The generated kernels hard-code the --gpu-name their instrument was generated for (sm_89/L40S for chime since #1608), but SASS built for one architecture does not load on an older or different one, so cudaTranspose2048_chime failed on the CI runner's A40 (sm_86) with "no kernel image is available for execution on the device" once #1605 started running test_xpose2048.j2.

The generators deliberately emit PTX with a .target floor of sm_86 so that ptxas can compile it for any newer architecture, so replace the requested --gpu-name with the compute capability of the local GPU when building. Kernels then run on whatever GPU is present (like the nvrtc/driver-JIT path already does), and compile identically to before on the instrument hardware they were generated for.
