### PR TITLE
lib/cuda: set ring buffer metadata once, on the first frame

### DIFF
--- a/julia/kernels/bb_template.cxx
+++ b/julia/kernels/bb_template.cxx
@@ -271,15 +271,16 @@ cuda{{{kernel_name}}}::cuda{{{kernel_name}}}(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("{{{kernel_name}}}_" + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name={{{cuda_arch}}}",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/{{{kernel_name}}}.ptx", {kernel_symbol}, opts, "{{{kernel_name}}}_");
-    });
+    }
 }
 
 cuda{{{kernel_name}}}::~cuda{{{kernel_name}}}() {}

--- a/julia/kernels/chimefrb_template.cxx
+++ b/julia/kernels/chimefrb_template.cxx
@@ -287,15 +287,16 @@ cuda{{{kernel_name}}}::cuda{{{kernel_name}}}(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("{{{kernel_name}}}_" + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name={{{cuda_arch}}}",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/{{{kernel_name}}}.ptx", {kernel_symbol}, opts, "{{{kernel_name}}}_");
-    });
+    }
 }
 
 cuda{{{kernel_name}}}::~cuda{{{kernel_name}}}() {}

--- a/julia/kernels/frb_template.cxx
+++ b/julia/kernels/frb_template.cxx
@@ -304,15 +304,16 @@ cuda{{{kernel_name}}}::cuda{{{kernel_name}}}(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("{{{kernel_name}}}_" + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name={{{cuda_arch}}}",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/{{{kernel_name}}}.ptx", {kernel_symbol}, opts, "{{{kernel_name}}}_");
-    });
+    }
 }
 
 cuda{{{kernel_name}}}::~cuda{{{kernel_name}}}() {}

--- a/julia/kernels/upchan_template.cxx
+++ b/julia/kernels/upchan_template.cxx
@@ -179,6 +179,9 @@ private:
         {{/isscalar}}
     {{/kernel_arguments}}
 
+    // Set once, on the first frame; see `NDArrayRingBuffer::set_metadata`
+    bool did_set_metadata;
+
     // To avoid trailing comma below
     int dummy;
 };
@@ -249,6 +252,7 @@ cuda{{{kernel_name}}}::cuda{{{kernel_name}}}(Config& config,
         {{/isscalar}}
     {{/kernel_arguments}}
 
+    did_set_metadata(false),
     dummy()                      // avoid trailing comma
 {
     // Register host memory
@@ -356,7 +360,6 @@ cudaEvent_t cuda{{{kernel_name}}}::execute(cudaPipelineState& /*pipestate*/, con
     {{/kernel_arguments}}
 
     // Since we use a ring buffer we need to set the metadata only once
-    static bool did_set_metadata = false;
     if (instance_num == 0 && !did_set_metadata) {
         did_set_metadata = true;
 

--- a/julia/kernels/upchan_template.cxx
+++ b/julia/kernels/upchan_template.cxx
@@ -287,15 +287,16 @@ cuda{{{kernel_name}}}::cuda{{{kernel_name}}}(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("{{{kernel_name}}}_" + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name={{{cuda_arch}}}",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/{{{kernel_name}}}.ptx", {kernel_symbol}, opts, "{{{kernel_name}}}_");
-    });
+    }
 }
 
 cuda{{{kernel_name}}}::~cuda{{{kernel_name}}}() {}

--- a/julia/kernels/xpose2048_template.cxx
+++ b/julia/kernels/xpose2048_template.cxx
@@ -169,6 +169,9 @@ private:
         {{/isscalar}}
     {{/kernel_arguments}}
 
+    // Set once, on the first frame; see `NDArrayRingBuffer::set_metadata`
+    bool did_set_metadata;
+
     // To avoid trailing comma below
     int dummy;
 };
