### PR TITLE
Config: report a malformed value rather than silently defaulting

### DIFF
--- a/lib/core/Config.hpp
+++ b/lib/core/Config.hpp
@@ -156,8 +156,11 @@ public:
     /**
      * @brief Get a config value or return the default value.
      *
-     * Same as get_int, but if it cannot find the value
-     * (or if it has the wrong type), it returns `default_value`.
+     * A value that is not set anywhere on the path returns @c default_value silently.
+     * A value that is set but cannot be read as @c T also returns @c default_value,
+     * but logs an error, since substituting the default for a malformed entry would
+     * otherwise leave the pipeline running an unintended configuration.
+     *
      * @param base_path     Path to the value in the config.
      * @param name          Name of the value.
      * @param default_value The default value.
@@ -435,6 +438,17 @@ T Config::get_default(const std::string& base_path, const std::string& name,
         T value = get<T>(base_path, name);
         return value;
     } catch (std::runtime_error const& ex) {
+        // get<T>() fails both for an absent value and for one of the wrong type.
+        // get_value() repeats the lookup without the conversion, and throws only in
+        // the former case.
+        try {
+            get_value(base_path, name);
+        } catch (std::runtime_error const&) {
+            return default_value;
+        }
+        ERROR_NON_OO("Config: '{:s}' at {:s} is set but cannot be read as '{:s}', so the default "
+                     "is used instead. The value found was: {:s}",
+                     name, base_path, demangle<T>(), get_value(base_path, name).dump());
         return default_value;
     }
 }

--- a/tests/boost/test_config.cpp
+++ b/tests/boost/test_config.cpp
@@ -181,3 +181,42 @@ BOOST_AUTO_TEST_CASE(_parse_usage_report_level) {
     BOOST_CHECK_THROW(Config::parse_usage_report_level(json("loud")), std::runtime_error);
     BOOST_CHECK_THROW(Config::parse_usage_report_level(json(3)), std::runtime_error);
 }
+
+// get_default() must distinguish an absent value, where the default is what the
+// caller asked for, from one that is set but unreadable, which is a config error.
+// ERROR_NON_OO throws when compiled into a boost test, so the second case appears
+// here as a throw rather than a log line.
+BOOST_AUTO_TEST_CASE(_get_default_malformed_value) {
+    json json_config = {
+        {"good_list", {0, 2, 4, 6}},
+        // A list of lists, as a YAML "- [0, 2, 4, 6]" produces.
+        {"nested_list", {{0, 2, 4, 6}}},
+        {"a_string", "not a number"},
+        {"stage", {{"child", json::object()}}},
+    };
+    Config config;
+    config.update_config(json_config);
+
+    const std::vector<uint32_t> fallback = {99};
+
+    // A readable value is returned unchanged.
+    BOOST_CHECK_EQUAL(config.get_default<std::vector<uint32_t>>("/", "good_list", fallback).size(),
+                      4u);
+
+    // An absent value returns the default and is not reported.
+    BOOST_CHECK_EQUAL(config.get_default<std::vector<uint32_t>>("/", "absent", fallback).size(),
+                      1u);
+
+    // A value of the wrong type is reported.
+    BOOST_CHECK_THROW(config.get_default<std::vector<uint32_t>>("/", "nested_list", fallback),
+                      std::runtime_error);
+    BOOST_CHECK_THROW(config.get_default<int>("/", "a_string", -1), std::runtime_error);
+
+    // Including one reached by walking up the tree from a deeper scope.
+    BOOST_CHECK_THROW(
+        config.get_default<std::vector<uint32_t>>("/stage/child", "nested_list", fallback),
+        std::runtime_error);
+
+    // get() remains strict for callers that want the failure themselves.
+    BOOST_CHECK_THROW(config.get<std::vector<uint32_t>>("/", "nested_list"), std::runtime_error);
+}


### PR DESCRIPTION
get_default() caught every std::runtime_error from get<T>() and returned the default, so a value of the wrong type was indistinguishable from one that was never set. A config could then declare a setting, have it quietly ignored, and run with the default while the rest of the config assumed otherwise -- with no warning anywhere.
