### PR TITLE
hdf5FileRead: add read_single_file mode to replay single-file dumps

### DIFF
--- a/config/chime_upgrade_frb.j2
+++ b/config/chime_upgrade_frb.j2
@@ -1884,7 +1884,7 @@ write_frb:
     base_dir: frb_beams
     in_buf: host_frb3_beams_buffer_post
     file_name: host_frb3_beams_buffer
-    create_single_file: true
+    create_single_file: false  # split time axis: dim_scaling[0] != time_downsampling_fpga
     input_order: CHIMEBeamformer
 
 # enable to dump sk statistics data

--- a/config/fengine/include/output_benchmark.j2
+++ b/config/fengine/include/output_benchmark.j2
@@ -22,15 +22,18 @@ write_data:
         kotekan_stage: hdf5FileWrite
         in_buf: host_bb_beams_buffer
         file_name: bb_beams
+        create_single_file: false  # split time axis: dim_scaling[0] != time_downsampling_fpga
     write_frb3_beams:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb3_beams_buffer
         file_name: frb3_beams
+        create_single_file: false  # split time axis: dim_scaling[0] != time_downsampling_fpga
     write_frb3_beams_offsetscale:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb3_beams_offsetscale_buffer
         file_name: frb3_beams_offsetscale
         max_frames: 32          # each frame has 335.54432 ms
+        create_single_file: false  # split time axis: dim_scaling[0] != time_downsampling_fpga
     # this is chime only
     write_hfb2_beams:
         kotekan_stage: hdf5FileWrite

--- a/config/fengine/include/output_charts.j2
+++ b/config/fengine/include/output_charts.j2
@@ -228,26 +228,32 @@ write_data:
         kotekan_stage: hdf5FileWrite
         in_buf: host_bb_beam_positions_buffer
         file_name: bb_beam_positions
+        create_single_file: false  # not time-major
     write_bb_beam_ids:
         kotekan_stage: hdf5FileWrite
         in_buf: host_bb_beam_ids_buffer
         file_name: bb_beam_ids
+        create_single_file: false  # not time-major
     write_bb_phase:
         kotekan_stage: hdf5FileWrite
         in_buf: host_bb_phase_buffer
         file_name: bb_phase
+        create_single_file: false  # not time-major
     write_bb_shift:
         kotekan_stage: hdf5FileWrite
         in_buf: host_bb_shift_buffer
         file_name: bb_shift
+        create_single_file: false  # not time-major
     write_bb_beams:
         kotekan_stage: hdf5FileWrite
         in_buf: host_bb_beams_buffer
         file_name: bb_beams
+        create_single_file: false  # split time axis: dim_scaling[0] != time_downsampling_fpga
     write_upchan_U32_gain:
         kotekan_stage: hdf5FileWrite
         in_buf: host_upchan_U32_gain_buffer
         file_name: upchan_U32_gain
+        create_single_file: false  # not time-major
     write_upchan_U32_expanded_pl_mask:
         kotekan_stage: hdf5FileWrite
         in_buf: host_upchan_U32_expanded_pl_mask_buffer
@@ -260,14 +266,17 @@ write_data:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb1_U32_phase_buffer
         file_name: frb1_U32_phase
+        create_single_file: false  # not time-major
     write_frb2_beam_positions:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb2_beam_positions_buffer
         file_name: frb2_beam_positions
+        create_single_file: false  # not time-major
     write_frb2_weights:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb2_weights_buffer
         file_name: frb2_weights
+        create_single_file: false  # not time-major
     write_frb1_beams:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb1_beams_buffer
@@ -277,6 +286,7 @@ write_data:
         in_buf: host_frb2_beams_buffer
         file_name: frb2_beams
         max_frames: 3
+        create_single_file: false  # split time axis: dim_scaling[0] != time_downsampling_fpga
 #TODO     write_frb3_beams:
 #TODO         kotekan_stage: hdf5FileWrite
 #TODO         in_buf: host_frb3_beams_buffer

--- a/config/fengine/include/output_chime.j2
+++ b/config/fengine/include/output_chime.j2
@@ -251,11 +251,13 @@ write_data:
         kotekan_stage: hdf5FileWrite
         in_buf: host_voltage_buffer_{{ id }}
         file_name: voltage_{{ id }}
+        create_single_file: false  # not time-major
 {% endfor %}
     write_scatter_indices:
         kotekan_stage: hdf5FileWrite
         in_buf: host_scatter_indices_buffer
         file_name: scatter_indices
+        create_single_file: false  # not time-major
     write_xposed_voltage:
         kotekan_stage: hdf5FileWrite
         in_buf: host_xposed_voltage_buffer
@@ -317,30 +319,37 @@ write_data:
         kotekan_stage: hdf5FileWrite
         in_buf: host_bb_beam_positions_buffer
         file_name: bb_beam_positions
+        create_single_file: false  # not time-major
     write_bb_beam_ids:
         kotekan_stage: hdf5FileWrite
         in_buf: host_bb_beam_ids_buffer
         file_name: bb_beam_ids
+        create_single_file: false  # not time-major
     write_bb_phase:
         kotekan_stage: hdf5FileWrite
         in_buf: host_bb_phase_buffer
         file_name: bb_phase
+        create_single_file: false  # not time-major
     write_bb_shift:
         kotekan_stage: hdf5FileWrite
         in_buf: host_bb_shift_buffer
         file_name: bb_shift
+        create_single_file: false  # not time-major
     write_bb_beams:
         kotekan_stage: hdf5FileWrite
         in_buf: host_bb_beams_buffer
         file_name: bb_beams
+        create_single_file: false  # split time axis: dim_scaling[0] != time_downsampling_fpga
     write_upchan_U16_gain:
         kotekan_stage: hdf5FileWrite
         in_buf: host_upchan_U16_gain_buffer
         file_name: upchan_U16_gain
+        create_single_file: false  # not time-major
     write_upchan_HFB_U128_gain:
         kotekan_stage: hdf5FileWrite
         in_buf: host_upchan_hfb_U128_gain_buffer
         file_name: upchan_hfb_U128_gain
+        create_single_file: false  # not time-major
     write_upchan_U16_expanded_pl_mask:
         kotekan_stage: hdf5FileWrite
         in_buf: host_upchan_U16_expanded_pl_mask_buffer
@@ -361,18 +370,22 @@ write_data:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb1_U16_phase_buffer
         file_name: frb1_U16_phase
+        create_single_file: false  # not time-major
     write_frb2_beam_ids:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb2_beam_ids_buffer
         file_name: frb2_beam_ids
+        create_single_file: false  # not time-major
     write_frb2_beam_positions:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb2_beam_positions_buffer
         file_name: frb2_beam_positions
+        create_single_file: false  # not time-major
     write_frb2_weights:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb2_weights_buffer
         file_name: frb2_weights
+        create_single_file: false  # not time-major
     write_frb1_beams:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb1_beams_buffer
@@ -381,27 +394,33 @@ write_data:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb2_beams_buffer
         file_name: frb2_beams
+        create_single_file: false  # split time axis: dim_scaling[0] != time_downsampling_fpga
     write_frb3_beams:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb3_beams_buffer
         file_name: frb3_beams
+        create_single_file: false  # split time axis: dim_scaling[0] != time_downsampling_fpga
     write_frb3_beams_offsetscale:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb3_beams_offsetscale_buffer
         file_name: frb3_beams_offsetscale
         max_frames: 4
+        create_single_file: false  # split time axis: dim_scaling[0] != time_downsampling_fpga
     write_hfb1_U128_phase:
         kotekan_stage: hdf5FileWrite
         in_buf: host_hfb1_U128_phase_buffer
         file_name: hfb1_U128_phase
+        create_single_file: false  # not time-major
     write_hfb2_beam_positions:
         kotekan_stage: hdf5FileWrite
         in_buf: host_hfb2_beam_positions_buffer
         file_name: hfb2_beam_positions
+        create_single_file: false  # not time-major
     write_hfb2_weights:
         kotekan_stage: hdf5FileWrite
         in_buf: host_hfb2_weights_buffer
         file_name: hfb2_weights
+        create_single_file: false  # not time-major
     write_hfb1_beams:
         kotekan_stage: hdf5FileWrite
         in_buf: host_hfb1_beams_buffer
@@ -415,6 +434,7 @@ write_data:
         in_buf: host_hfb2_beams_buffer
         file_name: hfb2_beams
         max_frames: 1
+        create_single_file: false  # split time axis: dim_scaling[0] != time_downsampling_fpga
     # write_hfb3_beams:
     #     kotekan_stage: hdf5FileWrite
     #     in_buf: host_hfb3_beams_buffer

--- a/config/fengine/include/output_chord.j2
+++ b/config/fengine/include/output_chord.j2
@@ -387,46 +387,57 @@ write_data:
         kotekan_stage: hdf5FileWrite
         in_buf: host_bb_beam_positions_buffer
         file_name: bb_beam_positions
+        create_single_file: false  # not time-major
     write_bb_beam_ids:
         kotekan_stage: hdf5FileWrite
         in_buf: host_bb_beam_ids_buffer
         file_name: bb_beam_ids
+        create_single_file: false  # not time-major
     write_bb_phase:
         kotekan_stage: hdf5FileWrite
         in_buf: host_bb_phase_buffer
         file_name: bb_phase
+        create_single_file: false  # not time-major
     write_bb_shift:
         kotekan_stage: hdf5FileWrite
         in_buf: host_bb_shift_buffer
         file_name: bb_shift
+        create_single_file: false  # not time-major
     write_bb_beams:
         kotekan_stage: hdf5FileWrite
         in_buf: host_bb_beams_buffer
         file_name: bb_beams
+        create_single_file: false  # split time axis: dim_scaling[0] != time_downsampling_fpga
     write_upchan_U2_gain:
         kotekan_stage: hdf5FileWrite
         in_buf: host_upchan_U2_gain_buffer
         file_name: upchan_U2_gain
+        create_single_file: false  # not time-major
     write_upchan_U4_gain:
         kotekan_stage: hdf5FileWrite
         in_buf: host_upchan_U4_gain_buffer
         file_name: upchan_U4_gain
+        create_single_file: false  # not time-major
     write_upchan_U8_gain:
         kotekan_stage: hdf5FileWrite
         in_buf: host_upchan_U8_gain_buffer
         file_name: upchan_U8_gain
+        create_single_file: false  # not time-major
     write_upchan_U16_gain:
         kotekan_stage: hdf5FileWrite
         in_buf: host_upchan_U16_gain_buffer
         file_name: upchan_U16_gain
+        create_single_file: false  # not time-major
     write_upchan_U32_gain:
         kotekan_stage: hdf5FileWrite
         in_buf: host_upchan_U32_gain_buffer
         file_name: upchan_U32_gain
+        create_single_file: false  # not time-major
     write_upchan_U64_gain:
         kotekan_stage: hdf5FileWrite
         in_buf: host_upchan_U64_gain_buffer
         file_name: upchan_U64_gain
+        create_single_file: false  # not time-major
     write_upchan_U2_expanded_pl_mask:
         kotekan_stage: hdf5FileWrite
         in_buf: host_upchan_U2_expanded_pl_mask_buffer
@@ -479,42 +490,52 @@ write_data:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb1_U1_phase_buffer
         file_name: frb1_U1_phase
+        create_single_file: false  # not time-major
     write_frb1_U2_phase:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb1_U2_phase_buffer
         file_name: frb1_U2_phase
+        create_single_file: false  # not time-major
     write_frb1_U4_phase:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb1_U4_phase_buffer
         file_name: frb1_U4_phase
+        create_single_file: false  # not time-major
     write_frb1_U8_phase:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb1_U8_phase_buffer
         file_name: frb1_U8_phase
+        create_single_file: false  # not time-major
     write_frb1_U16_phase:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb1_U16_phase_buffer
         file_name: frb1_U16_phase
+        create_single_file: false  # not time-major
     write_frb1_U32_phase:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb1_U32_phase_buffer
         file_name: frb1_U32_phase
+        create_single_file: false  # not time-major
     write_frb1_U64_phase:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb1_U64_phase_buffer
         file_name: frb1_U64_phase
+        create_single_file: false  # not time-major
     write_frb2_beam_positions:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb2_beam_positions_buffer
         file_name: frb2_beam_positions
+        create_single_file: false  # not time-major
     write_frb2_beam_ids:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb2_beam_ids_buffer
         file_name: frb2_beam_ids
+        create_single_file: false  # not time-major
     write_frb2_weights:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb2_weights_buffer
         file_name: frb2_weights
+        create_single_file: false  # not time-major
     write_frb1_beams:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb1_beams_buffer
@@ -523,12 +544,15 @@ write_data:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb2_beams_buffer
         file_name: frb2_beams
+        create_single_file: false  # split time axis: dim_scaling[0] != time_downsampling_fpga
     write_frb3_beams:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb3_beams_buffer
         file_name: frb3_beams
+        create_single_file: false  # split time axis: dim_scaling[0] != time_downsampling_fpga
     write_frb3_beams_offsetscale:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb3_beams_offsetscale_buffer
         file_name: frb3_beams_offsetscale
         max_frames: 4
+        create_single_file: false  # split time axis: dim_scaling[0] != time_downsampling_fpga

--- a/config/fengine/include/output_hirax.j2
+++ b/config/fengine/include/output_hirax.j2
@@ -291,34 +291,42 @@ write_data:
         kotekan_stage: hdf5FileWrite
         in_buf: host_bb_beam_positions_buffer
         file_name: bb_beam_positions
+        create_single_file: false  # not time-major
     write_bb_beam_ids:
         kotekan_stage: hdf5FileWrite
         in_buf: host_bb_beam_ids_buffer
         file_name: bb_beam_ids
+        create_single_file: false  # not time-major
     write_bb_phase:
         kotekan_stage: hdf5FileWrite
         in_buf: host_bb_phase_buffer
         file_name: bb_phase
+        create_single_file: false  # not time-major
     write_bb_shift:
         kotekan_stage: hdf5FileWrite
         in_buf: host_bb_shift_buffer
         file_name: bb_shift
+        create_single_file: false  # not time-major
     write_bb_beams:
         kotekan_stage: hdf5FileWrite
         in_buf: host_bb_beams_buffer
         file_name: bb_beams
+        create_single_file: false  # split time axis: dim_scaling[0] != time_downsampling_fpga
     write_upchan_U8_gain:
         kotekan_stage: hdf5FileWrite
         in_buf: host_upchan_U8_gain_buffer
         file_name: upchan_U8_gain
+        create_single_file: false  # not time-major
     write_upchan_U16_gain:
         kotekan_stage: hdf5FileWrite
         in_buf: host_upchan_U16_gain_buffer
         file_name: upchan_U16_gain
+        create_single_file: false  # not time-major
     write_upchan_U32_gain:
         kotekan_stage: hdf5FileWrite
         in_buf: host_upchan_U32_gain_buffer
         file_name: upchan_U32_gain
+        create_single_file: false  # not time-major
     write_upchan_U8_expanded_pl_mask:
         kotekan_stage: hdf5FileWrite
         in_buf: host_upchan_U8_expanded_pl_mask_buffer
@@ -347,26 +355,32 @@ write_data:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb1_U8_phase_buffer
         file_name: frb1_U8_phase
+        create_single_file: false  # not time-major
     write_frb1_U16_phase:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb1_U16_phase_buffer
         file_name: frb1_U16_phase
+        create_single_file: false  # not time-major
     write_frb1_U32_phase:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb1_U32_phase_buffer
         file_name: frb1_U32_phase
+        create_single_file: false  # not time-major
     write_frb2_beam_positions:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb2_beam_positions_buffer
         file_name: frb2_beam_positions
+        create_single_file: false  # not time-major
     write_frb2_beam_ids:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb2_beam_ids_buffer
         file_name: frb2_beam_ids
+        create_single_file: false  # not time-major
     write_frb2_weights:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb2_weights_buffer
         file_name: frb2_weights
+        create_single_file: false  # not time-major
     write_frb1_beams:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb1_beams_buffer
@@ -375,12 +389,15 @@ write_data:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb2_beams_buffer
         file_name: frb2_beams
+        create_single_file: false  # split time axis: dim_scaling[0] != time_downsampling_fpga
     write_frb3_beams:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb3_beams_buffer
         file_name: frb3_beams
+        create_single_file: false  # split time axis: dim_scaling[0] != time_downsampling_fpga
     write_frb3_beams_offsetscale:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb3_beams_offsetscale_buffer
         file_name: frb3_beams_offsetscale
         max_frames: 4
+        create_single_file: false  # split time axis: dim_scaling[0] != time_downsampling_fpga

--- a/config/fengine/include/output_pathfinder.j2
+++ b/config/fengine/include/output_pathfinder.j2
@@ -387,46 +387,57 @@ write_data:
         kotekan_stage: hdf5FileWrite
         in_buf: host_bb_beam_positions_buffer
         file_name: bb_beam_positions
+        create_single_file: false  # not time-major
     write_bb_beam_ids:
         kotekan_stage: hdf5FileWrite
         in_buf: host_bb_beam_ids_buffer
         file_name: bb_beam_ids
