### PR TITLE
CI: fetch the full history in the docker workflow

### DIFF
--- a/.github/workflows/build_push_docker.yaml
+++ b/.github/workflows/build_push_docker.yaml
@@ -56,6 +56,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          # `changed-files` with `since_last_remote_commit` needs the history: on a newly
+          # opened PR it falls back to `HEAD^`, which a depth-1 checkout does not have.
+          fetch-depth: 0
 
       # Has the Dockerfile ever changed vs base branch? (for tag selection)
       - name: Check Dockerfile diff vs base


### PR DESCRIPTION
## Summary

`tj-actions/changed-files` with `since_last_remote_commit: true` (the "has the Dockerfile changed in the latest push?" step of `build_push_docker.yaml`) has no previous commit on a newly opened PR and falls back to `HEAD^`. With the default depth-1 checkout that revision does not exist when the PR's head sits directly on the base branch's head, and the job fails with

```
Unable to locate the previous commit in the local history for pull_request (opened) event. Falling back to the previous commit in the local history.
fatal: ambiguous argument 'HEAD^': unknown revision or path not in the working tree.
```

Seen on #1644 (two attempts; a rerun replays the same `opened` event and fails the same way). Since every other job waits for the docker job, such a PR gets no CI at all.

Fetch the full history for that checkout (`fetch-depth: 0`; the pack is ~133 MiB, and the action already fetches tens of thousands of objects itself). The merge-commit checkout and the rest of the job are unchanged.
