### PR TITLE
most recent set of updates

### DIFF
--- a/lib/cuda/cudaFRBBeamReformer.cpp
+++ b/lib/cuda/cudaFRBBeamReformer.cpp
@@ -214,9 +214,13 @@ cudaEvent_t cudaFRBBeamReformer::execute(cudaPipelineState& /*pipestate*/,
     }
 
     // Since we do not use a ring buffer we need to set `meta->fpga_seq_num`
+    auto frb1_beams_meta =
+        std::dynamic_pointer_cast<chordMetadata>(frb1_beams_buffer.get_metadata());
+    assert(frb1_beams_meta);
     const std::shared_ptr<chordMetadata> frb2_beams_meta = frb2_beams_buffer.get_metadata();
-    frb2_beams_meta->set_fpga_seq_num(frb1_beams_offset
-                                      * frb2_beams_meta->get_time_downsampling_fpga());
+    frb2_beams_meta->set_fpga_seq_num(frb1_beams_meta->get_fpga_seq_num()
+                                      + frb1_beams_offset
+                                            * frb2_beams_meta->get_time_downsampling_fpga());
 
     if (poison_buffers)
         frb2_beams_buffer.set_to_poison(0xff); // 0xffff is a NaN16

--- a/lib/stages/N2Accumulate.cpp
+++ b/lib/stages/N2Accumulate.cpp
@@ -33,6 +33,7 @@
 #include <math.h>     // for floor
 #include <memory>     // for shared_ptr, __shared_ptr_access, dynamic_pointer_cast
 #include <ostream>    // for ostream, basic_ostream
+#include <utility>    // for swap
 #ifdef WITH_OMP
 #include <omp.h>
 #endif