+        create_single_file: false  # not time-major
     write_bb_phase:
         kotekan_stage: hdf5FileWrite
         in_buf: host_bb_phase_buffer
         file_name: bb_phase
+        create_single_file: false  # not time-major
     write_bb_shift:
         kotekan_stage: hdf5FileWrite
         in_buf: host_bb_shift_buffer
         file_name: bb_shift
+        create_single_file: false  # not time-major
     write_bb_beams:
         kotekan_stage: hdf5FileWrite
         in_buf: host_bb_beams_buffer
         file_name: bb_beams
+        create_single_file: false  # split time axis: dim_scaling[0] != time_downsampling_fpga
     write_upchan_U2_gain:
         kotekan_stage: hdf5FileWrite
         in_buf: host_upchan_U2_gain_buffer
         file_name: upchan_U2_gain
+        create_single_file: false  # not time-major
     write_upchan_U4_gain:
         kotekan_stage: hdf5FileWrite
         in_buf: host_upchan_U4_gain_buffer
         file_name: upchan_U4_gain
+        create_single_file: false  # not time-major
     write_upchan_U8_gain:
         kotekan_stage: hdf5FileWrite
         in_buf: host_upchan_U8_gain_buffer
         file_name: upchan_U8_gain
+        create_single_file: false  # not time-major
     write_upchan_U16_gain:
         kotekan_stage: hdf5FileWrite
         in_buf: host_upchan_U16_gain_buffer
         file_name: upchan_U16_gain
+        create_single_file: false  # not time-major
     write_upchan_U32_gain:
         kotekan_stage: hdf5FileWrite
         in_buf: host_upchan_U32_gain_buffer
         file_name: upchan_U32_gain
+        create_single_file: false  # not time-major
     write_upchan_U64_gain:
         kotekan_stage: hdf5FileWrite
         in_buf: host_upchan_U64_gain_buffer
         file_name: upchan_U64_gain
+        create_single_file: false  # not time-major
     write_upchan_U2_expanded_pl_mask:
         kotekan_stage: hdf5FileWrite
         in_buf: host_upchan_U2_expanded_pl_mask_buffer
@@ -479,42 +490,52 @@ write_data:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb1_U1_phase_buffer
         file_name: frb1_U1_phase
+        create_single_file: false  # not time-major
     write_frb1_U2_phase:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb1_U2_phase_buffer
         file_name: frb1_U2_phase
+        create_single_file: false  # not time-major
     write_frb1_U4_phase:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb1_U4_phase_buffer
         file_name: frb1_U4_phase
+        create_single_file: false  # not time-major
     write_frb1_U8_phase:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb1_U8_phase_buffer
         file_name: frb1_U8_phase
+        create_single_file: false  # not time-major
     write_frb1_U16_phase:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb1_U16_phase_buffer
         file_name: frb1_U16_phase
+        create_single_file: false  # not time-major
     write_frb1_U32_phase:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb1_U32_phase_buffer
         file_name: frb1_U32_phase
+        create_single_file: false  # not time-major
     write_frb1_U64_phase:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb1_U64_phase_buffer
         file_name: frb1_U64_phase
+        create_single_file: false  # not time-major
     write_frb2_beam_positions:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb2_beam_positions_buffer
         file_name: frb2_beam_positions
+        create_single_file: false  # not time-major
     write_frb2_beam_ids:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb2_beam_ids_buffer
         file_name: frb2_beam_ids
+        create_single_file: false  # not time-major
     write_frb2_weights:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb2_weights_buffer
         file_name: frb2_weights
+        create_single_file: false  # not time-major
     write_frb1_beams:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb1_beams_buffer
@@ -523,12 +544,15 @@ write_data:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb2_beams_buffer
         file_name: frb2_beams
+        create_single_file: false  # split time axis: dim_scaling[0] != time_downsampling_fpga
     write_frb3_beams:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb3_beams_buffer
         file_name: frb3_beams
+        create_single_file: false  # split time axis: dim_scaling[0] != time_downsampling_fpga
     write_frb3_beams_offsetscale:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb3_beams_offsetscale_buffer
         file_name: frb3_beams_offsetscale
         max_frames: 4
+        create_single_file: false  # split time axis: dim_scaling[0] != time_downsampling_fpga

--- a/docs/sphinx/user/file_formats/hdf5_frames.rst
+++ b/docs/sphinx/user/file_formats/hdf5_frames.rst
@@ -105,6 +105,43 @@ Dataset attributes:
    * - ``feed_positions_m``
      - Per-element 3D feed positions in the grid frame, metres.
 
+Single-file constraints
+-----------------------
+
+``create_single_file: true`` concatenates all frames along axis 0 and stores
+the attributes only once, taken from the first frame. The frame boundaries and
+the per-frame sequence numbers are therefore *not* on disk, and a reader can
+only reconstruct them if the file holds a contiguous, uniformly sampled time
+stream. ``hdf5FileWrite`` enforces that and aborts otherwise:
+
+* dimension 0 must be a time axis --- by kotekan convention a dimension is a
+  time axis iff its name starts with ``T`` (``T``, ``Tc``, ``Tbar``,
+  ``Ttilde``, ``Thi64``, ``T8hi128``, ...);
+* ``dim_scaling[0]`` must equal ``time_downsampling_fpga`` (1 when the
+  metadata does not carry that field), so a *split* time axis --- one whose
+  high and low halves are separate dimensions, e.g. ``Thi``/``T`` or
+  ``Ttildehi256`` --- does not qualify;
+* consecutive frames must advance ``fpga_seq_num`` by exactly ``dim[0] *
+  time_downsampling_fpga``, and must not change the frame shape or the
+  downsampling factor;
+* frame decimation (``write_x_frames``/``per_y_frames``) must not be
+  combined with ``create_single_file`` (rejected at startup).
+
+Time downsampling itself is allowed, as long as the time axis is sampled at
+the downsampling rate of the frame. A buffer that violates one of these rules
+has to be dumped as per-frame files (``create_single_file: false``): per-frame
+files store the full metadata of every frame and have no such constraints.
+That is why a number of writers in the F-engine configurations
+(``config/fengine/include/output_*.j2``, ``config/chime_upgrade_frb.j2``)
+override the group-wide ``create_single_file: true`` with
+``create_single_file: false`` --- the beamformer phases, gains, weights and
+beam positions are not time-major, and the packed beam outputs have a split
+time axis.
+
+The checks run per frame, so a single-file writer that aborts part-way leaves
+a truncated (but still readable) file behind; a dump that ended in a ``FATAL``
+should therefore not be trusted without checking the log.
+
 N2-metadata layout
 ==================
 
@@ -207,16 +244,21 @@ Configuration
    * - ``create_single_file``
      - false
      - Append all frames to one file (CHORD mode only) instead of one file
-       per frame.
+       per frame. Only for buffers that satisfy the
+       `Single-file constraints`_ (time axis first, ``dim_scaling[0] ==
+       time_downsampling_fpga``, contiguous ``fpga_seq_num``, no
+       decimation); every other writer has to keep the default.
    * - ``use_compression``
      - true
      - Compress the data with bitshuffle+zstd (filter 32008).
    * - ``write_x_frames``, ``per_y_frames``
      - -1
-     - Decimation: write only the first X out of every Y frames.
+     - Decimation: write only the first X out of every Y frames. Cannot be
+       combined with ``create_single_file``.
    * - ``max_frames``
      - -1
-     - Stop (and shut kotekan down) after this many frames.
+     - Values <= 0 (the default) mean unlimited; N > 0 stops (and shuts
+       kotekan down) after N frames.
    * - ``skip_writing``
      - false
      - Consume frames without writing (for benchmarking).
@@ -239,10 +281,21 @@ ndarray``; the reader validates the declared frame descriptor against the file.
 
 * **Per-frame files**: point ``input_dir``/``file_name`` (and
   ``prefix_hostname``/``prefix_host_rank``) at the files written above. The
-  reader starts at frame index 0 and stops when the next file is missing; a
-  missing file at index 0 is fatal.
+  reader starts at frame index 0 and stops when the next file is missing,
+  which it reports at ``INFO``; a missing file at index 0 is fatal. Per-frame
+  files carry their own metadata, so this mode places no constraints on the
+  axis order or on the sequence numbers of the frames.
 * **Single file**: additionally set ``read_single_file: true``. The reader
-  splits axis 0 of the dataset into frames.
+  splits axis 0 of the dataset into frames. It re-checks the
+  `Single-file constraints`_ that the writer enforced --- dimension 0 has to
+  be a time axis and ``dim_scalings[0]`` has to equal
+  ``time_downsampling_fpga`` --- and aborts if they do not hold, because the
+  reconstruction below would otherwise silently mislabel the frames.
+
+In both modes the attributes ``chord_metadata_version``, ``name``, ``type``,
+``dim_names`` and ``dim_scalings`` are mandatory and the HDF5 storage type of
+the dataset has to match the declared ``type``; a missing attribute, a type
+mismatch, or any other HDF5 error while reading is fatal.
 
 Because a single file stores the attributes only once (taken from the first
 frame), some per-frame information is *not* preserved: ``frame_counter``,
@@ -255,8 +308,8 @@ boundary itself. The replay therefore reconstructs them:
 * ``fpga_seq_num`` of frame *i* is ``fpga_seq_num + i * extents[0] *
   time_downsampling_fpga`` (a downsampling factor of 1 is assumed when the
   attribute is absent);
-* the number of frames is ``axis0 / extents[0]``; a remainder is reported
-  and ignored.
+* the number of frames is ``axis0 / extents[0]``; a remainder is reported and
+  ignored, but a dataset holding fewer than one frame is a read error.
 
 The writer must have finished before the reader starts, so the two have to run
 in separate kotekan sessions: the whole single file, or the first per-frame

--- a/docs/sphinx/user/file_formats/hdf5_frames.rst
+++ b/docs/sphinx/user/file_formats/hdf5_frames.rst
@@ -68,13 +68,17 @@ Dataset attributes:
    * - ``gps_time_enabled``
      - Whether the FPGA timestamp is GPS-disciplined.
    * - ``chord_metadata_version``
-     - int[2] metadata format version (currently {1, 0}).
+     - int[2] metadata format version (currently {2, 0}).
    * - ``name``
      - The ndarray name from the buffer metadata.
    * - ``type``
      - Element data type as a string (e.g. ``float16``).
    * - ``dim_names``
      - String array of dimension names (e.g. ``["T", "F", "D", "P"]``).
+   * - ``dim_scalings``
+     - int64 array of per-dimension scaling factors: how many elements of
+       the underlying, un-decimated axis one element along that dimension
+       represents (1 for an axis that is neither decimated nor combined).
    * - ``fpga_seq_num``, ``fpga_seq_time_nsec``
      - First FPGA sequence number of the frame and its instrument time in
        ns (only if the metadata carries a sequence number).
@@ -85,11 +89,8 @@ Dataset attributes:
        indices (if present).
    * - ``rfi_frame_excision_enabled``, ``rfi_frame_excision_thresholds``
      - RFI frame-excision state (if present).
-   * - ``num_polarizations``, ``num_dishes``, ``num_elements``
+   * - ``num_polarizations``, ``num_dishes``
      - Telescope input counts (from the stage configuration).
-   * - ``input_order``
-     - Element ordering of the data (an ``ElementOrder`` name; see
-       :ref:`element_order`).
    * - ``itrs_lat_deg``, ``itrs_lon_deg``
      - Telescope origin ITRS coordinates, degrees.
    * - ``grid_orientation``
@@ -98,8 +99,9 @@ Dataset attributes:
      - Dish grid dimensions.
    * - ``feed_separation_x_m``, ``feed_separation_y_m``
      - Grid spacing, metres.
-   * - ``main_array_grid_indices``
-     - Per-element (x, y) grid indices; (-1, -1) off the main array.
+   * - ``dish_grid_indices``
+     - Per-dish (x, y) grid indices, int64 with shape
+       (``num_dishes``, 2); (-1, -1) off the main array.
    * - ``feed_positions_m``
      - Per-element 3D feed positions in the grid frame, metres.
 
@@ -206,6 +208,9 @@ Configuration
      - false
      - Append all frames to one file (CHORD mode only) instead of one file
        per frame.
+   * - ``use_compression``
+     - true
+     - Compress the data with bitshuffle+zstd (filter 32008).
    * - ``write_x_frames``, ``per_y_frames``
      - -1
      - Decimation: write only the first X out of every Y frames.
@@ -218,9 +223,49 @@ Configuration
    * - ``num_polarizations``, ``num_dishes``
      - required
      - Telescope input counts recorded in the attributes.
-   * - ``input_order``
-     - required
-     - Element ordering recorded in the attributes.
 
 Reading the files requires the bitshuffle HDF5 plugin with zstd support
 (``import hdf5plugin`` in Python).
+
+Reading the files back
+======================
+
+CHORD-metadata files can be replayed into a kotekan buffer with the
+``hdf5FileRead`` stage (``lib/stages/hdf5FileRead.cpp``). It reconstructs the
+payload and the chord metadata from the dataset and its attributes, and aborts
+if the telescope attributes disagree with the telescope of the replaying
+session. The destination buffer must be declared with ``kotekan_buffer:
+ndarray``; the reader validates the declared frame descriptor against the file.
+
+* **Per-frame files**: point ``input_dir``/``file_name`` (and
+  ``prefix_hostname``/``prefix_host_rank``) at the files written above. The
+  reader starts at frame index 0 and stops when the next file is missing; a
+  missing file at index 0 is fatal.
+* **Single file**: additionally set ``read_single_file: true``. The reader
+  splits axis 0 of the dataset into frames.
+
+Because a single file stores the attributes only once (taken from the first
+frame), some per-frame information is *not* preserved: ``frame_counter``,
+``first_packet_recv_time``, the per-frame ``fpga_seq_num``, and the frame
+boundary itself. The replay therefore reconstructs them:
+
+* the axis-0 extent of one frame is the first extent declared for the
+  reader's ``out_buf`` (the remaining extents, the element type and the
+  labels must match the file);
+* ``fpga_seq_num`` of frame *i* is ``fpga_seq_num + i * extents[0] *
+  time_downsampling_fpga`` (a downsampling factor of 1 is assumed when the
+  attribute is absent);
+* the number of frames is ``axis0 / extents[0]``; a remainder is reported
+  and ignored.
+
+The writer must have finished before the reader starts, so the two have to run
+in separate kotekan sessions: the whole single file, or the first per-frame
+file, has to exist and be complete at startup. After a writer crash the file
+may need ``h5clear -s FILENAME.h5`` first.
+
+``hdf5FileReadSingleFile`` (``lib/stages/hdf5FileReadSingleFile.cpp``) is a
+different, special-purpose stage: it replays only CHIME/F-engine baseband
+voltages (rank-4 ``int4x2_swapped_withoffset`` data with a leading ``T`` axis
+and an ``F`` axis), selecting a subset of the frequency channels and optionally
+transposing time and frequency or combining dishes and polarizations. Use
+``hdf5FileRead`` with ``read_single_file`` for everything else.

--- a/lib/stages/hdf5FileRead.cpp
+++ b/lib/stages/hdf5FileRead.cpp
@@ -22,6 +22,8 @@
 #include <highfive/H5DataSpace.hpp>              // for DataSpace, DataSpace::getDimensions
 #include <highfive/H5Exception.hpp>              // for FileException
 #include <highfive/H5File.hpp>                   // for File, File::File, NodeTraits::getDataSet
+#include <highfive/H5Selection.hpp>              // for Selection, SliceTraits::select
+#include <highfive/bits/H5Selection_misc.hpp>    // for Selection::getSpace
 #include <highfive/bits/H5Slice_traits_misc.hpp> // for SliceTraits::read_raw
 #include <iomanip>                               // for operator<<, setfill, setw
 #include <kotekanLogging.hpp>                    // for DEBUG, FATAL_ERROR, ERROR
@@ -37,14 +39,76 @@
 using namespace hdf5;
 using namespace HighFive;
 
