### PR TITLE
bufferBadInputs: start the mask stream at the voltage stream's first seq num

### DIFF
--- a/.github/workflows/build_push_docker.yaml
+++ b/.github/workflows/build_push_docker.yaml
@@ -56,6 +56,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          # `changed-files` with `since_last_remote_commit` needs the history: on a newly
+          # opened PR it falls back to `HEAD^`, which a depth-1 checkout does not have.
+          fetch-depth: 0
 
       # Has the Dockerfile ever changed vs base branch? (for tag selection)
       - name: Check Dockerfile diff vs base

--- a/config/chime_upgrade_frb.j2
+++ b/config/chime_upgrade_frb.j2
@@ -551,6 +551,8 @@ set_bf_mask:
     updatable_config:
         bad_inputs: /updatable_config/bad_inputs
     out_buf: host_bf_mask_buffer
+    # The mask stream starts at the sequence number of the first voltage frame
+    in_clock_buf: host_voltage_buffer_0
 
 # Send the bad feed mask to its GPU ringbuffer. One mask element covers
 # bf_mask_lifetime_in_samples input samples, so this runs far less often than the other

--- a/config/chime_upgrade_n2.j2
+++ b/config/chime_upgrade_n2.j2
@@ -398,6 +398,8 @@ set_bf_mask:
     updatable_config:
         bad_inputs: /updatable_config/bad_inputs
     out_buf: host_bf_mask_buffer
+    # The mask stream starts at the sequence number of the first voltage frame
+    in_clock_buf: host_voltage_buffer_0
 
 # Send the bad feed mask to its GPU ringbuffer. One mask element covers
 # bf_mask_lifetime_in_samples input samples, so this runs far less often than the other

--- a/config/ci-tests/gpu_batch/verify_cuda_rfi_sktilde.yaml
+++ b/config/ci-tests/gpu_batch/verify_cuda_rfi_sktilde.yaml
@@ -155,6 +155,9 @@ gen_rfi_s012:
     log_level: DEBUG
     kotekan_stage: testRFIS012Gen
     out_buf: host_rfi_s012_buffer
+    # Start at a nonzero sequence number so that stages deriving sequence numbers from ring
+    # buffer positions are exercised with a nonzero origin
+    first_frame_index: 3
     type: random
     bar_mode: false
     downsampling_factor: rfi_downsampling_factor
@@ -165,6 +168,8 @@ set_bf_mask:
     updatable_config:
         bad_inputs: /updatable_config/bad_inputs
     out_buf: host_bf_mask_buffer
+    # Start the mask stream at the S012 stream's first sequence number
+    in_clock_buf: host_rfi_s012_buffer
 
 set_simulated_bf_mask:
     kotekan_stage: bufferBadInputs
@@ -173,6 +178,7 @@ set_simulated_bf_mask:
     # One mask per frame, matching `simulated_bf_mask_buffer` and the CPU reference below
     bf_mask_lifetime_in_samples: samples_per_data_set
     out_buf: simulated_bf_mask_buffer
+    in_clock_buf: host_rfi_s012_buffer
 
 run_send_bf_mask:
     gpu_0:

--- a/lib/stages/bufferBadInputs.cpp
+++ b/lib/stages/bufferBadInputs.cpp
@@ -64,6 +64,13 @@ bufferBadInputs::bufferBadInputs(Config& config_, const std::string& unique_name
         "bf_mask", {1, num_polarizations, num_dishes}, {"Tbf", "P", "D"},
         {bf_mask_lifetime_in_samples, 1, 1}));
 
+    // Optional clock: the produced frames' FPGA sequence numbers start at the sequence number
+    // of this buffer's first frame instead of at zero. See main_thread().
+    in_clock_buf =
+        config.exists(unique_name, "in_clock_buf") ? get_buffer("in_clock_buf") : nullptr;
+    if (in_clock_buf)
+        in_clock_buf->register_consumer(unique_name);
+
     updates.resize(config.get_default<uint32_t>(unique_name, "num_kept_updates", 5));
 
     // Construct the input -> output reorder table.
