### PR TITLE
testDataGen: per-instance timestamp; gains stages: require_frame_desc

### DIFF
--- a/lib/stages/loadFeedGains.cpp
+++ b/lib/stages/loadFeedGains.cpp
@@ -86,7 +86,7 @@ loadFeedGains::loadFeedGains(Config& config, const std::string& unique_name,
                         num_local_freq * num_elements * 2 * sizeof(float), buf->frame_size);
         }
         // Set frame description
-        buf->ensure_frame_desc(kotekan::NDArray<kotekan::GetType_t<kotekan::float32>, 3>::describe(
+        buf->require_frame_desc(kotekan::NDArray<kotekan::GetType_t<kotekan::float32>, 3>::describe(
             "gain",
             {static_cast<ptrdiff_t>(num_local_freq), static_cast<ptrdiff_t>(num_elements),
              static_cast<ptrdiff_t>(2)},

--- a/lib/stages/processFRBFeedGains.cpp
+++ b/lib/stages/processFRBFeedGains.cpp
@@ -41,7 +41,7 @@ void processFRBFeedGains::copy_upchannelize_f(const float* src_f, float16_t* dst
 }
 
 void processFRBFeedGains::set_frame_desc(Buffer* buf) {
-    buf->ensure_frame_desc(kotekan::NDArray<kotekan::GetType_t<kotekan::float16>, 5>::describe(
+    buf->require_frame_desc(kotekan::NDArray<kotekan::GetType_t<kotekan::float16>, 5>::describe(
         "W",
         {static_cast<ptrdiff_t>(num_local_freq * upchan_factor),
          static_cast<ptrdiff_t>(num_polarizations), static_cast<ptrdiff_t>(num_dishes_N),

--- a/lib/stages/testDataGen.cpp
+++ b/lib/stages/testDataGen.cpp
@@ -203,7 +203,7 @@ void testDataGen::main_thread() {
     uint64_t* frameu64 = nullptr;
     uint64_t seq_num = samples_per_data_set * _first_frame_index;
     bool finished_seeding_constant = false;
-    static struct timeval now;
+    struct timeval now;
 #if KOTEKAN_FLOAT16
     float16_t* framef16 = nullptr;
 #endif


### PR DESCRIPTION
Two independent one-line fixes carried on `chord`.

- `testDataGen`: the `timeval` holding the frame timestamp was a function-local static, so every generator instance shared one struct and concurrent instances tore each other's `gettimeofday()` results (`chime_upgrade_n2_fakedata` runs 20). Each stage thread now uses a local.
- `loadFeedGains`, `processFRBFeedGains`: call `require_frame_desc()` instead of `ensure_frame_desc()` on the gains buffers, as `processFeedGains` already does. These stages consume declared buffers, so a missing descriptor is a config error rather than something the stage should originate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