@@ -237,6 +240,7 @@ cuda{{{kernel_name}}}::cuda{{{kernel_name}}}(Config& config,
         {{/isscalar}}
     {{/kernel_arguments}}
 
+    did_set_metadata(false),
     dummy()                      // avoid trailing comma
 {
     // Register host memory
@@ -326,40 +330,45 @@ cudaEvent_t cuda{{{kernel_name}}}::execute(cudaPipelineState& /*pipestate*/, con
         {{/isscalar}}
     {{/kernel_arguments}}
 
-    {{#kernel_arguments}}
-        {{#hasbuffer}}
-            {{^isoutput}}
-                if (args::{{{name}}} == args::Ein) {
-                    // Replace "Ein" with "E" etc.
-                    // {{{name}}}_buffer.check_metadata();
-                    const std::shared_ptr<const chordMetadata>& metadata = Ein_buffer.get_metadata();
-                    const auto& ndarray = Ein_buffer.get_ndarray();
-                    if (!(metadata->get_name() == ndarray.quantity_name()))
-                        FATAL_ERROR("buffer name: {:s}, quantity: {:s}, metadata name: {:s}",
-                                    Ein_buffer.get_buffer_name(), ndarray.quantity_name(), metadata->get_name());
-                    assert(metadata->type == ndarray.value_datatype);
-                    assert(metadata->dims == ndarray.rank);
-                    for (std::size_t d = 0; d < ndarray.rank; ++d) {
-                        if (!(metadata->get_dimension_name(d) == ndarray.dimname(d)))
-                            FATAL_ERROR("buffer name: {:s}, dimension: {:d}: dimension name: {:s}, metadata name: {:s}",
-                                        Ein_buffer.get_buffer_name(), d, ndarray.dimname(d), metadata->get_dimension_name(d));
-                        // The ring buffer direction is special
-                        if (d > 0)
-                            assert(metadata->dim[d] == int(ndarray.extent(d)));
-                        assert(metadata->dim_scaling[d] == ndarray.dimscaling(d));
-                        if (!(metadata->stride[d] == ndarray.stride(d)))
-                            FATAL_ERROR("buffer name: {:s}, dimension: {:d}: metadata stride: {:d}, ndarray stride: {:d}",
-                                        Ein_buffer.get_buffer_name(), d, metadata->stride[d], ndarray.stride(d));
+    // Since we use a ring buffer we need to set the metadata only once
+    if (instance_num == 0 && !did_set_metadata) {
+        did_set_metadata = true;
+
+        {{#kernel_arguments}}
+            {{#hasbuffer}}
+                {{^isoutput}}
+                    if (args::{{{name}}} == args::Ein) {
+                        // Replace "Ein" with "E" etc.
+                        // {{{name}}}_buffer.check_metadata();
+                        const std::shared_ptr<const chordMetadata>& metadata = Ein_buffer.get_metadata();
+                        const auto& ndarray = Ein_buffer.get_ndarray();
+                        if (!(metadata->get_name() == ndarray.quantity_name()))
+                            FATAL_ERROR("buffer name: {:s}, quantity: {:s}, metadata name: {:s}",
+                                        Ein_buffer.get_buffer_name(), ndarray.quantity_name(), metadata->get_name());
+                        assert(metadata->type == ndarray.value_datatype);
+                        assert(metadata->dims == ndarray.rank);
+                        for (std::size_t d = 0; d < ndarray.rank; ++d) {
+                            if (!(metadata->get_dimension_name(d) == ndarray.dimname(d)))
+                                FATAL_ERROR("buffer name: {:s}, dimension: {:d}: dimension name: {:s}, metadata name: {:s}",
+                                            Ein_buffer.get_buffer_name(), d, ndarray.dimname(d), metadata->get_dimension_name(d));
+                            // The ring buffer direction is special
+                            if (d > 0)
+                                assert(metadata->dim[d] == int(ndarray.extent(d)));
+                            assert(metadata->dim_scaling[d] == ndarray.dimscaling(d));
+                            if (!(metadata->stride[d] == ndarray.stride(d)))
+                                FATAL_ERROR("buffer name: {:s}, dimension: {:d}: metadata stride: {:d}, ndarray stride: {:d}",
+                                            Ein_buffer.get_buffer_name(), d, metadata->stride[d], ndarray.stride(d));
+                        }
+                    } else {
+                        {{{name}}}_buffer.check_metadata();
                     }
-                } else {
-                    {{{name}}}_buffer.check_metadata();
-                }
-            {{/isoutput}}
-            {{#isoutput}}
-                {{{name}}}_buffer.set_metadata(Ein_buffer.get_metadata());
-            {{/isoutput}}
-        {{/hasbuffer}}
-    {{/kernel_arguments}}
+                {{/isoutput}}
+                {{#isoutput}}
+                    {{{name}}}_buffer.set_metadata(Ein_buffer.get_metadata());
+                {{/isoutput}}
+            {{/hasbuffer}}
+        {{/kernel_arguments}}
+    } // if !did_set_metadata
 
     const char* exc_arg = "exception";
     {{#kernel_arguments}}

--- a/julia/kernels/xpose2048_template.cxx
+++ b/julia/kernels/xpose2048_template.cxx
@@ -275,15 +275,16 @@ cuda{{{kernel_name}}}::cuda{{{kernel_name}}}(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("{{{kernel_name}}}_" + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name={{{cuda_arch}}}",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/{{{kernel_name}}}.ptx", {kernel_symbol}, opts, "{{{kernel_name}}}_");
-    });
+    }
 }
 
 cuda{{{kernel_name}}}::~cuda{{{kernel_name}}}() {}

--- a/julia/kernels/xpose_template.cxx
+++ b/julia/kernels/xpose_template.cxx
@@ -151,14 +151,16 @@ cuda{{{kernel_name}}}::cuda{{{kernel_name}}}(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("{{{kernel_name}}}_" + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name={{{cuda_arch}}}",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/{{{kernel_name}}}.ptx", {kernel_symbol}, opts, "{{{kernel_name}}}_");
-    });
+    }
 }
 
 cuda{{{kernel_name}}}::~cuda{{{kernel_name}}}() {}

--- a/lib/cuda/NDArrayRingBuffer.hpp
+++ b/lib/cuda/NDArrayRingBuffer.hpp
@@ -559,6 +559,15 @@ public:
         }
     }
 
+    // Set the ring buffer metadata. A ring buffer has a single metadata object for its whole
+    // lifetime: it describes the ring buffer as a whole, not any particular frame, and does not
+    // change over time. This function fills that object in place, so the producer must call it
+    // exactly once, on its first frame, before the first `finish_write` publishes data. From then
+    // on consumers -- which may run in other threads -- read the object without synchronization,
+    // and rewriting it, even with unchanged values, would race with them.
+    //
+    // A cudaCommand has `buffer_depth` instances sharing the ring buffer, and frame 0 is always
+    // handled by instance 0, so guard the call with `instance_num == 0` and a flag.
     void set_metadata(const std::shared_ptr<const chordMetadata>& other_metadata) {
         // const std::shared_ptr<metadataObject> mc =
         //     cuda_command.get_device().create_gpu_memory_array_metadata(buffer_name_device, 0,

--- a/lib/cuda/cudaFRBBeamReformer.cpp
+++ b/lib/cuda/cudaFRBBeamReformer.cpp
@@ -82,8 +82,6 @@ private:
     NDArrayBuffer<float16_t, 4> frb2_beams_buffer;
 
     cublasHandle_t handle;
-
-    bool did_set_metadata;
 };
 
 REGISTER_CUDA_COMMAND(cudaFRBBeamReformer);
@@ -125,9 +123,7 @@ cudaFRBBeamReformer::cudaFRBBeamReformer(kotekan::Config& config, const std::str
         frb2_beams_name, "I2",
         std::array<std::ptrdiff_t, 4>{1, frb2_num_beams, frb2_num_frequencies, frb2_num_times},
         std::array<std::string, 4>{"Ttildehi256", "R", "Fbar", "Ttildelo256"},
-        {frb_downsampling_factor * frb2_num_times, 1, 1, frb_downsampling_factor}, *this),
-
-    did_set_metadata(false)
+        {frb_downsampling_factor * frb2_num_times, 1, 1, frb_downsampling_factor}, *this)
 
 {
     frb2_weights_buffer.register_consumer();
@@ -187,18 +183,10 @@ cudaEvent_t cudaFRBBeamReformer::execute(cudaPipelineState& /*pipestate*/,
     frb2_weights_buffer.check_metadata();
     frb1_beams_buffer.check_metadata();
 
-    if (!did_set_metadata) {
-        did_set_metadata = true;
-        // Set metadata
-        const std::shared_ptr<const chordMetadata> frb1_beams_meta =
-            frb1_beams_buffer.get_metadata();
-        frb2_beams_buffer.set_metadata(frb1_beams_meta);
-        const std::shared_ptr<chordMetadata> frb2_beams_meta = frb2_beams_buffer.get_metadata();
-        frb2_beams_meta->set_time_downsampling_fpga(frb1_beams_meta->get_time_downsampling_fpga());
-        frb2_beams_meta->set_coarse_freq(frb1_beams_meta->get_coarse_freq());
-        frb2_beams_meta->set_freq_upchan_factor(frb1_beams_meta->get_freq_upchan_factor());
-        frb2_beams_meta->set_freq_upchan_index(frb1_beams_meta->get_freq_upchan_index());
-    }
+    // `frb2_beams_buffer` is not a ring buffer, so every frame gets its own metadata object
+    // (`NDArrayBuffer::set_metadata` takes a fresh one from the pool): `fpga_seq_num` below is
+    // frame-dependent, and frames already downstream still reference their own objects.
+    frb2_beams_buffer.set_metadata(frb1_beams_buffer.get_metadata());
     frb2_beams_buffer.check_metadata();
 
     const std::ptrdiff_t frb1_beams_offset = frb1_beams_buffer.get_read_valid().begin();

--- a/lib/cuda/cudaHFB1Accumulate.cpp
+++ b/lib/cuda/cudaHFB1Accumulate.cpp
@@ -85,6 +85,8 @@ private:
     // even though only `num_output_times == 1` element is produced per frame.
     NDArrayRingBuffer<float16_t, 4> hfb1_beams;
     NDArrayRingBuffer<float16_t, 4> hfb1_accumulated_beams;
+    // Set once, on the first frame; see `NDArrayRingBuffer::set_metadata`
+    bool did_set_metadata;
 };
 
 REGISTER_CUDA_COMMAND(cudaHFB1Accumulate);
@@ -119,7 +121,8 @@ cudaHFB1Accumulate::cudaHFB1Accumulate(kotekan::Config& config, const std::strin
         std::array<std::ptrdiff_t, 4>{buffer_depth * num_output_times, num_frequencies,
                                       frb1_num_beams_Q, frb1_num_beams_P},
         std::array<std::string, 4>{"Ttilde", "Fbar", "beamQ", "beamP"},
-        {hfb_downsampling_factor * hfb_second_downsampling_factor, 1, 1, 1}, *this)
+        {hfb_downsampling_factor * hfb_second_downsampling_factor, 1, 1, 1}, *this),
+    did_set_metadata(false)
 //
 {
     if (frb1_num_beams_P * frb1_num_beams_Q != cuda_num_beams)
@@ -163,16 +166,19 @@ cudaEvent_t cudaHFB1Accumulate::execute(cudaPipelineState& /*pipestate*/,
     record_start_event();
 
     hfb1_beams.check_metadata();
-    hfb1_accumulated_beams.set_metadata(hfb1_beams.get_metadata());
-
-    // Averaging `hfb_second_downsampling_factor` samples collapses the time axis: the output sample
-    // spans `hfb_second_downsampling_factor` input samples, so its FPGA time downsampling grows by
-    // that factor. (All other metadata is copied by set_metadata above; fpga_seq_num is inherited
-    // from the input window start.)
-    const std::shared_ptr<const chordMetadata> in_meta = hfb1_beams.get_metadata();
-    const std::shared_ptr<chordMetadata> out_meta = hfb1_accumulated_beams.get_metadata();
-    out_meta->set_time_downsampling_fpga(in_meta->get_time_downsampling_fpga()
-                                         * hfb_second_downsampling_factor);
+    // Set the ring buffer metadata once; see `NDArrayRingBuffer::set_metadata`
+    if (instance_num == 0 && !did_set_metadata) {
+        did_set_metadata = true;
+        hfb1_accumulated_beams.set_metadata(hfb1_beams.get_metadata());
+        // Averaging `hfb_second_downsampling_factor` samples collapses the time axis: the output
+        // sample spans `hfb_second_downsampling_factor` input samples, so its FPGA time
+        // downsampling grows by that factor. (All other metadata is copied by set_metadata above;
+        // fpga_seq_num is inherited from the input window start.)
+        const std::shared_ptr<const chordMetadata> in_meta = hfb1_beams.get_metadata();
+        const std::shared_ptr<chordMetadata> out_meta = hfb1_accumulated_beams.get_metadata();
+        out_meta->set_time_downsampling_fpga(in_meta->get_time_downsampling_fpga()
+                                             * hfb_second_downsampling_factor);
+    }
     hfb1_accumulated_beams.check_metadata();
 
     // The kernel is not ring-aware: it reads `hfb_second_downsampling_factor` contiguous time rows

--- a/lib/cuda/cudaPLMaskExpander.cpp
+++ b/lib/cuda/cudaPLMaskExpander.cpp
@@ -85,6 +85,8 @@ private:
     // Buffers
     NDArrayRingBuffer<kotekan::uint1x8_t, 5> pl_mask;
     NDArrayRingBuffer<kotekan::uint1x8_t, 5> pl_expanded_mask;
+    // Set once, on the first frame; see `NDArrayRingBuffer::set_metadata`
+    bool did_set_metadata;
 };
 
 REGISTER_CUDA_COMMAND(cudaPLMaskExpander);
@@ -116,7 +118,8 @@ cudaPLMaskExpander::cudaPLMaskExpander(kotekan::Config& config, const std::strin
                                                    num_frequencies, num_polarizations,
                                                    div_noremainder(num_dishes, 8), 64 / 8},
                      std::array<std::string, 5>{"Thi64", "F", "P", "D8", "Tlo64"}, {64, 1, 1, 8, 8},
-                     *this)
+                     *this),
+    did_set_metadata(false)
 //
 {
     // For pl_mask_T128_sample_bytes
@@ -168,13 +171,15 @@ cudaEvent_t cudaPLMaskExpander::execute(cudaPipelineState& /*pipestate*/,
 
     pl_mask.check_metadata();
 
-    pl_expanded_mask.set_metadata(pl_mask.get_metadata());
-    const auto& pl_mask_meta = pl_mask.get_metadata();
-    const auto& pl_expanded_mask_meta = pl_expanded_mask.get_metadata();
-
-    // TODO: Set these metadata only once
-    pl_expanded_mask_meta->set_time_downsampling_fpga(
-        div_noremainder(pl_mask_meta->get_time_downsampling_fpga(), 2));
+    // Set the ring buffer metadata once; see `NDArrayRingBuffer::set_metadata`
+    if (instance_num == 0 && !did_set_metadata) {
+        did_set_metadata = true;
+        pl_expanded_mask.set_metadata(pl_mask.get_metadata());
+        const auto& pl_mask_meta = pl_mask.get_metadata();
+        const auto& pl_expanded_mask_meta = pl_expanded_mask.get_metadata();
+        pl_expanded_mask_meta->set_time_downsampling_fpga(
+            div_noremainder(pl_mask_meta->get_time_downsampling_fpga(), 2));
+    }
 
     // There is no poison value
     // if (poison_buffers)

--- a/lib/cuda/cudaPLMaskUpchannelizer.cpp
+++ b/lib/cuda/cudaPLMaskUpchannelizer.cpp
@@ -111,6 +111,8 @@ private:
     // Buffers
     NDArrayRingBuffer<kotekan::uint1x8_t, 5> pl_expanded_mask;
     NDArrayRingBuffer<kotekan::uint1x8_t, 5> pl_upchannelized_expanded_mask;
+    // Set once, on the first frame; see `NDArrayRingBuffer::set_metadata`
+    bool did_set_metadata;
 };
 
 REGISTER_CUDA_COMMAND(cudaPLMaskUpchannelizer);
@@ -152,7 +154,8 @@ cudaPLMaskUpchannelizer::cudaPLMaskUpchannelizer(kotekan::Config& config,
         std::array<std::string, 5>{"Thi64", "F", "P", "D8", "Tlo64"},
         std::array<std::ptrdiff_t, 5>{64 * upchannelization_factor, 1, 1, 8,
                                       8 * upchannelization_factor},
-        *this)
+        *this),
+    did_set_metadata(false)
 //
 {
     if (!(0 <= Fmin && Fmin <= Fmax && Fmax <= num_frequencies))
@@ -222,15 +225,17 @@ cudaEvent_t cudaPLMaskUpchannelizer::execute(cudaPipelineState& /*pipestate*/,
     record_start_event();
 
     pl_expanded_mask.check_metadata();
-    pl_upchannelized_expanded_mask.set_metadata(pl_expanded_mask.get_metadata());
-
-    // The upchannelizer downsamples the time axis by `upchannelization_factor`; the frequency
-    // layout is unchanged (all other metadata is copied by set_metadata above).
-    // TODO: Set this metadata only once.
-    const auto& in_meta = pl_expanded_mask.get_metadata();
-    const auto& out_meta = pl_upchannelized_expanded_mask.get_metadata();
-    out_meta->set_time_downsampling_fpga(in_meta->get_time_downsampling_fpga()
-                                         * upchannelization_factor);
+    // Set the ring buffer metadata once; see `NDArrayRingBuffer::set_metadata`
+    if (instance_num == 0 && !did_set_metadata) {
+        did_set_metadata = true;
+        pl_upchannelized_expanded_mask.set_metadata(pl_expanded_mask.get_metadata());
+        // The upchannelizer downsamples the time axis by `upchannelization_factor`; the frequency
+        // layout is unchanged (all other metadata is copied by set_metadata above).
+        const auto& in_meta = pl_expanded_mask.get_metadata();
+        const auto& out_meta = pl_upchannelized_expanded_mask.get_metadata();
+        out_meta->set_time_downsampling_fpga(in_meta->get_time_downsampling_fpga()
+                                             * upchannelization_factor);
+    }
 
     kotekan::uint1x8_t* const in_memory = pl_expanded_mask.get_ndarray().data();
     kotekan::uint1x8_t* const out_memory = pl_upchannelized_expanded_mask.get_ndarray().data();

--- a/lib/cuda/cudaRFIS012.cpp
+++ b/lib/cuda/cudaRFIS012.cpp
@@ -82,6 +82,8 @@ private:
     NDArrayRingBuffer<kotekan::uint1x8_t, 5> pl_mask;
     NDArrayRingBuffer<kotekan::int4x2_swapped_withoffset_t, 4> voltage;
     NDArrayRingBuffer<std::uint64_t, 5> rfi_S012;
+    // Set once, on the first frame; see `NDArrayRingBuffer::set_metadata`
+    bool did_set_metadata;
 };
 
 REGISTER_CUDA_COMMAND(cudaRFIS012);
@@ -120,7 +122,8 @@ cudaRFIS012::cudaRFIS012(kotekan::Config& config, const std::string& unique_name
              std::array<std::ptrdiff_t, 5>{buffer_depth * rfi_num_times, num_frequencies, 3,
                                            num_polarizations, num_dishes},
              std::array<std::string, 5>{"Trfi", "F", "S", "P", "D"},
-             std::array<std::ptrdiff_t, 5>{rfi_downsampling_factor, 1, 1, 1, 1}, *this)
+             std::array<std::ptrdiff_t, 5>{rfi_downsampling_factor, 1, 1, 1, 1}, *this),
+    did_set_metadata(false)
 //
 {
     // For pl_mask_T128_sample_bytes
@@ -200,11 +203,14 @@ cudaEvent_t cudaRFIS012::execute(cudaPipelineState& /*pipestate*/,
     pl_mask.check_metadata();
     voltage.check_metadata();
 
-    // TODO: Set these metadata only once
-    rfi_S012.set_metadata(voltage.get_metadata());
-    const auto& rfi_S012_meta = rfi_S012.get_metadata();
-    rfi_S012_meta->set_time_downsampling_fpga(rfi_S012_meta->get_time_downsampling_fpga()
-                                              * rfi_downsampling_factor);
+    // Set the ring buffer metadata once; see `NDArrayRingBuffer::set_metadata`
+    if (instance_num == 0 && !did_set_metadata) {
+        did_set_metadata = true;
+        rfi_S012.set_metadata(voltage.get_metadata());
+        const auto& rfi_S012_meta = rfi_S012.get_metadata();
+        rfi_S012_meta->set_time_downsampling_fpga(rfi_S012_meta->get_time_downsampling_fpga()
+                                                  * rfi_downsampling_factor);
+    }
 
     // There is no poison value
     // if (poison_buffers)

--- a/lib/cuda/cudaRFIS012bar.cpp
+++ b/lib/cuda/cudaRFIS012bar.cpp
@@ -80,6 +80,8 @@ private:
     // Buffers
     NDArrayRingBuffer<std::uint64_t, 5> rfi_S012;
     NDArrayRingBuffer<std::uint64_t, 5> rfi_S012bar;
+    // Set once, on the first frame; see `NDArrayRingBuffer::set_metadata`
+    bool did_set_metadata;
 };
 
 REGISTER_CUDA_COMMAND(cudaRFIS012bar);
@@ -114,7 +116,8 @@ cudaRFIS012bar::cudaRFIS012bar(kotekan::Config& config, const std::string& uniqu
                 std::array<std::string, 5>{"Trfibar", "F", "S", "P", "D"},
                 std::array<std::ptrdiff_t, 5>{
                     rfi_downsampling_factor * rfi_second_downsampling_factor, 1, 1, 1, 1},
-                *this)
+                *this),
+    did_set_metadata(false)
 //
 {
     rfi_S012.register_consumer();
@@ -171,11 +174,14 @@ cudaEvent_t cudaRFIS012bar::execute(cudaPipelineState& /*pipestate*/,
 
     rfi_S012.check_metadata();
 
-    // TODO: Set these metadata only once
-    rfi_S012bar.set_metadata(rfi_S012.get_metadata());
-    const auto& rfi_S012bar_meta = rfi_S012bar.get_metadata();
-    rfi_S012bar_meta->set_time_downsampling_fpga(rfi_S012bar_meta->get_time_downsampling_fpga()
-                                                 * rfi_second_downsampling_factor);
+    // Set the ring buffer metadata once; see `NDArrayRingBuffer::set_metadata`
+    if (instance_num == 0 && !did_set_metadata) {
+        did_set_metadata = true;
+        rfi_S012bar.set_metadata(rfi_S012.get_metadata());
+        const auto& rfi_S012bar_meta = rfi_S012bar.get_metadata();
+        rfi_S012bar_meta->set_time_downsampling_fpga(rfi_S012bar_meta->get_time_downsampling_fpga()
+                                                     * rfi_second_downsampling_factor);
+    }
 
     // There is no poison value
     // if (poison_buffers)

--- a/lib/cuda/cudaRFIS012tilde.cpp
+++ b/lib/cuda/cudaRFIS012tilde.cpp
@@ -85,6 +85,8 @@ private:
     NDArrayRingBuffer<std::int8_t, 3> bf_mask;
     NDArrayRingBuffer<std::uint64_t, 5> rfi_S012;
     NDArrayRingBuffer<std::uint64_t, 3> rfi_S012tilde;
+    // Set once, on the first frame; see `NDArrayRingBuffer::set_metadata`
+    bool did_set_metadata;
 };
 
 REGISTER_CUDA_COMMAND(cudaRFIS012tilde);
@@ -124,7 +126,8 @@ cudaRFIS012tilde::cudaRFIS012tilde(kotekan::Config& config, const std::string& u
     rfi_S012tilde(rfi_S012tilde_name, "S012tilde",
                   std::array<std::ptrdiff_t, 3>{buffer_depth * rfi_num_times, num_frequencies, 3},
                   std::array<std::string, 3>{"Trfi", "F", "S"},
-                  std::array<std::ptrdiff_t, 3>{rfi_downsampling_factor, 1, 1}, *this)
+                  std::array<std::ptrdiff_t, 3>{rfi_downsampling_factor, 1, 1}, *this),
+    did_set_metadata(false)
 //
 {
     if (num_times % rfi_num_times != 0)
@@ -235,7 +238,11 @@ cudaEvent_t cudaRFIS012tilde::execute(cudaPipelineState& /*pipestate*/,
     bf_mask.check_metadata();
     rfi_S012.check_metadata();
 
-    rfi_S012tilde.set_metadata(rfi_S012.get_metadata());
+    // Set the ring buffer metadata once; see `NDArrayRingBuffer::set_metadata`
+    if (instance_num == 0 && !did_set_metadata) {
+        did_set_metadata = true;
+        rfi_S012tilde.set_metadata(rfi_S012.get_metadata());
+    }
 
     // There is no poison value
     // if (poison_buffers)

--- a/lib/cuda/cudaRFISKbar.cpp
+++ b/lib/cuda/cudaRFISKbar.cpp
@@ -89,6 +89,8 @@ private:
 
     // Kernels
     const n2k::SkKernel skKernel;
+    // Set once, on the first frame; see `NDArrayRingBuffer::set_metadata`
+    bool did_set_metadata;
 };
 
 REGISTER_CUDA_COMMAND(cudaRFISKbar);
@@ -150,7 +152,8 @@ cudaRFISKbar::cudaRFISKbar(kotekan::Config& config, const std::string& unique_na
         config.get<double>(unique_name, "rfi_mu_min"),
         config.get<double>(unique_name, "rfi_mu_max"),
         rfi_downsampling_factor * rfi_second_downsampling_factor,
-    })
+    }),
+    did_set_metadata(false)
 //
 {
     if (bf_mask_lifetime_in_samples % (rfi_downsampling_factor * rfi_second_downsampling_factor)
@@ -272,8 +275,12 @@ cudaEvent_t cudaRFISKbar::execute(cudaPipelineState& /*pipestate*/,
     bf_mask.check_metadata();
     rfi_S012bar.check_metadata();
 
-    rfi_SKbar.set_metadata(rfi_S012bar.get_metadata());
-    rfi_SKbartilde.set_metadata(rfi_S012bar.get_metadata());
+    // Set the ring buffer metadata once; see `NDArrayRingBuffer::set_metadata`
+    if (instance_num == 0 && !did_set_metadata) {
+        did_set_metadata = true;
+        rfi_SKbar.set_metadata(rfi_S012bar.get_metadata());
+        rfi_SKbartilde.set_metadata(rfi_S012bar.get_metadata());
+    }
 
     if (poison_buffers) {
         rfi_SKbar.set_to_poison(0xff);

--- a/lib/cuda/cudaRFISKtilde.cpp
+++ b/lib/cuda/cudaRFISKtilde.cpp
@@ -101,6 +101,8 @@ private:
 
     // Kernels
     const n2k::SkKernel skKernel;
+    // Set once, on the first frame; see `NDArrayRingBuffer::set_metadata`
+    bool did_set_metadata;
 };
 
 REGISTER_CUDA_COMMAND(cudaRFISKtilde);
@@ -158,7 +160,8 @@ cudaRFISKtilde::cudaRFISKtilde(kotekan::Config& config, const std::string& uniqu
         config.get<double>(unique_name, "rfi_mu_min"),
         config.get<double>(unique_name, "rfi_mu_max"),
         rfi_downsampling_factor,
-    })
+    }),
+    did_set_metadata(false)
 //
 {
     if (bf_mask_lifetime_in_samples % rfi_downsampling_factor != 0)
@@ -286,13 +289,16 @@ cudaEvent_t cudaRFISKtilde::execute(cudaPipelineState& /*pipestate*/,
     bf_mask.check_metadata();
     rfi_S012.check_metadata();
 
-    rfi_SKtilde.set_metadata(rfi_S012.get_metadata());
-    rfi_RFImask.set_metadata(rfi_S012.get_metadata());
-    // Correct RFImask metadata
-    // TODO: Set these metadata only once
-    const std::shared_ptr<chordMetadata> rfi_meta = rfi_RFImask.get_metadata();
-    rfi_meta->set_time_downsampling_fpga(rfi_meta->get_time_downsampling_fpga()
-                                         * div_noremainder(128 * 8, rfi_downsampling_factor));
+    // Set the ring buffer metadata once; see `NDArrayRingBuffer::set_metadata`
+    if (instance_num == 0 && !did_set_metadata) {
+        did_set_metadata = true;
+        rfi_SKtilde.set_metadata(rfi_S012.get_metadata());
+        rfi_RFImask.set_metadata(rfi_S012.get_metadata());
+        // Correct RFImask metadata
+        const std::shared_ptr<chordMetadata> rfi_meta = rfi_RFImask.get_metadata();
+        rfi_meta->set_time_downsampling_fpga(rfi_meta->get_time_downsampling_fpga()
+                                             * div_noremainder(128 * 8, rfi_downsampling_factor));
+    }
 
     if (poison_buffers) {
         rfi_SKtilde.set_to_poison(0xff);

--- a/lib/cuda/generated/cudaBasebandBeamformer_charts.cpp
+++ b/lib/cuda/generated/cudaBasebandBeamformer_charts.cpp
@@ -403,16 +403,17 @@ cudaBasebandBeamformer_charts::cudaBasebandBeamformer_charts(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("BasebandBeamformer_charts_" + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_120",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/BasebandBeamformer_charts.ptx", {kernel_symbol}, opts,
                          "BasebandBeamformer_charts_");
-    });
+    }
 }
 
 cudaBasebandBeamformer_charts::~cudaBasebandBeamformer_charts() {}

--- a/lib/cuda/generated/cudaBasebandBeamformer_chime.cpp
+++ b/lib/cuda/generated/cudaBasebandBeamformer_chime.cpp
@@ -403,16 +403,17 @@ cudaBasebandBeamformer_chime::cudaBasebandBeamformer_chime(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("BasebandBeamformer_chime_" + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_89",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/BasebandBeamformer_chime.ptx", {kernel_symbol}, opts,
                          "BasebandBeamformer_chime_");
-    });
+    }
 }
 
 cudaBasebandBeamformer_chime::~cudaBasebandBeamformer_chime() {}

--- a/lib/cuda/generated/cudaBasebandBeamformer_chord.cpp
+++ b/lib/cuda/generated/cudaBasebandBeamformer_chord.cpp
@@ -403,16 +403,17 @@ cudaBasebandBeamformer_chord::cudaBasebandBeamformer_chord(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("BasebandBeamformer_chord_" + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_86",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/BasebandBeamformer_chord.ptx", {kernel_symbol}, opts,
                          "BasebandBeamformer_chord_");
-    });
+    }
 }
 
 cudaBasebandBeamformer_chord::~cudaBasebandBeamformer_chord() {}

--- a/lib/cuda/generated/cudaBasebandBeamformer_hirax.cpp
+++ b/lib/cuda/generated/cudaBasebandBeamformer_hirax.cpp
@@ -403,16 +403,17 @@ cudaBasebandBeamformer_hirax::cudaBasebandBeamformer_hirax(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("BasebandBeamformer_hirax_" + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_86",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/BasebandBeamformer_hirax.ptx", {kernel_symbol}, opts,
                          "BasebandBeamformer_hirax_");
-    });
+    }
 }
 
 cudaBasebandBeamformer_hirax::~cudaBasebandBeamformer_hirax() {}