@@ -77,7 +78,17 @@ N2Accumulate::N2Accumulate(Config& config, const std::string& unique_name,
     _variance_mode(config.get<N2VarianceMode>(unique_name, "variance_mode")),
     _debug_accum_mode(config.get_default<bool>(unique_name, "debug_accum_mode", false)),
     _profile_info(config.get_default<bool>(unique_name, "profile_info", false)),
-    _tel(Telescope::instance()),
+    _tel(Telescope::instance()), _input_order(config.get_default<ElementOrder>(
+                                     unique_name, "input_order", _tel.fiducial_element_order())),
+    _output_order(config.get_default<ElementOrder>(unique_name, "output_order",
+                                                   _tel.fiducial_element_order())),
+    _reorder([&]() {
+        std::vector<int> reorder(_num_elements);
+        for (int idx_in = 0; idx_in < _num_elements; ++idx_in)
+            reorder.at(idx_in) = _tel.station_id_to_element_index(
+                _tel.element_index_to_station_id(idx_in, _input_order), _output_order);
+        return reorder;
+    }()),
     _feed_positions_m(_tel.get_feed_positions_m(_num_elements, _tel.fiducial_element_order())),
     n_valid_gauge(Metrics::instance().add_gauge("kotekan_N2accumulate_frac_valid_fpga_ticks",
                                                 unique_name, {"freq_id"})),
@@ -1026,13 +1037,21 @@ bool N2Accumulate::output_and_reset(frameID& in_frame_id, frameID& in_rfiframema
                     for (int64_t ilo = 0; ilo < _n2k_correlation_blocksize; ilo++) {
                         for (int64_t jlo = 0; jlo < _n2k_correlation_blocksize; jlo++) {
                             // 2D indices into the N2K matrix.
-                            int64_t i = ilo + _n2k_correlation_blocksize * ihi;
-                            int64_t j = jlo + _n2k_correlation_blocksize * jhi;
+                            const int64_t i_in = ilo + _n2k_correlation_blocksize * ihi;
+                            const int64_t j_in = jlo + _n2k_correlation_blocksize * jhi;
 
                             // Only proceed if we're in the *true* lower-triangular section of the
                             // matrix
-                            if (j > i)
+                            if (j_in > i_in)
                                 continue;
+
+                            bool swapped = false;
+                            int64_t i_out = _reorder.at(i_in);
+                            int64_t j_out = _reorder.at(j_in);
+                            if (j_out > i_out) { // re-ordering may (will) change relative ordering
+                                swapped = true;
+                                std::swap(i_out, j_out);
+                            }
 
                             // index into the intermediate N2K-shaped array
                             int64_t idx =
@@ -1054,11 +1073,13 @@ bool N2Accumulate::output_and_reset(frameID& in_frame_id, frameID& in_rfiframema
                             //
                             // vis_N2(i, j) = vis_n2k(j, i)*
 
-                            int64_t n2_idx = N2::cmap(j, i, _num_elements);
+                            int64_t n2_idx = N2::cmap(j_out, i_out, _num_elements);
 
                             // Populate the visibility matrix, remember the upper-tri element
                             // is the conjugate of the lower-tri element.
                             N2::cfloat v{(float)_vis[2 * idx], (float)_vis[2 * idx + 1]};
+                            if (swapped)
+                                v = std::conj(v);
                             out_vis.vis[n2_idx] = ins * std::conj(v);
 
                             out_vis.weight[n2_idx] = calc_out_vis_weight(idx, v);

--- a/lib/stages/N2Accumulate.hpp
+++ b/lib/stages/N2Accumulate.hpp
@@ -155,6 +155,10 @@ void from_json(const nlohmann::json& j, N2VarianceMode& m);
  *                                          the buffers.
  * @conf    do_fringestop                   bool    Whether to fringestop incoming correlations.
  *                                          Default: False
+ * @conf    input_order                     String. Ordering of data in input correlation matrix.
+ *                                          Default: Telescope::fiducial_element_order()
+ * @conf    output_order                    String. Ordering of data in ouput correlation matrix.
+ *                                          Default: Telescope::fiducial_element_order()
  */
 class N2Accumulate : public kotekan::Stage {
 public:
@@ -294,6 +298,11 @@ private:
 
     // The telescope
     const Telescope& _tel;
+
+    // these must bye after _tel sine their initialization requires _tel
+    const ElementOrder _input_order;  ///< ordering of data in input matrix
+    const ElementOrder _output_order; ///< ordering of data in output matrix
+    const std::vector<int> _reorder;  // cache of mapping input_order_index -> output_order_index
 
     const std::vector<vec3d_t>
         _feed_positions_m; ///< The position of each element in the telescope grid frame

--- a/lib/stages/UpchannelizationSchedule.cpp
+++ b/lib/stages/UpchannelizationSchedule.cpp
@@ -39,9 +39,11 @@ std::map<int, std::vector<int>> UpchannelizationSchedule::make_upchan_factors_to
         const auto& range = config.get<std::vector<int>>(unique_name, key.str());
         assert(range.size() == 2);
         std::vector<int> channels;
-        for (int channel = range.at(0); channel < range.at(1); ++channel) {
-            // Only include the local channels
-            if (has_frequency_channel(channel))
+        const auto& upchan_channels = get_frequency_channels();
+        // Only include local channels, in local order
+        for (const auto channel : upchan_channels) {
+            // Only include the requested channels
+            if (range.at(0) <= channel && channel < range.at(1))
                 channels.push_back(channel);
         }
         upchan_factors_to_channels[upchan_factor] = channels;

--- a/lib/stages/UpchannelizationSchedule.cpp
+++ b/lib/stages/UpchannelizationSchedule.cpp
@@ -20,13 +20,12 @@ std::map<int, int> UpchannelizationSchedule::make_frequency_channels_to_indices(
     return channels_to_indices;
 }
 
-std::set<int> UpchannelizationSchedule::make_upchan_factors() const {
-    const auto upchan_factors = config.get<std::vector<int>>(unique_name, "upchan_factors");
-    return std::set<int>(upchan_factors.begin(), upchan_factors.end());
+std::vector<int> UpchannelizationSchedule::make_upchan_factors() const {
+    return config.get<std::vector<int>>(unique_name, "upchan_factors");
 }
 
-std::map<int, std::set<int>> UpchannelizationSchedule::make_upchan_factors_to_channels() const {
-    std::map<int, std::set<int>> upchan_factors_to_channels;
+std::map<int, std::vector<int>> UpchannelizationSchedule::make_upchan_factors_to_channels() const {
+    std::map<int, std::vector<int>> upchan_factors_to_channels;
     // for (const int upchan_factor : upchan_factors) {
     //     std::ostringstream key;
     //     key << "upchan_U" << upchan_factor << "_channels";
@@ -39,23 +38,23 @@ std::map<int, std::set<int>> UpchannelizationSchedule::make_upchan_factors_to_ch
         key << "upchan_channel_ranges/" << upchan_factor << "";
         const auto& range = config.get<std::vector<int>>(unique_name, key.str());
         assert(range.size() == 2);
-        std::set<int> channels;
+        std::vector<int> channels;
         for (int channel = range.at(0); channel < range.at(1); ++channel) {
             // Only include the local channels
             if (has_frequency_channel(channel))
-                channels.insert(channel);
+                channels.push_back(channel);
         }
         upchan_factors_to_channels[upchan_factor] = channels;
     }
     return upchan_factors_to_channels;
 }
 
-std::map<int, std::set<int>> UpchannelizationSchedule::make_upchan_channels_to_factors() const {
-    std::map<int, std::set<int>> upchan_channels_to_factors;
+std::map<int, std::vector<int>> UpchannelizationSchedule::make_upchan_channels_to_factors() const {
+    std::map<int, std::vector<int>> upchan_channels_to_factors;
     for (const int upchan_factor : upchan_factors) {
         const auto& channels = get_upchan_channels(upchan_factor);
         for (const int channel : channels)
-            upchan_channels_to_factors[channel].insert(upchan_factor);
+            upchan_channels_to_factors[channel].push_back(upchan_factor);
     }
     return upchan_channels_to_factors;
 }
@@ -139,10 +138,11 @@ bool UpchannelizationSchedule::invariant() const {
             if (!has_frequency_channel(channel))
                 return false;
             const auto& factors = get_upchan_factors(channel);
-            if (!factors.count(factor))
+            if (std::find(factors.begin(), factors.end(), factor) == factors.end())
                 return false;
             for (const int factor2 : factors) {
-                if (!get_upchan_channels(factor2).count(channel))
+                const auto& channels2 = get_upchan_channels(factor2);
+                if (std::find(channels2.begin(), channels2.end(), channel) == channels2.end())
                     return false;
             }
         }
@@ -150,13 +150,15 @@ bool UpchannelizationSchedule::invariant() const {
     for (const int channel : upchan_channels) {
         const auto& factors = get_upchan_factors(channel);
         for (const int factor : factors) {
-            if (!upchan_factors.count(factor))
+            if (std::find(upchan_factors.begin(), upchan_factors.end(), factor)
+                == upchan_factors.end())
                 return false;
             const auto& channels = get_upchan_channels(factor);
-            if (!channels.count(channel))
+            if (std::find(channels.begin(), channels.end(), channel) == channels.end())
                 return false;
             for (const int channel2 : channels) {
-                if (!get_upchan_factors(channel2).count(factor))
+                const auto& factors2 = get_upchan_factors(channel2);
+                if (std::find(factors2.begin(), factors2.end(), factor) == factors2.end())
                     return false;
             }
         }
@@ -198,17 +200,18 @@ const UpchannelizationSchedule& UpchannelizationSchedule::instance(kotekan::Conf
 ////////////////////////////////////////////////////////////////////////////////
 
 // Map upchannelization factors to channels and back
-const std::set<int>& UpchannelizationSchedule::get_upchan_channels(const int upchan_factor) const {
+const std::vector<int>&
+UpchannelizationSchedule::get_upchan_channels(const int upchan_factor) const {
     if (!upchan_factors_to_channels.count(upchan_factor)) {
-        static const std::set<int> empty_set;
+        static const std::vector<int> empty_set;
         return empty_set;
     }
     return upchan_factors_to_channels.at(upchan_factor);
 }
 
-const std::set<int>& UpchannelizationSchedule::get_upchan_factors(const int channel) const {
+const std::vector<int>& UpchannelizationSchedule::get_upchan_factors(const int channel) const {
     if (!upchan_channels_to_factors.count(channel)) {
-        static const std::set<int> empty_set;
+        static const std::vector<int> empty_set;
         return empty_set;
     }
     return upchan_channels_to_factors.at(channel);

--- a/lib/stages/UpchannelizationSchedule.hpp
+++ b/lib/stages/UpchannelizationSchedule.hpp
@@ -7,7 +7,6 @@
 #include <assert.h> // for assert
 #include <cstddef>  // for size_t
 #include <map>      // for map
-#include <set>      // for set
 #include <string>   // for basic_string, string
 #include <vector>   // for vector
 
@@ -44,21 +43,21 @@ class UpchannelizationSchedule : kotekan::kotekanLogging {
     const std::map<int, int> frequency_channels_to_indices;
 
     // All upchannelization factors
-    const std::set<int> upchan_factors;
+    const std::vector<int> upchan_factors;
 
     // Map upchannelization factors to channels and back
-    const std::map<int, std::set<int>> upchan_factors_to_channels; // factor -> channels
-    const std::map<int, std::set<int>> upchan_channels_to_factors; // channel -> factors
+    const std::map<int, std::vector<int>> upchan_factors_to_channels; // factor -> channels
+    const std::map<int, std::vector<int>> upchan_channels_to_factors; // channel -> factors
 
     ////////////////////////////////////////////////////////////////////////////////
 
     std::vector<int> make_frequency_channels() const;
     std::map<int, int> make_frequency_channels_to_indices() const;
 
-    std::set<int> make_upchan_factors() const;
+    std::vector<int> make_upchan_factors() const;
 
-    std::map<int, std::set<int>> make_upchan_factors_to_channels() const;
-    std::map<int, std::set<int>> make_upchan_channels_to_factors() const;
+    std::map<int, std::vector<int>> make_upchan_factors_to_channels() const;
+    std::map<int, std::vector<int>> make_upchan_channels_to_factors() const;
 
     void output_statistics() const;
     bool invariant() const;
@@ -96,13 +95,13 @@ public:
     }
 
     // All upchannelization factors
-    const std::set<int>& get_upchan_factors() const {
+    const std::vector<int>& get_upchan_factors() const {
         return upchan_factors;
     }
 
     // Map upchannelization factors to channels and back
-    const std::set<int>& get_upchan_channels(const int upchan_factor) const;
-    const std::set<int>& get_upchan_factors(const int channel) const;
+    const std::vector<int>& get_upchan_channels(const int upchan_factor) const;
+    const std::vector<int>& get_upchan_factors(const int channel) const;
 };
 
 #endif // #ifndef UPCHANNELIZATION_SCHEDULE_H

--- a/lib/stages/lostSamplesToPLMask.cpp
+++ b/lib/stages/lostSamplesToPLMask.cpp
@@ -66,7 +66,7 @@ lostSamplesToPLMask::lostSamplesToPLMask(Config& config, const std::string& uniq
         FATAL_ERROR("Unexpected frames sizes for pl_mask {:d} and lost_samples {:d}",
                     pl_mask_buf->frame_size, lost_samples_bufs.at(0)->frame_size);
 
-    pl_mask_buf->require_frame_desc(
+    pl_mask_buf->ensure_frame_desc(
         kotekan::NDArray<kotekan::GetType_t<kotekan::uint1x8>, 5>::describe(
             "pl_mask",
             {ptrdiff_t(lost_samples_bufs.at(0)->frame_size / PL_MASK_DOWNSAMPLING_FACTOR


### PR DESCRIPTION
the usual mixed bag of stuff.

* code to preserve the ordering of frequencies in UpchannelizationSchedule (mostly just swapping the order of two nested loops)
* code to re-order visibility matrix entries, needed to preserve the ordering expected by the CHIME n2 backends
* a minor fix in chudaBeamReformer to report the correct FPGA sequence number (not starting at 0 at kotekan startup basically)