### PR TITLE
dpdk: validate CRS packets in the distributors before ring indexing

### DIFF
--- a/lib/dpdk/crs16BoardDistributor.hpp
+++ b/lib/dpdk/crs16BoardDistributor.hpp
@@ -27,8 +27,15 @@ public:
     /// Processes the incoming packets
     int handle_packet(struct rte_mbuf* mbuf) override;
 
-    /// Update stats, not used by this handler yet.
-    virtual void update_stats() override {};
+    /// Export the distributed/dropped packet counters.
+    virtual void update_stats() override {
+        std::vector<std::string> port_label = {std::to_string(port)};
+        packets_total_metric.labels(port_label).set(total_packets);
+        bad_checksum_packets_total_metric.labels(port_label).set(bad_checksum_packets);
+        non_crs_packets_total_metric.labels(port_label).set(non_crs_packets);
+        invalid_stream_id_packets_total_metric.labels(port_label).set(invalid_stream_id_packets);
+        ring_full_dropped_packets_total_metric.labels(port_label).set(ring_full_dropped_packets);
+    }
 
     /// This is a distributor: it takes ownership of the mbuf.
     bool is_distributor() const override {
@@ -42,7 +49,8 @@ protected:
 
     uint32_t num_crs_boards;
 
-    /// The expected CRS packet size; anything else is dropped as non-CRS traffic.
+    /// Expected size of a CRS packet; anything else is dropped before its
+    /// header fields are trusted.
     uint32_t packet_size;
 
     uint64_t total_packets = 0;
@@ -52,6 +60,17 @@ protected:
     uint64_t non_crs_packets = 0;
     /// Dropped CRS packets whose stream_id does not map to a worker ring.
     uint64_t invalid_stream_id_packets = 0;
+    /// Dropped CRS packets that arrived while the destination worker ring was full.
+    uint64_t ring_full_dropped_packets = 0;
+
+    kotekan::prometheus::MetricFamily<kotekan::prometheus::Gauge>& packets_total_metric;
+    kotekan::prometheus::MetricFamily<kotekan::prometheus::Gauge>&
+        bad_checksum_packets_total_metric;
+    kotekan::prometheus::MetricFamily<kotekan::prometheus::Gauge>& non_crs_packets_total_metric;
+    kotekan::prometheus::MetricFamily<kotekan::prometheus::Gauge>&
+        invalid_stream_id_packets_total_metric;
+    kotekan::prometheus::MetricFamily<kotekan::prometheus::Gauge>&
+        ring_full_dropped_packets_total_metric;
 };
 
 inline crs16BoardDistributor::crs16BoardDistributor(kotekan::Config& config,
@@ -59,7 +78,18 @@ inline crs16BoardDistributor::crs16BoardDistributor(kotekan::Config& config,
                                                     kotekan::bufferContainer& buffer_container,
                                                     int port,
                                                     const std::vector<rte_ring*>& worker_rings) :
-    dpdkRXhandler(config, unique_name, buffer_container, port), worker_rings(worker_rings) {
+    dpdkRXhandler(config, unique_name, buffer_container, port), worker_rings(worker_rings),
+    packet_size(config.get<uint32_t>(unique_name, "packet_size")),
+    packets_total_metric(kotekan::prometheus::Metrics::instance().add_gauge(
+        "kotekan_dpdk_distributor_packets_total", unique_name, {"port"})),
+    bad_checksum_packets_total_metric(kotekan::prometheus::Metrics::instance().add_gauge(
+        "kotekan_dpdk_distributor_bad_checksum_packets_total", unique_name, {"port"})),
+    non_crs_packets_total_metric(kotekan::prometheus::Metrics::instance().add_gauge(
+        "kotekan_dpdk_distributor_non_crs_packets_total", unique_name, {"port"})),
+    invalid_stream_id_packets_total_metric(kotekan::prometheus::Metrics::instance().add_gauge(
+        "kotekan_dpdk_distributor_invalid_stream_id_packets_total", unique_name, {"port"})),
+    ring_full_dropped_packets_total_metric(kotekan::prometheus::Metrics::instance().add_gauge(
+        "kotekan_dpdk_distributor_ring_full_dropped_packets_total", unique_name, {"port"})) {
 
     worker_ring_ids = config.get<std::vector<uint32_t>>(unique_name, "worker_rings");
 
@@ -79,27 +109,34 @@ inline crs16BoardDistributor::crs16BoardDistributor(kotekan::Config& config,
         throw std::runtime_error(fmt::format(
             fmt("num_crs_boards' parameter must be 16. Other configurations are not supported.")));
     }
-
-    packet_size = config.get<uint32_t>(unique_name, "packet_size");
 }
 
 inline int crs16BoardDistributor::handle_packet(struct rte_mbuf* mbuf) {
 
     // Check the packet checksum flag from the NIC.
     if (unlikely((mbuf->ol_flags & RTE_MBUF_F_RX_IP_CKSUM_MASK) == RTE_MBUF_F_RX_IP_CKSUM_BAD)) {
-        WARN("Port: {:d}; Got bad packet IP checksum", port);
-        rte_pktmbuf_free(mbuf);
+        if (bad_checksum_packets == 0) {
+            WARN("Port {:d}: dropping packet with bad IP checksum; counting further drops in "
+                 "kotekan_dpdk_distributor_bad_checksum_packets_total",
+                 port);
+        }
         bad_checksum_packets++;
+        rte_pktmbuf_free(mbuf);
         return 0;
     }
 
-    // Non-CRS traffic (LLDP, ARP, switch chatter) also lands here; drop it
-    // before interpreting CRS header fields. No WARN: junk frames are routine
-    // on a switch port and would flood the log.
+    // The port runs in promiscuous mode, so stray traffic (LLDP, ARP, ...)
+    // lands here too, and its bytes at the CRS header offsets are arbitrary.
+    // Drop anything that isn't a CRS packet before trusting header fields.
     if (unlikely(mbuf->pkt_len != packet_size
                  || get_crs_packet_cookie(mbuf) != CRS_PACKET_COOKIE)) {
-        rte_pktmbuf_free(mbuf);
+        if (non_crs_packets == 0) {
+            WARN("Port {:d}: dropping non-CRS packet (len {:d}, expected {:d}); counting further "
+                 "drops in kotekan_dpdk_distributor_non_crs_packets_total",
+                 port, mbuf->pkt_len, packet_size);
+        }
         non_crs_packets++;
+        rte_pktmbuf_free(mbuf);
         return 0;
     }
 
@@ -108,20 +145,23 @@ inline int crs16BoardDistributor::handle_packet(struct rte_mbuf* mbuf) {
     // Divide the streams between the worker rings
     uint32_t ring_index = stream_id / (128 / worker_ring_ids.size());
 
-    // A corrupt or misconfigured CRS packet can carry a stream_id >= 128,
-    // which would index past worker_ring_ids.
+    // A CRS packet with a stream_id outside [0, 128) must not index past the
+    // ring table.
     if (unlikely(ring_index >= worker_ring_ids.size())) {
-        rte_pktmbuf_free(mbuf);
-        WARN("Port: {:d}; Got CRS packet with invalid stream_id {:d}, dropping", port, stream_id);
+        if (invalid_stream_id_packets == 0) {
+            WARN("Port {:d}: dropping CRS packet with out-of-range stream_id {:d}", port,
+                 stream_id);
+        }
         invalid_stream_id_packets++;
+        rte_pktmbuf_free(mbuf);
         return 0;
     }
 
     // Put the packet into the worker ring
     int err = rte_ring_enqueue(worker_rings[worker_ring_ids[ring_index]], mbuf);
     if (err != 0) {
-        // TODO Make this into a metric
         // Failed to enqueue packet into worker ring, dropping packet
+        ring_full_dropped_packets++;
         rte_pktmbuf_free(mbuf);
     } else {
         total_packets++;

--- a/lib/dpdk/crs1BoardDistributor.hpp
+++ b/lib/dpdk/crs1BoardDistributor.hpp
@@ -27,8 +27,14 @@ public:
     /// Processes the incoming packets
     int handle_packet(struct rte_mbuf* mbuf) override;
 
-    /// Update stats, not used by this handler yet.
-    virtual void update_stats() override {};
+    /// Export the distributed/dropped packet counters.
+    virtual void update_stats() override {
+        std::vector<std::string> port_label = {std::to_string(port)};
+        packets_total_metric.labels(port_label).set(total_packets);
+        non_crs_packets_total_metric.labels(port_label).set(non_crs_packets);
+        invalid_stream_id_packets_total_metric.labels(port_label).set(invalid_stream_id_packets);
+        ring_full_dropped_packets_total_metric.labels(port_label).set(ring_full_dropped_packets);
+    }
 
     /// This is a distributor: it takes ownership of the mbuf.
     bool is_distributor() const override {
@@ -42,7 +48,21 @@ protected:
 
     uint32_t num_crs_boards;
 
+    /// Expected size of a CRS packet; anything else is dropped before its
+    /// header fields are trusted.
+    uint32_t packet_size;
+
     uint64_t total_packets = 0;
+    uint64_t non_crs_packets = 0;
+    uint64_t invalid_stream_id_packets = 0;
+    uint64_t ring_full_dropped_packets = 0;
+
+    kotekan::prometheus::MetricFamily<kotekan::prometheus::Gauge>& packets_total_metric;
+    kotekan::prometheus::MetricFamily<kotekan::prometheus::Gauge>& non_crs_packets_total_metric;
+    kotekan::prometheus::MetricFamily<kotekan::prometheus::Gauge>&
+        invalid_stream_id_packets_total_metric;
+    kotekan::prometheus::MetricFamily<kotekan::prometheus::Gauge>&
+        ring_full_dropped_packets_total_metric;
 };
 
 inline crs1BoardDistributor::crs1BoardDistributor(kotekan::Config& config,
@@ -50,7 +70,16 @@ inline crs1BoardDistributor::crs1BoardDistributor(kotekan::Config& config,
                                                   kotekan::bufferContainer& buffer_container,
                                                   int port,
                                                   const std::vector<rte_ring*>& worker_rings) :
-    dpdkRXhandler(config, unique_name, buffer_container, port), worker_rings(worker_rings) {
+    dpdkRXhandler(config, unique_name, buffer_container, port), worker_rings(worker_rings),
+    packet_size(config.get<uint32_t>(unique_name, "packet_size")),
+    packets_total_metric(kotekan::prometheus::Metrics::instance().add_gauge(
+        "kotekan_dpdk_distributor_packets_total", unique_name, {"port"})),
+    non_crs_packets_total_metric(kotekan::prometheus::Metrics::instance().add_gauge(
+        "kotekan_dpdk_distributor_non_crs_packets_total", unique_name, {"port"})),
+    invalid_stream_id_packets_total_metric(kotekan::prometheus::Metrics::instance().add_gauge(
+        "kotekan_dpdk_distributor_invalid_stream_id_packets_total", unique_name, {"port"})),
+    ring_full_dropped_packets_total_metric(kotekan::prometheus::Metrics::instance().add_gauge(
+        "kotekan_dpdk_distributor_ring_full_dropped_packets_total", unique_name, {"port"})) {
 
     worker_ring_ids = config.get<std::vector<uint32_t>>(unique_name, "worker_rings");
 
@@ -74,17 +103,43 @@ inline crs1BoardDistributor::crs1BoardDistributor(kotekan::Config& config,
 
 inline int crs1BoardDistributor::handle_packet(struct rte_mbuf* mbuf) {
 
+    // The port runs in promiscuous mode, so stray traffic (LLDP, ARP, ...)
+    // lands here too, and its bytes at the CRS header offsets are arbitrary.
+    // Drop anything that isn't a CRS packet before trusting header fields.
+    if (unlikely(mbuf->pkt_len != packet_size
+                 || get_crs_packet_cookie(mbuf) != CRS_PACKET_COOKIE)) {
+        if (non_crs_packets == 0) {
+            WARN("Port {:d}: dropping non-CRS packet (len {:d}, expected {:d}); counting further "
+                 "drops in kotekan_dpdk_distributor_non_crs_packets_total",
+                 port, mbuf->pkt_len, packet_size);
+        }
+        non_crs_packets++;
+        rte_pktmbuf_free(mbuf);
+        return 0;
+    }
+
     uint16_t stream_id = get_crs_packet_stream_id(mbuf);
 
     // Divide the streams between the worker rings
     uint32_t ring_index = stream_id / (128 / worker_ring_ids.size());
 
+    // A CRS packet with a stream_id outside [0, 128) must not index past the
+    // ring table.
+    if (unlikely(ring_index >= worker_ring_ids.size())) {
+        if (invalid_stream_id_packets == 0) {
+            WARN("Port {:d}: dropping CRS packet with out-of-range stream_id {:d}", port,
+                 stream_id);
+        }
+        invalid_stream_id_packets++;
+        rte_pktmbuf_free(mbuf);
+        return 0;
+    }
+
     // Put the packet into the worker ring
     int err = rte_ring_enqueue(worker_rings[worker_ring_ids[ring_index]], mbuf);
     if (err != 0) {
-        // TODO Make this into a metric
-        // WARN_NON_OO("Failed to enqueue packet into worker ring {:d}, dropping packet",
-        // worker_ring_ids[ring_index]);
+        // Failed to enqueue packet into worker ring, dropping packet
+        ring_full_dropped_packets++;
         rte_pktmbuf_free(mbuf);
     } else {
         total_packets++;


### PR DESCRIPTION
`crs16BoardDistributor` and `crs1BoardDistributor` computed `worker_ring_ids[stream_id / (128 / size)]` straight from packet bytes. The capture ports run in promiscuous mode, so stray traffic (LLDP, ARP, IPv6 ND) also reaches the distributor, and its bytes at the stream_id offset are arbitrary: any value >= 128 indexed past the ring-id vector and handed `rte_ring_enqueue` a wild `rte_ring*`. Observed on the CHORD pathfinder as an immediate lcore SEGV in `handle_packet`, or as heap corruption surfacing later in unrelated threads. The capture workers already validate `pkt_len` and the 0xCF cookie, but they run after the distributor.

Drop anything with the wrong `pkt_len`, a bad IP checksum or an out-of-range stream_id before touching the rings; count each class plus ring-full drops in per-port Prometheus gauges (`kotekan_dpdk_distributor_*_total`); warn once per class. The expected size comes from the `packet_size` config key, which every config using these handlers already sets.

Squashes two `chord` commits: the validation, and Andre Renard's review follow-ups (co-authored). Running on the pathfinder since July.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
