### PR TITLE
test_eigenStages: Don't ask the iterative solver for 2 eigenvalues of a rank-1 matrix

### DIFF
--- a/tests/boost/test_eigenStages.cpp
+++ b/tests/boost/test_eigenStages.cpp
@@ -68,7 +68,12 @@ struct RestServerFixture {
 struct EigenStageTestParams {
     size_t num_elements = 64;
     size_t num_ev = 2;
-    size_t num_ev_conv = 2;
+    // The `phase_ij` pattern is the rank-1 matrix `v v^H` with `v_i = exp(i*I)`, so only its
+    // dominant eigenpair is well determined; the others are numerical noise. Convergence is
+    // measured as the fractional change in each tested eigenvalue, which for a near-zero
+    // eigenvalue is noise divided by noise -- so asking the iterative solver to converge more
+    // than one eigenpair here cannot succeed. Only the iterative stages use this.
+    size_t num_ev_conv = 1;
     size_t total_frames = 6;
     size_t check_start_frame = 0;
     uint32_t num_diagonals_filled = 0;
@@ -291,7 +296,12 @@ static void verify_results(const EigenResults& res, const EigenStageTestParams& 
             BOOST_CHECK_SMALL(static_cast<double>(res.eval1[idx]) / (double)p.num_elements,
                               eval_tol);
         check_phase_vector(res.evec0[idx], p.exclude_inputs, p.num_elements, phase_tol, amp_tol);
-        BOOST_CHECK_LT(static_cast<double>(std::abs(res.erms[idx])), (double)rms_limit);
+        // The iterative stages write the residual RMS to `erms` when the solver converged,
+        // and minus the eigenvalue-convergence metric when it hit `max_iterations` first
+        // (see EigenVisIter::main_thread / EigenN2Iter::main_thread). A negative value
+        // therefore means "did not converge", which is a failure, not a small residual.
+        BOOST_CHECK_GE(res.erms[idx], 0.0f);
+        BOOST_CHECK_LT(static_cast<double>(res.erms[idx]), (double)rms_limit);
     }
 }
 
@@ -330,7 +340,7 @@ BOOST_AUTO_TEST_CASE(eigenN2Iter_iterative) {
     params.total_frames = 4;
     params.num_elements = 16;
     auto res = run_pipeline(params, "EigenN2Iter");
-    verify_results(res, params, 1e-4, 1e-4, 1e-4, 2e-2f);
+    verify_results(res, params, 1e-4, 1e-4, 1e-4, 1e-5f);
 }
 
 BOOST_AUTO_TEST_CASE(eigenVisIter_vis_buffers) {
@@ -338,7 +348,7 @@ BOOST_AUTO_TEST_CASE(eigenVisIter_vis_buffers) {
     params.total_frames = 4;
     params.num_elements = 16;
     auto res = run_pipeline(params, "EigenVisIter");
-    verify_results(res, params, 1e-4, 1e-4, 1e-4, 2e-2f);
+    verify_results(res, params, 1e-4, 1e-4, 1e-4, 1e-5f);
 }
 
 // Run two independent EigenN2Iter pipelines concurrently within one process,
@@ -535,6 +545,6 @@ BOOST_AUTO_TEST_CASE(eigenN2Iter_concurrent_pipelines) {
     params_b.cpu_affinity = {1};
 
     auto results = run_n2_pipeline_pair(params_a, params_b);
-    verify_results(results.first, params_a, 1e-4, 1e-4, 1e-4, 2e-2f);
-    verify_results(results.second, params_b, 1e-4, 1e-4, 1e-4, 2e-2f);
+    verify_results(results.first, params_a, 1e-4, 1e-4, 1e-4, 1e-5f);
+    verify_results(results.second, params_b, 1e-4, 1e-4, 1e-4, 1e-5f);
 }


### PR DESCRIPTION
## What

Set `num_ev_conv = 1` in the iterative eigen tests, and turn the `erms` check into a real residual check now that the solver actually converges.

Follows up on #1631, per @jbmertens' observation there:

> Without knowing the original intent of the test, it asks for 2 eigenvalues of a rank-1 matrix, so the non-convergence isn't surprising. We could switch to asking for convergence of just 1 eigenvalue.

## Why

The `phase_ij` fake pattern (`lib/testing/FakeVisPattern.cpp`) is

```cpp
float phase = (float)i - (float)j;
frame.vis[ind] = {cosf(phase), sinf(phase)};
```

i.e. `vis[i][j] = exp(I*(i-j))`, which is the outer product `v vᴴ` with `v_i = exp(I*i)`. That is **exactly rank 1**: one eigenvalue at `num_elements`, all the others zero.

The tests nonetheless asked for convergence of two eigenpairs. `eigen_masked_subspace` measures eigenvalue convergence as the fractional change in each tested eigenvalue:

```cpp
stats.eps_eval = rms(blaze::evaluate(
    blaze::subvector((evalsp - evals) / (blaze::abs(evals) + etols), k - k_conv, k_conv)));
```

For the second, near-zero eigenvalue that is noise divided by noise, so `tol_eval = 1e-6` was unreachable by construction. The stages always hit `max_iterations` and wrote `erms = -eps_eval` instead of a residual — confirmed in #1631 by sweeping `max_iterations` over 5…200, where `erms` was negative at every setting.

Because `verify_results` took `std::abs(erms)`, that non-convergence passed silently, and the loose `2e-2` limit was really bounding a convergence diagnostic that moved with the random starting subspace. That is why these two cases were the flaky ones.

## Changes

All in `tests/boost/test_eigenStages.cpp`:

- **`num_ev_conv` default 2 → 1**, with a comment recording the rank-1 argument. This covers all three iterative cases at once; the direct `eigenVis` stage ignores the parameter. `num_ev` stays at 2, so the tests still check that the second eigenvalue comes out ≈ 0 — they just no longer require it to *converge*.
- **`verify_results` asserts `erms >= 0`** and drops the `std::abs`. A non-converged frame is now a failure rather than a pass through the absolute value.
- **Residual limit `2e-2f` → `1e-5f`** for the three iterative cases.

## Measured residuals

With `num_ev_conv = 1` the solver converges and `erms` is a true residual. Measured on cx67 by temporarily setting the limit to zero so Boost printed the values:

```
1.4188941577231162e-07
1.5597032643199782e-07
1.6280964132420195e-07
1.6820700921016396e-07
3.548372546902101e-07
4.8766025884106057e-07
```

Float roundoff, ~5 orders of magnitude below the old limit. `1e-5f` leaves about 20x margin over the worst observed value.

## Testing

Built on cx67 from this branch (`Debug`, CUDA on, `WITH_BOOST_TESTS=ON`):

- **30 consecutive runs of `test_eigenStages`: 30/30 pass**, no failures — including `eigenN2Iter_concurrent_pipelines`, which converges reliably too now that `eigen_masked_subspace` draws from a per-thread fixed-seed generator (#1632).
- Full boost suite: **33 passed, 0 failed**.
- `clang-format-18 --dry-run --Werror` clean.

## Notes for the reviewer

This supersedes what remains of #1631. That PR's seed pinning is already handled inside the library by #1632, and this addresses the underlying non-convergence that #1631 only documented in comments. #1631 can probably be closed.

The production configs that set `num_ev_conv: 2` (`chime_science_run_gpu.yaml`, `chord_pathfinder.j2`, etc.) are unaffected and correct as they stand — real sky data is not rank 1, so a second converging eigenpair is meaningful there. Only the synthetic test matrix made it impossible.