+/**
+ * @class hdf5FileRead
+ * @brief Read CHORD-metadata HDF5 files written by @c hdf5FileWrite back into a buffer.
+ *
+ * This is the replay counterpart of @c hdf5FileWrite: it reconstructs both the frame
+ * payload and the CHORD metadata (name, type, dimensions, dimension names and scalings,
+ * strides, @c fpga_seq_num, @c time_downsampling_fpga, the frequency mapping, and the RFI
+ * excision settings) from the dataset and its attributes, and validates the telescope
+ * attributes against the telescope of the current session (a mismatch is fatal).
+ *
+ * Two on-disk layouts are supported, selected by @c read_single_file, the counterpart of the
+ * @c create_single_file option of @c hdf5FileWrite:
+ *
+ * - Per-frame files (default): one file per frame, named
+ *   `<input_dir>/[<hostname>_][x<rank:04d>_]<file_name>.<frame:08d>.h5`. The stage reads
+ *   files with consecutive indices starting at 0 until one is missing, then stops
+ *   producing frames (the pipeline has to be ended by something else, e.g. a
+ *   `testDataCheck*` stage or `num_frames` on a downstream stage).
+ * - Single file (`read_single_file: true`): all frames concatenated along axis 0 of one
+ *   dataset in `<input_dir>/[<hostname>_][x<rank:04d>_]<file_name>.h5`.
+ *
+ * @par Reading a single file
+ * The single-file format stores the metadata attributes only once (they are taken from the
+ * first frame), so neither the per-frame metadata (@c frame_counter,
+ * @c first_packet_recv_time, the per-frame @c fpga_seq_num) nor the frame boundary is on
+ * disk. The replay therefore reconstructs them:
+ * - the axis-0 extent of one frame is the first extent declared for @c out_buf in the
+ *   config (all other extents, the value type and the labels must match the file);
+ * - `fpga_seq_num(i) = fpga_seq_num + i * extents[0] * time_downsampling_fpga`, using a
+ *   downsampling factor of 1 if the attribute is absent;
+ * - the number of frames is `axis0 / extents[0]`; a remainder is reported and ignored.
+ *
+ * @par Sessions
+ * The writer must have finished before the reader starts: run the two in separate kotekan
+ * sessions. A missing input is fatal at frame index 0 (for a single file: a missing or
+ * unreadable file is always fatal), so the first per-frame file, or the whole single file,
+ * has to exist and be complete at startup. If a SWMR writer was killed the file may need
+ * `h5clear -s FILE.h5` before it can be opened.
+ *
+ * @par Buffers
+ * @buffer out_buf Buffer to fill with the frames read from the file(s)
+ *         @buffer_format any format, declared as `kotekan_buffer: ndarray`
+ *         @buffer_metadata chordMetadata
+ *
+ * @conf  input_dir             String. Required. Directory holding the input file(s).
+ * @conf  file_name             String. Required. Base name of the file(s), and the name of
+ *                              the dataset inside them.
+ * @conf  prefix_hostname       Bool. Default: true. Expect the hostname and an underscore
+ *                              in front of @c file_name.
+ * @conf  prefix_host_rank      Bool. Default: false. Expect `x<rank:04d>_` in front of
+ *                              @c file_name, using @c frequency_pool_rank.
+ * @conf  frequency_pool_rank   Int. Default: 0. The rank used by @c prefix_host_rank.
+ * @conf  do_once               Bool. Default: false. Read only the first frame and then
+ *                              idle instead of reading the whole input.
+ * @conf  read_single_file      Bool. Default: false. Read all frames from a single file
+ *                              instead of one file per frame; see above.
+ * @conf  num_polarizations     Int. Required. Cross-checked against the file.
+ * @conf  num_dishes            Int. Required. Cross-checked against the file.
+ *
+ * @par Metrics
+ * @metric kotekan_hdf5fileread_read_time_seconds Time required to read the last frame.
+ */
 class hdf5FileRead : public kotekan::Stage {
     const std::string input_dir = config.get<std::string>(unique_name, "input_dir");
     const std::string file_name = config.get<std::string>(unique_name, "file_name");
     const bool prefix_hostname = config.get_default<bool>(unique_name, "prefix_hostname", true);
     const bool prefix_host_rank = config.get_default<bool>(unique_name, "prefix_host_rank", false);
     const int host_pool_rank = config.get_default<int>(unique_name, "frequency_pool_rank", 0);
-    const int host_pool_size = config.get_default<int>(unique_name, "frequency_pool_size", 1);
     const bool do_once = config.get_default<bool>(unique_name, "do_once", false);
+    const bool read_single_file = config.get_default<bool>(unique_name, "read_single_file", false);
 
     const uint64_t num_polarizations = config.get<uint64_t>(unique_name, "num_polarizations");
     const uint64_t num_dishes = config.get<uint64_t>(unique_name, "num_dishes");
@@ -162,7 +226,148 @@ public:
         }
     }
 
+    /**
+     * @brief The common part of all file names of this stage:
+     *        "<input_dir>/[<hostname>_][x<rank:04d>_]<file_name>"
+     *
+     * The caller appends the suffix, i.e. ".<frame:08d>.h5" for per-frame files and ".h5"
+     * for a single file.
+     */
+    std::string file_path_prefix() const {
+        std::ostringstream buf;
+        buf << input_dir << "/";
+        if (prefix_hostname) {
+            char hostname[256];
+            gethostname(hostname, sizeof hostname);
+            buf << hostname << "_";
+        }
+        if (prefix_host_rank)
+            buf << "x" << std::setw(4) << std::setfill('0') << host_pool_rank << "_";
+        buf << file_name;
+        return buf.str();
+    }
+
+    /**
+     * @brief Check that this reader understands the metadata format of the dataset
+     *
+     * The major version has to match, and the file's minor version must not be newer than
+     * ours. A mismatch is fatal.
+     */
+    void check_metadata_version(const DataSet& dataset) const {
+        const auto version =
+            dataset.getAttribute("chord_metadata_version").read<std::array<int, 2>>();
+        if (version[0] != chord_metadata_version[0] || version[1] > chord_metadata_version[1])
+            FATAL_ERROR("Dataset \"{:s}\" has chord_metadata_version {:d}.{:d}; this reader "
+                        "understands {:d}.{:d}",
+                        file_name, version[0], version[1], chord_metadata_version[0],
+                        chord_metadata_version[1]);
+    }
+
+    /**
+     * @brief Fill @p meta from the attributes of @p dataset
+     *
+     * @param dataset      The dataset that is being read
+     * @param meta         The metadata of the frame that is being filled
+     * @param frame_dims   The shape of ONE frame: the dataset shape for per-frame files,
+     *                     with axis 0 replaced by the buffer's frame extent in single-file
+     *                     mode
+     * @param frame_index  The index of the frame within the dataset. It advances
+     *                     @c fpga_seq_num in single-file mode, where only the value of the
+     *                     first frame is stored on disk; it must be 0 for per-frame files.
+     */
+    void set_metadata(const DataSet& dataset, const std::shared_ptr<chordMetadata>& meta,
+                      const std::vector<std::size_t>& frame_dims,
+                      const std::int64_t frame_index) const {
+        meta->set_name(dataset.getAttribute("name").read<std::string>());
+        meta->type = kotekan::string_to_type(dataset.getAttribute("type").read<std::string>());
+        if (frame_dims.size() > CHORD_META_MAX_DIM)
+            FATAL_ERROR("Dataset \"{:s}\" has rank {:d} > CHORD_META_MAX_DIM ({:d})", file_name,
+                        frame_dims.size(), std::size_t(CHORD_META_MAX_DIM));
+        meta->dims = int(frame_dims.size());
+        const auto dim_names = dataset.getAttribute("dim_names").read<std::vector<std::string>>();
+        const auto dim_scalings =
+            dataset.getAttribute("dim_scalings").read<std::vector<std::ptrdiff_t>>();
+        if (dim_names.size() != frame_dims.size() || dim_scalings.size() != frame_dims.size())
+            FATAL_ERROR("Dataset \"{:s}\": dim_names ({:d}) and dim_scalings ({:d}) do not match "
+                        "rank {:d}",
+                        file_name, dim_names.size(), dim_scalings.size(), frame_dims.size());
+        for (int d = 0; d < meta->dims; ++d)
+            meta->set_array_dimension(d, frame_dims.at(d), dim_names.at(d), dim_scalings.at(d));
+        meta->set_strides_simple();
+        meta->offset = 0;
+
+        if (dataset.hasAttribute("fpga_seq_num")) {
+            std::int64_t fpga_seq_num = dataset.getAttribute("fpga_seq_num").read<std::int64_t>();
+            if (frame_index > 0) {
+                const int tds = dataset.hasAttribute("time_downsampling_fpga")
+                                    ? dataset.getAttribute("time_downsampling_fpga").read<int>()
+                                    : 1;
+                fpga_seq_num += frame_index * std::int64_t(frame_dims.at(0)) * tds;
+            }
+            meta->set_fpga_seq_num(fpga_seq_num);
+        }
+        if (dataset.hasAttribute("time_downsampling_fpga"))
+            meta->set_time_downsampling_fpga(
+                dataset.getAttribute("time_downsampling_fpga").read<int>());
+
+        if (dataset.hasAttribute("coarse_freq"))
+            meta->set_coarse_freq(dataset.getAttribute("coarse_freq").read<std::vector<int>>());
+        if (dataset.hasAttribute("freq_upchan_factor"))
+            meta->set_freq_upchan_factor(
+                dataset.getAttribute("freq_upchan_factor").read<std::vector<int>>());
+        if (dataset.hasAttribute("freq_upchan_index"))
+            meta->set_freq_upchan_index(
+                dataset.getAttribute("freq_upchan_index").read<std::vector<int>>());
+
+        if (dataset.hasAttribute("rfi_frame_excision_enabled"))
+            meta->set_rfi_frame_excision_enabled(
+                dataset.getAttribute("rfi_frame_excision_enabled").read<bool>());
+        if (dataset.hasAttribute("rfi_frame_excision_thresholds"))
+            meta->set_rfi_frame_excision_thresholds(
+                dataset.getAttribute("rfi_frame_excision_thresholds")
+                    .read<std::vector<std::array<float, 2>>>());
+    }
+
+    /**
+     * @brief Validate the buffer's declared frame descriptor against the file
+     *
+     * This fills in the labels that the config left unset, and is fatal on a structural or
+     * label conflict (see @c Buffer::require_frame_desc).
+     *
+     * @param dataset     The dataset that is being read
+     * @param frame_dims  The shape of ONE frame (see @c set_metadata)
+     */
+    void require_frame_desc_from(const DataSet& dataset,
+                                 const std::vector<std::size_t>& frame_dims) const {
+        const kotekan::DataType value_type =
+            kotekan::string_to_type(dataset.getAttribute("type").read<std::string>());
+        if (value_type == kotekan::unknown_type)
+            FATAL_ERROR("Dataset \"{:s}\" has unknown data type \"{:s}\"", file_name,
+                        dataset.getAttribute("type").read<std::string>());
+        const std::string name = dataset.getAttribute("name").read<std::string>();
+        const auto dim_names = dataset.getAttribute("dim_names").read<std::vector<std::string>>();
+        const auto dim_scalings =
+            dataset.getAttribute("dim_scalings").read<std::vector<std::ptrdiff_t>>();
+        const std::vector<std::ptrdiff_t> dimensions(frame_dims.begin(), frame_dims.end());
+        const std::vector<kotekan::Symbol> dimnames(dim_names.begin(), dim_names.end());
+        const std::vector<std::ptrdiff_t> dimscalings(dim_scalings.begin(), dim_scalings.end());
+        buffer->require_frame_desc(
+            kotekan::GenericNDArray::describe(value_type, name, dimensions, dimnames, dimscalings));
+    }
+
     void main_thread() override {
+        if (read_single_file)
+            read_single_file_frames();
+        else
+            read_per_frame_files();
+    }
+
+    /**
+     * @brief Read one file per frame, with consecutively numbered file names
+     *
+     * Reading stops when a file is missing; a missing file at index 0 is fatal.
+     */
+    void read_per_frame_files() {
         auto& read_time_metric = kotekan::prometheus::Metrics::instance().add_gauge(
             "kotekan_hdf5fileread_read_time_seconds", unique_name);
 
@@ -184,16 +389,8 @@ public:
 
             // Define file name
             std::ostringstream buf;
-            buf << input_dir << "/";
-            if (prefix_hostname) {
-                char hostname[256];
-                gethostname(hostname, sizeof hostname);
-                buf << hostname << "_";
-            }
-            if (prefix_host_rank) {
-                buf << "x" << std::setw(4) << std::setfill('0') << host_pool_rank << "_";
-            }
-            buf << file_name << "." << std::setw(8) << std::setfill('0') << frame_index << ".h5";
+            buf << file_path_prefix() << "." << std::setw(8) << std::setfill('0') << frame_index
+                << ".h5";
             const std::string full_path = buf.str();
 
             // Open HDF5 file
@@ -226,85 +423,17 @@ public:
                 const auto type = dataset.getDataType();
                 const auto dims = space.getDimensions();
 
-                {
-                    const auto metadata_version =
-                        dataset.getAttribute("chord_metadata_version").read<std::array<int, 2>>();
-                    const int major = metadata_version[0];
-                    const int minor = metadata_version[1];
-                    assert(major >= 0);
-                    assert(minor >= 0);
-                    assert(major == chord_metadata_version.at(0));
-                    assert(minor <= chord_metadata_version.at(1));
-                }
+                check_metadata_version(dataset);
 
-                meta->set_name(dataset.getAttribute("name").read<std::string>());
-                meta->type =
-                    kotekan::string_to_type(dataset.getAttribute("type").read<std::string>());
-                meta->dims = space.getNumberDimensions();
-                assert(meta->dims <= CHORD_META_MAX_DIM);
-                const auto dim_names =
-                    dataset.getAttribute("dim_names").read<std::vector<std::string>>();
-                assert(std::ptrdiff_t(dim_names.size()) == meta->dims);
-                const auto dim_scalings =
-                    dataset.getAttribute("dim_scalings").read<std::vector<std::ptrdiff_t>>();
-                assert(std::ptrdiff_t(dim_scalings.size()) == meta->dims);
-                for (int d = 0; d < meta->dims; ++d)
-                    meta->set_array_dimension(d, dims.at(d), dim_names.at(d), dim_scalings.at(d));
-                {
-                    std::ptrdiff_t npoints = 1;
-                    for (int d = meta->dims - 1; d >= 0; --d) {
-                        meta->stride[d] = npoints;
-                        npoints *= meta->dim[d];
-                    }
-                    assert(std::ptrdiff_t(space.getElementCount()) == npoints);
-                }
-                meta->offset = 0;
-
-                if (dataset.hasAttribute("fpga_seq_num"))
-                    meta->set_fpga_seq_num(
-                        dataset.getAttribute("fpga_seq_num").read<std::int64_t>());
-                if (dataset.hasAttribute("time_downsampling_fpga"))
-                    meta->set_time_downsampling_fpga(
-                        dataset.getAttribute("time_downsampling_fpga").read<int>());
-
-                if (dataset.hasAttribute("coarse_freq"))
-                    meta->set_coarse_freq(
-                        dataset.getAttribute("coarse_freq").read<std::vector<int>>());
-                if (dataset.hasAttribute("freq_upchan_factor"))
-                    meta->set_freq_upchan_factor(
-                        dataset.getAttribute("freq_upchan_factor").read<std::vector<int>>());
-                if (dataset.hasAttribute("freq_upchan_index"))
-                    meta->set_freq_upchan_index(
-                        dataset.getAttribute("freq_upchan_index").read<std::vector<int>>());
-
-                if (dataset.hasAttribute("rfi_frame_excision_enabled"))
-                    meta->set_rfi_frame_excision_enabled(
-                        dataset.getAttribute("rfi_frame_excision_enabled").read<bool>());
-                if (dataset.hasAttribute("rfi_frame_excision_thresholds"))
-                    meta->set_rfi_frame_excision_thresholds(
-                        dataset.getAttribute("rfi_frame_excision_thresholds")
-                            .read<std::vector<std::array<float, 2>>>());
+                set_metadata(dataset, meta, dims, 0);
 
                 // Read telescope fields and abort if they don't match
                 check_telescope_metadata(dataset);
 
-                {
-                    /* new style array description */
-                    const kotekan::DataType value_type =
-                        kotekan::string_to_type(dataset.getAttribute("type").read<std::string>());
-                    assert(value_type != kotekan::unknown_type);
-                    const std::string name = dataset.getAttribute("name").read<std::string>();
-
-                    std::vector<std::ptrdiff_t> dimensions(dims.begin(), dims.end());
-                    std::vector<kotekan::Symbol> dimnames(dim_names.begin(), dim_names.end());
-                    std::vector<std::ptrdiff_t> dimscalings(dim_scalings.begin(),
-                                                            dim_scalings.end());
-
-                    buffer->require_frame_desc(kotekan::GenericNDArray::describe(
-                        value_type, name, dimensions, dimnames, dimscalings));
-                    /* test that things are consistent */
-                    meta->check_frame_desc(buffer->get_frame_desc<kotekan::GenericNDArray>());
-                }
+                /* new style array description */
+                require_frame_desc_from(dataset, dims);
+                /* test that things are consistent */
+                meta->check_frame_desc(buffer->get_frame_desc<kotekan::GenericNDArray>());
 
                 // Read buffer
                 DEBUG("[{:s}/{:d}] Filling buffer...", buffer->buffer_name, frame_index);
@@ -327,6 +456,84 @@ public:
             }
 
         } // while !stop_thread
