### PR TITLE
test_eigenStages: Pin the Blaze RNG seed so the iterative tests are reproducible

### DIFF
--- a/tests/boost/test_eigenStages.cpp
+++ b/tests/boost/test_eigenStages.cpp
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include <array>
 #include <atomic>
+#include <blaze/Blaze.h> // for setSeed
 #include <boost/test/included/unit_test.hpp>
 #include <chrono>
 #include <cmath>
@@ -53,6 +54,27 @@ static void ensure_n2metadata_registered() {
         return true;
     }();
     (void)registered;
+}
+
+// The iterative solvers (EigenVisIter / EigenN2Iter) seed their starting subspace
+// with `blaze::rand` -- see `eigen_masked_subspace` in LinearAlgebra.hpp -- and Blaze
+// seeds its global generator from `std::time(0)` unless told otherwise. That left
+// these tests starting from a different subspace on every run, so the `erms` values
+// checked below drifted run to run: an unmodified build of this test failed 2 runs
+// out of 30 (~7%), always in `eigenVisIter_vis_buffers` or `eigenN2Iter_iterative`,
+// the two cases that use the randomized solver. Pin the seed before each pipeline so
+// the tests are reproducible and a failure means something.
+//
+// Seeding per pipeline rather than once globally keeps each test independent of how
+// many random numbers the tests before it happened to draw.
+//
+// NOTE: this does not make `eigenN2Iter_concurrent_pipelines` deterministic. Blaze's
+// generator is a single shared static with no locking, so two stage threads drawing
+// from it at once race regardless of the seed.
+static constexpr uint32_t eigen_test_seed = 0x9e3779b9;
+
+static void seed_blaze() {
+    blaze::setSeed(eigen_test_seed);
 }
 
 // Reuse the small fixtures used elsewhere to bootstrap REST/config for tests.
@@ -110,6 +132,7 @@ struct EigenResults {
 static EigenResults run_pipeline(const EigenStageTestParams& p, const string& stage_name) {
     ensure_fakevis_patterns_registered();
     ensure_n2metadata_registered();
+    seed_blaze();
 
     static std::atomic<int> run_counter{0};
     int rc = run_counter++;
@@ -291,6 +314,14 @@ static void verify_results(const EigenResults& res, const EigenStageTestParams& 
             BOOST_CHECK_SMALL(static_cast<double>(res.eval1[idx]) / (double)p.num_elements,
                               eval_tol);
         check_phase_vector(res.evec0[idx], p.exclude_inputs, p.num_elements, phase_tol, amp_tol);
+        // `erms` is the residual RMS when the solver converged, and minus the final
+        // eigenvalue-convergence metric (`eps_eval`) when it hit max_iterations first;
+        // see EigenVisIter::main_thread. For the iterative stages in these tests it is
+        // always the latter -- measured across max_iterations from 5 to 200, the
+        // subspace iteration never reaches tol_eval, because `eps_eval` is dominated by
+        // the noise on the near-zero second eigenvalue it divides through. So `abs` is
+        // required here, and `rms_limit` bounds that convergence metric rather than a
+        // residual. Do not read a value near the limit as "almost converged".
         BOOST_CHECK_LT(static_cast<double>(std::abs(res.erms[idx])), (double)rms_limit);
     }
 }
@@ -355,6 +386,7 @@ static std::pair<EigenResults, EigenResults>
 run_n2_pipeline_pair(const EigenStageTestParams& params_a, const EigenStageTestParams& params_b) {
     ensure_fakevis_patterns_registered();
     ensure_n2metadata_registered();
+    seed_blaze();
     BOOST_REQUIRE_EQUAL(params_a.num_elements, params_b.num_elements);
     BOOST_REQUIRE_EQUAL(params_a.num_ev, params_b.num_ev);
 


### PR DESCRIPTION
## What

Pin Blaze's global RNG seed in `tests/boost/test_eigenStages.cpp` so the two iterative eigen test cases stop failing at random in CI.

## Why

`eigen_masked_subspace` (`lib/utils/LinearAlgebra.hpp`) initialises its starting subspace with `blaze::rand`:

```cpp
// Initialise (randomly the vector array)
for (unsigned int i = 0; i < n; i++)
    for (unsigned int j = 0; j < k; j++)
        V(i, j) = blaze::rand<MT>();
```

Blaze seeds its global generator from `std::time(0)` unless told otherwise, and kotekan never calls `blaze::setSeed`. So every run started the subspace iteration from a different point and the `erms` values these tests bound moved with it.

There is no warm start to damp this out: `_krylov`/`_subspace` are the algorithm's `p`/`q` parameters, not carried state, so every frame re-randomises from scratch.

## Evidence

Measured on cx67, running the **unmodified** `test_eigenStages` binary 30 times with no recompile between runs:

| | result |
|---|---|
| unmodified `develop` | 28 pass / **2 fail** (~7%) |
| with the seed pinned | **30 pass / 0 fail** |

Both baseline failures were in `eigenVisIter_vis_buffers` or `eigenN2Iter_iterative` — the only two cases that use the randomized iterative solver, and the only two carrying the loose `2e-2` limits that exist because of it. The observed failure is a marginal overshoot, e.g. `0.02127 >= 0.02`.

This is the failure that has been showing up on unrelated PRs and reading as a numerical regression. Related history: #1034, #184.

## Notes for the reviewer

Seeding per pipeline rather than once globally keeps each test independent of how many random numbers the tests before it happened to draw.

Two things this deliberately does **not** fix, recorded in comments rather than papered over:

1. **`eigenN2Iter_concurrent_pipelines` stays nondeterministic.** Blaze's generator is a single shared static with no mutex and no `thread_local` (checked against Blaze's `util/Random.h`), so the two stage threads race on it regardless of the seed. That race is not confined to the test — any two Eigen stages in one process hit it.

2. **The iterative solver never converges in these configurations.** I swept `max_iterations` over 5, 10, 15, 20, 30, 50, 80, 120, 200 and `erms` is negative at *every* setting, i.e. the stage always reports `-eps_eval` rather than a residual. `eps_eval` divides through the near-zero second eigenvalue, so `tol_eval = 1e-6` looks unreachable by construction.

   This matters for how the test reads: `rms_limit` is bounding a convergence metric, not a residual, so a value near the limit is *not* "almost converged". The comment on the check now says so.

   My first draft of this PR raised `max_iterations` and asserted convergence — the sweep showed that would have changed nothing and made the assertion fail 100% of the time, so both were dropped. The seed is the actual fix.

Both of those are worth separate issues for whoever owns the eigen code; I did not want to fold them into a test-flakiness change.

## Testing

- 30x loop of `test_eigenStages` with the seed: 30/30 pass.
- Full boost suite on cx67: 32 passed, 1 failed — the failure is `test_buffer`, which is not on `develop` (untracked local WIP on the machine I built on) and is untouched by this change.
- `clang-format-18` clean.