### PR TITLE
Add bufferDedup: forward frames only when their contents change

### DIFF
--- a/lib/stages/CMakeLists.txt
+++ b/lib/stages/CMakeLists.txt
@@ -68,6 +68,7 @@ add_library(
     pulsarNetworkProcess.cpp
     bufferMerge.cpp
     bufferCopy.cpp
+    bufferDedup.cpp
     bufferSwitch.cpp
     bufferDelay.cpp
     bufferQuiet.cpp

--- a/lib/stages/bufferDedup.cpp
+++ b/lib/stages/bufferDedup.cpp
@@ -1,0 +1,67 @@
+#include "bufferDedup.hpp"
+
+#include "StageFactory.hpp"   // for REGISTER_KOTEKAN_STAGE
+#include "kotekanLogging.hpp" // for FATAL_ERROR, DEBUG
+#include "visUtil.hpp"        // for frameID, modulo
+
+#include "fmt.hpp" // for compile_string_to_view
+
+#include <cstring>    // for memcmp, memcpy
+#include <functional> // for bind, function
+
+using kotekan::bufferContainer;
+using kotekan::Config;
+using kotekan::Stage;
+
+REGISTER_KOTEKAN_STAGE(bufferDedup);
+
+bufferDedup::bufferDedup(Config& config, const std::string& unique_name,
+                         bufferContainer& buffer_container) :
+    Stage(config, unique_name, buffer_container, std::bind(&bufferDedup::main_thread, this)),
+    in_buf(get_buffer("in_buf")), out_buf(get_buffer("out_buf")),
+    resend_after_frames(config.get_default<int>(unique_name, "resend_after_frames", 0)) {
+
+    in_buf->register_consumer(unique_name);
+    out_buf->register_producer(unique_name);
+
+    if (in_buf->frame_size != out_buf->frame_size)
+        FATAL_ERROR("in_buf frame size ({:d}) must equal out_buf frame size ({:d})",
+                    in_buf->frame_size, out_buf->frame_size);
+}
+
+void bufferDedup::main_thread() {
+
+    frameID in_frame_id(in_buf);
+    frameID out_frame_id(out_buf);
+    int suppressed = 0;
+
+    while (!stop_thread) {
+        const uint8_t* frame = in_buf->wait_for_full_frame(unique_name, in_frame_id);
+        if (frame == nullptr)
+            break;
+
+        const bool changed =
+            last_sent.empty() || std::memcmp(last_sent.data(), frame, in_buf->frame_size) != 0;
+        const bool resend = resend_after_frames > 0 && suppressed >= resend_after_frames;
+
+        if (changed || resend) {
+            uint8_t* out_frame = out_buf->wait_for_empty_frame(unique_name, out_frame_id);
+            if (out_frame == nullptr)
+                break;
+
+            if (in_buf->get_metadata(in_frame_id))
+                in_buf->pass_metadata(in_frame_id, out_buf, out_frame_id);
+            std::memcpy(out_frame, frame, in_buf->frame_size);
+            last_sent.assign(frame, frame + in_buf->frame_size);
+
+            DEBUG("Forwarding {:s} frame {:d} ({:s})", in_buf->buffer_name, in_frame_id,
+                  changed ? "changed" : "resend");
+            out_buf->mark_frame_full(unique_name, out_frame_id++);
+            suppressed = 0;
+        } else {
+            suppressed++;
+        }
+
+        in_buf->mark_frame_empty(unique_name, in_frame_id++);
+    }
+}

--- a/lib/stages/bufferDedup.hpp
+++ b/lib/stages/bufferDedup.hpp
@@ -1,0 +1,51 @@
+#ifndef BUFFER_DEDUP_H
+#define BUFFER_DEDUP_H
+
+#include "Config.hpp"          // for Config
+#include "Stage.hpp"           // for Stage
+#include "buffer.hpp"          // for Buffer
+#include "bufferContainer.hpp" // for bufferContainer
+
+#include <stdint.h> // for uint8_t
+#include <string>   // for string
+#include <vector>   // for vector
+
+/**
+ * @class bufferDedup
+ * @brief Forward only frames whose contents differ from the last forwarded frame.
+ *
+ * The first frame after startup is always forwarded, so a record of the stream begins
+ * with a known value. Metadata is passed through unchanged, so a forwarded frame keeps
+ * e.g. the FPGA sequence number of the input frame that carried the change.
+ *
+ * @par Buffers
+ * @buffer in_buf   Frames to compare; consumed at the full input rate.
+ *      @buffer_format any
+ *      @buffer_metadata any
+ * @buffer out_buf  Frames that differed from the previously forwarded one.
+ *      @buffer_format matches in_buf
+ *      @buffer_metadata matches in_buf
+ *
+ * @conf  resend_after_frames  Int. Default 0 (disabled). If > 0, forward an unchanged
+ *                             frame after this many were suppressed, so a downstream
+ *                             consumer that can drop frames (e.g. a bufferSend link
+ *                             that was down) recovers the current contents.
+ *
+ * @author James Mertens
+ */
+class bufferDedup : public kotekan::Stage {
+public:
+    bufferDedup(kotekan::Config& config, const std::string& unique_name,
+                kotekan::bufferContainer& buffer_container);
+    ~bufferDedup() = default;
+    void main_thread() override;
+
+private:
+    Buffer* in_buf;
+    Buffer* out_buf;
+    const int resend_after_frames;
+    /// Contents of the last forwarded frame; empty until one is forwarded.
+    std::vector<uint8_t> last_sent;
+};
+
+#endif

--- a/tests/boost/CMakeLists.txt
+++ b/tests/boost/CMakeLists.txt
@@ -307,3 +307,30 @@ else()
 endif()
 target_include_directories(test_N2AutoSpectrum PRIVATE ${KOTEKAN_SOURCE_DIR}/lib/stages
                                                        ${KOTEKAN_SOURCE_DIR}/lib/utils)
+
+# test_bufferDedup - tests for the bufferDedup stage
+add_executable(test_bufferDedup test_bufferDedup.cpp)
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    target_link_libraries(
+        test_bufferDedup
+        PRIVATE libexternal
+                kotekan_stages
+                kotekan_libs
+                kotekan_utils
+                kotekan_core
+                -Wl,-all_load
+                kotekan_metadata)
+else()
+    target_link_libraries(
+        test_bufferDedup
+        PRIVATE libexternal
+                kotekan_stages
+                kotekan_libs
+                kotekan_utils
+                kotekan_core
+                -Wl,--whole-archive
+                kotekan_metadata
+                -Wl,--no-whole-archive)
+endif()
+target_include_directories(test_bufferDedup PRIVATE ${KOTEKAN_SOURCE_DIR}/lib/stages
+                                                    ${KOTEKAN_SOURCE_DIR}/lib/utils)

--- a/tests/boost/test_bufferDedup.cpp
+++ b/tests/boost/test_bufferDedup.cpp
@@ -1,0 +1,145 @@
+#define BOOST_TEST_MODULE "test_bufferDedup"
+
+#include "Config.hpp"          // for Config
+#include "buffer.hpp"          // for Buffer
+#include "bufferContainer.hpp" // for bufferContainer
+#include "bufferDedup.hpp"     // for bufferDedup
+#include "chordMetadata.hpp"   // for chordMetadata, get_chord_metadata
+#include "metadata.hpp"        // for metadataPool
+#include "metadataFactory.hpp" // for metadataFactory
+#include "test_utils.hpp"      // for GlobalFixture_Locale
+
+#include "json.hpp" // for json
+
+#include <boost/test/included/unit_test.hpp>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace kotekan;
+using json = nlohmann::json;
+
+BOOST_TEST_GLOBAL_FIXTURE(GlobalFixture_Locale);
+
+static const size_t frame_size = 64;
+static const int num_frames = 4;
+
+static Config make_test_config(const std::string& stage_name, int resend_after_frames) {
+    json cfg;
+    cfg["type"] = "config";
+    cfg["log_level"] = "WARN";
+    cfg["chord_pool"] = {{"kotekan_metadata_pool", "chordMetadata"}, {"num_metadata_objects", 32}};
+
+    json stage;
+    stage["kotekan_stage"] = "bufferDedup";
+    stage["cpu_affinity"] = std::vector<int>{0};
+    stage["in_buf"] = "in_buf";
+    stage["out_buf"] = "out_buf";
+    if (resend_after_frames > 0)
+        stage["resend_after_frames"] = resend_after_frames;
+    cfg[stage_name.substr(1)] = stage;
+
+    Config conf;
+    conf.update_config(cfg);
+    return conf;
+}
+
+struct TestSetup {
+    std::shared_ptr<metadataPool> chord_pool;
+    std::unique_ptr<Buffer> in_buf;
+    std::unique_ptr<Buffer> out_buf;
+    bufferContainer bc;
+
+    TestSetup(Config& config) {
+        metadataFactory mfac(config);
+        chord_pool = mfac.build_pools()["chord_pool"];
+
+        in_buf = std::make_unique<Buffer>(num_frames, frame_size, chord_pool, "in_buf", "standard",
+                                          0, false, false, std::vector<int>{}, true);
+        in_buf->register_producer("test_producer");
+
+        out_buf = std::make_unique<Buffer>(num_frames, frame_size, chord_pool, "out_buf",
+                                           "standard", 0, false, false, std::vector<int>{}, true);
+        out_buf->register_consumer("test_consumer");
+
+        bc.add_buffer("in_buf", in_buf.get());
+        bc.add_buffer("out_buf", out_buf.get());
+    }
+};
+
+// Produce one input frame filled with `value`, seq-stamped so forwarded frames can be
+// traced back to the input frame that carried them.
+static void produce_frame(Buffer* in_buf, int frame_id, uint8_t value, int64_t seq) {
+    uint8_t* frame = in_buf->wait_for_empty_frame("test_producer", frame_id);
+    BOOST_REQUIRE(frame != nullptr);
+    std::memset(frame, value, frame_size);
+    in_buf->allocate_new_metadata_object(frame_id);
+    get_chord_metadata(in_buf, frame_id)->set_fpga_seq_num(seq);
+    in_buf->mark_frame_full("test_producer", frame_id);
+}
+
+// Consume one output frame; check its fill value and the seq it carried.
+static void expect_output(Buffer* out_buf, int frame_id, uint8_t value, int64_t seq) {
+    const uint8_t* frame = out_buf->wait_for_full_frame("test_consumer", frame_id);
+    BOOST_REQUIRE(frame != nullptr);
+    for (size_t i = 0; i < frame_size; ++i)
+        BOOST_CHECK_EQUAL(frame[i], value);
+    BOOST_CHECK_EQUAL(get_chord_metadata(out_buf, frame_id)->get_fpga_seq_num(), seq);
+    out_buf->mark_frame_empty("test_consumer", frame_id);
+}
+
+// No output frame should be waiting: a zero deadline turns the wait into a poll.
+static void expect_no_output(Buffer* out_buf, int frame_id) {
+    const timespec poll = {0, 0};
+    BOOST_CHECK_EQUAL(out_buf->wait_for_full_frame_timeout("test_consumer", frame_id, poll), 1);
+}
+
+// The first frame and every content change are forwarded; repeats are suppressed.
+BOOST_AUTO_TEST_CASE(forward_on_change) {
+    const std::string stage_name = "/test_dedup";
+    Config config = make_test_config(stage_name, 0);
+    TestSetup setup(config);
+
+    bufferDedup stage(config, stage_name, setup.bc);
+    stage.start();
+
+    // A A A B B C: expect A(seq 0), B(seq 300), C(seq 500) forwarded.
+    const uint8_t values[] = {0xa1, 0xa1, 0xa1, 0xb2, 0xb2, 0xc3};
+    for (int i = 0; i < 6; ++i)
+        produce_frame(setup.in_buf.get(), i % num_frames, values[i], 100 * i);
+
+    expect_output(setup.out_buf.get(), 0, 0xa1, 0);
+    expect_output(setup.out_buf.get(), 1, 0xb2, 300);
+    expect_output(setup.out_buf.get(), 2, 0xc3, 500);
+    expect_no_output(setup.out_buf.get(), 3);
+
+    setup.in_buf->send_shutdown_signal();
+    stage.stop();
+    stage.join();
+}
+
+// With resend_after_frames set, an unchanged frame is forwarded after that many
+// suppressed frames, so a lossy consumer recovers the current contents.
+BOOST_AUTO_TEST_CASE(periodic_resend) {
+    const std::string stage_name = "/test_dedup";
+    Config config = make_test_config(stage_name, 2);
+    TestSetup setup(config);
+
+    bufferDedup stage(config, stage_name, setup.bc);
+    stage.start();
+
+    // A then five repeats: A forwarded (change), two suppressed, resend, two
+    // suppressed... only frames 0 and 3 come through.
+    for (int i = 0; i < 6; ++i)
+        produce_frame(setup.in_buf.get(), i % num_frames, 0xa1, 100 * i);
+
+    expect_output(setup.out_buf.get(), 0, 0xa1, 0);
+    expect_output(setup.out_buf.get(), 1, 0xa1, 300);
+    expect_no_output(setup.out_buf.get(), 2);
+
+    setup.in_buf->send_shutdown_signal();
+    stage.stop();
+    stage.join();
+}


### PR DESCRIPTION
A generic pass-through stage that compares each input frame against the last frame it forwarded and drops repeats. The first frame after startup is always forwarded, and metadata passes through, so a forwarded frame keeps the FPGA sequence number of the input that carried the change. An optional `resend_after_frames` re-emits unchanged contents periodically, so a downstream consumer that can drop frames (e.g. a `bufferSend` link that was down) recovers the current state.

On `chord` the stage deduplicates the applied bad-feed mask echoed back from the GPU before the `bufferSend` link to the receive node, so only mask changes cross the network. The stage itself has no CHORD-specific dependency.

Covered by `tests/boost/test_bufferDedup`. Carried on `chord`; extracted from the chord/develop diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
