### PR TITLE
Derive fpga_seq_num from the ring buffer's origin, not from zero

### DIFF
--- a/julia/kernels/bb_template.cxx
+++ b/julia/kernels/bb_template.cxx
@@ -363,10 +363,14 @@ cudaEvent_t cuda{{{kernel_name}}}::execute(cudaPipelineState& /*pipestate*/, con
 
     // Update metadata
     {
+        const std::shared_ptr<const chordMetadata> E_meta = E_buffer.get_metadata();
         const std::shared_ptr<chordMetadata> J_meta = J_buffer.get_metadata();
-    
-        // Since we do not use a ring buffer we need to set `meta->fpga_seq_num`
-        J_meta->set_fpga_seq_num(T_min);
+
+        // Since we do not use a ring buffer we need to set `meta->fpga_seq_num`. The ring
+        // buffer's `fpga_seq_num` is the sequence number of its logical beginning, not zero,
+        // and `T_min` counts samples from there.
+        J_meta->set_fpga_seq_num(E_meta->get_fpga_seq_num()
+                                 + T_min * E_meta->get_time_downsampling_fpga());
         assert(J_meta->get_time_downsampling_fpga() == 1);
     }
 

--- a/lib/cuda/cudaPLMaskAccumulator.cpp
+++ b/lib/cuda/cudaPLMaskAccumulator.cpp
@@ -183,8 +183,12 @@ cudaEvent_t cudaPLMaskAccumulator::execute(cudaPipelineState& /*pipestate*/,
     pl_mask.check_metadata();
     pl_counts.set_metadata(pl_mask.get_metadata());
 
+    const auto& pl_mask_meta = pl_mask.get_metadata();
     const auto& pl_counts_meta = pl_counts.get_metadata();
-    pl_counts_meta->set_fpga_seq_num(pl_mask.get_read_valid().begin() * 128);
+    // The ring buffer's `fpga_seq_num` is the sequence number of its logical beginning, not
+    // zero; each pl_mask element along the time axis spans 128 FPGA samples.
+    pl_counts_meta->set_fpga_seq_num(pl_mask_meta->get_fpga_seq_num()
+                                     + pl_mask.get_read_valid().begin() * 128);
     pl_counts_meta->set_time_downsampling_fpga(
         div_noremainder(pl_counts_meta->get_time_downsampling_fpga(), 128) * sub_integration_ntime);
 
@@ -209,7 +213,6 @@ cudaEvent_t cudaPLMaskAccumulator::execute(cudaPipelineState& /*pipestate*/,
 
     const std::ptrdiff_t F_stride = pl_counts.get_ndarray().stride(1);
 
-    const auto& pl_mask_meta = pl_mask.get_metadata();
     const std::ptrdiff_t Tpl_stride = pl_mask.get_ndarray().stride(0);
     const std::ptrdiff_t Tpl_offset = Tplmin * Tpl_stride;
 

--- a/lib/cuda/generated/cudaBasebandBeamformer_charts.cpp
+++ b/lib/cuda/generated/cudaBasebandBeamformer_charts.cpp
@@ -490,10 +490,14 @@ cudaEvent_t cudaBasebandBeamformer_charts::execute(cudaPipelineState& /*pipestat
 
     // Update metadata
     {
+        const std::shared_ptr<const chordMetadata> E_meta = E_buffer.get_metadata();
         const std::shared_ptr<chordMetadata> J_meta = J_buffer.get_metadata();
 
-        // Since we do not use a ring buffer we need to set `meta->fpga_seq_num`
-        J_meta->set_fpga_seq_num(T_min);
+        // Since we do not use a ring buffer we need to set `meta->fpga_seq_num`. The ring
+        // buffer's `fpga_seq_num` is the sequence number of its logical beginning, not zero,
+        // and `T_min` counts samples from there.
+        J_meta->set_fpga_seq_num(E_meta->get_fpga_seq_num()
+                                 + T_min * E_meta->get_time_downsampling_fpga());
         assert(J_meta->get_time_downsampling_fpga() == 1);
     }
 

--- a/lib/cuda/generated/cudaBasebandBeamformer_chime.cpp
+++ b/lib/cuda/generated/cudaBasebandBeamformer_chime.cpp
@@ -490,10 +490,14 @@ cudaEvent_t cudaBasebandBeamformer_chime::execute(cudaPipelineState& /*pipestate
 
     // Update metadata
     {
+        const std::shared_ptr<const chordMetadata> E_meta = E_buffer.get_metadata();
         const std::shared_ptr<chordMetadata> J_meta = J_buffer.get_metadata();
 
-        // Since we do not use a ring buffer we need to set `meta->fpga_seq_num`
-        J_meta->set_fpga_seq_num(T_min);
+        // Since we do not use a ring buffer we need to set `meta->fpga_seq_num`. The ring
+        // buffer's `fpga_seq_num` is the sequence number of its logical beginning, not zero,
+        // and `T_min` counts samples from there.
+        J_meta->set_fpga_seq_num(E_meta->get_fpga_seq_num()
+                                 + T_min * E_meta->get_time_downsampling_fpga());
         assert(J_meta->get_time_downsampling_fpga() == 1);
     }
 

--- a/lib/cuda/generated/cudaBasebandBeamformer_chord.cpp
+++ b/lib/cuda/generated/cudaBasebandBeamformer_chord.cpp
@@ -490,10 +490,14 @@ cudaEvent_t cudaBasebandBeamformer_chord::execute(cudaPipelineState& /*pipestate
 
     // Update metadata
     {
+        const std::shared_ptr<const chordMetadata> E_meta = E_buffer.get_metadata();
         const std::shared_ptr<chordMetadata> J_meta = J_buffer.get_metadata();
 
-        // Since we do not use a ring buffer we need to set `meta->fpga_seq_num`
-        J_meta->set_fpga_seq_num(T_min);
+        // Since we do not use a ring buffer we need to set `meta->fpga_seq_num`. The ring
+        // buffer's `fpga_seq_num` is the sequence number of its logical beginning, not zero,
+        // and `T_min` counts samples from there.
+        J_meta->set_fpga_seq_num(E_meta->get_fpga_seq_num()
+                                 + T_min * E_meta->get_time_downsampling_fpga());
         assert(J_meta->get_time_downsampling_fpga() == 1);
     }
 

--- a/lib/cuda/generated/cudaBasebandBeamformer_hirax.cpp
+++ b/lib/cuda/generated/cudaBasebandBeamformer_hirax.cpp
@@ -490,10 +490,14 @@ cudaEvent_t cudaBasebandBeamformer_hirax::execute(cudaPipelineState& /*pipestate
 
     // Update metadata
     {
+        const std::shared_ptr<const chordMetadata> E_meta = E_buffer.get_metadata();
         const std::shared_ptr<chordMetadata> J_meta = J_buffer.get_metadata();
 
-        // Since we do not use a ring buffer we need to set `meta->fpga_seq_num`
-        J_meta->set_fpga_seq_num(T_min);
+        // Since we do not use a ring buffer we need to set `meta->fpga_seq_num`. The ring
+        // buffer's `fpga_seq_num` is the sequence number of its logical beginning, not zero,
+        // and `T_min` counts samples from there.
+        J_meta->set_fpga_seq_num(E_meta->get_fpga_seq_num()
+                                 + T_min * E_meta->get_time_downsampling_fpga());
         assert(J_meta->get_time_downsampling_fpga() == 1);
     }
 

--- a/lib/cuda/generated/cudaBasebandBeamformer_pathfinder.cpp
+++ b/lib/cuda/generated/cudaBasebandBeamformer_pathfinder.cpp
@@ -492,10 +492,14 @@ cudaBasebandBeamformer_pathfinder::execute(cudaPipelineState& /*pipestate*/,
 
     // Update metadata
     {
+        const std::shared_ptr<const chordMetadata> E_meta = E_buffer.get_metadata();
         const std::shared_ptr<chordMetadata> J_meta = J_buffer.get_metadata();
 
-        // Since we do not use a ring buffer we need to set `meta->fpga_seq_num`
-        J_meta->set_fpga_seq_num(T_min);
+        // Since we do not use a ring buffer we need to set `meta->fpga_seq_num`. The ring
+        // buffer's `fpga_seq_num` is the sequence number of its logical beginning, not zero,
+        // and `T_min` counts samples from there.
+        J_meta->set_fpga_seq_num(E_meta->get_fpga_seq_num()
+                                 + T_min * E_meta->get_time_downsampling_fpga());
         assert(J_meta->get_time_downsampling_fpga() == 1);
     }
 


### PR DESCRIPTION
A ring buffer's `fpga_seq_num` is the sequence number of its logical beginning, and a ring position counts samples from there. Two stages that produce non-ring outputs from a ring position set the output's `fpga_seq_num` to the position alone, i.e. assumed the stream starts at sequence number zero, which it does not (the DPDK input starts at the FPGA counter):

- cudaBasebandBeamformer (julia/kernels/bb_template.cxx and the five generated cudaBasebandBeamformer_*.cpp, edited identically): `T_min`
- cudaPLMaskAccumulator: `begin * 128`

Add the ring's `fpga_seq_num`, the way cudaCorrelator, cudaPL1bitCorrelator and cudaCopyFromRingbuffer already do, and the way cudaFRBBeamReformer was fixed by @rhaas80 in 396b48b0f.  cudaPLMaskAccumulator keeps its literal 128: it is the ring's time-axis scaling, hardcoded in the kernel indexing as well.