@@ -163,9 +170,9 @@ bool bufferBadInputs::update_bad_inputs_callback(nlohmann::json& json) {
         mask[reorder[element]] = 0;
 
     // The seq the update takes effect at -- via the telescope, so identical on every node --
-    // or -1 when it predates the run and constrains nothing. Logged for diagnostics only: the
-    // frames' FPGA sequence numbers count mask samples, so there is nowhere to put it. The
-    // clamp also keeps to_seq()'s unsigned conversion from wrapping.
+    // or -1 when it predates the run and constrains nothing. Logged for diagnostics only: which
+    // frame an update lands in is decided by the wall clock when that frame is produced, not by
+    // this value. The clamp also keeps to_seq()'s unsigned conversion from wrapping.
     const Telescope& tel = Telescope::instance();
     const int64_t effective_seq = start_ts > tel.to_time(0) ? (int64_t)tel.to_seq(start_ts) : -1;
 
@@ -182,6 +189,29 @@ void bufferBadInputs::main_thread() {
     // Always present: the constructor requires it.
     const std::shared_ptr<const kotekan::GenericNDArray> frame_desc =
         out_buf->get_frame_desc<kotekan::GenericNDArray>();
+
+    // The FPGA sequence number of the first mask sample. The consumers of the bad feed mask ring
+    // buffer locate mask sample `k` at `k * bf_mask_lifetime_in_samples` FPGA samples after the
+    // logical beginning of the voltage ring buffer, which is the sequence number of the first
+    // voltage frame -- so that is where this stream has to start as well. Read it from the clock
+    // buffer's first frame, as setBBBeams does; without a clock buffer the stream starts at zero.
+    int64_t first_fpga_seq_num = 0;
+    if (in_clock_buf) {
+        if (in_clock_buf->wait_for_full_frame(unique_name, 0) == nullptr)
+            return;
+        const std::shared_ptr<const chordMetadata> clock_meta = get_chord_metadata(in_clock_buf, 0);
+        if (!clock_meta->has_fpga_seq_num())
+            FATAL_ERROR("in_clock_buf {:s} has no fpga_seq_num, needed to start the bad feed mask "
+                        "sequence numbers.",
+                        in_clock_buf->buffer_name);
+        first_fpga_seq_num = clock_meta->get_fpga_seq_num();
+        in_clock_buf->mark_frame_empty(unique_name, 0);
+        // Only the first frame is needed; stop being a consumer so that the producer does not
+        // wait for us on the frames after it.
+        in_clock_buf->unregister_consumer(unique_name);
+        INFO("Bad feed mask FPGA sequence numbers start at {:d}, from the first frame of {:s}",
+             first_fpga_seq_num, in_clock_buf->buffer_name);
+    }
 
     // `frame_index` counts all frames produced, not just the current slot, because the FPGA
     // sequence number has to keep increasing.
@@ -208,7 +238,7 @@ void bufferBadInputs::main_thread() {
         meta->set_from_frame_desc(frame_desc);
         // Each frame is one bad feed mask sample, and each sample is valid for
         // `bf_mask_lifetime_in_samples` FPGA samples.
-        meta->set_fpga_seq_num(frame_index * bf_mask_lifetime_in_samples);
+        meta->set_fpga_seq_num(first_fpga_seq_num + frame_index * bf_mask_lifetime_in_samples);
         meta->set_time_downsampling_fpga(bf_mask_lifetime_in_samples);
         out_buf->mark_frame_full(unique_name, frame_id);
     }

--- a/lib/stages/bufferBadInputs.hpp
+++ b/lib/stages/bufferBadInputs.hpp
@@ -42,7 +42,11 @@
  * Each frame is one bad feed mask sample, valid
  * for @c bf_mask_lifetime_in_samples FPGA samples, and its FPGA sequence
  * number is that sample's seq -- so it grows by the lifetime from frame to
- * frame, which is what the bad feed mask ring buffer requires.
+ * frame, which is what the bad feed mask ring buffer requires.  The
+ * sequence numbers start at the seq of the first frame of @c in_clock_buf
+ * (normally the voltage buffer, whose first frame also defines the logical
+ * beginning of the voltage ring buffer), or at zero if no clock buffer is
+ * configured.
  *
  * Out-of-order and malformed updates are counted and ignored while running
  * -- a bad POST must not stop the correlator -- but a malformed *initial*
@@ -56,6 +60,11 @@
  * reinterpretation of the mask rather than a reordering of it.
  *
  * @par Buffers
+ * @buffer in_clock_buf Optional.  Any buffer with an @c fpga_seq_num; only its
+ *     first frame is read, then the stage unregisters as a consumer.  The
+ *     voltage buffer is recommended.
+ *     @buffer_format Any
+ *     @buffer_metadata chordMetadata
  * @buffer out_buf Kotekan buffer of bad inputs (1 == good).
  *     @buffer_shape [1, num_polarizations, num_dishes]
  *     @buffer_format int8
@@ -110,6 +119,8 @@ private:
     };
 
     Buffer* out_buf;
+    /// Optional; see the class comment. Null when not configured.
+    Buffer* in_clock_buf;
     /// The size of the bad input mask.
     size_t num_elements;
     /// The shape of the bad input mask, num_elements == num_polarizations * num_dishes


### PR DESCRIPTION
> **Stacked on #1645.** This branch is rebased onto the CI fix so that its checks can run (the docker workflow's `changed-files` step failed on the original `opened` event, see #1645); the first commit in the diff belongs to #1645 and disappears once that merges.

## Summary

`bufferBadInputs` produced bad feed mask frames whose FPGA sequence numbers counted from zero (`frame_index * bf_mask_lifetime_in_samples`), i.e. it assumed the voltage stream starts at sequence number zero. It does not: the DPDK input starts at the FPGA counter. The consumers of the bad feed mask ring buffer locate mask sample `k` at `k * bf_mask_lifetime_in_samples` FPGA samples after the voltage ring buffer's logical beginning, which is the sequence number of the first voltage frame — so that is where the mask stream has to start as well.

This follows the existing precedent in `setBBBeams`: an optional `in_clock_buf` is registered as a consumer, its first frame's `fpga_seq_num` is read, the frame is released and the stage unregisters (so the producer never waits for it again), and the mask stream starts at that sequence number. Without a clock buffer the stream still starts at zero, so existing configs are unaffected.

Configured in:
- `config/chime_upgrade_frb.j2`, `config/chime_upgrade_n2.j2`: `in_clock_buf: host_voltage_buffer_0`
- `config/ci-tests/gpu_batch/verify_cuda_rfi_sktilde.yaml`: both `bufferBadInputs` stages clock off `host_rfi_s012_buffer`, and the S012 generator gets `first_frame_index: 3` so that this CI config exercises a **nonzero** origin (all CI generators started at 0 before, which is why this class of bug was never caught).

Related: #1643 (ring metadata write-once) and a follow-up fixing the same start-at-zero assumption in `cudaBasebandBeamformer`, `cudaFRBBeamReformer` and `cudaPLMaskAccumulator`.

## Verification

On cx67 (A40), Release `-O3`, `WERROR=ON`, asserts enabled: clang-format clean, `j2lint` clean on the edited configs, full build without warnings, all 19 `gpu_batch` configs pass. With `first_frame_index: 3`, `verify_cuda_rfi_sktilde` logs `Bad feed mask FPGA sequence numbers start at 24576, from the first frame of host_rfi_s012_buffer` for both stages and both checkers pass. The CHIME upgrade configs cannot run on cx67 (no FPGA controller); they are render-checked only.

