### PR TITLE
RfiSKMetrics: export per-feed spectral kurtosis from SKbar

### DIFF
--- a/docs/sphinx/user/processes/RfiSKMetrics.rst
+++ b/docs/sphinx/user/processes/RfiSKMetrics.rst
@@ -1,0 +1,5 @@
+************
+RfiSKMetrics
+************
+
+.. doxygenclass:: RfiSKMetrics

--- a/lib/stages/CMakeLists.txt
+++ b/lib/stages/CMakeLists.txt
@@ -120,6 +120,7 @@ add_library(
     N2FrameToVisFrame.cpp
     RfiMaskSum.cpp
     RfiFrameMask.cpp
+    RfiSKMetrics.cpp
     CountLostPLSamplesScalar.cpp
     PLMaskExpandedToCompact.cpp
     # Julia

--- a/lib/stages/RfiSKMetrics.cpp
+++ b/lib/stages/RfiSKMetrics.cpp
@@ -1,0 +1,130 @@
+#include "RfiSKMetrics.hpp"
+
+#include "N2Util.hpp"       // for frameID
+#include "StageFactory.hpp" // for REGISTER_KOTEKAN_STAGE
+#include "restServer.hpp"   // for restServer, connectionInstance
+
+#include <algorithm>  // for fill
+#include <cmath>      // for isnan
+#include <functional> // for bind
+#include <json.hpp>   // for json
+#include <limits>     // for numeric_limits
+#include <mutex>      // for lock_guard, mutex
+
+using kotekan::bufferContainer;
+using kotekan::Config;
+using kotekan::connectionInstance;
+using kotekan::restServer;
+using kotekan::Stage;
+using kotekan::prometheus::Metrics;
+using N2::frameID;
+
+REGISTER_KOTEKAN_STAGE(RfiSKMetrics);
+
+RfiSKMetrics::RfiSKMetrics(Config& config, const std::string& unique_name,
+                           bufferContainer& buffer_container) :
+    Stage(config, unique_name, buffer_container, std::bind(&RfiSKMetrics::main_thread, this)),
+    num_freq(config.get<size_t>(unique_name, "num_local_freq")),
+    num_times(config.get<size_t>(unique_name, "rfi_num_times_bar")),
+    num_elements(config.get<size_t>(unique_name, "num_polarizations")
+                 * config.get<size_t>(unique_name, "num_dishes")),
+    ema_frames(config.get_default<size_t>(unique_name, "ema_frames", 256)),
+    ema_alpha(1.0 / (double)ema_frames),
+    ema_sk(num_elements, std::numeric_limits<double>::quiet_NaN()),
+    ema_valid_frac(num_elements, 0.0) {
+
+    // labels() scans the family under a lock, so look each gauge up once here
+    // and keep the references (stable: metrics live in a deque, never removed).
+    auto& sk_metric =
+        Metrics::instance().add_gauge("kotekan_rfi_sk_per_feed", unique_name, {"element"});
+    auto& valid_frac_metric = Metrics::instance().add_gauge("kotekan_rfi_sk_per_feed_valid_frac",
+                                                            unique_name, {"element"});
+    for (size_t e = 0; e < num_elements; ++e) {
+        sk_gauges.push_back(&sk_metric.labels({std::to_string(e)}));
+        valid_frac_gauges.push_back(&valid_frac_metric.labels({std::to_string(e)}));
+    }
+
+    restServer::instance().register_get_callback(
+        unique_name + "/sk", std::bind(&RfiSKMetrics::send_sk, this, std::placeholders::_1));
+
+    in_buf = get_buffer("in_buf");
+    in_buf->register_consumer(unique_name);
+}
+
+RfiSKMetrics::~RfiSKMetrics() {
+    // Must manually remove GET callbacks
+    restServer::instance().remove_get_callback(unique_name + "/sk");
+}
+
+void RfiSKMetrics::send_sk(connectionInstance& conn) {
+    nlohmann::json reply;
+    reply["num_elements"] = num_elements;
+    reply["ema_frames"] = ema_frames;
+    nlohmann::json sk = nlohmann::json::array();
+    nlohmann::json valid_frac = nlohmann::json::array();
+    {
+        std::lock_guard<std::mutex> lock(mtx);
+        for (size_t e = 0; e < num_elements; e++) {
+            if (std::isnan(ema_sk[e]))
+                sk.push_back(nullptr); // no valid measurement yet
+            else
+                sk.push_back(ema_sk[e]);
+            valid_frac.push_back(ema_valid_frac[e]);
+        }
+    }
+    reply["sk"] = sk;
+    reply["valid_frac"] = valid_frac;
+    conn.send_json_reply(reply);
+}
+
+void RfiSKMetrics::main_thread() {
+    frameID frame_id(in_buf);
+
+    std::vector<double> sum(num_elements);
+    std::vector<size_t> count(num_elements);
+
+    while (!stop_thread) {
+        const float* frame = (const float*)in_buf->wait_for_full_frame(unique_name, frame_id);
+        if (frame == nullptr)
+            break;
+
+        std::fill(sum.begin(), sum.end(), 0.0);
+        std::fill(count.begin(), count.end(), 0);
+
+        // Frame layout: [num_times][num_freq][3 = {SK, b, sigma}][num_elements].
+        for (size_t tf = 0; tf < num_times * num_freq; tf++) {
+            const float* sk = frame + (tf * 3 + 0) * num_elements;
+            const float* sigma = frame + (tf * 3 + 2) * num_elements;
+            for (size_t e = 0; e < num_elements; e++) {
+                if (sigma[e] >= 0) { // a negative sigma marks an invalid (masked) cell
+                    sum[e] += sk[e];
+                    count[e]++;
+                }
+            }
+        }
+
+        // Per-element EMA over frames. (N2::movingAverage is integer-only —
+        // add_sample(uint64_t) — so it cannot hold these fractional values.)
+        const double ncells = (double)(num_times * num_freq);
+        {
+            std::lock_guard<std::mutex> lock(mtx);
+            for (size_t e = 0; e < num_elements; e++) {
+                ema_valid_frac[e] += ema_alpha * (count[e] / ncells - ema_valid_frac[e]);
+                if (count[e] > 0) {
+                    double mean = sum[e] / count[e];
+                    // seed with the first valid measurement, then track
+                    ema_sk[e] =
+                        std::isnan(ema_sk[e]) ? mean : ema_sk[e] + ema_alpha * (mean - ema_sk[e]);
+                }
+            }
+        }
+        for (size_t e = 0; e < num_elements; e++) {
+            if (!std::isnan(ema_sk[e]))
+                sk_gauges[e]->set(ema_sk[e]);
+            valid_frac_gauges[e]->set(ema_valid_frac[e]);
+        }
+
+        in_buf->mark_frame_empty(unique_name, frame_id);
+        frame_id++;
+    }
+}

--- a/lib/stages/RfiSKMetrics.cpp
+++ b/lib/stages/RfiSKMetrics.cpp
@@ -1,11 +1,14 @@
 #include "RfiSKMetrics.hpp"
 
+#include "DataType.hpp"     // for DataType, GetType_t
 #include "N2Util.hpp"       // for frameID
+#include "NDArray.hpp"      // for NDArray
 #include "StageFactory.hpp" // for REGISTER_KOTEKAN_STAGE
 #include "restServer.hpp"   // for restServer, connectionInstance
 
 #include <algorithm>  // for fill
 #include <cmath>      // for isnan
+#include <cstddef>    // for ptrdiff_t
 #include <functional> // for bind
 #include <json.hpp>   // for json
 #include <limits>     // for numeric_limits
@@ -26,8 +29,9 @@ RfiSKMetrics::RfiSKMetrics(Config& config, const std::string& unique_name,
     Stage(config, unique_name, buffer_container, std::bind(&RfiSKMetrics::main_thread, this)),
     num_freq(config.get<size_t>(unique_name, "num_local_freq")),
     num_times(config.get<size_t>(unique_name, "rfi_num_times_bar")),
-    num_elements(config.get<size_t>(unique_name, "num_polarizations")
-                 * config.get<size_t>(unique_name, "num_dishes")),
+    num_polarizations(config.get<size_t>(unique_name, "num_polarizations")),
+    num_dishes(config.get<size_t>(unique_name, "num_dishes")),
+    num_elements(num_polarizations * num_dishes),
     ema_frames(config.get_default<size_t>(unique_name, "ema_frames", 256)),
     ema_alpha(1.0 / (double)ema_frames),
     ema_sk(num_elements, std::numeric_limits<double>::quiet_NaN()),
@@ -49,6 +53,16 @@ RfiSKMetrics::RfiSKMetrics(Config& config, const std::string& unique_name,
 
     in_buf = get_buffer("in_buf");
     in_buf->register_consumer(unique_name);
+
+    // The buffer must be declared `kotekan_buffer: ndarray` with the layout main_thread
+    // reads: value type, extents and byte size are checked here, and the producer
+    // (cudaCopyFromRingbuffer) reconciles its descriptor and checks every frame's metadata
+    // against the same one.
+    in_buf->require_frame_desc(kotekan::NDArray<kotekan::GetType_t<kotekan::float32>, 5>::describe(
+        "SKbar",
+        {ptrdiff_t(num_times), ptrdiff_t(num_freq), 3, ptrdiff_t(num_polarizations),
+         ptrdiff_t(num_dishes)},
+        {"Trfibar", "F", "SK", "P", "D"}, {1, 1, 1, 1, 1}));
 }
 
 RfiSKMetrics::~RfiSKMetrics() {

--- a/lib/stages/RfiSKMetrics.hpp
+++ b/lib/stages/RfiSKMetrics.hpp
@@ -1,0 +1,99 @@
+/**
+ * @file
+ * @brief Export the per-feed spectral kurtosis as prometheus gauges.
+ *  - RfiSKMetrics : public kotekan::Stage
+ */
+
+#ifndef RFI_SK_METRICS_HPP
+#define RFI_SK_METRICS_HPP
+
+#include "Config.hpp"            // for Config
+#include "Stage.hpp"             // for Stage
+#include "buffer.hpp"            // for Buffer
+#include "bufferContainer.hpp"   // for bufferContainer
+#include "prometheusMetrics.hpp" // for Gauge, MetricFamily
+#include "restServer.hpp"        // for connectionInstance
+
+#include <mutex>    // for mutex
+#include <stddef.h> // for size_t
+#include <string>   // for string
+#include <vector>   // for vector
+
+/**
+ * @class RfiSKMetrics
+ * @brief Export the per-feed (single-feed) spectral kurtosis as prometheus gauges.
+ *
+ * Consumes the host copy of the second-stage RFI kernel's single-feed SK
+ * (cudaRFISKbar ``rfi_SKbar``): float32 with shape
+ * [rfi_num_times_bar, num_local_freq, 3, num_polarizations, num_dishes],
+ * where the length-3 axis is {SK, b, sigma} and sigma < 0 marks an invalid
+ * (masked) cell (see n2k rfi_kernels.hpp).
+ *
+ * Each frame, every element's SK is averaged over its valid (time, freq)
+ * cells and folded into an exponential moving average. Clean Gaussian noise
+ * has SK ~= 1. Elements are indexed by the flat [P][D] element index (the
+ * same indexing as /updatable_config/bad_inputs).
+ *
+ * The averages are served two ways: a GET endpoint ``<unique_name>/sk``
+ * returning JSON for machine consumers (the bffs feed flagger polls this),
+ * and prometheus gauges ``kotekan_rfi_sk_per_feed{element="..."}`` /
+ * ``kotekan_rfi_sk_per_feed_valid_frac{element="..."}`` for monitoring
+ * dashboards.
+ *
+ * The single-feed SK is computed by the kernel for every feed regardless of
+ * the bad-feed mask, so these outputs keep tracking flagged feeds — an
+ * external flagger can watch them and let a recovered feed heal.
+ *
+ * @par Buffers
+ * @buffer in_buf Single-feed SK copied from the GPU.
+ *     @buffer_shape [rfi_num_times_bar, num_local_freq, 3, num_polarizations, num_dishes]
+ *     @buffer_format float32
+ *
+ * @conf num_local_freq     Int. Frequencies per frame.
+ * @conf num_polarizations  Int. Polarizations; elements = num_polarizations * num_dishes.
+ * @conf num_dishes         Int. Dishes.
+ * @conf rfi_num_times_bar  Int. Downsampled time samples per frame.
+ * @conf ema_frames         Int, default 256. E-folding length of the moving average,
+ *                          in frames (~11 s at the pathfinder frame rate).
+ *
+ * REST Endpoints
+ *
+ * @endpoint /sk GET Returns ``{"num_elements": N, "ema_frames": M, "sk": [...],
+ *                   "valid_frac": [...]}``; the arrays are indexed by element,
+ *                   and ``sk`` entries are null until an element's first valid
+ *                   measurement.
+ *
+ * @author James Mertens
+ */
+class RfiSKMetrics : public kotekan::Stage {
+public:
+    RfiSKMetrics(kotekan::Config& config, const std::string& unique_name,
+                 kotekan::bufferContainer& buffer_container);
+    virtual ~RfiSKMetrics();
+    void main_thread() override;
+
+    /// GET handler for the /sk endpoint
+    void send_sk(kotekan::connectionInstance& conn);
+
+private:
+    size_t num_freq;
+    size_t num_times;
+    size_t num_elements;
+    size_t ema_frames;
+    double ema_alpha;
+
+    /// Guards the moving averages between main_thread and the /sk endpoint
+    std::mutex mtx;
+
+    /// Per-element moving averages (SK is NaN until the first valid frame)
+    std::vector<double> ema_sk;
+    std::vector<double> ema_valid_frac;
+
+    /// Per-element gauges, looked up once at construction
+    std::vector<kotekan::prometheus::Gauge*> sk_gauges;
+    std::vector<kotekan::prometheus::Gauge*> valid_frac_gauges;
+
+    Buffer* in_buf;
+};
+
+#endif

--- a/lib/stages/RfiSKMetrics.hpp
+++ b/lib/stages/RfiSKMetrics.hpp
@@ -45,7 +45,8 @@
  * external flagger can watch them and let a recovered feed heal.
  *
  * @par Buffers
- * @buffer in_buf Single-feed SK copied from the GPU.
+ * @buffer in_buf Single-feed SK copied from the GPU. Declared as ``kotekan_buffer: ndarray``;
+ *     the constructor requires its descriptor to match this shape and type.
  *     @buffer_shape [rfi_num_times_bar, num_local_freq, 3, num_polarizations, num_dishes]
  *     @buffer_format float32
  *
@@ -78,6 +79,8 @@ public:
 private:
     size_t num_freq;
     size_t num_times;
+    size_t num_polarizations;
+    size_t num_dishes;
     size_t num_elements;
     size_t ema_frames;
     double ema_alpha;


### PR DESCRIPTION
New CPU stage consuming the host copy of `cudaRFISKbar`'s single-feed SK output (`[T, F, {SK, b, sigma}, P, D]`; a negative sigma marks an invalid cell). Each element's SK is averaged over its valid cells per frame and folded into an exponential moving average (`ema_frames`, default 256).

The averages are served on a JSON GET endpoint `<unique_name>/sk` for machine consumers (the bffs feed flagger polls it) and as Prometheus gauges `kotekan_rfi_sk_per_feed{element=}` and `kotekan_rfi_sk_per_feed_valid_frac` for dashboards. Elements use the flat `[P][D]` element index, the same indexing as `/updatable_config/bad_inputs`. The single-feed SK is computed for every feed regardless of the bad-feed mask, so flagged feeds keep being measured and can heal.

Sphinx page added under processes. The CHORD pathfinder config block that wires the stage follows with the config PRs.

Carried on `chord`; extracted from the chord/develop diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
