### PR TITLE
TransposeBasebandArray: write the scalar path element-major

### DIFF
--- a/lib/stages/TransposeBasebandArray.cpp
+++ b/lib/stages/TransposeBasebandArray.cpp
@@ -142,16 +142,23 @@ STAGE_CONSTRUCTOR(TransposeBasebandArray) {
             NUM_ELEMENTS / 8));
     }
 
-    // AVX512 fast path is always enabled with these constants
+    // Escape hatch to run the scalar path on a machine that supports AVX512, so that both
+    // paths can be exercised and compared without rebuilding for a different -march.
+    const bool disable_avx512 = config.get_default<bool>(unique_name, "disable_avx512", false);
+
     use_avx512_fast_path = false;
+    if (disable_avx512) {
+        INFO("TransposeBasebandArray: AVX512 fast path disabled by config, using scalar path");
+    } else {
 #ifdef __AVX512F__
-    // With our constants: time_short=16, element_short=8, num_elements=128, element_long=16
-    // All requirements are met
-    use_avx512_fast_path = true;
-    INFO("TransposeBasebandArray: AVX512 fast path enabled");
+        // With our constants: time_short=16, element_short=8, num_elements=128, element_long=16
+        // All requirements are met
+        use_avx512_fast_path = true;
+        INFO("TransposeBasebandArray: AVX512 fast path enabled");
 #else
-    INFO("TransposeBasebandArray: AVX512 not available, using scalar path");
+        INFO("TransposeBasebandArray: AVX512 not available, using scalar path");
 #endif
+    }
 
     // Set the output buffer frame ndarray shape
 