+    }
+
+    /**
+     * @brief Read all frames from a single file, splitting the dataset along axis 0
+     *
+     * The per-frame axis-0 extent is taken from the buffer's declared frame descriptor
+     * because the file only stores the concatenation of all frames. A missing or
+     * unreadable file is always fatal.
+     */
+    void read_single_file_frames() {
+        auto& read_time_metric = kotekan::prometheus::Metrics::instance().add_gauge(
+            "kotekan_hdf5fileread_read_time_seconds", unique_name);
+        const std::string full_path = file_path_prefix() + ".h5";
+        try {
+            const File file(full_path, File::ReadOnly);
+            const auto dataset = file.getDataSet(file_name);
+            const auto type = dataset.getDataType();
+            const auto dims = dataset.getSpace().getDimensions();
+            if (dims.empty())
+                FATAL_ERROR("Dataset \"{:s}\" in {:s} has rank 0", file_name, full_path);
+            check_metadata_version(dataset);
+
+            // One frame's axis-0 extent comes from the destination buffer declaration;
+            // the file only records the concatenation of all frames.
+            const std::size_t frame_dim0 = std::size_t(
+                buffer->require_frame_desc<kotekan::GenericNDArray>()->get_extents().at(0));
+            if (frame_dim0 == 0)
+                FATAL_ERROR("Buffer {:s} declares a zero-length first axis", buffer->buffer_name);
+            std::vector<std::size_t> frame_dims(dims);
+            frame_dims.at(0) = frame_dim0;
+            require_frame_desc_from(dataset, frame_dims); // type, other extents, labels, bytes
+            check_telescope_metadata(dataset);
+
+            const std::int64_t num_frames = std::int64_t(dims.at(0) / frame_dim0);
+            if (dims.at(0) % frame_dim0 != 0)
+                WARN("{:s}: axis 0 ({:d}) is not a multiple of the frame extent ({:d}); "
+                     "ignoring the trailing {:d} samples",
+                     full_path, dims.at(0), frame_dim0, dims.at(0) % frame_dim0);
+            INFO("Reading {:d} frames of {:d} samples each from {:s}", num_frames, frame_dim0,
+                 full_path);
+
+            for (std::int64_t frame_index = 0; frame_index < num_frames; ++frame_index) {
+                if (stop_thread)
+                    break;
+                const int frame_id = int(frame_index % buffer->num_frames);
+                const double t0 = current_time();
+                DEBUG("[{:s}/{:d}] Waiting for buffer...", buffer->buffer_name, frame_index);
+                std::uint8_t* const frame = buffer->wait_for_empty_frame(unique_name, frame_id);
+                if (!frame)
+                    break;
+                buffer->allocate_new_metadata_object(frame_id);
+                const std::shared_ptr<metadataObject> metadata = buffer->get_metadata(frame_id);
+                if (!metadata || !metadata_is_chord(metadata))
+                    FATAL_ERROR("Metadata of buffer \"{:s}\" frame {:d} is not of type CHORD",
+                                buffer->buffer_name, frame_id);
+                const std::shared_ptr<chordMetadata> meta = get_chord_metadata(metadata);
+                set_metadata(dataset, meta, frame_dims, frame_index);
+                meta->check_frame_desc(buffer->get_frame_desc<kotekan::GenericNDArray>());
+
+                // Read this frame's hyperslab
+                DEBUG("[{:s}/{:d}] Filling buffer...", buffer->buffer_name, frame_index);
+                std::vector<std::size_t> offset(dims.size(), 0);
+                offset.at(0) = std::size_t(frame_index) * frame_dim0;
+                dataset.select(offset, frame_dims).read_raw(frame, type);
+
+                DEBUG("[{:s}/{:d}] Marking buffer as full...", buffer->buffer_name, frame_index);
+                buffer->mark_frame_full(unique_name, frame_id);
+                read_time_metric.set(current_time() - t0);
+                if (do_once) {
+                    while (!stop_thread)
+                        sleep(1);
+                    break;
+                }
+            }
+            INFO("Done reading {:d} frames from {:s}", num_frames, full_path);
+        } catch (const HighFive::Exception& ex) {
+            FATAL_ERROR("Could not read HDF5 file {:s}: {:s}", full_path, ex.what());
+        }
     }
 };
 

--- a/lib/stages/hdf5FileRead.cpp
+++ b/lib/stages/hdf5FileRead.cpp
@@ -12,27 +12,30 @@
 #include <bufferContainer.hpp> // for bufferContainer
 #include <cassert>             // for assert
 #include <chordMetadata.hpp>   // for chordMetadata, metadata_is_chord, get_c...
-#include <cstddef>             // for ptrdiff_t
+#include <cstddef>             // for ptrdiff_t, size_t
 #include <cstdint>             // for int64_t, uint8_t
+#include <exception>           // for exception
+#include <filesystem>          // for exists
 #include <fmt/ranges.h>
 #include <functional>                            // for function
-#include <hdf5Files.hpp>                         // for chord_metadata_version
+#include <hdf5Files.hpp>                         // for chord_metadata_version, chord2hdf5, is_...
 #include <highfive/H5Attribute.hpp>              // for Attribute, Attribute::read
 #include <highfive/H5DataSet.hpp>                // for DataSet, AnnotateTraits::getAttribute
 #include <highfive/H5DataSpace.hpp>              // for DataSpace, DataSpace::getDimensions
-#include <highfive/H5Exception.hpp>              // for FileException
+#include <highfive/H5DataType.hpp>               // for DataType
+#include <highfive/H5Exception.hpp>              // for Exception
 #include <highfive/H5File.hpp>                   // for File, File::File, NodeTraits::getDataSet
 #include <highfive/H5Selection.hpp>              // for Selection, SliceTraits::select
 #include <highfive/bits/H5Selection_misc.hpp>    // for Selection::getSpace
 #include <highfive/bits/H5Slice_traits_misc.hpp> // for SliceTraits::read_raw
 #include <iomanip>                               // for operator<<, setfill, setw
-#include <kotekanLogging.hpp>                    // for DEBUG, FATAL_ERROR, ERROR
+#include <kotekanLogging.hpp>                    // for DEBUG, FATAL_ERROR, INFO, WARN
 #include <memory>                                // for allocator, shared_ptr, __shared_ptr_access
 #include <metadata.hpp>                          // for metadataObject
 #include <prometheusMetrics.hpp>                 // for Metrics, Gauge
 #include <sstream>                               // for basic_ostream, operator<<, basic_ostrin...
 #include <string>                                // for basic_string, char_traits, string, oper...
-#include <unistd.h>                              // for gethostname, sleep
+#include <unistd.h>                              // for sleep
 #include <vector>                                // for vector
 #include <visUtil.hpp>                           // for current_time
 
@@ -54,11 +57,18 @@ using namespace HighFive;
  *
  * - Per-frame files (default): one file per frame, named
  *   `<input_dir>/[<hostname>_][x<rank:04d>_]<file_name>.<frame:08d>.h5`. The stage reads
- *   files with consecutive indices starting at 0 until one is missing, then stops
- *   producing frames (the pipeline has to be ended by something else, e.g. a
- *   `testDataCheck*` stage or `num_frames` on a downstream stage).
+ *   files with consecutive indices starting at 0 until one is missing, then logs that at
+ *   INFO and stops producing frames (the pipeline has to be ended by something else, e.g. a
+ *   `testDataCheck*` stage or `num_frames` on a downstream stage). Per-frame files carry
+ *   their own metadata, so this mode places no constraints on the axis order or on the
+ *   sequence numbers of the frames.
  * - Single file (`read_single_file: true`): all frames concatenated along axis 0 of one
  *   dataset in `<input_dir>/[<hostname>_][x<rank:04d>_]<file_name>.h5`.
+ *
+ * In both modes the attributes @c chord_metadata_version, @c name, @c type, @c dim_names
+ * and @c dim_scalings are mandatory (a missing one is fatal, naming the attribute), the
+ * HDF5 storage type of the dataset has to match the declared @c type attribute, and any
+ * HDF5 error while reading is fatal.
  *
  * @par Reading a single file
  * The single-file format stores the metadata attributes only once (they are taken from the
@@ -123,6 +133,10 @@ public:
                   return const_cast<kotekan::Stage&>(stage).main_thread();
               }),
         buffer(get_buffer("out_buf")) {
+    kotekan::prometheus::Gauge& read_time_metric =
+        kotekan::prometheus::Metrics::instance().add_gauge("kotekan_hdf5fileread_read_time_seconds",
+                                                           unique_name);
+
         assert(buffer);
         buffer->register_producer(unique_name);
     }
@@ -227,24 +241,59 @@ public:
     }
 
     /**
-     * @brief The common part of all file names of this stage:
-     *        "<input_dir>/[<hostname>_][x<rank:04d>_]<file_name>"
+     * @brief Abort unless @p dataset has the mandatory attribute @p key
      *
-     * The caller appends the suffix, i.e. ".<frame:08d>.h5" for per-frame files and ".h5"
-     * for a single file.
+     * @param dataset    The dataset that is being read
+     * @param key        The name of the attribute
+     * @param full_path  The file being read, for the error message
      */
