### PR TITLE
eigen_masked_subspace: Draw the starting subspace from a per-thread generator

### DIFF
--- a/lib/utils/LinearAlgebra.hpp
+++ b/lib/utils/LinearAlgebra.hpp
@@ -8,6 +8,10 @@
 #include "visUtil.hpp"
 
 #include <blaze/Blaze.h>
+#include <complex>     // for complex
+#include <cstdint>     // for uint32_t
+#include <random>      // for mt19937, uniform_real_distribution
+#include <type_traits> // for is_same_v
 
 // Type defs for simplicity
 // Map complex types to their real equivalent
@@ -220,6 +224,51 @@ struct EigConvergenceStats {
     double rms = 0.0;
 };
 
+/// Seed given to each thread's copy of `eigen_subspace_rng`.
+constexpr uint32_t eigen_subspace_seed = 0x9e3779b9;
+
+/**
+ * @brief The random number generator used to initialise the subspace iteration.
+ *
+ * Every thread gets its own generator, seeded identically. Blaze's `rand` cannot be
+ * used for this: it draws from a single static generator (`Random<RNG>::rng_` in
+ * blaze/util/Random.h) that is neither `thread_local` nor mutex protected, so two
+ * Eigen stages drawing their starting subspaces at the same time would be a data race
+ * on its state.
+ *
+ * The fixed seed also makes the stages reproducible: a given stage draws the same
+ * sequence of starting subspaces on every run.
+ *
+ * @return  The calling thread's generator.
+ **/
+inline std::mt19937& eigen_subspace_rng() {
+    static thread_local std::mt19937 rng(eigen_subspace_seed);
+    return rng;
+}
+
+/**
+ * @brief Draw one random matrix element uniformly from [0, 1).
+ *
+ * That is the range `blaze::rand` uses, for both parts of a complex value.
+ *
+ * @param  rng  The generator to draw from.
+ *
+ * @return      The random element.
+ **/
+template<typename MT>
+MT rand_subspace_element(std::mt19937& rng) {
+    std::uniform_real_distribution<real_t<MT>> dist(0.0, 1.0);
+    if constexpr (std::is_same_v<MT, real_t<MT>>) {
+        return dist(rng);
+    } else {
+        // Draw in a fixed order. `blaze::rand<complex<T>>` passes two draws as
+        // function arguments, whose evaluation order the compiler chooses.
+        const real_t<MT> re = dist(rng);
+        const real_t<MT> im = dist(rng);
+        return MT(re, im);
+    }
+}
+
 /**
  * @brief Find a low rank decomposition of a masked matrix.
  *
@@ -237,6 +286,8 @@ struct EigConvergenceStats {
  *                   zero, use all eigenpairs.
  * @param  p         Size of the Krylov subspace in the augmented Ritz.
  * @param  q         Number of subspace updates per iteration.
+ * @param  rng       Generator for the random starting subspace. Defaults to the
+ *                   calling thread's generator.
  *
  * @return           The estimated eigenpairs.
  **/