@@ -395,29 +402,30 @@ void TransposeBasebandArray::main_thread() {
                     uint64_t mask_val = pl_mask_ptr[pl_mask_idx];
                     bool has_packet_loss = (mask_val & check_mask) != check_mask;
 
-                    for (uint32_t e_long = 0; e_long < ELEMENT_LONG; e_long++) {
-                        for (uint32_t t_short = 0; t_short < TIME_SHORT; t_short++) {
-                            // Calculate output time index
-                            uint32_t time = t_long * TIME_SHORT + t_short;
+                    // Loop over time samples outermost so each one's whole row of elements is
+                    // written in order, rather than writing element_short bytes per
+                    // element_long and stepping by out_time_stride between them.
+                    for (uint32_t t_short = 0; t_short < TIME_SHORT; t_short++) {
+                        // Calculate output time index
+                        uint32_t time = t_long * TIME_SHORT + t_short;
 
-                            // Calculate output base index
-                            size_t out_base = (size_t)time * out_time_stride
-                                              + freq * out_freq_stride + e_long * ELEMENT_SHORT;
+                        // Calculate output base index
+                        size_t out_base = (size_t)time * out_time_stride + freq * out_freq_stride;
 
-                            if (has_packet_loss) {
-                                // Fill with 0x88 instead of copying
-                                std::memset(&out_frame[out_base], 0x88, ELEMENT_SHORT);
-                            } else {
-                                // Calculate input base index
-                                size_t in_base = (size_t)t_long * in_tlong_stride
-                                                 + freq * in_freq_stride
-                                                 + e_long * (TIME_SHORT * ELEMENT_SHORT)
-                                                 + t_short * ELEMENT_SHORT;
+                        if (has_packet_loss) {
+                            // Fill with 0x88 instead of copying
+                            std::memset(&out_frame[out_base], 0x88, NUM_ELEMENTS);
+                        } else {
+                            // Calculate input base index for this time sample
+                            size_t in_base = (size_t)t_long * in_tlong_stride
+                                             + freq * in_freq_stride + t_short * ELEMENT_SHORT;
 
-                                // Copy element_short contiguous bytes
-                                std::memcpy(&out_frame[out_base], &in_frame[in_base],
-                                            ELEMENT_SHORT);
-                            }
+                            // Copy element_short contiguous bytes per element_long
+                            for (uint32_t e_long = 0; e_long < ELEMENT_LONG; e_long++)
+                                std::memcpy(
+                                    &out_frame[out_base + e_long * ELEMENT_SHORT],
+                                    &in_frame[in_base + e_long * (TIME_SHORT * ELEMENT_SHORT)],
+                                    ELEMENT_SHORT);
                         }
                     }
                 }

--- a/lib/stages/TransposeBasebandArray.cpp
+++ b/lib/stages/TransposeBasebandArray.cpp
@@ -320,13 +320,12 @@ void TransposeBasebandArray::main_thread() {
         // Transpose the data
         // Input:  E[time_long][frequency_local][element_long][time_short][element_short]
         // Output: E'[time][frequency_local][element]
+        size_t lost_blocks = 0;
 
 #ifdef __AVX512F__
         if (use_avx512_fast_path) {
             // AVX512 fast path: process one (t_long, freq) block at a time
             // Each block is 2048 bytes and produces 16 rows of 128 bytes
-            size_t lost_blocks = 0;
-
             for (uint32_t t_long = 0; t_long < time_long; t_long++) {
                 const uint32_t base_time = t_long * TIME_SHORT;
 
@@ -380,12 +379,6 @@ void TransposeBasebandArray::main_thread() {
             }
             // Memory fence to ensure all non-temporal stores are completed
             _mm_sfence();
-
-            // Log packet loss percentage
-            double loss_percentage =
-                100.0 * double(lost_blocks) / double(time_long * NUM_LOCAL_FREQ);
-            DEBUG("TransposeBasebandArray: Frame {:d} data loss = {:.4f}%", (int)in_frame_id,
-                  loss_percentage);
         } else
 #endif
         {
@@ -401,6 +394,8 @@ void TransposeBasebandArray::main_thread() {
                     size_t pl_mask_idx = t64_idx * pl_mask_t64_stride + freq * pl_mask_freq_stride;
                     uint64_t mask_val = pl_mask_ptr[pl_mask_idx];
                     bool has_packet_loss = (mask_val & check_mask) != check_mask;
+                    if (has_packet_loss)
+                        lost_blocks++;
 
                     // Loop over time samples outermost so each one's whole row of elements is
                     // written in order, rather than writing element_short bytes per
@@ -432,7 +427,8 @@ void TransposeBasebandArray::main_thread() {
             }
         }
 
-        DEBUG("TransposeBasebandArray: Transposed frame {:d}", in_frame_id);
+        DEBUG("TransposeBasebandArray: Transposed frame {:d}, data loss = {:.4f}%", in_frame_id,
+              100.0 * double(lost_blocks) / double(time_long * NUM_LOCAL_FREQ));
 
         // get a copy of the input metadata
         auto in_meta = get_chord_metadata(in_buf, in_frame_id);

--- a/lib/stages/TransposeBasebandArray.hpp
+++ b/lib/stages/TransposeBasebandArray.hpp
@@ -46,6 +46,9 @@
  *                              Use "even"/"odd" to parallelize two instances on alternate frames.
  * @conf check_for_zero_nibbles Bool. Enable checking for zero nibbles in the input data (default:
  * false).
+ * @conf disable_avx512        Bool. Force the scalar path even where AVX512 is available
+ *                             (default: false).  Intended for testing and for comparing the
+ *                             two paths against each other.
  *
  * @author Kotekan Team
  */

--- a/tests/boost/CMakeLists.txt
+++ b/tests/boost/CMakeLists.txt
@@ -307,3 +307,30 @@ else()
 endif()
 target_include_directories(test_N2AutoSpectrum PRIVATE ${KOTEKAN_SOURCE_DIR}/lib/stages
                                                        ${KOTEKAN_SOURCE_DIR}/lib/utils)
+
+# test_TransposeBasebandArray - tests for TransposeBasebandArray stage
+add_executable(test_TransposeBasebandArray test_TransposeBasebandArray.cpp)
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    target_link_libraries(
+        test_TransposeBasebandArray
+        PRIVATE libexternal
+                kotekan_stages
+                kotekan_libs
+                kotekan_utils
+                kotekan_core
+                -Wl,-all_load
+                kotekan_metadata)
+else()
+    target_link_libraries(
+        test_TransposeBasebandArray
+        PRIVATE libexternal
+                kotekan_stages
+                kotekan_libs
+                kotekan_utils
+                kotekan_core
+                -Wl,--whole-archive
+                kotekan_metadata
+                -Wl,--no-whole-archive)
+endif()
+target_include_directories(test_TransposeBasebandArray PRIVATE ${KOTEKAN_SOURCE_DIR}/lib/stages
+                                                               ${KOTEKAN_SOURCE_DIR}/lib/utils)

--- a/tests/boost/test_TransposeBasebandArray.cpp
+++ b/tests/boost/test_TransposeBasebandArray.cpp
@@ -1,0 +1,247 @@
+#define BOOST_TEST_MODULE "test_TransposeBasebandArray"
+
+#include "Config.hpp"
+#include "DataType.hpp"
+#include "NDArray.hpp"
+#include "Stage.hpp"
+#include "TransposeBasebandArray.hpp"
+#include "buffer.hpp"
+#include "bufferContainer.hpp"
+#include "chordMetadata.hpp"
+#include "metadata.hpp"
+#include "metadataFactory.hpp"
+
+#include "json.hpp"
+
+#include <boost/test/included/unit_test.hpp>
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace kotekan;
+using json = nlohmann::json;
+
+// The stage hard-codes these, and fatally checks the config against them.
+static const uint32_t num_local_freq = 384;
+static const uint32_t num_elements = 128;
+static const uint32_t time_short = 16;
+static const uint32_t element_short = 8;
+static const uint32_t element_long = num_elements / element_short;
+
+// Small enough to keep the test quick, divisible by 64 for the pl_mask layout.
+static const uint32_t timesamples_per_frame = 64;
+static const uint32_t time_long = timesamples_per_frame / time_short;
+
+static const size_t in_frame_size =
+    (size_t)time_long * num_local_freq * element_long * time_short * element_short;
+static const size_t out_frame_size = (size_t)timesamples_per_frame * num_local_freq * num_elements;
+static const size_t pl_mask_frame_size =
+    (size_t)(timesamples_per_frame / 64) * num_local_freq * (num_elements / 8) * sizeof(uint64_t);
+
+static const uint8_t fill_value = 0x88;
+
+static Config make_test_config(const std::string& stage_name, bool disable_avx512) {
+    json cfg;
+    cfg["type"] = "config";
+    cfg["log_level"] = "WARN";
+    cfg["chord_pool"] = {{"kotekan_metadata_pool", "chordMetadata"}, {"num_metadata_objects", 16}};
+
+    json stage;
+    stage["kotekan_stage"] = "TransposeBasebandArray";
+    stage["log_level"] = "INFO";
+    stage["cpu_affinity"] = std::vector<int>{0};
+    stage["in_buf"] = "in_buf";
+    stage["out_buf"] = "out_buf";
+    stage["pl_mask_buf"] = "pl_mask_buf";
+    stage["timesamples_per_frame"] = timesamples_per_frame;
+    stage["num_local_freq"] = num_local_freq;
+    stage["num_elements"] = num_elements;
+    stage["time_short"] = time_short;
+    stage["element_short"] = element_short;
+    stage["disable_avx512"] = disable_avx512;
+
+    cfg[stage_name.substr(1)] = stage;
+
+    Config conf;
+    conf.update_config(cfg);
+    return conf;
+}
+
+struct TestSetup {
+    std::shared_ptr<metadataPool> chord_pool;
+    std::unique_ptr<Buffer> in_buf;
+    std::unique_ptr<Buffer> out_buf;
+    std::unique_ptr<Buffer> pl_mask_buf;
+
+    TestSetup(Config& config) {
+        metadataFactory mfac(config);
+        auto pools = mfac.build_pools();
+        chord_pool = pools["chord_pool"];
+
+        const int num_frames = 2;
+        // Matches the network_input_buffer configuration: unwritten bytes read as 0x88.
+        in_buf =
+            std::make_unique<Buffer>(num_frames, in_frame_size, chord_pool, "in_buf", "standard", 0,
+                                     false, false, std::vector<int>{}, true, fill_value);
+        in_buf->register_producer("test_producer");
+
+        out_buf = std::make_unique<Buffer>(num_frames, out_frame_size, chord_pool, "out_buf",
+                                           "ndarray", 0, false, false, std::vector<int>{}, true);
+        out_buf->ensure_frame_desc(GenericNDArray::describe(kotekan::int4x2_swapped_withoffset, "E",
+                                                            {(std::ptrdiff_t)timesamples_per_frame,
+                                                             (std::ptrdiff_t)num_local_freq, 2,
+                                                             (std::ptrdiff_t)num_elements / 2},
+                                                            {"T", "F", "P", "D"}, {1, 1, 1, 1}));
+        out_buf->register_consumer("test_consumer");
+
+        pl_mask_buf =
+            std::make_unique<Buffer>(num_frames, pl_mask_frame_size, chord_pool, "pl_mask_buf",
+                                     "standard", 0, false, false, std::vector<int>{}, true);
+        pl_mask_buf->register_producer("test_producer");
+    }
+};
+
+// Distinct per (source element, time, frequency) so a mix-up on any axis is caught.
+// 0x88 is excluded so that fill bytes are never mistaken for real data.
+static uint8_t source_value(uint32_t element, uint32_t time, uint32_t freq) {
+    uint8_t v = (uint8_t)((element * 31u + time * 17u + freq * 11u) & 0xff);
+    return v == fill_value ? (uint8_t)(fill_value + 1) : v;
+}
+
+// Fill one input frame, writing only the element_long blocks in live_boards. Blocks for
+// boards not listed keep the buffer's 0x88 fill, as an unwired CRS board would.
+static void produce_input_frame(Buffer* in_buf, Buffer* pl_mask_buf, int frame_id,
+                                const std::vector<uint32_t>& live_boards, bool packet_loss) {
+    uint8_t* frame = in_buf->wait_for_empty_frame("test_producer", frame_id);
+    BOOST_REQUIRE(frame != nullptr);
+    std::memset(frame, fill_value, in_frame_size);
+
+    for (uint32_t t_long = 0; t_long < time_long; t_long++) {
+        for (uint32_t freq = 0; freq < num_local_freq; freq++) {
+            const size_t block = ((size_t)t_long * num_local_freq + freq) * element_long
+                                 * time_short * element_short;
+            for (uint32_t board : live_boards) {
+                for (uint32_t t_s = 0; t_s < time_short; t_s++) {
+                    for (uint32_t e_s = 0; e_s < element_short; e_s++) {
+                        const size_t off =
+                            block + board * time_short * element_short + t_s * element_short + e_s;
+                        frame[off] = source_value(board * element_short + e_s,
+                                                  t_long * time_short + t_s, freq);
+                    }
+                }
+            }
+        }
+    }
+
+    in_buf->allocate_new_metadata_object(frame_id);
+    auto meta = get_chord_metadata(in_buf, frame_id);
+    meta->set_fpga_seq_num(1000 * frame_id);
+    // The stage forwards these to the output frame, so they must be present.
+    meta->set_coarse_freq(std::vector<int>(num_local_freq, 0));
+    meta->set_freq_upchan_factor(std::vector<int>(num_local_freq, 1));
+    meta->set_time_downsampling_fpga(1);
+    in_buf->mark_frame_full("test_producer", frame_id);
+
+    uint8_t* mask = pl_mask_buf->wait_for_empty_frame("test_producer", frame_id);
+    BOOST_REQUIRE(mask != nullptr);
+    // 0xff everywhere is "all data good"; clearing it all marks every block lost.
+    std::memset(mask, packet_loss ? 0x00 : 0xff, pl_mask_frame_size);
+    pl_mask_buf->mark_frame_full("test_producer", frame_id);
+}
+
+// Independent reference transpose, deliberately written as the plainest possible loop.
+static std::vector<uint8_t> expected_output(const std::vector<uint32_t>& live_boards,
+                                            bool packet_loss) {
+    std::vector<uint8_t> out(out_frame_size, 0);
+    for (uint32_t time = 0; time < timesamples_per_frame; time++) {
+        for (uint32_t freq = 0; freq < num_local_freq; freq++) {
+            for (uint32_t out_e = 0; out_e < num_elements; out_e++) {
+                const size_t idx = ((size_t)time * num_local_freq + freq) * num_elements + out_e;
+                const uint32_t src = out_e;
+                const uint32_t board = src / element_short;
+                const bool live =
+                    std::find(live_boards.begin(), live_boards.end(), board) != live_boards.end();
+                out[idx] = (packet_loss || !live) ? fill_value : source_value(src, time, freq);
+            }
+        }
+    }
+    return out;
+}
+
+// Compare and report the first mismatch, rather than one BOOST assertion per byte.
+static void check_frame(const uint8_t* actual, const std::vector<uint8_t>& expected) {
+    if (std::memcmp(actual, expected.data(), expected.size()) == 0) {
+        BOOST_CHECK(true);
+        return;
+    }
+    for (size_t i = 0; i < expected.size(); i++) {
+        if (actual[i] != expected[i]) {
+            const uint32_t out_e = i % num_elements;
+            const uint32_t freq = (i / num_elements) % num_local_freq;
+            const uint32_t time = i / ((size_t)num_local_freq * num_elements);
+            BOOST_FAIL("mismatch at time " << time << " freq " << freq << " element " << out_e
+                                           << ": got 0x" << std::hex << (int)actual[i]
+                                           << ", expected 0x" << (int)expected[i]);
+        }
+    }
+}
+
+// Run one frame through the stage and compare against the reference.
+static void run_case(const std::string& name, const std::vector<uint32_t>& live_boards,
+                     bool packet_loss, bool disable_avx512) {
+    std::cout << "  " << name << (disable_avx512 ? " [scalar]" : " [avx512]") << "\n";
+
+    const std::string stage_name = "/test_transpose";
+    Config config = make_test_config(stage_name, disable_avx512);
+    TestSetup setup(config);
+
+    bufferContainer bc;
+    bc.add_buffer("in_buf", setup.in_buf.get());
+    bc.add_buffer("out_buf", setup.out_buf.get());
+    bc.add_buffer("pl_mask_buf", setup.pl_mask_buf.get());
+
+    TransposeBasebandArray stage(config, stage_name, bc);
+    stage.start();
+
+    produce_input_frame(setup.in_buf.get(), setup.pl_mask_buf.get(), 0, live_boards, packet_loss);
+
+    const uint8_t* out = setup.out_buf->wait_for_full_frame("test_consumer", 0);
+    BOOST_REQUIRE(out != nullptr);
+    check_frame(out, expected_output(live_boards, packet_loss));
+    setup.out_buf->mark_frame_empty("test_consumer", 0);
+
+    setup.in_buf->send_shutdown_signal();
+    setup.pl_mask_buf->send_shutdown_signal();
+    stage.stop();
+    stage.join();
+}
+// All 16 boards present, and the 4 that are live on the pathfinder today.
+static const std::vector<uint32_t> all_boards = {0, 1, 2,  3,  4,  5,  6,  7,
+                                                 8, 9, 10, 11, 12, 13, 14, 15};
+static const std::vector<uint32_t> live_boards = {0, 1, 2, 3};
+
+BOOST_AUTO_TEST_CASE(test_transpose_all_boards) {
+    std::cout << "Testing TransposeBasebandArray: transpose with every board present...\n";
+    for (bool scalar : {false, true})
+        run_case("all boards wired", all_boards, false, scalar);
+    std::cout << "Success.\n";
+}
+
+// Source elements no board writes keep the input buffer's fill value, which is the
+// encoded zero for int4x2_swapped_withoffset rather than 0x00.
+BOOST_AUTO_TEST_CASE(test_unwired_boards_are_encoded_zero) {
+    std::cout << "Testing TransposeBasebandArray: unwired boards stay 0x88...\n";
+    for (bool scalar : {false, true})
+        run_case("4 of 16 boards live", live_boards, false, scalar);
+    std::cout << "Success.\n";
+}
+
+BOOST_AUTO_TEST_CASE(test_packet_loss_fill) {
+    std::cout << "Testing TransposeBasebandArray: packet loss fills 0x88...\n";
+    for (bool scalar : {false, true})
+        run_case("all blocks lost", all_boards, true, scalar);
+    std::cout << "Success.\n";
+}


### PR DESCRIPTION
The scalar fallback in `TransposeBasebandArray` looped `element_long` outside `time_short`, so it wrote `element_short` bytes and then stepped by `out_time_stride` (48 KiB) to the next time sample, coming back for the next 8 bytes only after touching all 16 output rows. No output cache line was ever completed in one visit.

Swapping the loops fills each time sample's whole row of elements in order, two complete cache lines at a time, keeping the same 8-byte moves since an `element_long`'s lanes are contiguous at both ends. Measured on cx69 with 3 MiB frames and the scalar path forced: 2.40 to 0.58 ms/frame, 4.1x. Adds `disable_avx512` so the scalar path can be exercised on a machine that has AVX512, and a boost test covering both paths, including that unwritten source elements arrive as `0x88` and a lost block is filled with it. No CHORD node runs the scalar path; this only matters where AVX512 is unavailable.

Carried on `chord`; extracted from the chord/develop diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