-    std::string file_path_prefix() const {
-        std::ostringstream buf;
-        buf << input_dir << "/";
-        if (prefix_hostname) {
-            char hostname[256];
-            gethostname(hostname, sizeof hostname);
-            buf << hostname << "_";
+    void require_attribute(const DataSet& dataset, const std::string& key,
+                           const std::string& full_path) const {
+        if (!dataset.hasAttribute(key))
+            FATAL_ERROR("Dataset \"{:s}\" in {:s} lacks the required attribute \"{:s}\"", file_name,
+                        full_path, key);
+    }
+
+    /**
+     * @brief Abort unless all mandatory attributes are present
+     *
+     * The optional attributes (the frequency mapping, the RFI excision settings, ...) are
+     * guarded by @c hasAttribute where they are read.
+     */
+    void require_attributes(const DataSet& dataset, const std::string& full_path) const {
+        require_attribute(dataset, "chord_metadata_version", full_path);
+        require_attribute(dataset, "name", full_path);
+        require_attribute(dataset, "type", full_path);
+        require_attribute(dataset, "dim_names", full_path);
+        require_attribute(dataset, "dim_scalings", full_path);
+    }
+
+    /**
+     * @brief Abort unless the HDF5 storage type matches the declared @c type attribute
+     *
+     * The @c type attribute names the kotekan data type of the payload, and it is what
+     * determines how the frame is interpreted. Reading the raw bytes of a dataset whose
+     * storage type disagrees with it would silently produce garbage, so a disagreement is
+     * fatal.
+     *
+     * @param dataset     The dataset that is being read
+     * @param value_type  The kotekan type from the @c type attribute
+     */
+    void check_storage_type(const DataSet& dataset, const kotekan::DataType value_type) const {
+        HighFive::DataType expected;
+        try {
+            expected = chord2hdf5(value_type);
+        } catch (const std::exception& ex) {
+            FATAL_ERROR("Dataset \"{:s}\": declared type {:s} has no HDF5 storage type ({:s})",
+                        file_name, kotekan::type_to_string(value_type), ex.what());
         }
-        if (prefix_host_rank)
-            buf << "x" << std::setw(4) << std::setfill('0') << host_pool_rank << "_";
-        buf << file_name;
-        return buf.str();
+        const HighFive::DataType storage = dataset.getDataType();
+        const std::size_t expected_bytes = kotekan::type_total_bytes(value_type);
+        if (storage != expected || storage.getSize() != expected_bytes)
+            FATAL_ERROR("Dataset \"{:s}\": HDF5 storage type ({:d} bytes) does not match the "
+                        "declared type attribute {:s} ({:d} bytes)",
+                        file_name, storage.getSize(), kotekan::type_to_string(value_type),
+                        expected_bytes);
     }
 
     /**
@@ -352,6 +401,7 @@ public:
         const std::vector<kotekan::Symbol> dimnames(dim_names.begin(), dim_names.end());
         const std::vector<std::ptrdiff_t> dimscalings(dim_scalings.begin(), dim_scalings.end());
         buffer->require_frame_desc(
+        check_storage_type(dataset, value_type);
             kotekan::GenericNDArray::describe(value_type, name, dimensions, dimnames, dimscalings));
     }
 
@@ -368,9 +418,6 @@ public:
      * Reading stops when a file is missing; a missing file at index 0 is fatal.
      */
     void read_per_frame_files() {
-        auto& read_time_metric = kotekan::prometheus::Metrics::instance().add_gauge(
-            "kotekan_hdf5fileread_read_time_seconds", unique_name);
-
         for (int frame_index = 0;; ++frame_index) {
             const int frame_id = frame_index % buffer->num_frames;
 
@@ -389,8 +436,9 @@ public:
 
             // Define file name
             std::ostringstream buf;
-            buf << file_path_prefix() << "." << std::setw(8) << std::setfill('0') << frame_index
-                << ".h5";
+            buf << hdf5::file_path_prefix(input_dir, file_name, prefix_hostname, prefix_host_rank,
+                                          host_pool_rank)
+                << "." << std::setw(8) << std::setfill('0') << frame_index << ".h5";
             const std::string full_path = buf.str();
 
             // Open HDF5 file
@@ -401,6 +449,17 @@ public:
                 DEBUG("[{:s}/{:d}] Waiting for buffer...", buffer->buffer_name, frame_index);
                 std::uint8_t* const frame = buffer->wait_for_empty_frame(unique_name, frame_id);
                 if (!frame)
+            // Stop at the first missing file. The very first file has to exist; see the
+            // note about sessions in the class documentation.
+            if (!std::filesystem::exists(full_path)) {
+                if (frame_index == 0)
+                    FATAL_ERROR("Could not open HDF5 file {:s}: no such file", full_path);
+                INFO("No more input files ({:s} does not exist) after {:d} frames, terminating "
+                     "reader",
+                     full_path, frame_index);
+                break;
+            }
+
                     break;
 
                 // Read metadata (attributes)
@@ -431,6 +490,7 @@ public:
                 check_telescope_metadata(dataset);
 
                 /* new style array description */
+                require_attributes(dataset, full_path);
                 require_frame_desc_from(dataset, dims);
                 /* test that things are consistent */
                 meta->check_frame_desc(buffer->get_frame_desc<kotekan::GenericNDArray>());
@@ -447,12 +507,8 @@ public:
                 const double t1 = current_time();
                 const double elapsed = t1 - t0;
                 read_time_metric.set(elapsed);
-            } catch (const FileException& ex) {
-                if (frame_index == 0)
-                    FATAL_ERROR("Could not open HDF5 file {:s}: {:s}", full_path, ex.what());
-                else
-                    ERROR("Could not open HDF5 file {:s}, terminating reader", full_path);
-                break;
+            } catch (const HighFive::Exception& ex) {
+                FATAL_ERROR("Could not read HDF5 file {:s}: {:s}", full_path, ex.what());
             }
 
         } // while !stop_thread
@@ -466,9 +522,9 @@ public:
      * unreadable file is always fatal.
      */
     void read_single_file_frames() {
-        auto& read_time_metric = kotekan::prometheus::Metrics::instance().add_gauge(
-            "kotekan_hdf5fileread_read_time_seconds", unique_name);
-        const std::string full_path = file_path_prefix() + ".h5";
+        const std::string full_path = hdf5::file_path_prefix(input_dir, file_name, prefix_hostname,
+                                                             prefix_host_rank, host_pool_rank)
+                                      + ".h5";
         try {
             const File file(full_path, File::ReadOnly);
             const auto dataset = file.getDataSet(file_name);
@@ -484,6 +540,7 @@ public:
                 buffer->require_frame_desc<kotekan::GenericNDArray>()->get_extents().at(0));
             if (frame_dim0 == 0)
                 FATAL_ERROR("Buffer {:s} declares a zero-length first axis", buffer->buffer_name);
+            require_attributes(dataset, full_path);
             std::vector<std::size_t> frame_dims(dims);
             frame_dims.at(0) = frame_dim0;
             require_frame_desc_from(dataset, frame_dims); // type, other extents, labels, bytes

--- a/lib/stages/hdf5FileRead.cpp
+++ b/lib/stages/hdf5FileRead.cpp
@@ -79,7 +79,14 @@ using namespace HighFive;
  *   config (all other extents, the value type and the labels must match the file);
  * - `fpga_seq_num(i) = fpga_seq_num + i * extents[0] * time_downsampling_fpga`, using a
  *   downsampling factor of 1 if the attribute is absent;
- * - the number of frames is `axis0 / extents[0]`; a remainder is reported and ignored.
+ * - the number of frames is `axis0 / extents[0]`; a remainder is reported and ignored, but
+ *   a dataset holding less than one frame is fatal.
+ *
+ * That reconstruction is only valid for the contiguous, uniformly sampled stream that
+ * @c hdf5FileWrite enforces for `create_single_file`, so this mode additionally requires
+ * (fatal otherwise) that dimension 0 is a time axis (its name starts with "T") and that
+ * `dim_scalings[0]` equals @c time_downsampling_fpga (1 if that attribute is absent).
+ * Data that does not satisfy this has to be written and read as per-frame files.
  *
  * @par Sessions
  * The writer must have finished before the reader starts: run the two in separate kotekan
@@ -102,7 +109,8 @@ using namespace HighFive;
  *                              @c file_name, using @c frequency_pool_rank.
  * @conf  frequency_pool_rank   Int. Default: 0. The rank used by @c prefix_host_rank.
  * @conf  do_once               Bool. Default: false. Read only the first frame and then
- *                              idle instead of reading the whole input.
+ *                              idle instead of reading the whole input. The stage never
+ *                              ends the pipeline in that case.
  * @conf  read_single_file      Bool. Default: false. Read all frames from a single file
  *                              instead of one file per frame; see above.
  * @conf  num_polarizations     Int. Required. Cross-checked against the file.
@@ -125,6 +133,10 @@ class hdf5FileRead : public kotekan::Stage {
 
     Buffer* const buffer;
 
+    kotekan::prometheus::Gauge& read_time_metric =
+        kotekan::prometheus::Metrics::instance().add_gauge("kotekan_hdf5fileread_read_time_seconds",
+                                                           unique_name);
+
 public:
     hdf5FileRead(kotekan::Config& config, const std::string& unique_name,
                  kotekan::bufferContainer& buffer_container) :
@@ -133,10 +145,6 @@ public:
                   return const_cast<kotekan::Stage&>(stage).main_thread();
               }),
         buffer(get_buffer("out_buf")) {
-    kotekan::prometheus::Gauge& read_time_metric =
-        kotekan::prometheus::Metrics::instance().add_gauge("kotekan_hdf5fileread_read_time_seconds",
-                                                           unique_name);
-
         assert(buffer);
         buffer->register_producer(unique_name);
     }
@@ -393,6 +401,7 @@ public:
         if (value_type == kotekan::unknown_type)
             FATAL_ERROR("Dataset \"{:s}\" has unknown data type \"{:s}\"", file_name,
                         dataset.getAttribute("type").read<std::string>());
+        check_storage_type(dataset, value_type);
         const std::string name = dataset.getAttribute("name").read<std::string>();
         const auto dim_names = dataset.getAttribute("dim_names").read<std::vector<std::string>>();
         const auto dim_scalings =
@@ -401,7 +410,6 @@ public:
         const std::vector<kotekan::Symbol> dimnames(dim_names.begin(), dim_names.end());
         const std::vector<std::ptrdiff_t> dimscalings(dim_scalings.begin(), dim_scalings.end());
         buffer->require_frame_desc(
-        check_storage_type(dataset, value_type);
             kotekan::GenericNDArray::describe(value_type, name, dimensions, dimnames, dimscalings));
     }
 
@@ -441,14 +449,6 @@ public:
                 << "." << std::setw(8) << std::setfill('0') << frame_index << ".h5";
             const std::string full_path = buf.str();
 
-            // Open HDF5 file
-            try {
-                const File file(full_path, File::ReadOnly);
-
-                // Wait for buffer
-                DEBUG("[{:s}/{:d}] Waiting for buffer...", buffer->buffer_name, frame_index);
-                std::uint8_t* const frame = buffer->wait_for_empty_frame(unique_name, frame_id);
-                if (!frame)
             // Stop at the first missing file. The very first file has to exist; see the
             // note about sessions in the class documentation.
             if (!std::filesystem::exists(full_path)) {
@@ -460,6 +460,14 @@ public:
                 break;
             }
 
+            // Open HDF5 file
+            try {
+                const File file(full_path, File::ReadOnly);
+
+                // Wait for buffer
+                DEBUG("[{:s}/{:d}] Waiting for buffer...", buffer->buffer_name, frame_index);
+                std::uint8_t* const frame = buffer->wait_for_empty_frame(unique_name, frame_id);
+                if (!frame)
                     break;
 
                 // Read metadata (attributes)
@@ -482,6 +490,7 @@ public:
                 const auto type = dataset.getDataType();
                 const auto dims = space.getDimensions();
 
+                require_attributes(dataset, full_path);
                 check_metadata_version(dataset);
 
                 set_metadata(dataset, meta, dims, 0);
@@ -490,7 +499,6 @@ public:
                 check_telescope_metadata(dataset);
 
                 /* new style array description */
-                require_attributes(dataset, full_path);
                 require_frame_desc_from(dataset, dims);
                 /* test that things are consistent */
                 meta->check_frame_desc(buffer->get_frame_desc<kotekan::GenericNDArray>());
@@ -532,6 +540,7 @@ public:
             const auto dims = dataset.getSpace().getDimensions();
             if (dims.empty())
                 FATAL_ERROR("Dataset \"{:s}\" in {:s} has rank 0", file_name, full_path);
+            require_attributes(dataset, full_path);
             check_metadata_version(dataset);
 
             // One frame's axis-0 extent comes from the destination buffer declaration;
@@ -540,13 +549,36 @@ public:
                 buffer->require_frame_desc<kotekan::GenericNDArray>()->get_extents().at(0));
             if (frame_dim0 == 0)
                 FATAL_ERROR("Buffer {:s} declares a zero-length first axis", buffer->buffer_name);
-            require_attributes(dataset, full_path);
             std::vector<std::size_t> frame_dims(dims);
             frame_dims.at(0) = frame_dim0;
             require_frame_desc_from(dataset, frame_dims); // type, other extents, labels, bytes
             check_telescope_metadata(dataset);
 
+            // Splitting the dataset into frames and reconstructing their fpga_seq_num is only
+            // valid for the contiguous, uniformly sampled time axis that hdf5FileWrite
+            // enforces for create_single_file.
+            const auto dim_names =
+                dataset.getAttribute("dim_names").read<std::vector<std::string>>();
+            const auto dim_scalings =
+                dataset.getAttribute("dim_scalings").read<std::vector<std::ptrdiff_t>>();
+            if (dim_names.empty() || !is_time_axis(dim_names.at(0)))
+                FATAL_ERROR("{:s}: read_single_file requires a time axis as dimension 0, but "
+                            "dimension 0 is \"{:s}\"",
+                            full_path, dim_names.empty() ? std::string() : dim_names.at(0));
+            const std::int64_t tds =
+                dataset.hasAttribute("time_downsampling_fpga")
+                    ? dataset.getAttribute("time_downsampling_fpga").read<int>()
+                    : 1;
+            if (dim_scalings.at(0) != tds)
+                FATAL_ERROR("{:s}: dim_scalings[0] ({:d}) != time_downsampling_fpga ({:d}); cannot "
+                            "reconstruct per-frame fpga_seq_num",
+                            full_path, dim_scalings.at(0), tds);
+
             const std::int64_t num_frames = std::int64_t(dims.at(0) / frame_dim0);
+            if (num_frames == 0)
+                FATAL_ERROR("{:s}: dataset holds {:d} samples along axis 0, fewer than one frame "
+                            "({:d})",
+                            full_path, dims.at(0), frame_dim0);
             if (dims.at(0) % frame_dim0 != 0)
                 WARN("{:s}: axis 0 ({:d}) is not a multiple of the frame extent ({:d}); "
                      "ignoring the trailing {:d} samples",
@@ -582,9 +614,11 @@ public:
                 buffer->mark_frame_full(unique_name, frame_id);
                 read_time_metric.set(current_time() - t0);
                 if (do_once) {
+                    INFO("do_once is set: read frame 0 of {:d} from {:s}, now idling", num_frames,
+                         full_path);
                     while (!stop_thread)
                         sleep(1);
-                    break;
+                    return;
                 }
             }
             INFO("Done reading {:d} frames from {:s}", num_frames, full_path);

--- a/lib/stages/hdf5FileReadSingleFile.cpp
+++ b/lib/stages/hdf5FileReadSingleFile.cpp
@@ -47,7 +47,7 @@ using namespace HighFive;
  * @c int4x2_swapped_withoffset), selects a subset of the frequency channels, and hands the
  * data out one frame of @c num_times time samples at a time. It can transpose time and
  * frequency and combine the dish and polarization axes into a single element axis, as the
- * CHIME F-engine pipeline expects. Anything that does not match these expectations is
+ * CHIME X-engine pipeline expects. Anything that does not match these expectations is
  * fatal.
  *
  * This stage is NOT a general replay path for the files written by @c hdf5FileWrite: use
@@ -97,6 +97,10 @@ public:
                            kotekan::bufferContainer& buffer_container) :
         Stage(config, unique_name, buffer_container,
               [](const kotekan::Stage& stage) {
+    kotekan::prometheus::Gauge& read_time_metric =
+        kotekan::prometheus::Metrics::instance().add_gauge(
+            "kotekan_hdf5filereadsinglefile_read_time_seconds", unique_name);
+
                   return const_cast<kotekan::Stage&>(stage).main_thread();
               }),
         buffer(get_buffer("out_buf")) {
@@ -107,9 +111,6 @@ public:
     virtual ~hdf5FileReadSingleFile() {}
 
     void main_thread() override {
-        auto& read_time_metric = kotekan::prometheus::Metrics::instance().add_gauge(
-            "kotekan_hdf5filereadsinglefile_read_time_seconds", unique_name);
-
         // Define file name
         std::ostringstream buf;
         buf << input_dir << "/" << file_name << ".h5";

--- a/lib/stages/hdf5FileReadSingleFile.cpp
+++ b/lib/stages/hdf5FileReadSingleFile.cpp
@@ -50,6 +50,11 @@ using namespace HighFive;
  * CHIME X-engine pipeline expects. Anything that does not match these expectations is
  * fatal.
  *
+ * Time downsampling is supported as long as the file is self-consistent: the time axis'
+ * @c dim_scalings entry has to equal the @c time_downsampling_fpga attribute (1 if that
+ * attribute is absent), because the per-frame @c fpga_seq_num is reconstructed as
+ * `fpga_seq_num + frame_index * num_times * time_downsampling_fpga`.
+ *
  * This stage is NOT a general replay path for the files written by @c hdf5FileWrite: use
  * @c hdf5FileRead (with @c read_single_file for a single file) for any other data type,
  * rank, or axis order. Unlike @c hdf5FileRead, this stage never ends the pipeline; it
@@ -92,15 +97,15 @@ class hdf5FileReadSingleFile : public kotekan::Stage {
 
     Buffer* const buffer;
 
+    kotekan::prometheus::Gauge& read_time_metric =
+        kotekan::prometheus::Metrics::instance().add_gauge(
+            "kotekan_hdf5filereadsinglefile_read_time_seconds", unique_name);
+
 public:
     hdf5FileReadSingleFile(kotekan::Config& config, const std::string& unique_name,
                            kotekan::bufferContainer& buffer_container) :
         Stage(config, unique_name, buffer_container,
               [](const kotekan::Stage& stage) {
-    kotekan::prometheus::Gauge& read_time_metric =
-        kotekan::prometheus::Metrics::instance().add_gauge(
-            "kotekan_hdf5filereadsinglefile_read_time_seconds", unique_name);
-
                   return const_cast<kotekan::Stage&>(stage).main_thread();
               }),
         buffer(get_buffer("out_buf")) {
@@ -252,9 +257,13 @@ public:
                 FATAL_ERROR("Dataset \"{:s}\": dimension 0 is named \"{:s}\", but "
                             "hdf5FileReadSingleFile requires the time axis \"T\" there",
                             file_name, dim_names.at(0));
-            if (dim_scalings.at(0) != 1)
-                FATAL_ERROR("Dataset \"{:s}\": the time axis has dim_scaling {:d}, expected 1",
-                            file_name, dim_scalings.at(0));
+            // The per-frame fpga_seq_num is reconstructed as
+            // fpga_seq_num + frame_index * num_times * time_downsampling_fpga, which is only
+            // correct if the time axis is sampled at the downsampling rate of the file.
+            if (dim_scalings.at(0) != time_downsampling_fpga)
+                FATAL_ERROR("Dataset \"{:s}\": the time axis has dim_scaling {:d} but "
+                            "time_downsampling_fpga is {:d}",
+                            file_name, dim_scalings.at(0), time_downsampling_fpga);
             const std::ptrdiff_t available_num_times = dims.at(0);
             const std::ptrdiff_t available_num_frames = available_num_times / num_times;
             INFO("This file has {} time samples", available_num_times);

--- a/lib/stages/hdf5FileReadSingleFile.cpp
+++ b/lib/stages/hdf5FileReadSingleFile.cpp
@@ -1,5 +1,5 @@
 #include "Config.hpp"            // for Config
-#include "DataType.hpp"          // for string_to_type, DataType
+#include "DataType.hpp"          // for string_to_type, type_to_string, DataType
 #include "NDArray.hpp"           // for GenericNDArray
 #include "Stage.hpp"             // for Stage
 #include "StageFactory.hpp"      // for REGISTER_KOTEKAN_STAGE
@@ -17,17 +17,18 @@
 #include <algorithm>                          // for minmax_element, copy, find
 #include <cassert>                            // for assert
 #include <cstddef>                            // for size_t, ptrdiff_t
-#include <cstdint>                            // for uint8_t
+#include <cstdint>                            // for int64_t, uint8_t
 #include <cstring>                            // for memchr, memcpy, memset
 #include <functional>                         // for function
 #include <highfive/H5Attribute.hpp>           // for Attribute, Attribute::read
 #include <highfive/H5DataSet.hpp>             // for DataSet, AnnotateTraits::getAttribute, Dat...
 #include <highfive/H5DataSpace.hpp>           // for DataSpace, DataSpace::getDimensions
-#include <highfive/H5Exception.hpp>           // for FileException
+#include <highfive/H5Exception.hpp>           // for Exception
 #include <highfive/H5File.hpp>                // for File, File::File, NodeTraits::getDataSet
 #include <highfive/H5Selection.hpp>           // for Selection, SliceTraits::read_raw, SliceTra...
 #include <highfive/bits/H5Selection_misc.hpp> // for Selection::getSpace
 #include <memory>                             // for allocator, __shared_ptr_access, shared_ptr
+#include <optional>                           // for optional
 #include <sstream>                            // for basic_ostream, operator<<, basic_ostringst...
 #include <string>                             // for basic_string, string, char_traits, operator==
 #include <unistd.h>                           // for sleep
@@ -37,6 +38,46 @@
 using namespace hdf5;
 using namespace HighFive;
 
+/**
+ * @class hdf5FileReadSingleFile
+ * @brief Replay CHIME/F-engine voltage data from a single HDF5 file.
+ *
+ * This is a special-purpose reader for baseband voltages: it reads one dataset holding all
+ * time samples of a recording (rank 4, `[T, F, ...]`, element type
+ * @c int4x2_swapped_withoffset), selects a subset of the frequency channels, and hands the
+ * data out one frame of @c num_times time samples at a time. It can transpose time and
+ * frequency and combine the dish and polarization axes into a single element axis, as the
+ * CHIME F-engine pipeline expects. Anything that does not match these expectations is
+ * fatal.
+ *
+ * This stage is NOT a general replay path for the files written by @c hdf5FileWrite: use
+ * @c hdf5FileRead (with @c read_single_file for a single file) for any other data type,
+ * rank, or axis order. Unlike @c hdf5FileRead, this stage never ends the pipeline; it
+ * idles after the last frame until kotekan is stopped, so something else has to shut the
+ * pipeline down.
+ *
+ * @par Buffers
+ * @buffer out_buf Buffer to fill with the voltage frames
+ *         @buffer_format any format, declared as `kotekan_buffer: ndarray`
+ *         @buffer_metadata chordMetadata
+ *
+ * @conf  input_dir             String. Required. Directory holding the input file.
+ * @conf  file_name             String. Required. The file is `<input_dir>/<file_name>.h5`,
+ *                              and @c file_name is also the name of the dataset in it.
+ * @conf  frequency_channels    Vector of ints. Required. The coarse frequency channels to
+ *                              read, in the order they should appear in the frames. Every
+ *                              one of them has to be present in the file's @c coarse_freq.
+ * @conf  num_times             Int. Required. Number of time samples per frame. The file
+ *                              provides `floor(T / num_times)` frames.
+ * @conf  combine_dishes_and_polarizations  Bool. Default: false. Merge the last two axes
+ *                              of the file into one axis named "E" (for CHIME).
+ * @conf  transpose_frequency_and_time  Bool. Default: false. Emit frequency before time
+ *                              instead of time before frequency (for CHIME).
+ *
+ * @par Metrics
+ * @metric kotekan_hdf5filereadsinglefile_read_time_seconds Time required to read the last
+ *         frame.
+ */
 class hdf5FileReadSingleFile : public kotekan::Stage {
     const std::string input_dir = config.get<std::string>(unique_name, "input_dir");
     const std::string file_name = config.get<std::string>(unique_name, "file_name");
@@ -90,28 +131,54 @@ public:
             const auto name = dataset.getAttribute("name").read<std::string>();
             const auto type =
                 kotekan::string_to_type(dataset.getAttribute("type").read<std::string>());
-            assert(type == kotekan::int4x2_swapped_withoffset);
+            if (type != kotekan::int4x2_swapped_withoffset)
+                FATAL_ERROR("hdf5FileReadSingleFile reads only int4x2_swapped_withoffset voltage "
+                            "files (got {:s}); use hdf5FileRead with read_single_file for other "
+                            "data",
+                            kotekan::type_to_string(type));
             const auto dim_names =
                 dataset.getAttribute("dim_names").read<std::vector<std::string>>();
             const auto dim_scalings =
                 dataset.getAttribute("dim_scalings").read<std::vector<std::ptrdiff_t>>();
 
+            // The frequency mapping is required: this stage selects frequency channels
+            const auto require_attribute = [&](const std::string& key) {
+                if (!dataset.hasAttribute(key))
+                    FATAL_ERROR("Dataset \"{:s}\" in {:s} does not have the required attribute "
+                                "{:s}; hdf5FileReadSingleFile needs the frequency mapping of the "
+                                "voltage file",
+                                file_name, full_path, key);
+            };
+            require_attribute("coarse_freq");
+            require_attribute("freq_upchan_factor");
+            require_attribute("freq_upchan_index");
             const auto coarse_freq = dataset.getAttribute("coarse_freq").read<std::vector<int>>();
             const auto freq_upchan_factor =
                 dataset.getAttribute("freq_upchan_factor").read<std::vector<int>>();
             const auto freq_upchan_index =
                 dataset.getAttribute("freq_upchan_index").read<std::vector<int>>();
 
-            const auto time_downsampling_fpga =
-                dataset.getAttribute("time_downsampling_fpga").read<int>();
-            const auto fpga_seq_num = dataset.getAttribute("fpga_seq_num").read<int>();
-            const auto seq_length_nsec [[maybe_unused]] =
-                dataset.getAttribute("seq_length_nsec").read<double>();
+            const int time_downsampling_fpga =
+                dataset.hasAttribute("time_downsampling_fpga")
+                    ? dataset.getAttribute("time_downsampling_fpga").read<int>()
+                    : 1;
+            const std::optional<std::int64_t> fpga_seq_num =
+                dataset.hasAttribute("fpga_seq_num")
+                    ? std::optional<std::int64_t>(
+                          dataset.getAttribute("fpga_seq_num").read<std::int64_t>())
+                    : std::nullopt;
 
             // Convert dimensions
-            assert(dims.size() == 4);
-            assert(dim_names.size() == 4);
-            assert(dim_scalings.size() == 4);
+            if (dims.size() != 4)
+                FATAL_ERROR("Dataset \"{:s}\" in {:s} has rank {:d}, but hdf5FileReadSingleFile "
+                            "reads only rank-4 voltage data",
+                            file_name, full_path, dims.size());
+            if (dim_names.size() != 4)
+                FATAL_ERROR("Dataset \"{:s}\": attribute dim_names has {:d} entries, expected 4",
+                            file_name, dim_names.size());
+            if (dim_scalings.size() != 4)
+                FATAL_ERROR("Dataset \"{:s}\": attribute dim_scalings has {:d} entries, expected 4",
+                            file_name, dim_scalings.size());
             std::vector<std::ptrdiff_t> new_dims;
             std::vector<kotekan::Symbol> new_dim_names;
             std::vector<std::ptrdiff_t> new_dim_scalings;
@@ -148,8 +215,13 @@ public:
             }
 
             // Find which frequencies to read
-            assert(std::string(dim_names.at(1)) == "F");
-            assert(dim_scalings.at(1) == 1);
+            if (dim_names.at(1) != "F")
+                FATAL_ERROR("Dataset \"{:s}\": dimension 1 is named \"{:s}\", but "
+                            "hdf5FileReadSingleFile requires the frequency axis \"F\" there",
+                            file_name, dim_names.at(1));
+            if (dim_scalings.at(1) != 1)
+                FATAL_ERROR("Dataset \"{:s}\": the frequency axis has dim_scaling {:d}, expected 1",
+                            file_name, dim_scalings.at(1));
             INFO("This file has {} frequencies", dims.at(1));
             INFO("Will read {} frequencies", frequency_channels.size());
             std::vector<int> frequency_indices(frequency_channels.size());
@@ -157,7 +229,10 @@ public:
                 const int frequency_channel = frequency_channels.at(n);
                 const auto frequency_index_iter =
                     std::find(coarse_freq.begin(), coarse_freq.end(), frequency_channel);
-                assert(frequency_index_iter != coarse_freq.end());
+                if (frequency_index_iter == coarse_freq.end())
+                    FATAL_ERROR("Frequency channel {:d} is not in the coarse_freq attribute of "
+                                "dataset \"{:s}\" in {:s}",
+                                frequency_channel, file_name, full_path);
                 const int frequency_index = frequency_index_iter - coarse_freq.begin();
                 frequency_indices.at(n) = frequency_index;
                 INFO("   local array index {}, file dataset index {}, channel {}", n,
@@ -172,8 +247,13 @@ public:
             }
 
             // Calculate available number of frames
-            assert(std::string(dim_names.at(0)) == "T");
-            assert(dim_scalings.at(0) == 1);
+            if (dim_names.at(0) != "T")
+                FATAL_ERROR("Dataset \"{:s}\": dimension 0 is named \"{:s}\", but "
+                            "hdf5FileReadSingleFile requires the time axis \"T\" there",
+                            file_name, dim_names.at(0));
+            if (dim_scalings.at(0) != 1)
+                FATAL_ERROR("Dataset \"{:s}\": the time axis has dim_scaling {:d}, expected 1",
+                            file_name, dim_scalings.at(0));
             const std::ptrdiff_t available_num_times = dims.at(0);
             const std::ptrdiff_t available_num_frames = available_num_times / num_times;
             INFO("This file has {} time samples", available_num_times);
@@ -210,7 +290,9 @@ public:
                 meta->set_freq_upchan_index(new_freq_upchan_index);
 
                 meta->set_time_downsampling_fpga(time_downsampling_fpga);
-                meta->set_fpga_seq_num(fpga_seq_num + 1LL * frame_index * num_times);
+                if (fpga_seq_num)
+                    meta->set_fpga_seq_num(
+                        *fpga_seq_num + 1LL * frame_index * num_times * time_downsampling_fpga);
 
                 // Poison buffer
                 const std::uint8_t voltage_poison = 0x00;
@@ -264,8 +346,8 @@ public:
 
             DEBUG("Done reading frames.");
 
-        } catch (const FileException& ex) {
-            FATAL_ERROR("Could not open HDF5 file {:s}: {:s}", full_path, ex.what());
+        } catch (const HighFive::Exception& ex) {
+            FATAL_ERROR("Could not read HDF5 file {:s}: {:s}", full_path, ex.what());
         }
 
         // Wait for shutdown (don't trigger a shutdown)

--- a/lib/stages/hdf5FileWrite.cpp
+++ b/lib/stages/hdf5FileWrite.cpp
@@ -70,11 +70,15 @@ using namespace HighFive;
  * @conf prefix_host_rank  Bool. Prepend rank to output file names. Default: false.
  * @conf frequency_pool_rank    Int. This stage's rank in the frequency pool.
  * @conf frequency_pool_size    Int. Number of stages in the frequency pool.
- * @conf max_frames  Int. Stop writing after this many frames, Default 0 = unlimited
- *       frames.
+ * @conf max_frames  Int. Default: -1 = unlimited; N >= 0 stops after N frames and
+ *       shuts kotekan down.
  * @conf skip_writing  Bool. Do not actually write anything. Default:
  *       false.
- * @conf create_single_file Bool. Write all data to one single file.
+ * @conf use_compression  Bool. Default: true. bitshuffle+zstd (filter 32008).
+ * @conf create_single_file Bool. Write all data to one single file. Only supported for
+ *       chord metadata. Note that this stores the metadata attributes only once (from
+ *       the first frame), so the per-frame metadata and the frame boundary are not
+ *       preserved; see hdf5FileRead for how they are reconstructed when replaying.
  * @conf write_x_frames  Int. Write the first X out of every Y frames (see per_y_frames).
  *       Default: -1 (disabled).
  * @conf per_y_frames  Int. Period Y for frame decimation (see write_x_frames).

--- a/lib/stages/hdf5FileWrite.cpp
+++ b/lib/stages/hdf5FileWrite.cpp
@@ -47,7 +47,6 @@
 #include <string.h>                              // for strerror
 #include <string>                                // for basic_string, char_traits, string, oper...
 #include <sys/stat.h>                            // for mkdir
-#include <unistd.h>                              // for gethostname
 #include <vector>                                // for vector
 
 
@@ -127,6 +126,10 @@ public:
               }),
         buffer(get_buffer("in_buf")) {
 
+    kotekan::prometheus::Gauge& write_time_metric =
+        kotekan::prometheus::Metrics::instance().add_gauge(
+            "kotekan_hdf5filewrite_write_time_seconds", unique_name);
+
         if (max_frames >= 0)
             ++waiting_for_max_frames;
 
@@ -140,16 +143,8 @@ public:
     std::shared_ptr<File> create_file(const std::int64_t frame_counter) const {
         // Define file name
         std::ostringstream buf;
-        buf << base_dir << "/";
-        if (prefix_hostname) {
-            char hostname[256];
-            gethostname(hostname, sizeof hostname);
-            buf << hostname << "_";
-        }
-        if (prefix_host_rank) {
-            buf << "x" << std::setw(4) << std::setfill('0') << host_pool_rank << "_";
-        }
-        buf << file_name;
+        buf << hdf5::file_path_prefix(base_dir, file_name, prefix_hostname, prefix_host_rank,
+                                      host_pool_rank);
         if (create_single_file) {
             // Do not include the frame counter when all output is written to a single file
             if (frame_counter >= 0)
@@ -552,9 +547,6 @@ public:
      * This function is responsible for the main logic of the hdf5FileWrite class.
      */
     void main_thread() override {
-        auto& write_time_metric = kotekan::prometheus::Metrics::instance().add_gauge(
-            "kotekan_hdf5filewrite_write_time_seconds", unique_name);
-
         const double start_time = current_time();
 
         for (std::int64_t frame_counter = 0;; ++frame_counter) {

--- a/lib/stages/hdf5FileWrite.cpp
+++ b/lib/stages/hdf5FileWrite.cpp
@@ -69,19 +69,28 @@ using namespace HighFive;
  * @conf prefix_host_rank  Bool. Prepend rank to output file names. Default: false.
  * @conf frequency_pool_rank    Int. This stage's rank in the frequency pool.
  * @conf frequency_pool_size    Int. Number of stages in the frequency pool.
- * @conf max_frames  Int. Default: -1 = unlimited; N >= 0 stops after N frames and
- *       shuts kotekan down.
+ * @conf max_frames  Int. Default: -1. Values <= 0 mean unlimited; N > 0 stops after N
+ *       frames and shuts kotekan down.
  * @conf skip_writing  Bool. Do not actually write anything. Default:
  *       false.
  * @conf use_compression  Bool. Default: true. bitshuffle+zstd (filter 32008).
- * @conf create_single_file Bool. Write all data to one single file. Only supported for
- *       chord metadata. Note that this stores the metadata attributes only once (from
- *       the first frame), so the per-frame metadata and the frame boundary are not
- *       preserved; see hdf5FileRead for how they are reconstructed when replaying.
+ * @conf create_single_file Bool. Default: false. Write all data to one single file,
+ *       concatenating the frames along axis 0. Only supported for chord metadata. The
+ *       metadata attributes are stored only once (from the first frame), so neither the
+ *       per-frame metadata nor the frame boundary is on disk; see hdf5FileRead for how
+ *       they are reconstructed when replaying. Because of that a single file must hold a
+ *       contiguous, uniformly sampled stream, which is enforced here (fatal otherwise):
+ *       - dimension 0 must be a time axis (its name starts with "T");
+ *       - `dim_scaling[0]` must equal `time_downsampling_fpga` (1 if that is not set);
+ *       - consecutive frames must advance `fpga_seq_num` by exactly
+ *         `dim[0] * time_downsampling_fpga`, and must not change the frame shape;
+ *       - frame decimation (@c write_x_frames / @c per_y_frames) must not be used.
+ *       A writer whose buffer violates one of these has to use per-frame files
+ *       (`create_single_file: false`), which have no such constraints.
  * @conf write_x_frames  Int. Write the first X out of every Y frames (see per_y_frames).
- *       Default: -1 (disabled).
+ *       Default: -1 (disabled). Cannot be combined with @c create_single_file.
  * @conf per_y_frames  Int. Period Y for frame decimation (see write_x_frames).
- *       Default: -1 (disabled).
+ *       Default: -1 (disabled). Cannot be combined with @c create_single_file.
  *
  * @par Metrics
  * @metric kotekan_hdf5filewrite_write_time_seconds
@@ -117,6 +126,17 @@ class hdf5FileWrite : public kotekan::Stage {
 
     std::shared_ptr<File> the_single_file;
 
+    // The state of the single-file stream: the shape and time downsampling of the first frame,
+    // and the fpga_seq_num the next frame has to start at. See the checks in write_chord.
+    std::size_t single_file_dim0 = 0;
+    std::int64_t single_file_tds = 0;
+    bool single_file_has_seq = false;
+    std::int64_t single_file_next_seq = 0;
+
+    kotekan::prometheus::Gauge& write_time_metric =
+        kotekan::prometheus::Metrics::instance().add_gauge(
+            "kotekan_hdf5filewrite_write_time_seconds", unique_name);
+
 public:
     hdf5FileWrite(kotekan::Config& config, const std::string& unique_name,
                   kotekan::bufferContainer& buffer_container) :
@@ -126,11 +146,13 @@ public:
               }),
         buffer(get_buffer("in_buf")) {
 
-    kotekan::prometheus::Gauge& write_time_metric =
-        kotekan::prometheus::Metrics::instance().add_gauge(
-            "kotekan_hdf5filewrite_write_time_seconds", unique_name);
+        if (create_single_file && write_x_frames >= 0 && per_y_frames > 0)
+            FATAL_ERROR("hdf5FileWrite {:s}: write_x_frames/per_y_frames (frame decimation) cannot "
+                        "be combined with create_single_file; a single file must hold a contiguous "
+                        "stream",
+                        unique_name);
 
-        if (max_frames >= 0)
+        if (max_frames > 0)
             ++waiting_for_max_frames;
 
         buffer->register_consumer(unique_name);
@@ -247,6 +269,48 @@ public:
             do_create_dataset = true;
         }
         auto& file = *fileptr;
+
+        if (create_single_file) {
+            // A single file concatenates frames along axis 0 and stores the metadata only once,
+            // so hdf5FileRead can only reconstruct the per-frame fpga_seq_num if axis 0 is a
+            // contiguous, uniformly sampled time axis.
+            const std::string dim0_name = meta->get_dimension_name(0);
+            if (!is_time_axis(dim0_name))
+                FATAL_ERROR("Buffer \"{:s}\": create_single_file requires a time axis as dimension "
+                            "0, but dimension 0 is \"{:s}\"; set create_single_file: false for "
+                            "this writer",
+                            buffer->buffer_name, dim0_name);
+            const std::int64_t tds =
+                meta->has_time_downsampling_fpga() ? meta->get_time_downsampling_fpga() : 1;
+            if (meta->dim_scaling[0] != tds)
+                FATAL_ERROR("Buffer \"{:s}\": create_single_file requires dim_scaling[0] ({:d}) == "
+                            "time_downsampling_fpga ({:d}); set create_single_file: false for this "
+                            "writer",
+                            buffer->buffer_name, meta->dim_scaling[0], tds);
+            if (do_create_dataset) {
+                single_file_dim0 = meta->dim[0];
+                single_file_tds = tds;
+            } else {
+                if (std::size_t(meta->dim[0]) != single_file_dim0 || tds != single_file_tds)
+                    FATAL_ERROR("Buffer \"{:s}\": frame {:d} changes the frame shape/downsampling "
+                                "(dim[0] {:d}->{:d}, time_downsampling_fpga {:d}->{:d}) within a "
+                                "single file",
+                                buffer->buffer_name, frame_counter, single_file_dim0, meta->dim[0],
+                                single_file_tds, tds);
+                if (meta->has_fpga_seq_num() != single_file_has_seq)
+                    FATAL_ERROR("Buffer \"{:s}\": fpga_seq_num is present in some frames but not "
+                                "in others; cannot write a single file",
+                                buffer->buffer_name);
+                if (single_file_has_seq && meta->get_fpga_seq_num() != single_file_next_seq)
+                    FATAL_ERROR("Buffer \"{:s}\": create_single_file requires a contiguous stream, "
+                                "but frame {:d} starts at fpga_seq_num {:d}, expected {:d}",
+                                buffer->buffer_name, frame_counter, meta->get_fpga_seq_num(),
+                                single_file_next_seq);
+            }
+            single_file_has_seq = meta->has_fpga_seq_num();
+            if (single_file_has_seq)
+                single_file_next_seq = meta->get_fpga_seq_num() + std::int64_t(meta->dim[0]) * tds;
+        }
 
         if (do_create_dataset) {
 
@@ -618,7 +682,7 @@ public:
             DEBUG("mark_frame_empty: frame_id={}", frame_id);
             buffer->mark_frame_empty(unique_name, frame_id);
 
-            if (max_frames >= 0 && frame_counter + 1 >= max_frames) {
+            if (max_frames > 0 && frame_counter + 1 >= max_frames) {
                 WARN("Processed {} frames", frame_counter + 1);
                 break;
             }
@@ -627,7 +691,7 @@ public:
         // Close file if necessary
         the_single_file.reset();
 
-        if (max_frames >= 0) {
+        if (max_frames > 0) {
             // Unregister to allow the pipeline to continue, unless I'm the last
             // consumer on this buffer.
             buffer->unregister_consumer(unique_name, true);

--- a/lib/stages/hdf5Files.cpp
+++ b/lib/stages/hdf5Files.cpp
@@ -47,7 +47,7 @@ HighFive::DataType chord2hdf5(const kotekan::DataType type) {
             return HighFive::AtomicType<double>();
         default:
             throw std::runtime_error(
-                fmt::format("chord2hdf5 given unknown DataType value: {;d} ", (int64_t)type));
+                fmt::format("chord2hdf5 given unknown DataType value: {:d} ", (int64_t)type));
     }
 }
 

--- a/lib/stages/hdf5Files.cpp
+++ b/lib/stages/hdf5Files.cpp
@@ -5,7 +5,11 @@
 #include "fmt.hpp" // for format, format_string
 
 #include <cstdint>   // for uint8_t, int64_t, int16_t, int32_t, int8_t, uint16_t, uint32_t
+#include <iomanip>   // for operator<<, setfill, setw
+#include <sstream>   // for basic_ostream, operator<<, basic_ostringstream
 #include <stdexcept> // for runtime_error
+#include <string>    // for string
+#include <unistd.h>  // for gethostname
 
 namespace hdf5 {
 
@@ -49,6 +53,22 @@ HighFive::DataType chord2hdf5(const kotekan::DataType type) {
             throw std::runtime_error(
                 fmt::format("chord2hdf5 given unknown DataType value: {:d} ", (int64_t)type));
     }
+}
+
+std::string file_path_prefix(const std::string& dir, const std::string& file_name,
+                             const bool prefix_hostname, const bool prefix_host_rank,
+                             const int host_pool_rank) {
+    std::ostringstream buf;
+    buf << dir << "/";
+    if (prefix_hostname) {
+        char hostname[256];
+        gethostname(hostname, sizeof hostname);
+        buf << hostname << "_";
+    }
+    if (prefix_host_rank)
+        buf << "x" << std::setw(4) << std::setfill('0') << host_pool_rank << "_";
+    buf << file_name;
+    return buf.str();
 }
 
 } // namespace hdf5

--- a/lib/stages/hdf5Files.hpp
+++ b/lib/stages/hdf5Files.hpp
@@ -6,6 +6,7 @@
 #include <array>                         // for array
 #include <highfive/H5DataType.hpp>       // for AtomicType, DataType, H5T_NATIVE_FLOAT
 #include <highfive/bits/h5t_wrapper.hpp> // for h5t_copy, h5t_set_ebias, h5t_set_fields, h5t_se...
+#include <string>                        // for string
 
 namespace hdf5 {
 
@@ -35,6 +36,26 @@ constexpr unsigned int BITSHUFFLE_COMPRESS_LZ4 = 2;
 constexpr unsigned int BITSHUFFLE_COMPRESS_ZSTD = 3;
 
 HighFive::DataType chord2hdf5(const kotekan::DataType type);
+
+/**
+ * @brief The common part of the file names used by hdf5FileWrite and hdf5FileRead:
+ *        "<dir>/[<hostname>_][x<rank:04d>_]<file_name>"
+ *
+ * The caller appends the suffix, i.e. ".<frame:08d>.h5" for per-frame files and ".h5" for a
+ * single file.
+ */
+std::string file_path_prefix(const std::string& dir, const std::string& file_name,
+                             bool prefix_hostname, bool prefix_host_rank, int host_pool_rank);
+
+/**
+ * @brief Whether a dimension is a time axis
+ *
+ * Kotekan convention: a dimension is a time axis iff its name starts with 'T'
+ * ("T", "Tc", "Tbar", "Ttilde", "Thi64", "T8hi128", ...).
+ */
+inline bool is_time_axis(const std::string& dim_name) {
+    return !dim_name.empty() && dim_name[0] == 'T';
+}
 
 } // namespace hdf5
 

--- a/lib/testing/testDataGenFloat.cpp
+++ b/lib/testing/testDataGenFloat.cpp
@@ -78,6 +78,12 @@ testDataGenFloat::testDataGenFloat(Config& config, const std::string& unique_nam
         throw std::invalid_argument("testDataGen: 'array_shape' and 'dim_name' config "
                                     "settings must be the same length!");
     }
+    _dim_scaling = config.get_default<std::vector<std::ptrdiff_t>>(
+        unique_name, "dim_scaling", std::vector<std::ptrdiff_t>(_array_shape.size(), 1));
+    if (_array_shape.size() != _dim_scaling.size()) {
+        throw std::invalid_argument("testDataGenFloat: 'array_shape' and 'dim_scaling' config "
+                                    "settings must be the same length!");
+    }
 
     // TODO: rename this parameter to `num_freq_per_stream` in the config
     _num_freq_in_frame = config.get_default<size_t>(unique_name, "num_local_freq", 1);

--- a/lib/testing/testDataGenFloat.hpp
+++ b/lib/testing/testDataGenFloat.hpp
@@ -10,8 +10,55 @@
 #include <stdint.h> // for uint32_t
 #include <string>   // for string, basic_string
 
-// Type: one of "random", "const"
-// Value: the value of the constant
+/**
+ * @class testDataGenFloat
+ * @brief Generate floating-point test data as a stand-in for a GPU or network stage.
+ *
+ * Fills frames with a constant, a ramp, or random values in a floating-point type
+ * (`float16`, `float32`, or `float64`) and attaches CHORD metadata describing the
+ * array (name, dimensions, dimension names and scalings, coarse frequencies and
+ * `fpga_seq_num`). One frame is produced roughly every 83 ms; the stage runs until
+ * kotekan is stopped.
+ *
+ * @par Buffers
+ * @buffer network_out_buf Buffer to fill
+ *         @buffer_format any format, declared as `kotekan_buffer: ndarray`
+ *         @buffer_metadata chordMetadata
+ *
+ * @conf  type                  String. "const", "ramp", or "random".
+ * @conf  value                 Float. Required for type "const" and "ramp". For "ramp",
+ *                              element j is set to `fmod(j * value, 256 * value)`.
+ * @conf  seed                  Int. Required for type "random"; seeds the random number
+ *                              generator for reproducible results.
+ * @conf  rand_min              Float. Default: 0. Lower bound for type "random".
+ * @conf  rand_max              Float. Default: 1. Upper bound for type "random".
+ * @conf  value_type            String. Default: "float32". One of "float16", "float32",
+ *                              or "float64"; sets the element type of the frames.
+ * @conf  name                  String. Default: "E". Array name in the metadata.
+ * @conf  array_shape           Vector of ints. Default: the whole frame as one dimension.
+ *                              The product times the element size must equal the buffer
+ *                              frame size.
+ * @conf  dim_name              Vector of strings. Default: ["D"]. Must have the same
+ *                              length as `array_shape`.
+ * @conf  dim_scaling           Vector of ints. Default: all ones. Must have the same
+ *                              length as `array_shape`.
+ * @conf  samples_per_data_set  Int. Required. Number of time samples per frame; also the
+ *                              increment of `fpga_seq_num` from frame to frame.
+ * @conf  num_local_freq        Int. Default: 1. Number of frequencies in each frame.
+ * @conf  manual_freq_ids       Vector of ints. Default: empty. If given, the coarse
+ *                              frequency IDs to use (cycled); otherwise consecutive IDs
+ *                              starting at 0, or at the telescope's minimum science
+ *                              frequency ID on a CHORDTelescope.
+ * @conf  meta_time_downsample_factor  Int. Default: 1. Currently only read, not written
+ *                              to the metadata.
+ * @conf  first_frame_index     Int. Default: 0. Index of the first frame, i.e.
+ *                              `fpga_seq_num` starts at `first_frame_index *
+ *                              samples_per_data_set`.
+ * @conf  pathfinder_test_mode  Bool. Default: false. Advance `fpga_seq_num` only every
+ *                              eighth frame, simulating eight pathfinder links.
+ * @conf  gen_all_const_data    Bool. Default: false. For type "const", keep filling every
+ *                              frame instead of only the first pass through the buffer.
+ */
 class testDataGenFloat : public kotekan::Stage {
 public:
     testDataGenFloat(kotekan::Config& config, const std::string& unique_name,

--- a/tests/test_hdf5_roundtrip.py
+++ b/tests/test_hdf5_roundtrip.py
@@ -1,0 +1,273 @@
+"""Round-trip kotekan buffers through hdf5FileWrite and hdf5FileRead.
+
+Session A ("siphon") generates deterministic frames and writes them with
+hdf5FileWrite, either one file per frame or a single file
+(`create_single_file: true`). Python then inspects the files with h5py.
+Session B ("replay") reads the files back with hdf5FileRead, regenerates the
+identical frames with the same generator config, and compares payload and
+chordMetadata with a testDataCheck* stage.
+
+The two sessions are separate kotekan processes on purpose: hdf5FileRead
+requires its input to exist when it starts, and a single file is only
+complete once the writer has closed it.
+"""
+import glob
+import os
+
+import h5py
+import numpy as np
+import pytest
+
+try:
+    import hdf5plugin  # noqa: F401  registers the bitshuffle filter for h5py
+except ImportError:  # HDF5_PLUGIN_PATH may still be set in the environment
+    pass
+
+from kotekan import runner
+
+if not runner.has_hdf5():
+    pytest.fail("HDF5 support not available; unable to run tests!")
+
+NUM_FRAMES = 6
+FILE_NAME = "siphon"
+
+
+def _available_stages():
+    return set(runner.KotekanRunner.kotekan_config().get("available_stages", []))
+
+
+def _ramp(extents, dtype):
+    return (np.arange(int(np.prod(extents))) % 256).astype(dtype).reshape(extents)
+
+
+# generator stage + config, matching ndarray buffer declaration, checker,
+# numpy dtype of the payload, optional expected payload of every frame.
+CASES = {
+    "int8_random": dict(
+        gen_stage="testDataGen",
+        gen=dict(
+            type="random8",
+            seed=12345,
+            samples_per_data_set=256,
+            num_local_freq=4,
+            name="E",
+            array_shape=[256, 4, 8],
+            dim_name=["T", "F", "D"],
+            dim_scaling=[1, 1, 1],
+        ),
+        buf=dict(
+            value_type="int8",
+            quantity_name="E",
+            extents=[256, 4, 8],
+            dimnames=["T", "F", "D"],
+            dimscalings=[1, 1, 1],
+        ),
+        checker="testDataCheckUchar",
+        dtype=np.int8,
+        expected=None,
+    ),
+    "uint8_ramp": dict(
+        gen_stage="testDataGen",
+        gen=dict(
+            type="ramp",
+            value=1,
+            samples_per_data_set=256,
+            num_local_freq=4,
+            name="E",
+            array_shape=[256, 4, 8],
+            dim_name=["T", "F", "D"],
+            dim_scaling=[1, 1, 1],
+        ),
+        buf=dict(
+            value_type="uint8",
+            quantity_name="E",
+            extents=[256, 4, 8],
+            dimnames=["T", "F", "D"],
+            dimscalings=[1, 1, 1],
+        ),
+        checker="testDataCheckUchar",
+        dtype=np.uint8,
+        expected=_ramp([256, 4, 8], np.uint8),
+    ),
+    # 4-byte elements + time downsampling: fpga_seq_num advances by 256 per
+    # frame = extents[0] (16) * time_downsampling_fpga (16).
+    "int32_downsampled": dict(
+        gen_stage="testDataGen",
+        gen=dict(
+            type="random32",
+            seed=777,
+            samples_per_data_set=256,
+            meta_time_downsample_factor=16,
+            num_local_freq=4,
+            name="N",
+            array_shape=[16, 4, 8],
+            dim_name=["Tc", "F", "D"],
+            dim_scaling=[16, 1, 1],
+        ),
+        buf=dict(
+            value_type="int32",
+            quantity_name="N",
+            extents=[16, 4, 8],
+            dimnames=["Tc", "F", "D"],
+            dimscalings=[16, 1, 1],
+        ),
+        checker="testDataCheckInt",
+        dtype=np.int32,
+        expected=None,
+    ),
+    # FRB-beam-like: float16, 4 axes, zeros in the payload.
+    "float16_beams": dict(
+        gen_stage="testDataGenFloat",
+        gen=dict(
+            type="ramp",
+            value=1.0,
+            value_type="float16",
+            samples_per_data_set=64,
+            num_local_freq=4,
+            name="I",
+            array_shape=[64, 4, 4, 2],
+            dim_name=["Ttilde", "Fbar", "beamQ", "beamP"],
+            dim_scaling=[1, 1, 1, 1],
+        ),
+        buf=dict(
+            value_type="float16",
+            quantity_name="I",
+            extents=[64, 4, 4, 2],
+            dimnames=["Ttilde", "Fbar", "beamQ", "beamP"],
+            dimscalings=[1, 1, 1, 1],
+        ),
+        checker="testDataCheckFloat16",
+        dtype=np.float16,
+        expected=_ramp([64, 4, 4, 2], np.float16),
+    ),
+}
+
+
+def _buffer(name, buf):
+    return {
+        name: dict(
+            kotekan_buffer="ndarray",
+            metadata_pool="main_pool",
+            num_frames="buffer_depth",
+            **buf
+        )
+    }
+
+
+def _generator(case, out_buf):
+    gen = dict(
+        case["gen"], kotekan_stage=case["gen_stage"], num_frames=NUM_FRAMES, wait=False
+    )
+    key = "network_out_buf" if case["gen_stage"] == "testDataGenFloat" else "out_buf"
+    gen[key] = out_buf
+    return gen
+
+
+def _siphon(tmpdir, case, single_file):
+    write = dict(
+        kotekan_stage="hdf5FileWrite",
+        in_buf="siphon_buf",
+        base_dir=str(tmpdir),
+        file_name=FILE_NAME,
+        prefix_hostname=False,
+        max_frames=NUM_FRAMES,
+        create_single_file=single_file,
+    )
+    runner.KotekanRunner(
+        _buffer("siphon_buf", case["buf"]),
+        {"gen": _generator(case, "siphon_buf"), "write": write},
+        {},
+    ).run()
+
+
+def _check_files(tmpdir, case, single_file):
+    extents = case["buf"]["extents"]
+    indexed = sorted(glob.glob(os.path.join(str(tmpdir), FILE_NAME + ".*.h5")))
+    if single_file:
+        assert indexed == []
+        files = [os.path.join(str(tmpdir), FILE_NAME + ".h5")]
+        frames_per_file = NUM_FRAMES
+    else:
+        assert [os.path.basename(f) for f in indexed] == [
+            "%s.%08d.h5" % (FILE_NAME, i) for i in range(NUM_FRAMES)
+        ]
+        assert not os.path.exists(os.path.join(str(tmpdir), FILE_NAME + ".h5"))
+        files = indexed
+        frames_per_file = 1
+    for i, path in enumerate(files):
+        with h5py.File(path, "r") as f:
+            assert list(f.keys()) == [FILE_NAME]
+            ds = f[FILE_NAME]
+            assert ds.dtype == np.dtype(case["dtype"])
+            assert list(ds.shape) == [frames_per_file * extents[0]] + extents[1:]
+            a = ds.attrs
+            assert list(a["chord_metadata_version"]) == [2, 0]
+            assert a["name"] == case["buf"]["quantity_name"]
+            assert a["type"] == case["buf"]["value_type"]
+            assert list(a["dim_names"]) == case["buf"]["dimnames"]
+            assert list(a["dim_scalings"]) == case["buf"]["dimscalings"]
+            assert a["fpga_seq_num"] == i * case["gen"]["samples_per_data_set"]
+            assert list(a["coarse_freq"]) == list(range(case["gen"]["num_local_freq"]))
+            for key in ("telescope_name", "num_dishes", "num_polarizations"):
+                assert key in a
+            if case["expected"] is not None:
+                data = ds[...]
+                for k in range(frames_per_file):
+                    np.testing.assert_array_equal(
+                        data[k * extents[0] : (k + 1) * extents[0]], case["expected"]
+                    )
+
+
+def _replay(tmpdir, case, single_file):
+    read = dict(
+        kotekan_stage="hdf5FileRead",
+        out_buf="read_buf",
+        input_dir=str(tmpdir),
+        file_name=FILE_NAME,
+        prefix_hostname=False,
+        read_single_file=single_file,
+    )
+    check = dict(
+        kotekan_stage=case["checker"],
+        first_buf="regen_buf",
+        second_buf="read_buf",
+        num_frames_to_test=NUM_FRAMES,
+        check_metadata=True,
+        epsilon=0.0,
+    )
+    buffers = {**_buffer("regen_buf", case["buf"]), **_buffer("read_buf", case["buf"])}
+    runner.KotekanRunner(
+        buffers,
+        {"regen": _generator(case, "regen_buf"), "read": read, "check": check},
+        {},
+    ).run()
+
+
+@pytest.mark.parametrize("single_file", [False, True], ids=["perframe", "singlefile"])
+@pytest.mark.parametrize("case_name", sorted(CASES))
+def test_roundtrip(tmpdir_factory, case_name, single_file):
+    case = CASES[case_name]
+    if case["checker"] not in _available_stages():
+        pytest.skip("%s not built" % case["checker"])
+    tmpdir = tmpdir_factory.mktemp("hdf5_roundtrip")
+    _siphon(tmpdir, case, single_file)
+    _check_files(tmpdir, case, single_file)
+    _replay(tmpdir, case, single_file)
+
+
+def test_singlefile_missing_input_is_fatal(tmpdir_factory):
+    case = CASES["int8_random"]
+    tmpdir = tmpdir_factory.mktemp("hdf5_roundtrip_missing")
+    read = dict(
+        kotekan_stage="hdf5FileRead",
+        out_buf="read_buf",
+        input_dir=str(tmpdir),
+        file_name=FILE_NAME,
+        prefix_hostname=False,
+        read_single_file=True,
+    )
+    r = runner.KotekanRunner(
+        _buffer("read_buf", case["buf"]), {"read": read}, {}, expect_failure=True
+    )
+    r.run()
+    assert r.return_code != 0

--- a/tests/test_hdf5_roundtrip.py
+++ b/tests/test_hdf5_roundtrip.py
@@ -10,9 +10,19 @@ chordMetadata with a testDataCheck* stage.
 The two sessions are separate kotekan processes on purpose: hdf5FileRead
 requires its input to exist when it starts, and a single file is only
 complete once the writer has closed it.
+
+A single file concatenates all frames along axis 0 and stores the metadata
+only once, so hdf5FileWrite accepts it only for a contiguous stream: axis 0
+must be a time axis, `dim_scaling[0]` must equal `time_downsampling_fpga`,
+`fpga_seq_num` must advance by `dim[0] * time_downsampling_fpga` per frame,
+and frame decimation is forbidden. The negative tests below check that each
+violation aborts the writer, that the same data round-trips fine as per-frame
+files (which have none of those constraints), and that hdf5FileRead rejects a
+single file that violates the same rules on disk.
 """
 import glob
 import os
+import shutil
 
 import h5py
 import numpy as np
@@ -142,6 +152,44 @@ CASES = {
     ),
 }
 
+# CHIME baseband voltages for hdf5FileReadSingleFile: rank 4, [T, F, P, D],
+# int4x2_swapped_withoffset. `random_signed_offset` puts 1..15 into both
+# nibbles, so no byte is ever 0x00 -- that is the poison value the reader
+# checks for.
+VOLTAGE_CASE = dict(
+    gen_stage="testDataGen",
+    gen=dict(
+        type="random_signed_offset",
+        seed=4242,
+        samples_per_data_set=256,
+        num_local_freq=4,
+        name="E",
+        array_shape=[256, 4, 2, 8],
+        dim_name=["T", "F", "P", "D"],
+        dim_scaling=[1, 1, 1, 1],
+    ),
+    buf=dict(
+        value_type="int4x2_swapped_withoffset",
+        quantity_name="E",
+        extents=[256, 4, 2, 8],
+        dimnames=["T", "F", "P", "D"],
+        dimscalings=[1, 1, 1, 1],
+    ),
+    checker="testDataCheckUchar",
+    dtype=np.uint8,
+    expected=None,
+)
+
+
+def _variant(case, gen=None, buf=None):
+    """A copy of `case` with some generator and/or buffer settings replaced."""
+    variant = dict(case)
+    if gen is not None:
+        variant["gen"] = dict(case["gen"], **gen)
+    if buf is not None:
+        variant["buf"] = dict(case["buf"], **buf)
+    return variant
+
 
 def _buffer(name, buf):
     return {
@@ -163,7 +211,8 @@ def _generator(case, out_buf):
     return gen
 
 
-def _siphon(tmpdir, case, single_file):
+def _siphon(tmpdir, case, single_file, write_extra=None, expect_failure=False):
+    """Session A: generate frames and write them. Returns the runner."""
     write = dict(
         kotekan_stage="hdf5FileWrite",
         in_buf="siphon_buf",
@@ -173,11 +222,15 @@ def _siphon(tmpdir, case, single_file):
         max_frames=NUM_FRAMES,
         create_single_file=single_file,
     )
-    runner.KotekanRunner(
+    write.update(write_extra or {})
+    r = runner.KotekanRunner(
         _buffer("siphon_buf", case["buf"]),
         {"gen": _generator(case, "siphon_buf"), "write": write},
         {},
-    ).run()
+        expect_failure=expect_failure,
+    )
+    r.run()
+    return r
 
 
 def _check_files(tmpdir, case, single_file):
@@ -218,7 +271,8 @@ def _check_files(tmpdir, case, single_file):
                     )
 
 
-def _replay(tmpdir, case, single_file):
+def _replay(tmpdir, case, single_file, read_extra=None, check_extra=None):
+    """Session B: read the files back and compare against the generator."""
     read = dict(
         kotekan_stage="hdf5FileRead",
         out_buf="read_buf",
@@ -227,6 +281,7 @@ def _replay(tmpdir, case, single_file):
         prefix_hostname=False,
         read_single_file=single_file,
     )
+    read.update(read_extra or {})
     check = dict(
         kotekan_stage=case["checker"],
         first_buf="regen_buf",
@@ -235,12 +290,33 @@ def _replay(tmpdir, case, single_file):
         check_metadata=True,
         epsilon=0.0,
     )
+    check.update(check_extra or {})
     buffers = {**_buffer("regen_buf", case["buf"]), **_buffer("read_buf", case["buf"])}
-    runner.KotekanRunner(
+    r = runner.KotekanRunner(
         buffers,
         {"regen": _generator(case, "regen_buf"), "read": read, "check": check},
         {},
-    ).run()
+    )
+    r.run()
+    return r
+
+
+def _read_only(tmpdir, buf, read_extra=None):
+    """A reader-only session that is expected to abort. Returns the runner."""
+    read = dict(
+        kotekan_stage="hdf5FileRead",
+        out_buf="read_buf",
+        input_dir=str(tmpdir),
+        file_name=FILE_NAME,
+        prefix_hostname=False,
+        read_single_file=True,
+    )
+    read.update(read_extra or {})
+    r = runner.KotekanRunner(
+        _buffer("read_buf", buf), {"read": read}, {}, expect_failure=True
+    )
+    r.run()
+    return r
 
 
 @pytest.mark.parametrize("single_file", [False, True], ids=["perframe", "singlefile"])
@@ -258,16 +334,259 @@ def test_roundtrip(tmpdir_factory, case_name, single_file):
 def test_singlefile_missing_input_is_fatal(tmpdir_factory):
     case = CASES["int8_random"]
     tmpdir = tmpdir_factory.mktemp("hdf5_roundtrip_missing")
+    r = _read_only(tmpdir, case["buf"])
+    assert r.return_code != 0
+
+
+def test_perframe_end_of_input_is_info(tmpdir_factory):
+    """Running out of per-frame files is a normal end of input, not an error."""
+    case = CASES["int8_random"]
+    tmpdir = tmpdir_factory.mktemp("hdf5_perframe_eoi")
+    _siphon(tmpdir, case, False)
+    r = _replay(tmpdir, case, False)
+    assert "terminating reader" in r.output
+    # No ERROR from the reader stage, apart from the benign thread-affinity
+    # complaints every stage logs in this environment.
+    read_errors = [
+        line
+        for line in r.output.splitlines()
+        if line.startswith("ERROR: /read")
+        and "thread affinity" not in line
+        and "thread name" not in line
+    ]
+    assert read_errors == []
+
+
+def test_singlefile_do_once(tmpdir_factory):
+    """`do_once` reads frame 0 and then idles instead of ending the pipeline."""
+    case = CASES["int8_random"]
+    tmpdir = tmpdir_factory.mktemp("hdf5_singlefile_do_once")
+    _siphon(tmpdir, case, True)
+    r = _replay(
+        tmpdir,
+        case,
+        True,
+        read_extra=dict(do_once=True),
+        check_extra=dict(num_frames_to_test=1),
+    )
+    assert "do_once is set" in r.output
+    assert "Done reading" not in r.output
+
+
+def test_singlefile_rejects_frame_decimation(tmpdir_factory):
+    case = CASES["int8_random"]
+    tmpdir = tmpdir_factory.mktemp("hdf5_singlefile_decimation")
+    r = _siphon(
+        tmpdir,
+        case,
+        True,
+        write_extra=dict(write_x_frames=0, per_y_frames=2),
+        expect_failure=True,
+    )
+    assert r.return_code != 0
+    assert "cannot be combined with create_single_file" in r.output
+
+
+def test_singlefile_rejects_non_time_axis0(tmpdir_factory):
+    """Axis 0 of a single file has to be a time axis (a name starting with T)."""
+    case = _variant(
+        CASES["int8_random"],
+        gen=dict(dim_name=["F", "T", "D"]),
+        buf=dict(dimnames=["F", "T", "D"]),
+    )
+    tmpdir = tmpdir_factory.mktemp("hdf5_singlefile_axis0")
+    r = _siphon(tmpdir, case, True, expect_failure=True)
+    assert r.return_code != 0
+    assert (
+        "create_single_file requires a time axis as dimension 0, but dimension 0 is"
+        in r.output
+    )
+
+
+def test_perframe_allows_non_time_axis0(tmpdir_factory):
+    """The same non-time-major buffer round-trips fine as per-frame files."""
+    case = _variant(
+        CASES["int8_random"],
+        gen=dict(dim_name=["F", "T", "D"]),
+        buf=dict(dimnames=["F", "T", "D"]),
+    )
+    if case["checker"] not in _available_stages():
+        pytest.skip("%s not built" % case["checker"])
+    tmpdir = tmpdir_factory.mktemp("hdf5_perframe_axis0")
+    _siphon(tmpdir, case, False)
+    _check_files(tmpdir, case, False)
+    _replay(tmpdir, case, False)
+
+
+def test_singlefile_rejects_dim_scaling_tds_mismatch(tmpdir_factory):
+    """dim_scaling[0] must equal time_downsampling_fpga in single-file mode."""
+    case = _variant(CASES["int8_random"], gen=dict(meta_time_downsample_factor=16),)
+    tmpdir = tmpdir_factory.mktemp("hdf5_singlefile_scaling")
+    r = _siphon(tmpdir, case, True, expect_failure=True)
+    assert r.return_code != 0
+    assert (
+        "create_single_file requires dim_scaling[0] (1) == time_downsampling_fpga (16)"
+        in r.output
+    )
+
+
+def test_singlefile_rejects_gap_in_stream(tmpdir_factory):
+    """An fpga_seq_num jump (simulated FPGA restart) breaks the single stream."""
+    case = _variant(CASES["int8_random"], gen=dict(simulate_fpga_restart_at_frame=3))
+    tmpdir = tmpdir_factory.mktemp("hdf5_singlefile_gap")
+    r = _siphon(tmpdir, case, True, expect_failure=True)
+    assert r.return_code != 0
+    assert "create_single_file requires a contiguous stream" in r.output
+
+
+def test_perframe_allows_gap_in_stream(tmpdir_factory):
+    """Per-frame files carry their own fpga_seq_num, so a gap is fine there."""
+    case = _variant(CASES["int8_random"], gen=dict(simulate_fpga_restart_at_frame=3))
+    if case["checker"] not in _available_stages():
+        pytest.skip("%s not built" % case["checker"])
+    tmpdir = tmpdir_factory.mktemp("hdf5_perframe_gap")
+    _siphon(tmpdir, case, False)
+    _replay(tmpdir, case, False)
+
+
+@pytest.fixture(scope="module")
+def good_single_file(tmpdir_factory):
+    """One valid single-file dump of the int8 case, written once.
+
+    The reader-negative tests below copy it and corrupt the copy with h5py.
+    """
+    tmpdir = tmpdir_factory.mktemp("hdf5_singlefile_source")
+    _siphon(tmpdir, CASES["int8_random"], True)
+    path = os.path.join(str(tmpdir), FILE_NAME + ".h5")
+    assert os.path.exists(path)
+    return path
+
+
+def _corrupt_copy(tmpdir_factory, good_single_file, name, corrupt):
+    """Copy the good single file into a fresh directory and corrupt the copy."""
+    tmpdir = tmpdir_factory.mktemp(name)
+    path = os.path.join(str(tmpdir), FILE_NAME + ".h5")
+    shutil.copy(good_single_file, path)
+    with h5py.File(path, "r+") as f:
+        corrupt(f[FILE_NAME])
+    return tmpdir
+
+
+def test_singlefile_read_rejects_truncated_file(tmpdir_factory, good_single_file):
+    """Fewer samples along axis 0 than one frame is a read error."""
+    case = CASES["int8_random"]
+    extents = case["buf"]["extents"]
+
+    def corrupt(ds):
+        ds.resize((extents[0] - 1, *extents[1:]))
+
+    tmpdir = _corrupt_copy(
+        tmpdir_factory, good_single_file, "hdf5_read_truncated", corrupt
+    )
+    r = _read_only(tmpdir, case["buf"])
+    assert r.return_code != 0
+    assert "fewer than one frame" in r.output
+
+
+def test_singlefile_read_rejects_storage_type_mismatch(
+    tmpdir_factory, good_single_file
+):
+    """The HDF5 storage type has to agree with the declared `type` attribute."""
+    case = CASES["int8_random"]
+
+    def corrupt(ds):
+        ds.attrs["type"] = "int32"
+
+    tmpdir = _corrupt_copy(
+        tmpdir_factory, good_single_file, "hdf5_read_storage_type", corrupt
+    )
+    r = _read_only(tmpdir, case["buf"])
+    assert r.return_code != 0
+    assert "storage type" in r.output
+
+
+def test_singlefile_read_rejects_missing_attribute(tmpdir_factory, good_single_file):
+    """A missing mandatory attribute is fatal, and the message names it."""
+    case = CASES["int8_random"]
+
+    def corrupt(ds):
+        del ds.attrs["dim_names"]
+
+    tmpdir = _corrupt_copy(
+        tmpdir_factory, good_single_file, "hdf5_read_missing_attr", corrupt
+    )
+    r = _read_only(tmpdir, case["buf"])
+    assert r.return_code != 0
+    assert 'lacks the required attribute "dim_names"' in r.output
+
+
+def test_singlefile_read_rejects_non_time_axis0(tmpdir_factory, good_single_file):
+    """The reader enforces the time axis rule on what is actually in the file."""
+    case = CASES["int8_random"]
+
+    def corrupt(ds):
+        ds.attrs["dim_names"] = ["X", "F", "D"]
+
+    tmpdir = _corrupt_copy(tmpdir_factory, good_single_file, "hdf5_read_axis0", corrupt)
+    # Leave `dimnames` out of the buffer declaration so the labels come from
+    # the file; a declared "T" would be reported as a label conflict first.
+    buf = {k: v for k, v in case["buf"].items() if k != "dimnames"}
+    r = _read_only(tmpdir, buf)
+    assert r.return_code != 0
+    assert "read_single_file requires a time axis as dimension 0" in r.output
+
+
+def test_singlefile_read_rejects_dim_scaling_tds_mismatch(
+    tmpdir_factory, good_single_file
+):
+    """dim_scalings[0] != time_downsampling_fpga makes the frames unsplittable."""
+    case = CASES["int8_random"]
+
+    def corrupt(ds):
+        ds.attrs["time_downsampling_fpga"] = np.int32(2)
+
+    tmpdir = _corrupt_copy(
+        tmpdir_factory, good_single_file, "hdf5_read_scaling", corrupt
+    )
+    r = _read_only(tmpdir, case["buf"])
+    assert r.return_code != 0
+    assert "dim_scalings[0] (1) != time_downsampling_fpga (2)" in r.output
+
+
+def test_voltage_reader_roundtrip(tmpdir_factory):
+    """hdf5FileReadSingleFile replays a single-file voltage dump.
+
+    hdf5FileWrite writes the CHIME-style rank-4 voltage buffer, and the
+    special-purpose reader hands it back one frame of `num_times` samples at a
+    time. That stage never ends the pipeline; the checker does.
+    """
+    case = VOLTAGE_CASE
+    stages = _available_stages()
+    for stage in ("hdf5FileReadSingleFile", case["checker"]):
+        if stage not in stages:
+            pytest.skip("%s not built" % stage)
+    tmpdir = tmpdir_factory.mktemp("hdf5_voltage")
+    _siphon(tmpdir, case, True)
+    _check_files(tmpdir, case, True)
     read = dict(
-        kotekan_stage="hdf5FileRead",
+        kotekan_stage="hdf5FileReadSingleFile",
         out_buf="read_buf",
         input_dir=str(tmpdir),
         file_name=FILE_NAME,
-        prefix_hostname=False,
-        read_single_file=True,
+        frequency_channels=list(range(case["gen"]["num_local_freq"])),
+        num_times=case["buf"]["extents"][0],
     )
-    r = runner.KotekanRunner(
-        _buffer("read_buf", case["buf"]), {"read": read}, {}, expect_failure=True
+    check = dict(
+        kotekan_stage=case["checker"],
+        first_buf="regen_buf",
+        second_buf="read_buf",
+        num_frames_to_test=NUM_FRAMES,
+        check_metadata=True,
+        epsilon=0.0,
     )
-    r.run()
-    assert r.return_code != 0
+    buffers = {**_buffer("regen_buf", case["buf"]), **_buffer("read_buf", case["buf"])}
+    runner.KotekanRunner(
+        buffers,
+        {"regen": _generator(case, "regen_buf"), "read": read, "check": check},
+        {},
+    ).run()


### PR DESCRIPTION
hdf5FileWrite can produce output files with a single data stream, i.e. not producing one dataset per frame.

This PR adds the converse, letting hdf5FileRead read such a data stream.