@@ -245,7 +296,7 @@ std::pair<eig_t<MT>, EigConvergenceStats>
 eigen_masked_subspace(const DynamicHermitian<MT>& A,
                       const DynamicHermitian<float>& W, // Should this be symmetric
                       size_t k, float tol_eval, float tol_evec, size_t maxiter, size_t k_conv = 0,
-                      size_t p = 2, size_t q = 3) {
+                      size_t p = 2, size_t q = 3, std::mt19937& rng = eigen_subspace_rng()) {
     blaze::DynamicVector<real_t<MT>> evals, evalsp, etols;
     blaze::DynamicMatrix<MT, blaze::columnMajor> V, Vp;
 
@@ -260,7 +311,7 @@ eigen_masked_subspace(const DynamicHermitian<MT>& A,
     V.resize(n, k);
     for (unsigned int i = 0; i < n; i++) {
         for (unsigned int j = 0; j < k; j++) {
-            V(i, j) = blaze::rand<MT>();
+            V(i, j) = rand_subspace_element<MT>(rng);
         }
     }
     V = orth(V);

--- a/tests/boost/CMakeLists.txt
+++ b/tests/boost/CMakeLists.txt
@@ -110,6 +110,10 @@ if(HDF5_FOUND
 endif()
 
 if(LAPACKE_FOUND AND BLAZE_FOUND)
+    add_executable(test_linearAlgebra test_linearAlgebra.cpp)
+    target_link_libraries(test_linearAlgebra PRIVATE pthread libexternal kotekan_utils kotekan_core)
+    target_include_directories(test_linearAlgebra PUBLIC . ${CUDA_INCLUDE_DIR} ${CUDA_INCLUDE_DIRS})
+
     add_executable(test_eigenStages test_eigenStages.cpp)
     target_link_libraries(test_eigenStages PRIVATE libexternal kotekan_stages kotekan_libs
                                                    kotekan_utils kotekan_core)

--- a/tests/boost/test_linearAlgebra.cpp
+++ b/tests/boost/test_linearAlgebra.cpp
@@ -1,0 +1,200 @@
+#define BOOST_TEST_MODULE "test_linearAlgebra"
+
+#include "LinearAlgebra.hpp" // for DynamicHermitian, EigConvergenceStats, eigen_masked_subspace
+
+#include <boost/test/included/unit_test.hpp>
+#include <cmath>   // for M_PI
+#include <complex> // for complex, polar
+#include <cstdint> // for uint32_t
+#include <random>  // for mt19937
+#include <thread>  // for thread
+#include <vector>  // for vector
+
+using cfloat = std::complex<float>;
+
+namespace {
+
+constexpr size_t num_elements = 16;
+constexpr size_t num_ev = 2;
+constexpr size_t max_iterations = 20;
+constexpr float tol = 1e-6f;
+
+// Number of threads used by the concurrency checks. Two is enough to hit a shared
+// generator; more makes it hit harder.
+constexpr size_t num_threads = 8;
+
+// A rank-2 Hermitian matrix: two point sources with different fringe rates, the
+// first four times as bright as the second. This is the shape of input the Eigen
+// stages see. The fringe rates are whole numbers of turns across the array, so the
+// two sources are exactly orthogonal and the eigenvalues are known: `4 * num_elements`
+// and `num_elements`.
+constexpr float source_amplitude[2] = {2.0f, 1.0f};
+constexpr float source_turns[2] = {1.0f, 3.0f};
+
+DynamicHermitian<cfloat> test_matrix() {
+    blaze::DynamicMatrix<cfloat, blaze::columnMajor> M(num_elements, num_elements, cfloat(0.0f));
+    for (size_t s = 0; s < 2; s++) {
+        const float rate = 2.0f * M_PI * source_turns[s] / num_elements;
+        for (size_t i = 0; i < num_elements; i++)
+            for (size_t j = 0; j < num_elements; j++)
+                M(i, j) += source_amplitude[s] * source_amplitude[s]
+                           * std::polar(1.0f, rate * (float(i) - float(j)));
+    }
+    return blaze::declherm(M);
+}
+
+// Every input included, as in the default stage configuration.
+DynamicHermitian<float> test_mask() {
+    blaze::DynamicMatrix<float, blaze::columnMajor> M(num_elements, num_elements, 1.0f);
+    return blaze::declherm(M);
+}
+
+struct Result {
+    blaze::DynamicVector<float> evals;
+    blaze::DynamicMatrix<cfloat, blaze::columnMajor> evecs;
+    EigConvergenceStats stats;
+};
+
+// Decompose with an explicitly supplied generator.
+Result decompose(const DynamicHermitian<cfloat>& A, const DynamicHermitian<float>& W,
+                 std::mt19937& rng) {
+    const auto out = eigen_masked_subspace(A, W, num_ev, tol, tol, max_iterations, 0, 2, 3, rng);
+    return {out.first.first, out.first.second, out.second};
+}
+
+// Decompose using the calling thread's own generator, as the stages do, after
+// resetting it so every thread starts from the same point in the sequence.
+Result decompose_thread_rng(const DynamicHermitian<cfloat>& A, const DynamicHermitian<float>& W) {
+    eigen_subspace_rng().seed(eigen_subspace_seed);
+    const auto out = eigen_masked_subspace(A, W, num_ev, tol, tol, max_iterations);
+    return {out.first.first, out.first.second, out.second};
+}
+
+// The same starting subspace must give the same answer, to the last bit.
+void check_identical(const Result& a, const Result& b) {
+    BOOST_REQUIRE_EQUAL(a.evals.size(), b.evals.size());
+    BOOST_CHECK_EQUAL(a.stats.iterations, b.stats.iterations);
+    BOOST_CHECK_EQUAL(a.stats.converged, b.stats.converged);
+    for (size_t i = 0; i < a.evals.size(); i++)
+        BOOST_CHECK_EQUAL(a.evals[i], b.evals[i]);
+    BOOST_REQUIRE_EQUAL(a.evecs.rows(), b.evecs.rows());
+    BOOST_REQUIRE_EQUAL(a.evecs.columns(), b.evecs.columns());
+    for (size_t i = 0; i < a.evecs.rows(); i++)
+        for (size_t j = 0; j < a.evecs.columns(); j++)
+            BOOST_CHECK_EQUAL(a.evecs(i, j), b.evecs(i, j));
+}
+
+} // namespace
+
+// The eigenvalues of the test matrix are known, so check the decomposition is
+// actually solving the problem before checking that it does so reproducibly.
+BOOST_AUTO_TEST_CASE(eigen_masked_subspace_recovers_sources) {
+    std::mt19937 rng(eigen_subspace_seed);
+    const auto r = decompose(test_matrix(), test_mask(), rng);
+
+    BOOST_REQUIRE_EQUAL(r.evals.size(), num_ev);
+    BOOST_CHECK(r.stats.converged);
+    // Eigenvalues come back in ascending order.
+    BOOST_CHECK_CLOSE(r.evals[num_ev - 1], 4.0f * num_elements, 1e-2);
+    BOOST_CHECK_CLOSE(r.evals[num_ev - 2], 1.0f * num_elements, 1e-2);
+}
+
+// `eigen_subspace_rng` must hand each thread its own generator: this is what keeps
+// two Eigen stages from racing on a shared one. Every thread starting from the same
+// seed must therefore see the same sequence of draws.
+BOOST_AUTO_TEST_CASE(eigen_subspace_rng_is_per_thread) {
+    std::mt19937 reference(eigen_subspace_seed);
+    std::vector<uint32_t> expected(1000);
+    for (auto& v : expected)
+        v = reference();
+
+    std::vector<std::vector<uint32_t>> drawn(num_threads);
+    std::vector<std::thread> threads;
+    for (size_t t = 0; t < num_threads; t++) {
+        threads.emplace_back([&drawn, t]() {
+            auto& rng = eigen_subspace_rng();
+            rng.seed(eigen_subspace_seed);
+            drawn[t].resize(1000);
+            for (auto& v : drawn[t])
+                v = rng();
+        });
+    }
+    for (auto& thread : threads)
+        thread.join();
+
+    for (size_t t = 0; t < num_threads; t++)
+        BOOST_CHECK(drawn[t] == expected);
+}
+
+// A thread that has not touched its generator must still start from the fixed seed,
+// so a stage's results do not depend on which thread it happens to run on.
+BOOST_AUTO_TEST_CASE(eigen_subspace_rng_default_seed) {
+    std::mt19937 reference(eigen_subspace_seed);
+    const uint32_t expected = reference();
+
+    uint32_t drawn = 0;
+    std::thread thread([&drawn]() { drawn = eigen_subspace_rng()(); });
+    thread.join();
+
+    BOOST_CHECK_EQUAL(drawn, expected);
+}
+
+// Concurrent decompositions must not disturb each other's random draws. With a
+// generator shared between threads, as `blaze::rand` uses, the threads take each
+// other's numbers and the starting subspaces -- and so the results -- differ.
+BOOST_AUTO_TEST_CASE(eigen_masked_subspace_concurrent_matches_serial) {
+    const auto A = test_matrix();
+    const auto W = test_mask();
+
+    const auto serial = decompose_thread_rng(A, W);
+
+    std::vector<Result> concurrent(num_threads);
+    std::vector<std::thread> threads;
+    for (size_t t = 0; t < num_threads; t++)
+        threads.emplace_back(
+            [&concurrent, &A, &W, t]() { concurrent[t] = decompose_thread_rng(A, W); });
+    for (auto& thread : threads)
+        thread.join();
+
+    for (const auto& result : concurrent)
+        check_identical(serial, result);
+}
+
+// The same check for a caller that supplies its own generator rather than using the
+// per-thread one.
+BOOST_AUTO_TEST_CASE(eigen_masked_subspace_explicit_rng_is_reproducible) {
+    const auto A = test_matrix();
+    const auto W = test_mask();
+
+    std::mt19937 rng(eigen_subspace_seed);
+    const auto serial = decompose(A, W, rng);
+
+    std::vector<Result> concurrent(num_threads);
+    std::vector<std::thread> threads;
+    for (size_t t = 0; t < num_threads; t++)
+        threads.emplace_back([&concurrent, &A, &W, t]() {
+            std::mt19937 thread_rng(eigen_subspace_seed);
+            concurrent[t] = decompose(A, W, thread_rng);
+        });
+    for (auto& thread : threads)
+        thread.join();
+
+    for (const auto& result : concurrent)
+        check_identical(serial, result);
+}
+
+// A different starting subspace is allowed to take a different path, but it has to
+// arrive at the same eigenvalues.
+BOOST_AUTO_TEST_CASE(eigen_masked_subspace_seed_independent_result) {
+    const auto A = test_matrix();
+    const auto W = test_mask();
+
+    std::mt19937 rng_a(eigen_subspace_seed);
+    std::mt19937 rng_b(eigen_subspace_seed + 1);
+    const auto a = decompose(A, W, rng_a);
+    const auto b = decompose(A, W, rng_b);
+
+    BOOST_REQUIRE_EQUAL(a.evals.size(), b.evals.size());
+    for (size_t i = 0; i < a.evals.size(); i++)
+        BOOST_CHECK_CLOSE(a.evals[i], b.evals[i], 1e-2);
+}


### PR DESCRIPTION
## The race

`eigen_masked_subspace` (lib/utils/LinearAlgebra.hpp) initialised its starting subspace with `blaze::rand`. That dispatches to `Rand<T>::generate()`, which does `dist( Random<>::rng_ )`, and in `blaze/util/Random.h`:

```cpp
template< typename RNG > RNG Random<RNG>::rng_ ( defaultSeed() );
```

One `static std::mt19937` for the whole process, with neither a mutex nor `thread_local` storage. Every draw advances the twister's internal state array, so two threads drawing at once is a data race on that state, not just an interleaving of draws.

`EigenVisIter` and `EigenN2Iter` each call `eigen_masked_subspace` from their own stage thread, so **any process running two Eigen stages hits this**. The boost test `eigenN2Iter_concurrent_pipelines` runs two `EigenN2Iter` pipelines concurrently and exercises it directly, but the race is in the production path, not a test artifact.

`blaze::rand` is used in exactly one place in kotekan, so this is the only site affected.

## The fix

Draw from a `thread_local` generator instead, so each stage has its own and never touches another's. Blaze's generator is left alone.

The draws are otherwise unchanged — uniform over [0, 1), the range `blaze::rand` uses, for both parts of a complex value. The one difference: the real and imaginary parts are now drawn in a defined order. `blaze::rand<complex<T>>` builds the value as `complex<T>( tmp.generate(), tmp.generate() )`, whose argument evaluation order the compiler chooses.

The per-thread generator is seeded from a fixed constant rather than the clock, so a stage draws the same sequence of starting subspaces on every run and its output is reproducible. Each call still advances the sequence, so successive frames start from different subspaces as before. `eigen_masked_subspace` also gained an optional generator argument for callers that want to control the starting subspace explicitly.

## Tests

`tests/boost/test_linearAlgebra.cpp` is new. It checks that the generator really is per-thread, that a thread which has not touched it starts from the fixed seed, and that eight concurrent decompositions of the same matrix return bit-identical eigenpairs — both through the per-thread generator as the stages use it, and through an explicitly supplied one.

## Verification (cx67)

- Replacing the `thread_local` with a plain `static`, which is what Blaze does, fails four of the six new checks: the threads take each other's numbers and the eigenpairs no longer match. The test catches the bug it exists for.
- With the fix, `test_linearAlgebra` passes 30/30 runs and the full boost suite passes.
- `test_eigenStages` passes 30/30 with no seed pinning.

## Interaction with #eschnett/eigenstages-flaky-seed

That branch pins the Blaze seed inside `test_eigenStages` to stop the ~7% flakiness (2 failures in 30 runs) and records in a `NOTE` that it deliberately does not address this race. With the starting subspace now reproducible on its own, an unseeded `test_eigenStages` passes 30/30 here. If both land, that branch's `seed_blaze()` no longer has any effect on the Eigen stages and the `NOTE` beside it about the shared generator is stale — worth deleting at merge time.
