### PR TITLE
TransposeBasebandArray: mark lost_blocks maybe_unused for Release builds

### DIFF
--- a/lib/stages/TransposeBasebandArray.cpp
+++ b/lib/stages/TransposeBasebandArray.cpp
@@ -320,7 +320,8 @@ void TransposeBasebandArray::main_thread() {
         // Transpose the data
         // Input:  E[time_long][frequency_local][element_long][time_short][element_short]
         // Output: E'[time][frequency_local][element]
-        size_t lost_blocks = 0;
+        // Read only by the DEBUG log below, which Release builds compile out.
+        [[maybe_unused]] size_t lost_blocks = 0;
 
 #ifdef __AVX512F__
         if (use_avx512_fast_path) {


### PR DESCRIPTION
#1653 hoisted `lost_blocks` out of the AVX512 block so the scalar path counts lost blocks too, which left its only read inside a `DEBUG` call. Release builds compile `DEBUG` to `(void)0`, so clang with `-Werror` rejects the variable as set but not used (`-Wunused-but-set-variable`) and the `release_clang_install` job now fails on every PR (first seen on #1650). gcc treats the increment as a read, so only the clang job trips.

Marks it `[[maybe_unused]]`, the idiom lib/core already uses for logging-only locals. Verified with clang 18 on the CI flags (Release, WERROR, LINK_WHAT_YOU_USE, OMP on, NUMA off): the translation unit fails before the change and compiles clean after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
