### PR TITLE
Check the SK kernel against analytically known values in CI

### DIFF
--- a/config/ci-tests/gpu_batch/verify_cuda_rfi_sktilde_analytic.j2
+++ b/config/ci-tests/gpu_batch/verify_cuda_rfi_sktilde_analytic.j2
@@ -1,0 +1,259 @@
+{#-
+  verify_cuda_rfi_sktilde_analytic.j2
+
+  Checks cudaRFISKtilde against analytically known values, complementing the
+  GPU-vs-CPU-oracle comparison in verify_cuda_rfi_sktilde.yaml (which cannot catch a
+  bug shared by both implementations).
+
+  The S012 input is constant with two feed groups sharing (S0, S1) -- so the
+  Nita-Gary bias and sigma, which come from interpolation tables and are not
+  hand-computable, are identical for every feed -- but differing in S2:
+
+      group A (elements 0..63):    S0=256, S1=1024, S2=8192  -> raw SK = 257/255
+      group B (elements 64..127):  S0=256, S1=1024, S2=12288 -> raw SK = 514/255
+
+  One S012 stream feeds three SK kernels differing only in their bad feed mask:
+
+      all:     no feeds masked   -> feed-averaged SK = (257+514)/510 - bias
+      half:    group B masked    -> feed-averaged SK = 514/510 - bias
+      starved: 120 feeds masked  -> den = 8*256 = 2048 < 0.25*256*128 = 8192, so the
+               validity gate fails and the output is exactly [0, 0, -1]
+
+  The bias cancels in (all - half) = 257/510 per bin, checked to 1e-5; the starved
+  path's dummy values are exact. All thresholds are dyadic so no comparison sits on a
+  float rounding boundary.
+-#}
+---
+type: config
+log_level: INFO
+
+buffer_depth: 4
+cpu_affinity: [0]
+sizeof_float: 4
+sizeof_long: 8
+
+samples_per_data_set: 8192
+frame_arrival_period: 5.12e-6 * samples_per_data_set
+num_polarizations: 2
+num_dishes: 64
+num_elements: num_polarizations * num_dishes
+num_local_freq: 4
+
+rfi_downsampling_factor: 256
+bf_mask_lifetime_in_samples: 4 * samples_per_data_set
+
+# Gate arithmetic (see header comment): all values dyadic, mu = S1/S0 = 4 in [2, 80].
+rfi_sk_rfimask_sigmas: 3.0
+rfi_single_feed_min_good_frac: 0.25
+rfi_feed_averaged_min_good_frac: 0.25
+rfi_mu_min: 2.0
+rfi_mu_max: 80.0
+
+{% set paths = [
+    ("all", []),
+    ("half", range(64, 128) | list),
+    ("starved", range(8, 128) | list),
+] %}
+
+updatable_config:
+{% for name, bad in paths %}
+    bad_inputs_{{ name }}:
+        kotekan_update_endpoint: json
+        # yamlfix:off
+        bad_inputs: {{ bad }}
+        # yamlfix:on
+        start_time: 1535048997.
+        update_id: "initial_flags_{{ name }}"
+{% endfor %}
+
+main_pool:
+    kotekan_metadata_pool: chordMetadata
+    num_metadata_objects: 30 * buffer_depth
+
+# One constant S012 stream, shared by all three SK kernels.
+host_rfi_s012_buffer:
+    kotekan_buffer: ndarray
+    num_frames: buffer_depth
+    value_type: uint64
+    extents: [samples_per_data_set / rfi_downsampling_factor, num_local_freq, 3, num_polarizations, num_dishes]
+    metadata_pool: main_pool
+
+host_rfi_s012_ringbuffer:
+    kotekan_buffer: ring
+    ring_buffer_size: buffer_depth * (samples_per_data_set / rfi_downsampling_factor) * num_local_freq * 3 * num_elements * sizeof_long
+    metadata_pool: main_pool
+
+{% for name, bad in paths %}
+host_bf_mask_{{ name }}_buffer:
+    kotekan_buffer: ndarray
+    num_frames: buffer_depth
+    value_type: int8
+    extents: [1, num_polarizations, num_dishes]
+    quantity_name: "bf_mask"
+    dimnames: ["Tbf", "P", "D"]
+    dimscalings: [bf_mask_lifetime_in_samples, 1, 1]
+    metadata_pool: main_pool
+
+host_bf_mask_{{ name }}_ringbuffer:
+    kotekan_buffer: ring
+    ring_buffer_size: buffer_depth * num_elements
+    metadata_pool: main_pool
+
+host_rfi_sktilde_{{ name }}_buffer:
+    kotekan_buffer: ndarray
+    num_frames: buffer_depth
+    value_type: float32
+    extents: [samples_per_data_set / rfi_downsampling_factor, num_local_freq, 3]
+    metadata_pool: main_pool
+
+host_rfi_sktilde_{{ name }}_ringbuffer:
+    kotekan_buffer: ring
+    ring_buffer_size: buffer_depth * (samples_per_data_set / rfi_downsampling_factor) * num_local_freq * 3 * sizeof_float
+    metadata_pool: main_pool
+
+host_rfi_mask_{{ name }}_buffer:
+    kotekan_buffer: ndarray
+    num_frames: buffer_depth
+    value_type: uint1x8
+    extents: [samples_per_data_set / 1024, num_local_freq, 128]
+    metadata_pool: main_pool
+
+host_rfi_mask_{{ name }}_ringbuffer:
+    kotekan_buffer: ring
+    ring_buffer_size: buffer_depth * samples_per_data_set * num_local_freq / 8
+    metadata_pool: main_pool
+{% endfor %}
+
+gen_rfi_s012:
+    kotekan_stage: testRFIS012Gen
+    out_buf: host_rfi_s012_buffer
+    type: const
+    bar_mode: false
+    downsampling_factor: rfi_downsampling_factor
+    num_frames: 2 * buffer_depth
+    S0_value: 256
+    S1_value: 1024
+    # yamlfix:off
+    S2_values: {{ [8192] * 64 + [12288] * 64 }}
+    # yamlfix:on
+
+run_send_rfi_s012:
+    gpu_0:
+        kotekan_stage: cudaProcess
+        gpu_id: 0
+        in_buffers:
+            host_rfi_s012_buffer_in: host_rfi_s012_buffer
+        out_buffers:
+            host_rfi_s012_ringbuffer_out: host_rfi_s012_ringbuffer
+        commands:
+            - name: cudaCopyToRingbuffer
+              input_size: samples_per_data_set / rfi_downsampling_factor * num_local_freq * 3 * num_elements * sizeof_long
+              ring_buffer_size: buffer_depth * input_size
+              in_buf: host_rfi_s012_buffer_in
+              signal_buf: host_rfi_s012_ringbuffer_out
+              gpu_mem_output: rfi_s012_buffer
+
+{% for name, bad in paths %}
+set_bf_mask_{{ name }}:
+    kotekan_stage: bufferBadInputs
+    updatable_config:
+        bad_inputs: /updatable_config/bad_inputs_{{ name }}
+    out_buf: host_bf_mask_{{ name }}_buffer
+
+run_send_bf_mask_{{ name }}:
+    gpu_0:
+        kotekan_stage: cudaProcess
+        gpu_id: 0
+        in_buffers:
+            host_bf_mask_buffer_in: host_bf_mask_{{ name }}_buffer
+        out_buffers:
+            host_bf_mask_{{ name }}_ringbuffer: host_bf_mask_{{ name }}_ringbuffer
+        commands:
+            - name: cudaCopyToRingbuffer
+              input_size: num_dishes * num_polarizations
+              ring_buffer_size: buffer_depth * input_size
+              in_buf: host_bf_mask_buffer_in
+              signal_buf: host_bf_mask_{{ name }}_ringbuffer
+              gpu_mem_output: bf_mask_{{ name }}_buffer
+
+run_rfi_sktilde_{{ name }}:
+    gpu_0:
+        kotekan_stage: cudaProcess
+        gpu_id: 0
+        in_buffers:
+            host_bf_mask_{{ name }}_ringbuffer: host_bf_mask_{{ name }}_ringbuffer
+            host_rfi_s012_ringbuffer: host_rfi_s012_ringbuffer
+        out_buffers:
+            host_rfi_sktilde_{{ name }}_ringbuffer: host_rfi_sktilde_{{ name }}_ringbuffer
+            host_rfi_mask_{{ name }}_ringbuffer: host_rfi_mask_{{ name }}_ringbuffer
+        commands:
+            - name: cudaRFISKtilde
+              rfi_S012_name: rfi_s012
+              bf_mask_name: bf_mask_{{ name }}
+              rfi_SKtilde_name: rfi_sktilde_{{ name }}
+              rfi_RFImask_name: rfi_mask_{{ name }}
+              num_times: samples_per_data_set
+              num_frequencies: num_local_freq
+              rfi_num_times: samples_per_data_set / rfi_downsampling_factor
+
+run_recv_rfi_sktilde_{{ name }}:
+    gpu_0:
+        kotekan_stage: cudaProcess
+        gpu_id: 0
+        in_buffers:
+            host_rfi_sktilde_ringbuffer_in: host_rfi_sktilde_{{ name }}_ringbuffer
+        out_buffers:
+            host_rfi_sktilde_buffer_out: host_rfi_sktilde_{{ name }}_buffer
+        commands:
+            - name: cudaCopyFromRingbuffer
+              host_signal: host_rfi_sktilde_ringbuffer_in
+              gpu_mem_input: rfi_sktilde_{{ name }}_buffer
+              output_size: (samples_per_data_set / rfi_downsampling_factor) * num_local_freq * 3 * sizeof_float
+              ring_buffer_size: buffer_depth * output_size
+              out_buf: host_rfi_sktilde_buffer_out
+
+run_recv_rfi_mask_{{ name }}:
+    gpu_0:
+        kotekan_stage: cudaProcess
+        gpu_id: 0
+        in_buffers:
+            host_rfi_mask_ringbuffer_in: host_rfi_mask_{{ name }}_ringbuffer
+        out_buffers:
+            host_rfi_mask_buffer_out: host_rfi_mask_{{ name }}_buffer
+        commands:
+            - name: cudaCopyFromRingbuffer
+              host_signal: host_rfi_mask_ringbuffer_in
+              gpu_mem_input: rfi_mask_{{ name }}_buffer
+              output_size: samples_per_data_set * num_local_freq / 8
+              ring_buffer_size: buffer_depth * output_size
+              out_buf: host_rfi_mask_buffer_out
+
+# The first-stage mask content is covered by the oracle comparison test; here it only
+# needs draining.
+drop_rfi_mask_{{ name }}:
+    kotekan_stage: dropAllFrames
+    in_buf: host_rfi_mask_{{ name }}_buffer
+{% endfor %}
+
+# The bias cancels between the two passing paths: (all - half) = 257/510 in the
+# feed-averaged SK, 0 in the bias component. Sigma shrinks with the feed count by an
+# unknown table value, so component 2 is skipped.
+check_mask_diff:
+    kotekan_stage: testDataCheckExpected
+    first_buf: host_rfi_sktilde_all_buffer
+    second_buf: host_rfi_sktilde_half_buffer
+    expected: [0.503921568627451, 0.0, 0.0]
+    skip_components: [2]
+    epsilon: 1.0e-5
+    num_frames_to_test: 2 * buffer_depth
+
+# The starved path misses the feed-averaged validity gate, so every bin holds the
+# exact dummy values.
+check_gate:
+    kotekan_stage: testDataCheckExpected
+    first_buf: host_rfi_sktilde_starved_buffer
+    expected: [0.0, 0.0, -1.0]
+    epsilon: 1.0e-6
+    num_frames_to_test: 2 * buffer_depth
+
+log_config_usage: fatal_error

--- a/config/ci-tests/gpu_batch/verify_cuda_rfi_sktilde_analytic.j2
+++ b/config/ci-tests/gpu_batch/verify_cuda_rfi_sktilde_analytic.j2
@@ -235,14 +235,23 @@ drop_rfi_mask_{{ name }}:
     in_buf: host_rfi_mask_{{ name }}_buffer
 {% endfor %}
 
-# The bias cancels between the two passing paths: (all - half) = 257/510 in the
-# feed-averaged SK, 0 in the bias component. Sigma shrinks with the feed count by an
-# unknown table value, so component 2 is skipped.
+# Where 257/510 comes from. n2k's SkKernel computes per feed
+#     SK = (S0+1)/(S0-1) * (S0*S2/S1^2 - 1) - b
+# and the feed average weights each unmasked feed by its S0, which is 256 for every feed
+# here, so it is the plain mean over unmasked feeds. With S0=256 and S1=1024, S0*S2/S1^2
+# is 2 for group A (S2=8192) and 3 for group B (S2=12288):
+#     SK_A = 257/255 * 1 - b        SK_B = 257/255 * 2 - b
+#     all  = (64*SK_A + 64*SK_B)/128 = 771/510 - b
+#     half = SK_A                    = 514/510 - b
+#     all - half = 257/510 = 0.50392156862745...
+# The bias b depends only on (S1/S0, S0), identical for every feed, so it cancels and
+# the bias component of the difference is exactly 0. Sigma shrinks with the feed count
+# by an unknown table value, so component 2 is skipped.
 check_mask_diff:
     kotekan_stage: testDataCheckExpected
     first_buf: host_rfi_sktilde_all_buffer
     second_buf: host_rfi_sktilde_half_buffer
-    expected: [0.503921568627451, 0.0, 0.0]
+    expected: [0.503921568627451, 0.0, 0.0] # 257/510, 0, skipped
     skip_components: [2]
     epsilon: 1.0e-5
     num_frames_to_test: 2 * buffer_depth

--- a/lib/testing/CMakeLists.txt
+++ b/lib/testing/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(
     networkOutputSim.cpp
     simVdifData.cpp
     testDataCheck.cpp
+    testDataCheckExpected.cpp
     testDataGenQuad.cpp
     testDataGenFloat.cpp
     testLostCountsGen.cpp

--- a/lib/testing/testDataCheckExpected.cpp
+++ b/lib/testing/testDataCheckExpected.cpp
@@ -1,0 +1,120 @@
+#include "testDataCheckExpected.hpp"
+
+#include "StageFactory.hpp"       // for REGISTER_KOTEKAN_STAGE
+#include "errors.h"               // for TEST_FAILED, TEST_PASSED
+#include "kotekanLogging.hpp"     // for ERROR, FATAL_ERROR, INFO
+#include "visUtil.hpp"            // for frameID, modulo
+#include "waitingForAllTests.hpp" // for waiting_for_all_tests
+
+#include "fmt.hpp" // for compile_string_to_view
+
+#include <cmath>      // for fabs
+#include <functional> // for bind, function
+
+using kotekan::bufferContainer;
+using kotekan::Config;
+using kotekan::Stage;
+
+REGISTER_KOTEKAN_STAGE(testDataCheckExpected);
+
+testDataCheckExpected::testDataCheckExpected(Config& config, const std::string& unique_name,
+                                             bufferContainer& buffer_container) :
+    Stage(config, unique_name, buffer_container,
+          std::bind(&testDataCheckExpected::main_thread, this)),
+    first_buf(get_buffer("first_buf")),
+    second_buf(config.exists(unique_name, "second_buf") ? get_buffer("second_buf") : nullptr),
+    expected(config.get<std::vector<float>>(unique_name, "expected")),
+    epsilon(config.get_default<double>(unique_name, "epsilon", 1e-6)),
+    num_frames_to_test(config.get<int32_t>(unique_name, "num_frames_to_test")),
+    max_num_errors_logged(config.get_default<int32_t>(unique_name, "max_num_errors_logged", 100)),
+    trigger_exit_on_pass(config.get_default<bool>(unique_name, "trigger_exit_on_pass", true)) {
+
+    first_buf->register_consumer(unique_name);
+    if (second_buf != nullptr) {
+        second_buf->register_consumer(unique_name);
+        if (second_buf->frame_size != first_buf->frame_size)
+            FATAL_ERROR("first_buf frame size ({:d}) must equal second_buf frame size ({:d})",
+                        first_buf->frame_size, second_buf->frame_size);
+    }
+
+    if (expected.empty())
+        FATAL_ERROR("'expected' must hold at least one value");
+    if (first_buf->frame_size % sizeof(float) != 0)
+        FATAL_ERROR("first_buf frame size ({:d}) is not a whole number of floats",
+                    first_buf->frame_size);
+
+    check_component.assign(expected.size(), true);
+    for (const int c : config.get_default<std::vector<int>>(unique_name, "skip_components", {})) {
+        if (c < 0 || (size_t)c >= expected.size())
+            FATAL_ERROR("skip_components entry {:d} outside expected list of {:d}", c,
+                        expected.size());
+        check_component[c] = false;
+    }
+
+    if (trigger_exit_on_pass)
+        waiting_for_all_tests++;
+}
+
+void testDataCheckExpected::main_thread() {
+
+    frameID first_id(first_buf);
+    frameID second_id(second_buf != nullptr ? second_buf : first_buf);
+    const size_t num_values = first_buf->frame_size / sizeof(float);
+    int frames = 0;
+
+    while (!stop_thread) {
+        const float* first = (const float*)first_buf->wait_for_full_frame(unique_name, first_id);
+        if (first == nullptr)
+            break;
+        const float* second = nullptr;
+        if (second_buf != nullptr) {
+            second = (const float*)second_buf->wait_for_full_frame(unique_name, second_id);
+            if (second == nullptr)
+                break;
+        }
+
+        int num_errors = 0;
+        for (size_t i = 0; i < num_values; ++i) {
+            const size_t c = i % expected.size();
+            if (!check_component[c])
+                continue;
+            const double value =
+                second != nullptr ? (double)first[i] - (double)second[i] : (double)first[i];
+            if (std::fabs(value - (double)expected[c]) > epsilon) {
+                num_errors++;
+                if (num_errors <= max_num_errors_logged)
+                    ERROR("{:s}[{:d}][{:d}]: got {:g}, expected {:g} (component {:d})",
+                          first_buf->buffer_name, first_id, i, value, expected[c], c);
+            }
+        }
+
+        first_buf->mark_frame_empty(unique_name, first_id++);
+        if (second_buf != nullptr)
+            second_buf->mark_frame_empty(unique_name, second_id++);
+        frames++;
+
+        if (num_errors > 0) {
+            ERROR("{:s}[{:d}]: {:d} of {:d} values did not match. Test failed, exiting.",
+                  first_buf->buffer_name, first_id, num_errors, num_values);
+            TEST_FAILED();
+            break;
+        }
+
+        if (frames == num_frames_to_test) {
+            if (trigger_exit_on_pass) {
+                INFO("Test passed, exiting.");
+                // Unregister to allow the pipeline to continue, unless I'm the last
+                // consumer on this buffer.
+                first_buf->unregister_consumer(unique_name, true);
+                if (second_buf != nullptr)
+                    second_buf->unregister_consumer(unique_name, true);
+                if (--waiting_for_all_tests == 0) {
+                    TEST_PASSED();
+                }
+            } else {
+                INFO("Test passed.");
+            }
+            break;
+        }
+    }
+}

--- a/lib/testing/testDataCheckExpected.hpp
+++ b/lib/testing/testDataCheckExpected.hpp
@@ -1,0 +1,64 @@
+#ifndef TEST_DATA_CHECK_EXPECTED_HPP
+#define TEST_DATA_CHECK_EXPECTED_HPP
+
+#include "Config.hpp"          // for Config
+#include "Stage.hpp"           // for Stage
+#include "buffer.hpp"          // for Buffer
+#include "bufferContainer.hpp" // for bufferContainer
+
+#include <stddef.h> // for size_t
+#include <string>   // for string
+#include <vector>   // for vector
+
+/**
+ * @class testDataCheckExpected
+ * @brief Check float frames against expected constant values, known analytically.
+ *
+ * The expected values are cycled over each frame's floats, so a short list checks a
+ * repeating pattern (e.g. one entry per component of the innermost axis). With a
+ * second buffer, the elementwise difference (first - second) is checked instead --
+ * useful when two pipelines differ by an analytically known amount while sharing an
+ * unknown term (e.g. a bias) that cancels in the difference.
+ *
+ * Follows the testDataCheck conventions: after `num_frames_to_test` clean frames the
+ * test passes (exiting kotekan once every checker has passed), and any mismatching
+ * frame fails the test immediately.
+ *
+ * @par Buffers
+ * @buffer first_buf   Float frames to check.
+ *      @buffer_format float32
+ * @buffer second_buf  Optional. When set, check (first_buf - second_buf) elementwise;
+ *                     frame sizes must match.
+ *      @buffer_format float32
+ *
+ * @conf  expected             Array<Float>. Values the frame (or difference) must
+ *                             hold, cycled over each frame's floats.
+ * @conf  skip_components      Array<Int>, default empty. Indices into the expected
+ *                             cycle to skip (e.g. a component with no analytic value).
+ * @conf  epsilon              Double, default 1e-6. Maximum absolute deviation.
+ * @conf  num_frames_to_test   Int. Frames to check before declaring a pass.
+ * @conf  max_num_errors_logged Int, default 100. Per-frame cap on logged mismatches.
+ * @conf  trigger_exit_on_pass Bool, default true. Exit kotekan when every checker
+ *                             has passed.
+ *
+ * @author James Mertens
+ */
+class testDataCheckExpected : public kotekan::Stage {
+public:
+    testDataCheckExpected(kotekan::Config& config, const std::string& unique_name,
+                          kotekan::bufferContainer& buffer_container);
+    ~testDataCheckExpected() = default;
+    void main_thread() override;
+
+private:
+    Buffer* first_buf;
+    Buffer* second_buf; // null when only first_buf is checked
+    std::vector<float> expected;
+    std::vector<bool> check_component; // per expected-cycle index
+    const double epsilon;
+    const int num_frames_to_test;
+    const int max_num_errors_logged;
+    const bool trigger_exit_on_pass;
+};
+
+#endif // TEST_DATA_CHECK_EXPECTED_HPP


### PR DESCRIPTION
`verify_cuda_rfi_sktilde` compares the GPU kernel to the CPU oracle, which cannot catch a bug shared by both implementations. `verify_cuda_rfi_sktilde_analytic` feeds one constant S012 stream (via `testRFIS012Gen`'s per-element value arrays) to three SK kernels differing only in their bad-feed mask and asserts values known on paper. The two feed groups share (S0, S1), so the Nita-Gary bias and sigma (table interpolations with no closed form) are identical for every feed, and the bias cancels exactly in the difference between the unmasked and half-masked paths: 257/510 in the feed-averaged SK, zero in the bias component. The third path masks feeds past the validity gate's threshold and must hold the exact `[0, 0, -1]` dummy values. All thresholds are dyadic, so no comparison sits on a float rounding boundary.

Adds `testDataCheckExpected`, a generic checker of float frames against expected constants cycled per component, optionally on the difference of two buffers, with a skip list for components that have no analytic value (here sigma, which shrinks with the feed count by a table value).

Runs with the rest of `config/ci-tests/gpu_batch`. Verified standalone: passes on an A40 pair (2 devices), 2s runtime.

Carried on `chord`; extracted from the chord/develop diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
