### PR TITLE
Config: make a malformed get_default() value fatal

### DIFF
--- a/lib/core/Config.hpp
+++ b/lib/core/Config.hpp
@@ -6,7 +6,7 @@
 #ifndef CONFIG_HPP
 #define CONFIG_HPP
 
-#include "kotekanLogging.hpp" // for ERROR_NON_OO
+#include "kotekanLogging.hpp" // for ERROR_NON_OO, FATAL_ERROR_NON_OO
 
 #include "fmt.hpp"  // for compile_string_to_view, fmt, format, format_string
 #include "json.hpp" // for json
@@ -157,9 +157,9 @@ public:
      * @brief Get a config value or return the default value.
      *
      * A value that is not set anywhere on the path returns @c default_value silently.
-     * A value that is set but cannot be read as @c T also returns @c default_value,
-     * but logs an error, since substituting the default for a malformed entry would
-     * otherwise leave the pipeline running an unintended configuration.
+     * A value that is set but cannot be read as @c T is fatal: substituting the default
+     * for a malformed entry would leave the pipeline running an unintended
+     * configuration, which is worse than refusing to start.
      *
      * @param base_path     Path to the value in the config.
      * @param name          Name of the value.
@@ -446,9 +446,9 @@ T Config::get_default(const std::string& base_path, const std::string& name,
         } catch (std::runtime_error const&) {
             return default_value;
         }
-        ERROR_NON_OO("Config: '{:s}' at {:s} is set but cannot be read as '{:s}', so the default "
-                     "is used instead. The value found was: {:s}",
-                     name, base_path, demangle<T>(), get_value(base_path, name).dump());
+        FATAL_ERROR_NON_OO("Config: '{:s}' at {:s} is set but cannot be read as '{:s}'. The value "
+                           "found was: {:s}",
+                           name, base_path, demangle<T>(), get_value(base_path, name).dump());
         return default_value;
     }
 }

--- a/tests/boost/test_config.cpp
+++ b/tests/boost/test_config.cpp
@@ -183,9 +183,9 @@ BOOST_AUTO_TEST_CASE(_parse_usage_report_level) {
 }
 
 // get_default() must distinguish an absent value, where the default is what the
-// caller asked for, from one that is set but unreadable, which is a config error.
-// ERROR_NON_OO throws when compiled into a boost test, so the second case appears
-// here as a throw rather than a log line.
+// caller asked for, from one that is set but unreadable, which is fatal. In a boost
+// test the ERROR_NON_OO inside FATAL_ERROR_NON_OO throws before exit_kotekan runs,
+// so the fatal case is observed here as a std::runtime_error and raises no SIGTERM.
 BOOST_AUTO_TEST_CASE(_get_default_malformed_value) {
     json json_config = {
         {"good_list", {0, 2, 4, 6}},
@@ -207,7 +207,7 @@ BOOST_AUTO_TEST_CASE(_get_default_malformed_value) {
     BOOST_CHECK_EQUAL(config.get_default<std::vector<uint32_t>>("/", "absent", fallback).size(),
                       1u);
 
-    // A value of the wrong type is reported.
+    // A value of the wrong type is fatal.
     BOOST_CHECK_THROW(config.get_default<std::vector<uint32_t>>("/", "nested_list", fallback),
                       std::runtime_error);
     BOOST_CHECK_THROW(config.get_default<int>("/", "a_string", -1), std::runtime_error);


### PR DESCRIPTION
`Config::get_default()` returned the default for a value that is set but cannot be read as the requested type, and logged an error. Substituting the default for a malformed entry leaves the pipeline running an unintended configuration, which is worse than stopping, so the case is now `FATAL_ERROR_NON_OO`. An absent value still returns the default silently.

`test_config` covers both cases: an absent value yields the default; a value of the wrong type throws (inside a boost test the error logged by the fatal macro throws before `exit_kotekan` runs).

Carried on `chord` since August; extracted from the chord/develop diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