--- a/lib/cuda/generated/cudaBasebandBeamformer_pathfinder.cpp
+++ b/lib/cuda/generated/cudaBasebandBeamformer_pathfinder.cpp
@@ -403,16 +403,18 @@ cudaBasebandBeamformer_pathfinder::cudaBasebandBeamformer_pathfinder(Config& con
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("BasebandBeamformer_pathfinder_"
+                                      + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_86",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/BasebandBeamformer_pathfinder.ptx", {kernel_symbol},
                          opts, "BasebandBeamformer_pathfinder_");
-    });
+    }
 }
 
 cudaBasebandBeamformer_pathfinder::~cudaBasebandBeamformer_pathfinder() {}

--- a/lib/cuda/generated/cudaCHIMEFRBBeamformer_chime_U128.cpp
+++ b/lib/cuda/generated/cudaCHIMEFRBBeamformer_chime_U128.cpp
@@ -348,16 +348,18 @@ cudaCHIMEFRBBeamformer_chime_U128::cudaCHIMEFRBBeamformer_chime_U128(Config& con
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("CHIMEFRBBeamformer_chime_U128_"
+                                      + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_89",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/CHIMEFRBBeamformer_chime_U128.ptx", {kernel_symbol},
                          opts, "CHIMEFRBBeamformer_chime_U128_");
-    });
+    }
 }
 
 cudaCHIMEFRBBeamformer_chime_U128::~cudaCHIMEFRBBeamformer_chime_U128() {}

--- a/lib/cuda/generated/cudaCHIMEFRBBeamformer_chime_U16.cpp
+++ b/lib/cuda/generated/cudaCHIMEFRBBeamformer_chime_U16.cpp
@@ -348,16 +348,18 @@ cudaCHIMEFRBBeamformer_chime_U16::cudaCHIMEFRBBeamformer_chime_U16(Config& confi
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("CHIMEFRBBeamformer_chime_U16_"
+                                      + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_89",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/CHIMEFRBBeamformer_chime_U16.ptx", {kernel_symbol},
                          opts, "CHIMEFRBBeamformer_chime_U16_");
-    });
+    }
 }
 
 cudaCHIMEFRBBeamformer_chime_U16::~cudaCHIMEFRBBeamformer_chime_U16() {}

--- a/lib/cuda/generated/cudaFRBBeamformer_charts_U32.cpp
+++ b/lib/cuda/generated/cudaFRBBeamformer_charts_U32.cpp
@@ -443,16 +443,17 @@ cudaFRBBeamformer_charts_U32::cudaFRBBeamformer_charts_U32(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("FRBBeamformer_charts_U32_" + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_120",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/FRBBeamformer_charts_U32.ptx", {kernel_symbol}, opts,
                          "FRBBeamformer_charts_U32_");
-    });
+    }
 }
 
 cudaFRBBeamformer_charts_U32::~cudaFRBBeamformer_charts_U32() {}

--- a/lib/cuda/generated/cudaFRBBeamformer_chord_U1.cpp
+++ b/lib/cuda/generated/cudaFRBBeamformer_chord_U1.cpp
@@ -443,16 +443,17 @@ cudaFRBBeamformer_chord_U1::cudaFRBBeamformer_chord_U1(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("FRBBeamformer_chord_U1_" + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_86",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/FRBBeamformer_chord_U1.ptx", {kernel_symbol}, opts,
                          "FRBBeamformer_chord_U1_");
-    });
+    }
 }
 
 cudaFRBBeamformer_chord_U1::~cudaFRBBeamformer_chord_U1() {}

--- a/lib/cuda/generated/cudaFRBBeamformer_chord_U128.cpp
+++ b/lib/cuda/generated/cudaFRBBeamformer_chord_U128.cpp
@@ -443,16 +443,17 @@ cudaFRBBeamformer_chord_U128::cudaFRBBeamformer_chord_U128(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("FRBBeamformer_chord_U128_" + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_86",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/FRBBeamformer_chord_U128.ptx", {kernel_symbol}, opts,
                          "FRBBeamformer_chord_U128_");
-    });
+    }
 }
 
 cudaFRBBeamformer_chord_U128::~cudaFRBBeamformer_chord_U128() {}

--- a/lib/cuda/generated/cudaFRBBeamformer_chord_U16.cpp
+++ b/lib/cuda/generated/cudaFRBBeamformer_chord_U16.cpp
@@ -443,16 +443,17 @@ cudaFRBBeamformer_chord_U16::cudaFRBBeamformer_chord_U16(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("FRBBeamformer_chord_U16_" + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_86",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/FRBBeamformer_chord_U16.ptx", {kernel_symbol}, opts,
                          "FRBBeamformer_chord_U16_");
-    });
+    }
 }
 
 cudaFRBBeamformer_chord_U16::~cudaFRBBeamformer_chord_U16() {}

--- a/lib/cuda/generated/cudaFRBBeamformer_chord_U2.cpp
+++ b/lib/cuda/generated/cudaFRBBeamformer_chord_U2.cpp
@@ -443,16 +443,17 @@ cudaFRBBeamformer_chord_U2::cudaFRBBeamformer_chord_U2(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("FRBBeamformer_chord_U2_" + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_86",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/FRBBeamformer_chord_U2.ptx", {kernel_symbol}, opts,
                          "FRBBeamformer_chord_U2_");
-    });
+    }
 }
 
 cudaFRBBeamformer_chord_U2::~cudaFRBBeamformer_chord_U2() {}

--- a/lib/cuda/generated/cudaFRBBeamformer_chord_U32.cpp
+++ b/lib/cuda/generated/cudaFRBBeamformer_chord_U32.cpp
@@ -443,16 +443,17 @@ cudaFRBBeamformer_chord_U32::cudaFRBBeamformer_chord_U32(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("FRBBeamformer_chord_U32_" + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_86",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/FRBBeamformer_chord_U32.ptx", {kernel_symbol}, opts,
                          "FRBBeamformer_chord_U32_");
-    });
+    }
 }
 
 cudaFRBBeamformer_chord_U32::~cudaFRBBeamformer_chord_U32() {}

--- a/lib/cuda/generated/cudaFRBBeamformer_chord_U4.cpp
+++ b/lib/cuda/generated/cudaFRBBeamformer_chord_U4.cpp
@@ -443,16 +443,17 @@ cudaFRBBeamformer_chord_U4::cudaFRBBeamformer_chord_U4(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("FRBBeamformer_chord_U4_" + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_86",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/FRBBeamformer_chord_U4.ptx", {kernel_symbol}, opts,
                          "FRBBeamformer_chord_U4_");
-    });
+    }
 }
 
 cudaFRBBeamformer_chord_U4::~cudaFRBBeamformer_chord_U4() {}

--- a/lib/cuda/generated/cudaFRBBeamformer_chord_U64.cpp
+++ b/lib/cuda/generated/cudaFRBBeamformer_chord_U64.cpp
@@ -443,16 +443,17 @@ cudaFRBBeamformer_chord_U64::cudaFRBBeamformer_chord_U64(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("FRBBeamformer_chord_U64_" + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_86",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/FRBBeamformer_chord_U64.ptx", {kernel_symbol}, opts,
                          "FRBBeamformer_chord_U64_");
-    });
+    }
 }
 
 cudaFRBBeamformer_chord_U64::~cudaFRBBeamformer_chord_U64() {}

--- a/lib/cuda/generated/cudaFRBBeamformer_chord_U8.cpp
+++ b/lib/cuda/generated/cudaFRBBeamformer_chord_U8.cpp
@@ -443,16 +443,17 @@ cudaFRBBeamformer_chord_U8::cudaFRBBeamformer_chord_U8(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("FRBBeamformer_chord_U8_" + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_86",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/FRBBeamformer_chord_U8.ptx", {kernel_symbol}, opts,
                          "FRBBeamformer_chord_U8_");
-    });
+    }
 }
 
 cudaFRBBeamformer_chord_U8::~cudaFRBBeamformer_chord_U8() {}

--- a/lib/cuda/generated/cudaFRBBeamformer_hirax_U1.cpp
+++ b/lib/cuda/generated/cudaFRBBeamformer_hirax_U1.cpp
@@ -443,16 +443,17 @@ cudaFRBBeamformer_hirax_U1::cudaFRBBeamformer_hirax_U1(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("FRBBeamformer_hirax_U1_" + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_86",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/FRBBeamformer_hirax_U1.ptx", {kernel_symbol}, opts,
                          "FRBBeamformer_hirax_U1_");
-    });
+    }
 }
 
 cudaFRBBeamformer_hirax_U1::~cudaFRBBeamformer_hirax_U1() {}

--- a/lib/cuda/generated/cudaFRBBeamformer_hirax_U128.cpp
+++ b/lib/cuda/generated/cudaFRBBeamformer_hirax_U128.cpp
@@ -443,16 +443,17 @@ cudaFRBBeamformer_hirax_U128::cudaFRBBeamformer_hirax_U128(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("FRBBeamformer_hirax_U128_" + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_86",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/FRBBeamformer_hirax_U128.ptx", {kernel_symbol}, opts,
                          "FRBBeamformer_hirax_U128_");
-    });
+    }
 }
 
 cudaFRBBeamformer_hirax_U128::~cudaFRBBeamformer_hirax_U128() {}

--- a/lib/cuda/generated/cudaFRBBeamformer_hirax_U16.cpp
+++ b/lib/cuda/generated/cudaFRBBeamformer_hirax_U16.cpp
@@ -443,16 +443,17 @@ cudaFRBBeamformer_hirax_U16::cudaFRBBeamformer_hirax_U16(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("FRBBeamformer_hirax_U16_" + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_86",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/FRBBeamformer_hirax_U16.ptx", {kernel_symbol}, opts,
                          "FRBBeamformer_hirax_U16_");
-    });
+    }
 }
 
 cudaFRBBeamformer_hirax_U16::~cudaFRBBeamformer_hirax_U16() {}

