### PR TITLE
cudaCopyFromRingbuffer: read the metadata snapshot, not the live ring object

### DIFF
--- a/lib/cuda/cudaCopyFromRingbuffer.cpp
+++ b/lib/cuda/cudaCopyFromRingbuffer.cpp
@@ -114,21 +114,29 @@ cudaEvent_t cudaCopyFromRingbuffer::execute(cudaPipelineState& pipestate,
     auto out_meta = std::make_shared<chordMetadata>();
     out_meta->deepCopy(in_meta);
 
-    assert(input_cursor % in_meta->sample_bytes() == 0);
+    // Everything below reads `out_meta`, the snapshot taken above, never `in_meta`.
+    // `get_metadata(0)` returns the LIVE slot-0 object, which its producer fills in place
+    // (and may patch after publishing); reading it field by field samples it at several
+    // instants and can mix old and new values, whereas `deepCopy` takes
+    // `chordMetadata::lock` and yields one coherent copy. That matters here because the
+    // sequence number derived below scales `time_downsampling_fpga` by the absolute byte
+    // count since startup, so a torn read is not off by one frame but by a fraction of
+    // the whole uptime.
+    assert(input_cursor % out_meta->sample_bytes() == 0);
     if (initial_fpga_seq_num == -1) { // first time
         if (instance_num == 0) {      // we handle frame 0 of the buffer depth
             assert(input_cursor == 0);
-            initial_fpga_seq_num = in_meta->get_fpga_seq_num();
+            initial_fpga_seq_num = out_meta->get_fpga_seq_num();
         } else { // handle one of the later frames, frame 0 handler has set metadata
-            initial_fpga_seq_num = in_meta->get_fpga_seq_num();
+            initial_fpga_seq_num = out_meta->get_fpga_seq_num();
         }
     } else { // not first time
-        assert(in_meta->get_fpga_seq_num() == initial_fpga_seq_num);
+        assert(out_meta->get_fpga_seq_num() == initial_fpga_seq_num);
     }
-    out_meta->set_fpga_seq_num(in_meta->get_fpga_seq_num()
-                               + in_meta->get_time_downsampling_fpga()
-                                     * (input_cursor / in_meta->sample_bytes()));
-    assert(input_cursor % in_meta->sample_bytes() == 0);
+    out_meta->set_fpga_seq_num(out_meta->get_fpga_seq_num()
+                               + out_meta->get_time_downsampling_fpga()
+                                     * (input_cursor / out_meta->sample_bytes()));
+    assert(input_cursor % out_meta->sample_bytes() == 0);
     assert(out_meta->dims > 0);
     assert(out_buffer->frame_size % out_meta->sample_bytes() == 0);
     out_meta->dim[0] = out_buffer->frame_size / out_meta->sample_bytes();


### PR DESCRIPTION
Consumer-side half of the metadata publish-then-mutate fix in #1638; independent of it (based on current `chord`), merges in either order.

**The change.** `cudaCopyFromRingbuffer::execute` already takes a coherent snapshot of the ring's slot-0 metadata (`out_meta->deepCopy(in_meta)`, under `chordMetadata::lock`) — and then goes back to the LIVE object for every value it actually uses: `sample_bytes()`, `fpga_seq_num`, `time_downsampling_fpga`. Each of those reads samples the shared object at a different instant while its producer may be writing it (`NDArrayRingBuffer::set_metadata` fills slot 0 in place; before #1638 several producers also patched fields after publishing). Every `in_meta->` below the copy becomes `out_meta->`. One file, +16/−8.

**Why this consumer in particular.** It derives

    out_seq = anchor + time_downsampling_fpga * (input_cursor / sample_bytes)

with `input_cursor` the absolute byte count since startup, so a torn read is not off by one frame: catching `time_downsampling_fpga` at 256 instead of 1024 (the `cudaRFISKtilde` RFImask state fixed in #1638) quarters the whole accumulated offset and emits a sequence number `0.75 × uptime` behind. `N2Accumulate` FATALs on the correlation-vs-RFICounts mismatch and the node exits — nine CHORD nodes on 2026-09-02/03.

**What this does and does not buy** (narrowing a claim from the first version of this description, per @jbmertens's review of #1638). It removes TORN reads: the three values are now guaranteed to come from one instant and one state of the object, which is what the existing locked `deepCopy` was already paying for and then discarding. It does **not** make the consumer immune to a producer that publishes and later patches — a snapshot taken inside that window is coherent but stale, and reads the same wrong value the old code would. Closing that window is the producer-side job, and is #1638. The two are complementary, not redundant, and neither subsumes the other.

**No behaviour change on the happy path:** `out_meta` is a byte copy of the object the old code read.

**Note on CI:** targets `chord`, which `.github/workflows/main.yaml` does not trigger on. Verified locally: the file compiles with the fleet's production flags (gcc 13, `-DWERROR=ON`, CUDA build).