--- a/lib/cuda/generated/cudaFRBBeamformer_hirax_U2.cpp
+++ b/lib/cuda/generated/cudaFRBBeamformer_hirax_U2.cpp
@@ -443,16 +443,17 @@ cudaFRBBeamformer_hirax_U2::cudaFRBBeamformer_hirax_U2(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("FRBBeamformer_hirax_U2_" + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_86",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/FRBBeamformer_hirax_U2.ptx", {kernel_symbol}, opts,
                          "FRBBeamformer_hirax_U2_");
-    });
+    }
 }
 
 cudaFRBBeamformer_hirax_U2::~cudaFRBBeamformer_hirax_U2() {}

--- a/lib/cuda/generated/cudaFRBBeamformer_hirax_U32.cpp
+++ b/lib/cuda/generated/cudaFRBBeamformer_hirax_U32.cpp
@@ -443,16 +443,17 @@ cudaFRBBeamformer_hirax_U32::cudaFRBBeamformer_hirax_U32(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("FRBBeamformer_hirax_U32_" + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_86",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/FRBBeamformer_hirax_U32.ptx", {kernel_symbol}, opts,
                          "FRBBeamformer_hirax_U32_");
-    });
+    }
 }
 
 cudaFRBBeamformer_hirax_U32::~cudaFRBBeamformer_hirax_U32() {}

--- a/lib/cuda/generated/cudaFRBBeamformer_hirax_U4.cpp
+++ b/lib/cuda/generated/cudaFRBBeamformer_hirax_U4.cpp
@@ -443,16 +443,17 @@ cudaFRBBeamformer_hirax_U4::cudaFRBBeamformer_hirax_U4(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("FRBBeamformer_hirax_U4_" + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_86",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/FRBBeamformer_hirax_U4.ptx", {kernel_symbol}, opts,
                          "FRBBeamformer_hirax_U4_");
-    });
+    }
 }
 
 cudaFRBBeamformer_hirax_U4::~cudaFRBBeamformer_hirax_U4() {}

--- a/lib/cuda/generated/cudaFRBBeamformer_hirax_U64.cpp
+++ b/lib/cuda/generated/cudaFRBBeamformer_hirax_U64.cpp
@@ -443,16 +443,17 @@ cudaFRBBeamformer_hirax_U64::cudaFRBBeamformer_hirax_U64(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("FRBBeamformer_hirax_U64_" + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_86",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/FRBBeamformer_hirax_U64.ptx", {kernel_symbol}, opts,
                          "FRBBeamformer_hirax_U64_");
-    });
+    }
 }
 
 cudaFRBBeamformer_hirax_U64::~cudaFRBBeamformer_hirax_U64() {}

--- a/lib/cuda/generated/cudaFRBBeamformer_hirax_U8.cpp
+++ b/lib/cuda/generated/cudaFRBBeamformer_hirax_U8.cpp
@@ -443,16 +443,17 @@ cudaFRBBeamformer_hirax_U8::cudaFRBBeamformer_hirax_U8(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("FRBBeamformer_hirax_U8_" + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_86",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/FRBBeamformer_hirax_U8.ptx", {kernel_symbol}, opts,
                          "FRBBeamformer_hirax_U8_");
-    });
+    }
 }
 
 cudaFRBBeamformer_hirax_U8::~cudaFRBBeamformer_hirax_U8() {}

--- a/lib/cuda/generated/cudaFRBBeamformer_pathfinder_U1.cpp
+++ b/lib/cuda/generated/cudaFRBBeamformer_pathfinder_U1.cpp
@@ -443,16 +443,18 @@ cudaFRBBeamformer_pathfinder_U1::cudaFRBBeamformer_pathfinder_U1(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("FRBBeamformer_pathfinder_U1_"
+                                      + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_86",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/FRBBeamformer_pathfinder_U1.ptx", {kernel_symbol},
                          opts, "FRBBeamformer_pathfinder_U1_");
-    });
+    }
 }
 
 cudaFRBBeamformer_pathfinder_U1::~cudaFRBBeamformer_pathfinder_U1() {}

--- a/lib/cuda/generated/cudaFRBBeamformer_pathfinder_U16.cpp
+++ b/lib/cuda/generated/cudaFRBBeamformer_pathfinder_U16.cpp
@@ -443,16 +443,18 @@ cudaFRBBeamformer_pathfinder_U16::cudaFRBBeamformer_pathfinder_U16(Config& confi
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("FRBBeamformer_pathfinder_U16_"
+                                      + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_86",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/FRBBeamformer_pathfinder_U16.ptx", {kernel_symbol},
                          opts, "FRBBeamformer_pathfinder_U16_");
-    });
+    }
 }
 
 cudaFRBBeamformer_pathfinder_U16::~cudaFRBBeamformer_pathfinder_U16() {}

--- a/lib/cuda/generated/cudaFRBBeamformer_pathfinder_U2.cpp
+++ b/lib/cuda/generated/cudaFRBBeamformer_pathfinder_U2.cpp
@@ -443,16 +443,18 @@ cudaFRBBeamformer_pathfinder_U2::cudaFRBBeamformer_pathfinder_U2(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("FRBBeamformer_pathfinder_U2_"
+                                      + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_86",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/FRBBeamformer_pathfinder_U2.ptx", {kernel_symbol},
                          opts, "FRBBeamformer_pathfinder_U2_");
-    });
+    }
 }
 
 cudaFRBBeamformer_pathfinder_U2::~cudaFRBBeamformer_pathfinder_U2() {}

--- a/lib/cuda/generated/cudaFRBBeamformer_pathfinder_U32.cpp
+++ b/lib/cuda/generated/cudaFRBBeamformer_pathfinder_U32.cpp
@@ -443,16 +443,18 @@ cudaFRBBeamformer_pathfinder_U32::cudaFRBBeamformer_pathfinder_U32(Config& confi
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("FRBBeamformer_pathfinder_U32_"
+                                      + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_86",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/FRBBeamformer_pathfinder_U32.ptx", {kernel_symbol},
                          opts, "FRBBeamformer_pathfinder_U32_");
-    });
+    }
 }
 
 cudaFRBBeamformer_pathfinder_U32::~cudaFRBBeamformer_pathfinder_U32() {}

--- a/lib/cuda/generated/cudaFRBBeamformer_pathfinder_U4.cpp
+++ b/lib/cuda/generated/cudaFRBBeamformer_pathfinder_U4.cpp
@@ -443,16 +443,18 @@ cudaFRBBeamformer_pathfinder_U4::cudaFRBBeamformer_pathfinder_U4(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("FRBBeamformer_pathfinder_U4_"
+                                      + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_86",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/FRBBeamformer_pathfinder_U4.ptx", {kernel_symbol},
                          opts, "FRBBeamformer_pathfinder_U4_");
-    });
+    }
 }
 
 cudaFRBBeamformer_pathfinder_U4::~cudaFRBBeamformer_pathfinder_U4() {}

--- a/lib/cuda/generated/cudaFRBBeamformer_pathfinder_U64.cpp
+++ b/lib/cuda/generated/cudaFRBBeamformer_pathfinder_U64.cpp
@@ -443,16 +443,18 @@ cudaFRBBeamformer_pathfinder_U64::cudaFRBBeamformer_pathfinder_U64(Config& confi
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("FRBBeamformer_pathfinder_U64_"
+                                      + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_86",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/FRBBeamformer_pathfinder_U64.ptx", {kernel_symbol},
                          opts, "FRBBeamformer_pathfinder_U64_");
-    });
+    }
 }
 
 cudaFRBBeamformer_pathfinder_U64::~cudaFRBBeamformer_pathfinder_U64() {}

--- a/lib/cuda/generated/cudaFRBBeamformer_pathfinder_U8.cpp
+++ b/lib/cuda/generated/cudaFRBBeamformer_pathfinder_U8.cpp
@@ -443,16 +443,18 @@ cudaFRBBeamformer_pathfinder_U8::cudaFRBBeamformer_pathfinder_U8(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("FRBBeamformer_pathfinder_U8_"
+                                      + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_86",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/FRBBeamformer_pathfinder_U8.ptx", {kernel_symbol},
                          opts, "FRBBeamformer_pathfinder_U8_");
-    });
+    }
 }
 
 cudaFRBBeamformer_pathfinder_U8::~cudaFRBBeamformer_pathfinder_U8() {}

--- a/lib/cuda/generated/cudaTranspose2048_chime.cpp
+++ b/lib/cuda/generated/cudaTranspose2048_chime.cpp
@@ -341,16 +341,17 @@ cudaTranspose2048_chime::cudaTranspose2048_chime(Config& config, const std::stri
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("Transpose2048_chime_" + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_89",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/Transpose2048_chime.ptx", {kernel_symbol}, opts,
                          "Transpose2048_chime_");
-    });
+    }
 }
 
 cudaTranspose2048_chime::~cudaTranspose2048_chime() {}

--- a/lib/cuda/generated/cudaTranspose2048_chime.cpp
+++ b/lib/cuda/generated/cudaTranspose2048_chime.cpp
@@ -290,6 +290,9 @@ private:
     NDArrayBuffer<kotekan::GetType_t<info_type>, info_rank> info_buffer;
     std::vector<kotekan::GetType_t<info_type>> host_info_buffer;
 
+    // Set once, on the first frame; see `NDArrayRingBuffer::set_metadata`
+    bool did_set_metadata;
+
     // To avoid trailing comma below
     int dummy;
 };
@@ -321,7 +324,7 @@ cudaTranspose2048_chime::cudaTranspose2048_chime(Config& config, const std::stri
                 reverse(info_dimscalings), *this),
     host_info_buffer(info_length),
 
-    dummy() // avoid trailing comma
+    did_set_metadata(false), dummy() // avoid trailing comma
 {
     // Register host memory
     {
@@ -394,67 +397,72 @@ cudaEvent_t cudaTranspose2048_chime::execute(cudaPipelineState& /*pipestate*/,
     void* const scatter_indices_memory = scatter_indices_buffer.get_ndarray().data();
     void* const info_memory = info_buffer.get_ndarray().data();
 
-    if (args::Ein == args::Ein) {
-        // Replace "Ein" with "E" etc.
-        // Ein_buffer.check_metadata();
-        const std::shared_ptr<const chordMetadata>& metadata = Ein_buffer.get_metadata();
-        const auto& ndarray = Ein_buffer.get_ndarray();
-        if (!(metadata->get_name() == ndarray.quantity_name()))
-            FATAL_ERROR("buffer name: {:s}, quantity: {:s}, metadata name: {:s}",
-                        Ein_buffer.get_buffer_name(), ndarray.quantity_name(),
-                        metadata->get_name());
-        assert(metadata->type == ndarray.value_datatype);
-        assert(metadata->dims == ndarray.rank);
-        for (std::size_t d = 0; d < ndarray.rank; ++d) {
-            if (!(metadata->get_dimension_name(d) == ndarray.dimname(d)))
-                FATAL_ERROR(
-                    "buffer name: {:s}, dimension: {:d}: dimension name: {:s}, metadata name: {:s}",
-                    Ein_buffer.get_buffer_name(), d, ndarray.dimname(d),
-                    metadata->get_dimension_name(d));
-            // The ring buffer direction is special
-            if (d > 0)
-                assert(metadata->dim[d] == int(ndarray.extent(d)));
-            assert(metadata->dim_scaling[d] == ndarray.dimscaling(d));
-            if (!(metadata->stride[d] == ndarray.stride(d)))
-                FATAL_ERROR("buffer name: {:s}, dimension: {:d}: metadata stride: {:d}, ndarray "
-                            "stride: {:d}",
-                            Ein_buffer.get_buffer_name(), d, metadata->stride[d],
-                            ndarray.stride(d));
+    // Since we use a ring buffer we need to set the metadata only once
+    if (instance_num == 0 && !did_set_metadata) {
+        did_set_metadata = true;
+
+        if (args::Ein == args::Ein) {
+            // Replace "Ein" with "E" etc.
+            // Ein_buffer.check_metadata();
+            const std::shared_ptr<const chordMetadata>& metadata = Ein_buffer.get_metadata();
+            const auto& ndarray = Ein_buffer.get_ndarray();
+            if (!(metadata->get_name() == ndarray.quantity_name()))
+                FATAL_ERROR("buffer name: {:s}, quantity: {:s}, metadata name: {:s}",
+                            Ein_buffer.get_buffer_name(), ndarray.quantity_name(),
+                            metadata->get_name());
+            assert(metadata->type == ndarray.value_datatype);
+            assert(metadata->dims == ndarray.rank);
+            for (std::size_t d = 0; d < ndarray.rank; ++d) {
+                if (!(metadata->get_dimension_name(d) == ndarray.dimname(d)))
+                    FATAL_ERROR("buffer name: {:s}, dimension: {:d}: dimension name: {:s}, "
+                                "metadata name: {:s}",
+                                Ein_buffer.get_buffer_name(), d, ndarray.dimname(d),
+                                metadata->get_dimension_name(d));
+                // The ring buffer direction is special
+                if (d > 0)
+                    assert(metadata->dim[d] == int(ndarray.extent(d)));
+                assert(metadata->dim_scaling[d] == ndarray.dimscaling(d));
+                if (!(metadata->stride[d] == ndarray.stride(d)))
+                    FATAL_ERROR(
+                        "buffer name: {:s}, dimension: {:d}: metadata stride: {:d}, ndarray "
+                        "stride: {:d}",
+                        Ein_buffer.get_buffer_name(), d, metadata->stride[d], ndarray.stride(d));
+            }
+        } else {
+            Ein_buffer.check_metadata();
         }
-    } else {
-        Ein_buffer.check_metadata();
-    }
-    E_buffer.set_metadata(Ein_buffer.get_metadata());
-    if (args::scatter_indices == args::Ein) {
-        // Replace "Ein" with "E" etc.
-        // scatter_indices_buffer.check_metadata();
-        const std::shared_ptr<const chordMetadata>& metadata = Ein_buffer.get_metadata();
-        const auto& ndarray = Ein_buffer.get_ndarray();
-        if (!(metadata->get_name() == ndarray.quantity_name()))
-            FATAL_ERROR("buffer name: {:s}, quantity: {:s}, metadata name: {:s}",
-                        Ein_buffer.get_buffer_name(), ndarray.quantity_name(),
-                        metadata->get_name());
-        assert(metadata->type == ndarray.value_datatype);
-        assert(metadata->dims == ndarray.rank);
-        for (std::size_t d = 0; d < ndarray.rank; ++d) {
-            if (!(metadata->get_dimension_name(d) == ndarray.dimname(d)))
-                FATAL_ERROR(
-                    "buffer name: {:s}, dimension: {:d}: dimension name: {:s}, metadata name: {:s}",
-                    Ein_buffer.get_buffer_name(), d, ndarray.dimname(d),
-                    metadata->get_dimension_name(d));
-            // The ring buffer direction is special
-            if (d > 0)
-                assert(metadata->dim[d] == int(ndarray.extent(d)));
-            assert(metadata->dim_scaling[d] == ndarray.dimscaling(d));
-            if (!(metadata->stride[d] == ndarray.stride(d)))
-                FATAL_ERROR("buffer name: {:s}, dimension: {:d}: metadata stride: {:d}, ndarray "
-                            "stride: {:d}",
-                            Ein_buffer.get_buffer_name(), d, metadata->stride[d],
-                            ndarray.stride(d));
+        E_buffer.set_metadata(Ein_buffer.get_metadata());
+        if (args::scatter_indices == args::Ein) {
+            // Replace "Ein" with "E" etc.
+            // scatter_indices_buffer.check_metadata();
+            const std::shared_ptr<const chordMetadata>& metadata = Ein_buffer.get_metadata();
+            const auto& ndarray = Ein_buffer.get_ndarray();
+            if (!(metadata->get_name() == ndarray.quantity_name()))
+                FATAL_ERROR("buffer name: {:s}, quantity: {:s}, metadata name: {:s}",
+                            Ein_buffer.get_buffer_name(), ndarray.quantity_name(),
+                            metadata->get_name());
+            assert(metadata->type == ndarray.value_datatype);
+            assert(metadata->dims == ndarray.rank);
+            for (std::size_t d = 0; d < ndarray.rank; ++d) {
+                if (!(metadata->get_dimension_name(d) == ndarray.dimname(d)))
+                    FATAL_ERROR("buffer name: {:s}, dimension: {:d}: dimension name: {:s}, "
+                                "metadata name: {:s}",
+                                Ein_buffer.get_buffer_name(), d, ndarray.dimname(d),
+                                metadata->get_dimension_name(d));
+                // The ring buffer direction is special
+                if (d > 0)
+                    assert(metadata->dim[d] == int(ndarray.extent(d)));
+                assert(metadata->dim_scaling[d] == ndarray.dimscaling(d));
+                if (!(metadata->stride[d] == ndarray.stride(d)))
+                    FATAL_ERROR(
+                        "buffer name: {:s}, dimension: {:d}: metadata stride: {:d}, ndarray "
+                        "stride: {:d}",
+                        Ein_buffer.get_buffer_name(), d, metadata->stride[d], ndarray.stride(d));
+            }
+        } else {
+            scatter_indices_buffer.check_metadata();
         }
-    } else {
-        scatter_indices_buffer.check_metadata();
-    }
+    } // if !did_set_metadata
 
     const char* exc_arg = "exception";
     std::int32_t Tin_min_arg;

--- a/lib/cuda/generated/cudaUpchannelizer_charts_U32.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_charts_U32.cpp
@@ -302,6 +302,9 @@ private:
     NDArrayBuffer<kotekan::GetType_t<info_type>, info_rank> info_buffer;
     std::vector<kotekan::GetType_t<info_type>> host_info_buffer;
 
+    // Set once, on the first frame; see `NDArrayRingBuffer::set_metadata`
+    bool did_set_metadata;
+
     // To avoid trailing comma below
     int dummy;
 };
@@ -334,7 +337,7 @@ cudaUpchannelizer_charts_U32::cudaUpchannelizer_charts_U32(Config& config,
                 reverse(info_dimscalings), *this),
     host_info_buffer(info_length),
 
-    dummy() // avoid trailing comma
+    did_set_metadata(false), dummy() // avoid trailing comma
 {
     // Register host memory
     {
@@ -429,7 +432,6 @@ cudaEvent_t cudaUpchannelizer_charts_U32::execute(cudaPipelineState& /*pipestate
     void* const info_memory = info_buffer.get_ndarray().data();
 
     // Since we use a ring buffer we need to set the metadata only once
-    static bool did_set_metadata = false;
     if (instance_num == 0 && !did_set_metadata) {
         did_set_metadata = true;
 

--- a/lib/cuda/generated/cudaUpchannelizer_charts_U32.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_charts_U32.cpp
@@ -354,16 +354,17 @@ cudaUpchannelizer_charts_U32::cudaUpchannelizer_charts_U32(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("Upchannelizer_charts_U32_" + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_120",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/Upchannelizer_charts_U32.ptx", {kernel_symbol}, opts,
                          "Upchannelizer_charts_U32_");
-    });
+    }
 }
 
 cudaUpchannelizer_charts_U32::~cudaUpchannelizer_charts_U32() {}

--- a/lib/cuda/generated/cudaUpchannelizer_chime_U128.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_chime_U128.cpp
@@ -302,6 +302,9 @@ private:
     NDArrayBuffer<kotekan::GetType_t<info_type>, info_rank> info_buffer;
     std::vector<kotekan::GetType_t<info_type>> host_info_buffer;
 
+    // Set once, on the first frame; see `NDArrayRingBuffer::set_metadata`
+    bool did_set_metadata;
+
     // To avoid trailing comma below
     int dummy;
 };
@@ -334,7 +337,7 @@ cudaUpchannelizer_chime_U128::cudaUpchannelizer_chime_U128(Config& config,
                 reverse(info_dimscalings), *this),
     host_info_buffer(info_length),
 
-    dummy() // avoid trailing comma
+    did_set_metadata(false), dummy() // avoid trailing comma
 {
     // Register host memory
     {
@@ -429,7 +432,6 @@ cudaEvent_t cudaUpchannelizer_chime_U128::execute(cudaPipelineState& /*pipestate
     void* const info_memory = info_buffer.get_ndarray().data();
 
     // Since we use a ring buffer we need to set the metadata only once
-    static bool did_set_metadata = false;
     if (instance_num == 0 && !did_set_metadata) {
         did_set_metadata = true;
 

--- a/lib/cuda/generated/cudaUpchannelizer_chime_U128.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_chime_U128.cpp
@@ -354,16 +354,17 @@ cudaUpchannelizer_chime_U128::cudaUpchannelizer_chime_U128(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("Upchannelizer_chime_U128_" + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_89",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/Upchannelizer_chime_U128.ptx", {kernel_symbol}, opts,
                          "Upchannelizer_chime_U128_");
-    });
+    }
 }
 
 cudaUpchannelizer_chime_U128::~cudaUpchannelizer_chime_U128() {}

--- a/lib/cuda/generated/cudaUpchannelizer_chime_U16.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_chime_U16.cpp
@@ -302,6 +302,9 @@ private:
     NDArrayBuffer<kotekan::GetType_t<info_type>, info_rank> info_buffer;
     std::vector<kotekan::GetType_t<info_type>> host_info_buffer;
 
+    // Set once, on the first frame; see `NDArrayRingBuffer::set_metadata`
+    bool did_set_metadata;
+
     // To avoid trailing comma below
     int dummy;
 };
@@ -334,7 +337,7 @@ cudaUpchannelizer_chime_U16::cudaUpchannelizer_chime_U16(Config& config,
                 reverse(info_dimscalings), *this),
     host_info_buffer(info_length),
 
-    dummy() // avoid trailing comma
+    did_set_metadata(false), dummy() // avoid trailing comma
 {
     // Register host memory
     {
@@ -429,7 +432,6 @@ cudaEvent_t cudaUpchannelizer_chime_U16::execute(cudaPipelineState& /*pipestate*
     void* const info_memory = info_buffer.get_ndarray().data();
 
     // Since we use a ring buffer we need to set the metadata only once
-    static bool did_set_metadata = false;
     if (instance_num == 0 && !did_set_metadata) {
         did_set_metadata = true;
 

--- a/lib/cuda/generated/cudaUpchannelizer_chime_U16.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_chime_U16.cpp
@@ -354,16 +354,17 @@ cudaUpchannelizer_chime_U16::cudaUpchannelizer_chime_U16(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("Upchannelizer_chime_U16_" + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_89",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/Upchannelizer_chime_U16.ptx", {kernel_symbol}, opts,
                          "Upchannelizer_chime_U16_");
-    });
+    }
 }
 
 cudaUpchannelizer_chime_U16::~cudaUpchannelizer_chime_U16() {}

--- a/lib/cuda/generated/cudaUpchannelizer_chime_U2.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_chime_U2.cpp
@@ -302,6 +302,9 @@ private:
     NDArrayBuffer<kotekan::GetType_t<info_type>, info_rank> info_buffer;
     std::vector<kotekan::GetType_t<info_type>> host_info_buffer;
 
+    // Set once, on the first frame; see `NDArrayRingBuffer::set_metadata`
+    bool did_set_metadata;
+
     // To avoid trailing comma below
     int dummy;
 };
@@ -334,7 +337,7 @@ cudaUpchannelizer_chime_U2::cudaUpchannelizer_chime_U2(Config& config,
                 reverse(info_dimscalings), *this),
     host_info_buffer(info_length),
 
-    dummy() // avoid trailing comma
+    did_set_metadata(false), dummy() // avoid trailing comma
 {
     // Register host memory
     {
@@ -429,7 +432,6 @@ cudaEvent_t cudaUpchannelizer_chime_U2::execute(cudaPipelineState& /*pipestate*/
     void* const info_memory = info_buffer.get_ndarray().data();
 
     // Since we use a ring buffer we need to set the metadata only once
-    static bool did_set_metadata = false;
     if (instance_num == 0 && !did_set_metadata) {
         did_set_metadata = true;
 

--- a/lib/cuda/generated/cudaUpchannelizer_chime_U2.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_chime_U2.cpp
@@ -354,16 +354,17 @@ cudaUpchannelizer_chime_U2::cudaUpchannelizer_chime_U2(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("Upchannelizer_chime_U2_" + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_89",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/Upchannelizer_chime_U2.ptx", {kernel_symbol}, opts,
                          "Upchannelizer_chime_U2_");
-    });
+    }
 }
 
 cudaUpchannelizer_chime_U2::~cudaUpchannelizer_chime_U2() {}

--- a/lib/cuda/generated/cudaUpchannelizer_chime_U32.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_chime_U32.cpp
@@ -354,16 +354,17 @@ cudaUpchannelizer_chime_U32::cudaUpchannelizer_chime_U32(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("Upchannelizer_chime_U32_" + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_89",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/Upchannelizer_chime_U32.ptx", {kernel_symbol}, opts,
                          "Upchannelizer_chime_U32_");
-    });
+    }
 }
 
 cudaUpchannelizer_chime_U32::~cudaUpchannelizer_chime_U32() {}

--- a/lib/cuda/generated/cudaUpchannelizer_chime_U32.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_chime_U32.cpp
@@ -302,6 +302,9 @@ private:
     NDArrayBuffer<kotekan::GetType_t<info_type>, info_rank> info_buffer;
     std::vector<kotekan::GetType_t<info_type>> host_info_buffer;
 
+    // Set once, on the first frame; see `NDArrayRingBuffer::set_metadata`
+    bool did_set_metadata;
+
     // To avoid trailing comma below
     int dummy;
 };
@@ -334,7 +337,7 @@ cudaUpchannelizer_chime_U32::cudaUpchannelizer_chime_U32(Config& config,
                 reverse(info_dimscalings), *this),
     host_info_buffer(info_length),
 
-    dummy() // avoid trailing comma
+    did_set_metadata(false), dummy() // avoid trailing comma
 {
     // Register host memory
     {
@@ -429,7 +432,6 @@ cudaEvent_t cudaUpchannelizer_chime_U32::execute(cudaPipelineState& /*pipestate*
     void* const info_memory = info_buffer.get_ndarray().data();
 
     // Since we use a ring buffer we need to set the metadata only once
-    static bool did_set_metadata = false;
     if (instance_num == 0 && !did_set_metadata) {
         did_set_metadata = true;
 

--- a/lib/cuda/generated/cudaUpchannelizer_chime_U4.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_chime_U4.cpp
@@ -354,16 +354,17 @@ cudaUpchannelizer_chime_U4::cudaUpchannelizer_chime_U4(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("Upchannelizer_chime_U4_" + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_89",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/Upchannelizer_chime_U4.ptx", {kernel_symbol}, opts,
                          "Upchannelizer_chime_U4_");
-    });
+    }
 }
 
 cudaUpchannelizer_chime_U4::~cudaUpchannelizer_chime_U4() {}

--- a/lib/cuda/generated/cudaUpchannelizer_chime_U4.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_chime_U4.cpp
@@ -302,6 +302,9 @@ private:
     NDArrayBuffer<kotekan::GetType_t<info_type>, info_rank> info_buffer;
     std::vector<kotekan::GetType_t<info_type>> host_info_buffer;
 
+    // Set once, on the first frame; see `NDArrayRingBuffer::set_metadata`
+    bool did_set_metadata;
+
     // To avoid trailing comma below
     int dummy;
 };
@@ -334,7 +337,7 @@ cudaUpchannelizer_chime_U4::cudaUpchannelizer_chime_U4(Config& config,
                 reverse(info_dimscalings), *this),
     host_info_buffer(info_length),
 
-    dummy() // avoid trailing comma
+    did_set_metadata(false), dummy() // avoid trailing comma
 {
     // Register host memory
     {
@@ -429,7 +432,6 @@ cudaEvent_t cudaUpchannelizer_chime_U4::execute(cudaPipelineState& /*pipestate*/
     void* const info_memory = info_buffer.get_ndarray().data();
 
     // Since we use a ring buffer we need to set the metadata only once
-    static bool did_set_metadata = false;
     if (instance_num == 0 && !did_set_metadata) {
         did_set_metadata = true;
 

--- a/lib/cuda/generated/cudaUpchannelizer_chime_U64.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_chime_U64.cpp
@@ -302,6 +302,9 @@ private:
     NDArrayBuffer<kotekan::GetType_t<info_type>, info_rank> info_buffer;
     std::vector<kotekan::GetType_t<info_type>> host_info_buffer;
 
+    // Set once, on the first frame; see `NDArrayRingBuffer::set_metadata`
+    bool did_set_metadata;
+
     // To avoid trailing comma below
     int dummy;
 };
@@ -334,7 +337,7 @@ cudaUpchannelizer_chime_U64::cudaUpchannelizer_chime_U64(Config& config,
                 reverse(info_dimscalings), *this),
     host_info_buffer(info_length),
 
-    dummy() // avoid trailing comma
+    did_set_metadata(false), dummy() // avoid trailing comma
 {
     // Register host memory
     {
@@ -429,7 +432,6 @@ cudaEvent_t cudaUpchannelizer_chime_U64::execute(cudaPipelineState& /*pipestate*
     void* const info_memory = info_buffer.get_ndarray().data();
 
     // Since we use a ring buffer we need to set the metadata only once
-    static bool did_set_metadata = false;
     if (instance_num == 0 && !did_set_metadata) {
         did_set_metadata = true;
 

--- a/lib/cuda/generated/cudaUpchannelizer_chime_U64.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_chime_U64.cpp
@@ -354,16 +354,17 @@ cudaUpchannelizer_chime_U64::cudaUpchannelizer_chime_U64(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("Upchannelizer_chime_U64_" + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_89",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/Upchannelizer_chime_U64.ptx", {kernel_symbol}, opts,
                          "Upchannelizer_chime_U64_");
-    });
+    }
 }
 
 cudaUpchannelizer_chime_U64::~cudaUpchannelizer_chime_U64() {}

--- a/lib/cuda/generated/cudaUpchannelizer_chime_U8.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_chime_U8.cpp
@@ -302,6 +302,9 @@ private:
     NDArrayBuffer<kotekan::GetType_t<info_type>, info_rank> info_buffer;
     std::vector<kotekan::GetType_t<info_type>> host_info_buffer;
 
+    // Set once, on the first frame; see `NDArrayRingBuffer::set_metadata`
+    bool did_set_metadata;
+
     // To avoid trailing comma below
     int dummy;
 };
@@ -334,7 +337,7 @@ cudaUpchannelizer_chime_U8::cudaUpchannelizer_chime_U8(Config& config,
                 reverse(info_dimscalings), *this),
     host_info_buffer(info_length),
 
-    dummy() // avoid trailing comma
+    did_set_metadata(false), dummy() // avoid trailing comma
 {
     // Register host memory
     {
@@ -429,7 +432,6 @@ cudaEvent_t cudaUpchannelizer_chime_U8::execute(cudaPipelineState& /*pipestate*/
     void* const info_memory = info_buffer.get_ndarray().data();
 
     // Since we use a ring buffer we need to set the metadata only once
-    static bool did_set_metadata = false;
     if (instance_num == 0 && !did_set_metadata) {
         did_set_metadata = true;
 

--- a/lib/cuda/generated/cudaUpchannelizer_chime_U8.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_chime_U8.cpp
@@ -354,16 +354,17 @@ cudaUpchannelizer_chime_U8::cudaUpchannelizer_chime_U8(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("Upchannelizer_chime_U8_" + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_89",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/Upchannelizer_chime_U8.ptx", {kernel_symbol}, opts,
                          "Upchannelizer_chime_U8_");
-    });
+    }
 }
 
 cudaUpchannelizer_chime_U8::~cudaUpchannelizer_chime_U8() {}

--- a/lib/cuda/generated/cudaUpchannelizer_chord_U128.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_chord_U128.cpp
@@ -354,16 +354,17 @@ cudaUpchannelizer_chord_U128::cudaUpchannelizer_chord_U128(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("Upchannelizer_chord_U128_" + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_86",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/Upchannelizer_chord_U128.ptx", {kernel_symbol}, opts,
                          "Upchannelizer_chord_U128_");
-    });
+    }
 }
 
 cudaUpchannelizer_chord_U128::~cudaUpchannelizer_chord_U128() {}

--- a/lib/cuda/generated/cudaUpchannelizer_chord_U128.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_chord_U128.cpp
@@ -302,6 +302,9 @@ private:
     NDArrayBuffer<kotekan::GetType_t<info_type>, info_rank> info_buffer;
     std::vector<kotekan::GetType_t<info_type>> host_info_buffer;
 
+    // Set once, on the first frame; see `NDArrayRingBuffer::set_metadata`
+    bool did_set_metadata;
+
     // To avoid trailing comma below
     int dummy;
 };
@@ -334,7 +337,7 @@ cudaUpchannelizer_chord_U128::cudaUpchannelizer_chord_U128(Config& config,
                 reverse(info_dimscalings), *this),
     host_info_buffer(info_length),
 
-    dummy() // avoid trailing comma
+    did_set_metadata(false), dummy() // avoid trailing comma
 {
     // Register host memory
     {
@@ -429,7 +432,6 @@ cudaEvent_t cudaUpchannelizer_chord_U128::execute(cudaPipelineState& /*pipestate
     void* const info_memory = info_buffer.get_ndarray().data();
 
     // Since we use a ring buffer we need to set the metadata only once
-    static bool did_set_metadata = false;
     if (instance_num == 0 && !did_set_metadata) {
         did_set_metadata = true;
 

--- a/lib/cuda/generated/cudaUpchannelizer_chord_U16.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_chord_U16.cpp
@@ -354,16 +354,17 @@ cudaUpchannelizer_chord_U16::cudaUpchannelizer_chord_U16(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("Upchannelizer_chord_U16_" + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_86",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/Upchannelizer_chord_U16.ptx", {kernel_symbol}, opts,
                          "Upchannelizer_chord_U16_");
-    });
+    }
 }
 
 cudaUpchannelizer_chord_U16::~cudaUpchannelizer_chord_U16() {}

--- a/lib/cuda/generated/cudaUpchannelizer_chord_U16.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_chord_U16.cpp
@@ -302,6 +302,9 @@ private:
     NDArrayBuffer<kotekan::GetType_t<info_type>, info_rank> info_buffer;
     std::vector<kotekan::GetType_t<info_type>> host_info_buffer;
 
+    // Set once, on the first frame; see `NDArrayRingBuffer::set_metadata`
+    bool did_set_metadata;
+
     // To avoid trailing comma below
     int dummy;
 };
@@ -334,7 +337,7 @@ cudaUpchannelizer_chord_U16::cudaUpchannelizer_chord_U16(Config& config,
                 reverse(info_dimscalings), *this),
     host_info_buffer(info_length),
 
-    dummy() // avoid trailing comma
+    did_set_metadata(false), dummy() // avoid trailing comma
 {
     // Register host memory
     {
@@ -429,7 +432,6 @@ cudaEvent_t cudaUpchannelizer_chord_U16::execute(cudaPipelineState& /*pipestate*
     void* const info_memory = info_buffer.get_ndarray().data();
 
     // Since we use a ring buffer we need to set the metadata only once
-    static bool did_set_metadata = false;
     if (instance_num == 0 && !did_set_metadata) {
         did_set_metadata = true;
 

--- a/lib/cuda/generated/cudaUpchannelizer_chord_U2.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_chord_U2.cpp
@@ -354,16 +354,17 @@ cudaUpchannelizer_chord_U2::cudaUpchannelizer_chord_U2(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("Upchannelizer_chord_U2_" + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_86",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/Upchannelizer_chord_U2.ptx", {kernel_symbol}, opts,
                          "Upchannelizer_chord_U2_");
-    });
+    }
 }
 
 cudaUpchannelizer_chord_U2::~cudaUpchannelizer_chord_U2() {}

--- a/lib/cuda/generated/cudaUpchannelizer_chord_U2.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_chord_U2.cpp
@@ -302,6 +302,9 @@ private:
     NDArrayBuffer<kotekan::GetType_t<info_type>, info_rank> info_buffer;
     std::vector<kotekan::GetType_t<info_type>> host_info_buffer;
 
+    // Set once, on the first frame; see `NDArrayRingBuffer::set_metadata`
+    bool did_set_metadata;
+
     // To avoid trailing comma below
     int dummy;
 };
@@ -334,7 +337,7 @@ cudaUpchannelizer_chord_U2::cudaUpchannelizer_chord_U2(Config& config,
                 reverse(info_dimscalings), *this),
     host_info_buffer(info_length),
 
-    dummy() // avoid trailing comma
+    did_set_metadata(false), dummy() // avoid trailing comma
 {
     // Register host memory
     {
@@ -429,7 +432,6 @@ cudaEvent_t cudaUpchannelizer_chord_U2::execute(cudaPipelineState& /*pipestate*/
     void* const info_memory = info_buffer.get_ndarray().data();
 
     // Since we use a ring buffer we need to set the metadata only once
-    static bool did_set_metadata = false;
     if (instance_num == 0 && !did_set_metadata) {
         did_set_metadata = true;
 

--- a/lib/cuda/generated/cudaUpchannelizer_chord_U32.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_chord_U32.cpp
@@ -302,6 +302,9 @@ private:
     NDArrayBuffer<kotekan::GetType_t<info_type>, info_rank> info_buffer;
     std::vector<kotekan::GetType_t<info_type>> host_info_buffer;
 
+    // Set once, on the first frame; see `NDArrayRingBuffer::set_metadata`
+    bool did_set_metadata;
+
     // To avoid trailing comma below
     int dummy;
 };
@@ -334,7 +337,7 @@ cudaUpchannelizer_chord_U32::cudaUpchannelizer_chord_U32(Config& config,
                 reverse(info_dimscalings), *this),
     host_info_buffer(info_length),
 
-    dummy() // avoid trailing comma
+    did_set_metadata(false), dummy() // avoid trailing comma
 {
     // Register host memory
     {
@@ -429,7 +432,6 @@ cudaEvent_t cudaUpchannelizer_chord_U32::execute(cudaPipelineState& /*pipestate*
     void* const info_memory = info_buffer.get_ndarray().data();
 
     // Since we use a ring buffer we need to set the metadata only once
-    static bool did_set_metadata = false;
     if (instance_num == 0 && !did_set_metadata) {
         did_set_metadata = true;
 

--- a/lib/cuda/generated/cudaUpchannelizer_chord_U32.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_chord_U32.cpp
@@ -354,16 +354,17 @@ cudaUpchannelizer_chord_U32::cudaUpchannelizer_chord_U32(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("Upchannelizer_chord_U32_" + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_86",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/Upchannelizer_chord_U32.ptx", {kernel_symbol}, opts,
                          "Upchannelizer_chord_U32_");
-    });
+    }
 }
 
 cudaUpchannelizer_chord_U32::~cudaUpchannelizer_chord_U32() {}

--- a/lib/cuda/generated/cudaUpchannelizer_chord_U4.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_chord_U4.cpp
@@ -302,6 +302,9 @@ private:
     NDArrayBuffer<kotekan::GetType_t<info_type>, info_rank> info_buffer;
     std::vector<kotekan::GetType_t<info_type>> host_info_buffer;
 
+    // Set once, on the first frame; see `NDArrayRingBuffer::set_metadata`
+    bool did_set_metadata;
+
     // To avoid trailing comma below
     int dummy;
 };
@@ -334,7 +337,7 @@ cudaUpchannelizer_chord_U4::cudaUpchannelizer_chord_U4(Config& config,
                 reverse(info_dimscalings), *this),
     host_info_buffer(info_length),
 
-    dummy() // avoid trailing comma
+    did_set_metadata(false), dummy() // avoid trailing comma
 {
     // Register host memory
     {
@@ -429,7 +432,6 @@ cudaEvent_t cudaUpchannelizer_chord_U4::execute(cudaPipelineState& /*pipestate*/
     void* const info_memory = info_buffer.get_ndarray().data();
 
     // Since we use a ring buffer we need to set the metadata only once
-    static bool did_set_metadata = false;
     if (instance_num == 0 && !did_set_metadata) {
         did_set_metadata = true;
 

--- a/lib/cuda/generated/cudaUpchannelizer_chord_U4.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_chord_U4.cpp
@@ -354,16 +354,17 @@ cudaUpchannelizer_chord_U4::cudaUpchannelizer_chord_U4(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("Upchannelizer_chord_U4_" + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_86",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/Upchannelizer_chord_U4.ptx", {kernel_symbol}, opts,
                          "Upchannelizer_chord_U4_");
-    });
+    }
 }
 
 cudaUpchannelizer_chord_U4::~cudaUpchannelizer_chord_U4() {}

--- a/lib/cuda/generated/cudaUpchannelizer_chord_U64.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_chord_U64.cpp
@@ -302,6 +302,9 @@ private:
     NDArrayBuffer<kotekan::GetType_t<info_type>, info_rank> info_buffer;
     std::vector<kotekan::GetType_t<info_type>> host_info_buffer;
 
+    // Set once, on the first frame; see `NDArrayRingBuffer::set_metadata`
+    bool did_set_metadata;
+
     // To avoid trailing comma below
     int dummy;
 };
@@ -334,7 +337,7 @@ cudaUpchannelizer_chord_U64::cudaUpchannelizer_chord_U64(Config& config,
                 reverse(info_dimscalings), *this),
     host_info_buffer(info_length),
 
-    dummy() // avoid trailing comma
+    did_set_metadata(false), dummy() // avoid trailing comma
 {
     // Register host memory
     {
@@ -429,7 +432,6 @@ cudaEvent_t cudaUpchannelizer_chord_U64::execute(cudaPipelineState& /*pipestate*
     void* const info_memory = info_buffer.get_ndarray().data();
 
     // Since we use a ring buffer we need to set the metadata only once
-    static bool did_set_metadata = false;
     if (instance_num == 0 && !did_set_metadata) {
         did_set_metadata = true;
 

--- a/lib/cuda/generated/cudaUpchannelizer_chord_U64.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_chord_U64.cpp
@@ -354,16 +354,17 @@ cudaUpchannelizer_chord_U64::cudaUpchannelizer_chord_U64(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("Upchannelizer_chord_U64_" + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_86",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/Upchannelizer_chord_U64.ptx", {kernel_symbol}, opts,
                          "Upchannelizer_chord_U64_");
-    });
+    }
 }
 
 cudaUpchannelizer_chord_U64::~cudaUpchannelizer_chord_U64() {}

--- a/lib/cuda/generated/cudaUpchannelizer_chord_U8.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_chord_U8.cpp
@@ -302,6 +302,9 @@ private:
     NDArrayBuffer<kotekan::GetType_t<info_type>, info_rank> info_buffer;
     std::vector<kotekan::GetType_t<info_type>> host_info_buffer;
 
+    // Set once, on the first frame; see `NDArrayRingBuffer::set_metadata`
+    bool did_set_metadata;
+
     // To avoid trailing comma below
     int dummy;
 };
@@ -334,7 +337,7 @@ cudaUpchannelizer_chord_U8::cudaUpchannelizer_chord_U8(Config& config,
                 reverse(info_dimscalings), *this),
     host_info_buffer(info_length),
 
-    dummy() // avoid trailing comma
+    did_set_metadata(false), dummy() // avoid trailing comma
 {
     // Register host memory
     {
@@ -429,7 +432,6 @@ cudaEvent_t cudaUpchannelizer_chord_U8::execute(cudaPipelineState& /*pipestate*/
     void* const info_memory = info_buffer.get_ndarray().data();
 
     // Since we use a ring buffer we need to set the metadata only once
-    static bool did_set_metadata = false;
     if (instance_num == 0 && !did_set_metadata) {
         did_set_metadata = true;
 

--- a/lib/cuda/generated/cudaUpchannelizer_chord_U8.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_chord_U8.cpp
@@ -354,16 +354,17 @@ cudaUpchannelizer_chord_U8::cudaUpchannelizer_chord_U8(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("Upchannelizer_chord_U8_" + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_86",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/Upchannelizer_chord_U8.ptx", {kernel_symbol}, opts,
                          "Upchannelizer_chord_U8_");
-    });
+    }
 }
 
 cudaUpchannelizer_chord_U8::~cudaUpchannelizer_chord_U8() {}

--- a/lib/cuda/generated/cudaUpchannelizer_hirax_U128.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_hirax_U128.cpp
@@ -302,6 +302,9 @@ private:
     NDArrayBuffer<kotekan::GetType_t<info_type>, info_rank> info_buffer;
     std::vector<kotekan::GetType_t<info_type>> host_info_buffer;
 
+    // Set once, on the first frame; see `NDArrayRingBuffer::set_metadata`
+    bool did_set_metadata;
+
     // To avoid trailing comma below
     int dummy;
 };
@@ -334,7 +337,7 @@ cudaUpchannelizer_hirax_U128::cudaUpchannelizer_hirax_U128(Config& config,
                 reverse(info_dimscalings), *this),
     host_info_buffer(info_length),
 
-    dummy() // avoid trailing comma
+    did_set_metadata(false), dummy() // avoid trailing comma
 {
     // Register host memory
     {
@@ -429,7 +432,6 @@ cudaEvent_t cudaUpchannelizer_hirax_U128::execute(cudaPipelineState& /*pipestate
     void* const info_memory = info_buffer.get_ndarray().data();
 
     // Since we use a ring buffer we need to set the metadata only once
-    static bool did_set_metadata = false;
     if (instance_num == 0 && !did_set_metadata) {
         did_set_metadata = true;
 

--- a/lib/cuda/generated/cudaUpchannelizer_hirax_U128.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_hirax_U128.cpp
@@ -354,16 +354,17 @@ cudaUpchannelizer_hirax_U128::cudaUpchannelizer_hirax_U128(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("Upchannelizer_hirax_U128_" + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_86",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/Upchannelizer_hirax_U128.ptx", {kernel_symbol}, opts,
                          "Upchannelizer_hirax_U128_");
-    });
+    }
 }
 
 cudaUpchannelizer_hirax_U128::~cudaUpchannelizer_hirax_U128() {}

--- a/lib/cuda/generated/cudaUpchannelizer_hirax_U16.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_hirax_U16.cpp
@@ -354,16 +354,17 @@ cudaUpchannelizer_hirax_U16::cudaUpchannelizer_hirax_U16(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("Upchannelizer_hirax_U16_" + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_86",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/Upchannelizer_hirax_U16.ptx", {kernel_symbol}, opts,
                          "Upchannelizer_hirax_U16_");
-    });
+    }
 }
 
 cudaUpchannelizer_hirax_U16::~cudaUpchannelizer_hirax_U16() {}

--- a/lib/cuda/generated/cudaUpchannelizer_hirax_U16.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_hirax_U16.cpp
@@ -302,6 +302,9 @@ private:
     NDArrayBuffer<kotekan::GetType_t<info_type>, info_rank> info_buffer;
     std::vector<kotekan::GetType_t<info_type>> host_info_buffer;
 
+    // Set once, on the first frame; see `NDArrayRingBuffer::set_metadata`
+    bool did_set_metadata;
+
     // To avoid trailing comma below
     int dummy;
 };
@@ -334,7 +337,7 @@ cudaUpchannelizer_hirax_U16::cudaUpchannelizer_hirax_U16(Config& config,
                 reverse(info_dimscalings), *this),
     host_info_buffer(info_length),
 
-    dummy() // avoid trailing comma
+    did_set_metadata(false), dummy() // avoid trailing comma
 {
     // Register host memory
     {
@@ -429,7 +432,6 @@ cudaEvent_t cudaUpchannelizer_hirax_U16::execute(cudaPipelineState& /*pipestate*
     void* const info_memory = info_buffer.get_ndarray().data();
 
     // Since we use a ring buffer we need to set the metadata only once
-    static bool did_set_metadata = false;
     if (instance_num == 0 && !did_set_metadata) {
         did_set_metadata = true;
 

--- a/lib/cuda/generated/cudaUpchannelizer_hirax_U32.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_hirax_U32.cpp
@@ -354,16 +354,17 @@ cudaUpchannelizer_hirax_U32::cudaUpchannelizer_hirax_U32(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("Upchannelizer_hirax_U32_" + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_86",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/Upchannelizer_hirax_U32.ptx", {kernel_symbol}, opts,
                          "Upchannelizer_hirax_U32_");
-    });
+    }
 }
 
 cudaUpchannelizer_hirax_U32::~cudaUpchannelizer_hirax_U32() {}

--- a/lib/cuda/generated/cudaUpchannelizer_hirax_U32.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_hirax_U32.cpp
@@ -302,6 +302,9 @@ private:
     NDArrayBuffer<kotekan::GetType_t<info_type>, info_rank> info_buffer;
     std::vector<kotekan::GetType_t<info_type>> host_info_buffer;
 
+    // Set once, on the first frame; see `NDArrayRingBuffer::set_metadata`
+    bool did_set_metadata;
+
     // To avoid trailing comma below
     int dummy;
 };
@@ -334,7 +337,7 @@ cudaUpchannelizer_hirax_U32::cudaUpchannelizer_hirax_U32(Config& config,
                 reverse(info_dimscalings), *this),
     host_info_buffer(info_length),
 
-    dummy() // avoid trailing comma
+    did_set_metadata(false), dummy() // avoid trailing comma
 {
     // Register host memory
     {
@@ -429,7 +432,6 @@ cudaEvent_t cudaUpchannelizer_hirax_U32::execute(cudaPipelineState& /*pipestate*
     void* const info_memory = info_buffer.get_ndarray().data();
 
     // Since we use a ring buffer we need to set the metadata only once
-    static bool did_set_metadata = false;
     if (instance_num == 0 && !did_set_metadata) {
         did_set_metadata = true;
 

--- a/lib/cuda/generated/cudaUpchannelizer_hirax_U64.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_hirax_U64.cpp
@@ -302,6 +302,9 @@ private:
     NDArrayBuffer<kotekan::GetType_t<info_type>, info_rank> info_buffer;
     std::vector<kotekan::GetType_t<info_type>> host_info_buffer;
 
+    // Set once, on the first frame; see `NDArrayRingBuffer::set_metadata`
+    bool did_set_metadata;
+
     // To avoid trailing comma below
     int dummy;
 };
@@ -334,7 +337,7 @@ cudaUpchannelizer_hirax_U64::cudaUpchannelizer_hirax_U64(Config& config,
                 reverse(info_dimscalings), *this),
     host_info_buffer(info_length),
 
-    dummy() // avoid trailing comma
+    did_set_metadata(false), dummy() // avoid trailing comma
 {
     // Register host memory
     {
@@ -429,7 +432,6 @@ cudaEvent_t cudaUpchannelizer_hirax_U64::execute(cudaPipelineState& /*pipestate*
     void* const info_memory = info_buffer.get_ndarray().data();
 
     // Since we use a ring buffer we need to set the metadata only once
-    static bool did_set_metadata = false;
     if (instance_num == 0 && !did_set_metadata) {
         did_set_metadata = true;
 

--- a/lib/cuda/generated/cudaUpchannelizer_hirax_U64.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_hirax_U64.cpp
@@ -354,16 +354,17 @@ cudaUpchannelizer_hirax_U64::cudaUpchannelizer_hirax_U64(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("Upchannelizer_hirax_U64_" + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_86",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/Upchannelizer_hirax_U64.ptx", {kernel_symbol}, opts,
                          "Upchannelizer_hirax_U64_");
-    });
+    }
 }
 
 cudaUpchannelizer_hirax_U64::~cudaUpchannelizer_hirax_U64() {}

--- a/lib/cuda/generated/cudaUpchannelizer_hirax_U8.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_hirax_U8.cpp
@@ -302,6 +302,9 @@ private:
     NDArrayBuffer<kotekan::GetType_t<info_type>, info_rank> info_buffer;
     std::vector<kotekan::GetType_t<info_type>> host_info_buffer;
 
+    // Set once, on the first frame; see `NDArrayRingBuffer::set_metadata`
+    bool did_set_metadata;
+
     // To avoid trailing comma below
     int dummy;
 };
@@ -334,7 +337,7 @@ cudaUpchannelizer_hirax_U8::cudaUpchannelizer_hirax_U8(Config& config,
                 reverse(info_dimscalings), *this),
     host_info_buffer(info_length),
 
-    dummy() // avoid trailing comma
+    did_set_metadata(false), dummy() // avoid trailing comma
 {
     // Register host memory
     {
@@ -429,7 +432,6 @@ cudaEvent_t cudaUpchannelizer_hirax_U8::execute(cudaPipelineState& /*pipestate*/
     void* const info_memory = info_buffer.get_ndarray().data();
 
     // Since we use a ring buffer we need to set the metadata only once
-    static bool did_set_metadata = false;
     if (instance_num == 0 && !did_set_metadata) {
         did_set_metadata = true;
 

--- a/lib/cuda/generated/cudaUpchannelizer_hirax_U8.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_hirax_U8.cpp
@@ -354,16 +354,17 @@ cudaUpchannelizer_hirax_U8::cudaUpchannelizer_hirax_U8(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("Upchannelizer_hirax_U8_" + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_86",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/Upchannelizer_hirax_U8.ptx", {kernel_symbol}, opts,
                          "Upchannelizer_hirax_U8_");
-    });
+    }
 }
 
 cudaUpchannelizer_hirax_U8::~cudaUpchannelizer_hirax_U8() {}

--- a/lib/cuda/generated/cudaUpchannelizer_pathfinder_U128.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_pathfinder_U128.cpp
@@ -302,6 +302,9 @@ private:
     NDArrayBuffer<kotekan::GetType_t<info_type>, info_rank> info_buffer;
     std::vector<kotekan::GetType_t<info_type>> host_info_buffer;
 
+    // Set once, on the first frame; see `NDArrayRingBuffer::set_metadata`
+    bool did_set_metadata;
+
     // To avoid trailing comma below
     int dummy;
 };
@@ -334,7 +337,7 @@ cudaUpchannelizer_pathfinder_U128::cudaUpchannelizer_pathfinder_U128(Config& con
                 reverse(info_dimscalings), *this),
     host_info_buffer(info_length),
 
-    dummy() // avoid trailing comma
+    did_set_metadata(false), dummy() // avoid trailing comma
 {
     // Register host memory
     {
@@ -430,7 +433,6 @@ cudaUpchannelizer_pathfinder_U128::execute(cudaPipelineState& /*pipestate*/,
     void* const info_memory = info_buffer.get_ndarray().data();
 
     // Since we use a ring buffer we need to set the metadata only once
-    static bool did_set_metadata = false;
     if (instance_num == 0 && !did_set_metadata) {
         did_set_metadata = true;
 

--- a/lib/cuda/generated/cudaUpchannelizer_pathfinder_U128.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_pathfinder_U128.cpp
@@ -354,16 +354,18 @@ cudaUpchannelizer_pathfinder_U128::cudaUpchannelizer_pathfinder_U128(Config& con
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("Upchannelizer_pathfinder_U128_"
+                                      + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_86",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/Upchannelizer_pathfinder_U128.ptx", {kernel_symbol},
                          opts, "Upchannelizer_pathfinder_U128_");
-    });
+    }
 }
 
 cudaUpchannelizer_pathfinder_U128::~cudaUpchannelizer_pathfinder_U128() {}

--- a/lib/cuda/generated/cudaUpchannelizer_pathfinder_U16.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_pathfinder_U16.cpp
@@ -302,6 +302,9 @@ private:
     NDArrayBuffer<kotekan::GetType_t<info_type>, info_rank> info_buffer;
     std::vector<kotekan::GetType_t<info_type>> host_info_buffer;
 
+    // Set once, on the first frame; see `NDArrayRingBuffer::set_metadata`
+    bool did_set_metadata;
+
     // To avoid trailing comma below
     int dummy;
 };
@@ -334,7 +337,7 @@ cudaUpchannelizer_pathfinder_U16::cudaUpchannelizer_pathfinder_U16(Config& confi
                 reverse(info_dimscalings), *this),
     host_info_buffer(info_length),
 
-    dummy() // avoid trailing comma
+    did_set_metadata(false), dummy() // avoid trailing comma
 {
     // Register host memory
     {
@@ -430,7 +433,6 @@ cudaUpchannelizer_pathfinder_U16::execute(cudaPipelineState& /*pipestate*/,
     void* const info_memory = info_buffer.get_ndarray().data();
 
     // Since we use a ring buffer we need to set the metadata only once
-    static bool did_set_metadata = false;
     if (instance_num == 0 && !did_set_metadata) {
         did_set_metadata = true;
 

--- a/lib/cuda/generated/cudaUpchannelizer_pathfinder_U16.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_pathfinder_U16.cpp
@@ -354,16 +354,18 @@ cudaUpchannelizer_pathfinder_U16::cudaUpchannelizer_pathfinder_U16(Config& confi
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("Upchannelizer_pathfinder_U16_"
+                                      + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_86",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/Upchannelizer_pathfinder_U16.ptx", {kernel_symbol},
                          opts, "Upchannelizer_pathfinder_U16_");
-    });
+    }
 }
 
 cudaUpchannelizer_pathfinder_U16::~cudaUpchannelizer_pathfinder_U16() {}

--- a/lib/cuda/generated/cudaUpchannelizer_pathfinder_U2.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_pathfinder_U2.cpp
@@ -302,6 +302,9 @@ private:
     NDArrayBuffer<kotekan::GetType_t<info_type>, info_rank> info_buffer;
     std::vector<kotekan::GetType_t<info_type>> host_info_buffer;
 
+    // Set once, on the first frame; see `NDArrayRingBuffer::set_metadata`
+    bool did_set_metadata;
+
     // To avoid trailing comma below
     int dummy;
 };
@@ -334,7 +337,7 @@ cudaUpchannelizer_pathfinder_U2::cudaUpchannelizer_pathfinder_U2(Config& config,
                 reverse(info_dimscalings), *this),
     host_info_buffer(info_length),
 
-    dummy() // avoid trailing comma
+    did_set_metadata(false), dummy() // avoid trailing comma
 {
     // Register host memory
     {
@@ -430,7 +433,6 @@ cudaUpchannelizer_pathfinder_U2::execute(cudaPipelineState& /*pipestate*/,
     void* const info_memory = info_buffer.get_ndarray().data();
 
     // Since we use a ring buffer we need to set the metadata only once
-    static bool did_set_metadata = false;
     if (instance_num == 0 && !did_set_metadata) {
         did_set_metadata = true;
 

--- a/lib/cuda/generated/cudaUpchannelizer_pathfinder_U2.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_pathfinder_U2.cpp
@@ -354,16 +354,18 @@ cudaUpchannelizer_pathfinder_U2::cudaUpchannelizer_pathfinder_U2(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("Upchannelizer_pathfinder_U2_"
+                                      + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_86",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/Upchannelizer_pathfinder_U2.ptx", {kernel_symbol},
                          opts, "Upchannelizer_pathfinder_U2_");
-    });
+    }
 }
 
 cudaUpchannelizer_pathfinder_U2::~cudaUpchannelizer_pathfinder_U2() {}

--- a/lib/cuda/generated/cudaUpchannelizer_pathfinder_U32.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_pathfinder_U32.cpp
@@ -302,6 +302,9 @@ private:
     NDArrayBuffer<kotekan::GetType_t<info_type>, info_rank> info_buffer;
     std::vector<kotekan::GetType_t<info_type>> host_info_buffer;
 
+    // Set once, on the first frame; see `NDArrayRingBuffer::set_metadata`
+    bool did_set_metadata;
+
     // To avoid trailing comma below
     int dummy;
 };
@@ -334,7 +337,7 @@ cudaUpchannelizer_pathfinder_U32::cudaUpchannelizer_pathfinder_U32(Config& confi
                 reverse(info_dimscalings), *this),
     host_info_buffer(info_length),
 
-    dummy() // avoid trailing comma
+    did_set_metadata(false), dummy() // avoid trailing comma
 {
     // Register host memory
     {
@@ -430,7 +433,6 @@ cudaUpchannelizer_pathfinder_U32::execute(cudaPipelineState& /*pipestate*/,
     void* const info_memory = info_buffer.get_ndarray().data();
 
     // Since we use a ring buffer we need to set the metadata only once
-    static bool did_set_metadata = false;
     if (instance_num == 0 && !did_set_metadata) {
         did_set_metadata = true;
 

--- a/lib/cuda/generated/cudaUpchannelizer_pathfinder_U32.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_pathfinder_U32.cpp
@@ -354,16 +354,18 @@ cudaUpchannelizer_pathfinder_U32::cudaUpchannelizer_pathfinder_U32(Config& confi
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("Upchannelizer_pathfinder_U32_"
+                                      + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_86",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/Upchannelizer_pathfinder_U32.ptx", {kernel_symbol},
                          opts, "Upchannelizer_pathfinder_U32_");
-    });
+    }
 }
 
 cudaUpchannelizer_pathfinder_U32::~cudaUpchannelizer_pathfinder_U32() {}

--- a/lib/cuda/generated/cudaUpchannelizer_pathfinder_U4.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_pathfinder_U4.cpp
@@ -302,6 +302,9 @@ private:
     NDArrayBuffer<kotekan::GetType_t<info_type>, info_rank> info_buffer;
     std::vector<kotekan::GetType_t<info_type>> host_info_buffer;
 
+    // Set once, on the first frame; see `NDArrayRingBuffer::set_metadata`
+    bool did_set_metadata;
+
     // To avoid trailing comma below
     int dummy;
 };
@@ -334,7 +337,7 @@ cudaUpchannelizer_pathfinder_U4::cudaUpchannelizer_pathfinder_U4(Config& config,
                 reverse(info_dimscalings), *this),
     host_info_buffer(info_length),
 
-    dummy() // avoid trailing comma
+    did_set_metadata(false), dummy() // avoid trailing comma
 {
     // Register host memory
     {
@@ -430,7 +433,6 @@ cudaUpchannelizer_pathfinder_U4::execute(cudaPipelineState& /*pipestate*/,
     void* const info_memory = info_buffer.get_ndarray().data();
 
     // Since we use a ring buffer we need to set the metadata only once
-    static bool did_set_metadata = false;
     if (instance_num == 0 && !did_set_metadata) {
         did_set_metadata = true;
 

--- a/lib/cuda/generated/cudaUpchannelizer_pathfinder_U4.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_pathfinder_U4.cpp
@@ -354,16 +354,18 @@ cudaUpchannelizer_pathfinder_U4::cudaUpchannelizer_pathfinder_U4(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("Upchannelizer_pathfinder_U4_"
+                                      + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_86",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/Upchannelizer_pathfinder_U4.ptx", {kernel_symbol},
                          opts, "Upchannelizer_pathfinder_U4_");
-    });
+    }
 }
 
 cudaUpchannelizer_pathfinder_U4::~cudaUpchannelizer_pathfinder_U4() {}

--- a/lib/cuda/generated/cudaUpchannelizer_pathfinder_U64.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_pathfinder_U64.cpp
@@ -354,16 +354,18 @@ cudaUpchannelizer_pathfinder_U64::cudaUpchannelizer_pathfinder_U64(Config& confi
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("Upchannelizer_pathfinder_U64_"
+                                      + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_86",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/Upchannelizer_pathfinder_U64.ptx", {kernel_symbol},
                          opts, "Upchannelizer_pathfinder_U64_");
-    });
+    }
 }
 
 cudaUpchannelizer_pathfinder_U64::~cudaUpchannelizer_pathfinder_U64() {}

--- a/lib/cuda/generated/cudaUpchannelizer_pathfinder_U64.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_pathfinder_U64.cpp
@@ -302,6 +302,9 @@ private:
     NDArrayBuffer<kotekan::GetType_t<info_type>, info_rank> info_buffer;
     std::vector<kotekan::GetType_t<info_type>> host_info_buffer;
 
+    // Set once, on the first frame; see `NDArrayRingBuffer::set_metadata`
+    bool did_set_metadata;
+
     // To avoid trailing comma below
     int dummy;
 };
@@ -334,7 +337,7 @@ cudaUpchannelizer_pathfinder_U64::cudaUpchannelizer_pathfinder_U64(Config& confi
                 reverse(info_dimscalings), *this),
     host_info_buffer(info_length),
 
-    dummy() // avoid trailing comma
+    did_set_metadata(false), dummy() // avoid trailing comma
 {
     // Register host memory
     {
@@ -430,7 +433,6 @@ cudaUpchannelizer_pathfinder_U64::execute(cudaPipelineState& /*pipestate*/,
     void* const info_memory = info_buffer.get_ndarray().data();
 
     // Since we use a ring buffer we need to set the metadata only once
-    static bool did_set_metadata = false;
     if (instance_num == 0 && !did_set_metadata) {
         did_set_metadata = true;
 

--- a/lib/cuda/generated/cudaUpchannelizer_pathfinder_U8.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_pathfinder_U8.cpp
@@ -302,6 +302,9 @@ private:
     NDArrayBuffer<kotekan::GetType_t<info_type>, info_rank> info_buffer;
     std::vector<kotekan::GetType_t<info_type>> host_info_buffer;
 
+    // Set once, on the first frame; see `NDArrayRingBuffer::set_metadata`
+    bool did_set_metadata;
+
     // To avoid trailing comma below
     int dummy;
 };
@@ -334,7 +337,7 @@ cudaUpchannelizer_pathfinder_U8::cudaUpchannelizer_pathfinder_U8(Config& config,
                 reverse(info_dimscalings), *this),
     host_info_buffer(info_length),
 
-    dummy() // avoid trailing comma
+    did_set_metadata(false), dummy() // avoid trailing comma
 {
     // Register host memory
     {
@@ -430,7 +433,6 @@ cudaUpchannelizer_pathfinder_U8::execute(cudaPipelineState& /*pipestate*/,
     void* const info_memory = info_buffer.get_ndarray().data();
 
     // Since we use a ring buffer we need to set the metadata only once
-    static bool did_set_metadata = false;
     if (instance_num == 0 && !did_set_metadata) {
         did_set_metadata = true;
 

--- a/lib/cuda/generated/cudaUpchannelizer_pathfinder_U8.cpp
+++ b/lib/cuda/generated/cudaUpchannelizer_pathfinder_U8.cpp
@@ -354,16 +354,18 @@ cudaUpchannelizer_pathfinder_U8::cudaUpchannelizer_pathfinder_U8(Config& config,
 
     set_command_type(gpuCommandType::KERNEL);
 
-    // Build the PTX only once
-    static std::once_flag build_ptx_flag;
-    std::call_once(build_ptx_flag, [&]() {
+    // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
+    // by the `buffer_depth` instances of this command (building twice is fatal), while a stage on
+    // another GPU has its own device. (A static flag would be shared by the stages of all GPUs.)
+    if (!device.runtime_kernels.count("Upchannelizer_pathfinder_U8_"
+                                      + std::string(kernel_symbol))) {
         const std::vector<std::string> opts = {
             "--gpu-name=sm_86",
             "--verbose",
         };
         device.build_ptx("lib/cuda/generated/Upchannelizer_pathfinder_U8.ptx", {kernel_symbol},
                          opts, "Upchannelizer_pathfinder_U8_");
-    });
+    }
 }
 
 cudaUpchannelizer_pathfinder_U8::~cudaUpchannelizer_pathfinder_U8() {}

--- a/lib/stages/testDataGen.cpp
+++ b/lib/stages/testDataGen.cpp
@@ -203,7 +203,7 @@ void testDataGen::main_thread() {
     uint64_t* frameu64 = nullptr;
     uint64_t seq_num = samples_per_data_set * _first_frame_index;
     bool finished_seeding_constant = false;
-    static struct timeval now;
+    struct timeval now;
 #if KOTEKAN_FLOAT16
     float16_t* framef16 = nullptr;
 #endif

--- a/lib/testing/testDataGenFloat.cpp
+++ b/lib/testing/testDataGenFloat.cpp
@@ -97,7 +97,10 @@ void testDataGenFloat::main_thread() {
     void* frame = nullptr;
     uint64_t seq_num = _samples_per_data_set * _first_frame_index;
     bool finished_seeding_consant = false;
-    static struct timeval now;
+    struct timeval now;
+    // Random-number state for `type == "random"`; per stage, so that two instances do not share it
+    std::mt19937 eng(seed);
+    std::uniform_real_distribution<float> dis(_rand_min, _rand_max);
 
     int link_id = 0;
 
@@ -176,8 +179,6 @@ void testDataGenFloat::main_thread() {
                 fvalue = fmod(j * value, 256 * value);
             } else if (type == "random") {
                 // Generate a random float between _rand_min and _rand_max
-                static std::mt19937 eng(seed);
-                static std::uniform_real_distribution<float> dis(_rand_min, _rand_max);
                 fvalue = dis(eng);
             } else {
                 throw std::runtime_error("Unexpected type " + type);

--- a/lib/testing/testDataGenQuad.cpp
+++ b/lib/testing/testDataGenQuad.cpp
@@ -46,7 +46,7 @@ void testDataGenQuad::main_thread() {
     int frame_id = 0;
     uint8_t* frame[4] = {nullptr, nullptr, nullptr, nullptr};
     uint64_t seq_num = 0;
-    static struct timeval now;
+    struct timeval now;
 
     // pre-seed everything!
     INFO("Seeding...");


### PR DESCRIPTION
## Summary

Ring buffer metadata are written **once**, on the first frame, instead of on every frame. This is the `develop` counterpart to the discussion on #1638: same race, different remedy.

A ring buffer has a single metadata object for its whole lifetime, and `NDArrayRingBuffer::set_metadata` fills that live slot-0 object in place. The RFI and PL-mask stages called it on every frame (and patched `time_downsampling_fpga` afterwards), so a consumer in another cudaProcess could observe the object mid-rewrite: `cudaCopyFromRingbuffer` read the RFImask's downsampling factor as 256 instead of 1024 and emitted sequence numbers `0.75 * uptime` behind, which took down nine CHORD nodes (#1638). Even with unchanged values, the per-frame rewrite is a data race on the unlocked `name`/`type`/`dims`/`stride` fields.

### Ring stages: write once

```cpp
// Set the ring buffer metadata once; see `NDArrayRingBuffer::set_metadata`
if (instance_num == 0 && !did_set_metadata) {
    did_set_metadata = true;
    rfi_RFImask.set_metadata(rfi_S012.get_metadata());
    // Correct RFImask metadata
    ...
}
```

After the first `finish_write` no writer touches the object, and the `RingBuffer` mutex (`finish_write` / `wait_and_claim_readable`) orders that write before any consumer's read, so no further synchronization is needed. The guard is `instance_num == 0 && !did_set_metadata` because `gpuProcess` creates `buffer_depth` instances of every command: frame 0 is always handled by instance 0, and a per-instance flag alone would rewrite the metadata `buffer_depth` times at startup. This is the convention the generated FRB kernels and `cudaCopyToRingbuffer` already follow, and it resolves the `// TODO: Set these metadata only once` comments.

Hand-written stages: `cudaRFIS012`, `cudaRFIS012bar`, `cudaRFIS012tilde`, `cudaRFISKtilde`, `cudaRFISKbar`, `cudaHFB1Accumulate`, `cudaPLMaskExpander`, `cudaPLMaskUpchannelizer`.

Generated: `cudaTranspose2048_chime` had the same per-frame rewrite of its ring output's metadata with no flag at all; the guard is added to `julia/kernels/xpose2048_template.cxx` and, identically, to the checked-in generated file. `cudaUpchannelizer_*` guarded with a function-local `static bool did_set_metadata`, i.e. one flag per *class* per process: in a multi-GPU process (one kotekan process per node) the upchannelizer stages of all GPUs but the first would skip setting their ring's metadata. It is now a member, as in the FRB beamformers (`julia/kernels/upchan_template.cxx` + 27 generated files). The other generated families were audited: the FRB beamformers already write once with a member flag; the baseband beamformer's output is not a ring buffer and is correctly set per frame.

### `cudaFRBBeamReformer`: the opposite fix

Its output is **not** a ring buffer, and `NDArrayBuffer::set_metadata` takes a fresh pool object per call, so the metadata is now set every frame. Previously `did_set_metadata` made `set_metadata` run once, and the per-frame `fpga_seq_num` write then modified an object that frames already downstream still referenced. The `deepCopy` inside `set_metadata` carries the fields the four explicit setters copied, so those and the flag are removed.

### `NDArrayRingBuffer::set_metadata`

Gains a doc comment stating the contract (single object for the ring's lifetime, call once before the first `finish_write`, guard by instance 0 + flag).

### Second commit: per-class static state (multi-GPU single-process runs)

A multi-GPU node runs all its GPU pipelines in one kotekan process, so a class has one stage object per GPU. All function-local `static` state was audited:

- **PTX build.** Every generated kernel built its PTX under a per-class `static std::once_flag`. `cudaDeviceInterface::build_ptx` loads the module into *that device's* `runtime_kernels` and is fatal if the kernel already exists there, so the flag kept the `buffer_depth` instances on one device from building twice -- but it also kept every GPU after the first from building at all, leaving those stages without a kernel. Now: build iff this device does not have the kernel yet (`runtime_kernels` is public). That also covers two stages of the same class on one GPU, which the hand-written `if (instance_num == 0)` idiom in `cudaUpchannelize.cpp` would not. Stages are constructed sequentially, so no lock. Six templates + all 59 generated files.
- **Test data generators.** `testDataGen`, `testDataGenFloat`, `testDataGenQuad` kept a `static struct timeval` (and `testDataGenFloat` its random-number engine) shared across instances; now per stage.
- Everything else found (`lib/core` singletons, registries, `fftwPlannerLock`, `gdalFileRead`'s `once_flag`, `frb_I_lock`) is intentionally process-wide.

## Verification

On cx67 (A40), Release `-O3` with `WERROR=ON` and asserts enabled:

- clang-format clean.
- Full build, no warnings, after each commit.
- All 19 `config/ci-tests/gpu_batch` configs pass after each commit, including `verify_cuda_rfi_sktilde` (writer and RFImask reader in separate cudaProcess stages with `buffer_depth: 4`, i.e. the multi-instance, cross-thread path this change is about) and `test_xpose2048.j2` for the transpose.
- `cudaHFB1Accumulate`, `cudaPLMaskUpchannelizer` and `cudaFRBBeamReformer` have no CI config and are compile-verified only.

## Notes

- `chord`'s `cudaRFISKtilde` has an additional ring output (`bf_mask_applied`) whose `set_metadata` belongs inside the same guard when this is merged there.

