### PR TITLE
round of updates, mostly minor fixes but also data layout changes for CHIME quantized beamformer data

### DIFF
--- a/lib/cuda/cudaQuantize8Chime.cpp
+++ b/lib/cuda/cudaQuantize8Chime.cpp
@@ -13,7 +13,7 @@
 #include "gpuCommand.hpp"               // for gpuCommandType
 #include "metadata.hpp"                 // for metadataObject
 
-#include <algorithm>          // for max
+#include <algorithm>          // for max, reverse
 #include <array>              // for array
 #include <cassert>            // for assert
 #include <cmath>              //
@@ -168,6 +168,20 @@ cudaEvent_t cudaQuantize8Chime::execute(cudaPipelineState&, const std::vector<cu
     // Set metadata
     beam_buffer.set_metadata(input_meta);
     offsetscale_buffer.set_metadata(input_meta);
+
+    // we reverse the order of the upchannelized frequency channels so that they
+    // are high-MHz -> low-MHz like the coarse frequency channels. Make sure
+    // metadata reflects this.
+    auto freq_upchan_index = input_meta->get_freq_upchan_index();
+    assert(freq_upchan_index.size() == in_nfreqs
+           && freq_upchan_index.size() % out_nfreqs_chunk == 0);
+    for (size_t chunk = 0; chunk < freq_upchan_index.size() / unsigned(out_nfreqs_chunk); ++chunk) {
+        auto first = freq_upchan_index.begin() + chunk * out_nfreqs_chunk;
+        auto last = first + out_nfreqs_chunk;
+        std::reverse(first, last);
+    }
+    beam_buffer.get_metadata()->set_freq_upchan_index(freq_upchan_index);
+    offsetscale_buffer.get_metadata()->set_freq_upchan_index(freq_upchan_index);
 
     const auto& input_ndarray = input_buffer.get_ndarray();
     const float* const input = input_ndarray.data();

--- a/lib/cuda/cudaQuantizeKernel8Chime.cu
+++ b/lib/cuda/cudaQuantizeKernel8Chime.cu
@@ -133,7 +133,7 @@ void cpu_quantize8chime_chunk(const float* __restrict__ const input,
     for (int freq = 0; freq < out_nfreqs_chunk; ++freq) {
         for (int time = 0; time < out_ntimes_chunk; ++time) {
             const int in_ind = time + in_ntimes * freq;
-            const int out_ind = time + out_ntimes_chunk * freq;
+            const int out_ind = time + out_ntimes_chunk * (out_nfreqs_chunk - 1 - freq);
             // Get value
             const float x = input[in_ind];
             // Scale
@@ -194,7 +194,7 @@ __global__ void gpu_quantize8chime_chunks(const float* __restrict__ const input,
                                     int beam_outer) {
         return time_chunk
                + out_ntimes_chunk
-                     * (freq_chunk
+                     * ((out_nfreqs_chunk - 1 - freq_chunk)
                         + out_nfreqs_chunk
                               * (freq_packet
                                  + out_nfreqs_packet

--- a/lib/cuda/testQuantizeKernel8Chime.cpp
+++ b/lib/cuda/testQuantizeKernel8Chime.cpp
@@ -127,7 +127,7 @@ public:
             return beams.at(
                 time_chunk
                 + out_ntimes_chunk
-                      * (freq_chunk
+                      * ((out_nfreqs_chunk - 1 - freq_chunk)
                          + out_nfreqs_chunk
                                * (freq_packet
                                   + out_nfreqs_packet
@@ -228,7 +228,7 @@ public:
                                     for (int time_chunk = 0; time_chunk < out_ntimes_chunk;
                                          ++time_chunk) {
                                         const int freq =
-                                            freq_chunk
+                                            (out_nfreqs_chunk - 1 - freq_chunk)
                                             + out_nfreqs_chunk
                                                   * (freq_packet + out_nfreqs_packet * freq_outer);
                                         const int time = time_chunk + out_ntimes_chunk * time_outer;

--- a/lib/stages/bufferBadInputs.cpp
+++ b/lib/stages/bufferBadInputs.cpp
@@ -78,9 +78,12 @@ bufferBadInputs::bufferBadInputs(Config& config_, const std::string& unique_name
         for (size_t idx = 0; idx < num_elements; ++idx)
             reorder.at(idx) = idx;
     } else {
-        for (size_t output_idx = 0; output_idx < num_elements; ++output_idx) {
-            station_id_t st_id = tel.element_index_to_station_id(output_idx, output_order);
-            reorder.at(tel.station_id_to_element_index(st_id, input_order)) = output_idx;
+        // Note: this is overkill. The input received by this stage's REST
+        // endpoint takes channel ids (which happen to by element indices in
+        // cylinder order in CHIME).
+        for (station_id_t station_id = 0; station_id < num_elements; ++station_id) {
+            const int output_idx = tel.station_id_to_element_index(station_id, output_order);
+            reorder.at(tel.station_id_to_element_index(station_id, input_order)) = output_idx;
         }
     }
 

--- a/lib/stages/processFeedGains.cpp
+++ b/lib/stages/processFeedGains.cpp
@@ -32,6 +32,7 @@ processFeedGains::processFeedGains(Config& config, const std::string& unique_nam
     upchan_factor = config.get_default<uint32_t>(unique_name, "upchan_factor", 1);
     num_components = config.get<uint32_t>(unique_name, "num_components");
     scaling_factor = config.get_default<float>(unique_name, "scaling_factor", 1.0);
+    conjugate_gains = config.get_default<bool>(unique_name, "conjugate_gains", false);
 
     // Input gain buffers
     json in_buf_list = config.get_value(unique_name, "gain_buffers");
@@ -105,6 +106,16 @@ void processFeedGains::copy_upchannelize(float* frame, size_t beam_id) {
         float16_t* dst = out_ptr + f * out_fstride;
         // upchannelize and copy
         copy_upchannelize_f(src, dst, f);
+    }
+
+    // conjugate if gains are complex
+    if (conjugate_gains && num_components > 1) {
+        size_t num_beam_elements = num_elements * num_local_freq * upchan_factor * num_components;
+
+        for (size_t i = 1; i < num_beam_elements; i += 2) {
+            float16_t* u_ptr = out_ptr + i;
+            *u_ptr *= float16_t(-1.0);
+        }
     }
 }
 

--- a/lib/stages/processFeedGains.hpp
+++ b/lib/stages/processFeedGains.hpp
@@ -51,6 +51,8 @@ using std::vector;
  * @conf   upchan_factor                         Int. Frequency upchannelization factor.
  * @conf   num_components                        Int. Number of gain components. Should be either
  *                                                   1 (real) or 2 (real/imag).
+ * @conf conjugate_gains                         Bool. If true, save the conjugate of the input
+ *                                                   gains.
  *
  * @author Liam Gray
  *
@@ -103,6 +105,9 @@ private:
 
     /// Number of elements in the output buffer
     uint32_t out_num_values;
+
+    /// Whether or not to conjugate the gains
+    bool conjugate_gains;
 
     /// Fixed buffers used to hold gains separately from the kotekan buffers
     std::vector<float16_t> gain_store_buf;

--- a/lib/stages/rfiBroadcast.cpp
+++ b/lib/stages/rfiBroadcast.cpp
@@ -1,8 +1,9 @@
 #include "rfiBroadcast.hpp"
 
-#include "Config.hpp"          // for Config
-#include "N2Util.hpp"          // for frameID, modulo
-#include "StageFactory.hpp"    // for REGISTER_KOTEKAN_STAGE
+#include "Config.hpp"       // for Config
+#include "N2Util.hpp"       // for frameID, modulo
+#include "StageFactory.hpp" // for REGISTER_KOTEKAN_STAGE
+#include "Telescope.hpp"
 #include "buffer.hpp"          // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
 #include "chordMetadata.hpp"   // for chordMetadata, get_chord_metadata
@@ -99,6 +100,20 @@ rfiBroadcast::rfiBroadcast(Config& config, const std::string& unique_name,
         FATAL_ERROR(
             "`rfi_skbar_buf` does not have the expected frame size. Expected {:d}, got {:d}",
             _skbar_expected_frame_size, sk_bar_buf->frame_size);
+
+    // Construct the beamformer -> cylinder reorder table
+    // NB: the CHIME receiver system _always_ expects inputs to be in cylinder order
+    // reorder[beamformer_idx] = cylinder_idx
+    reorder.resize(num_elements);
+
+    const Telescope& tel = Telescope::instance();
+
+    for (size_t beamformer_idx = 0; beamformer_idx < num_elements; ++beamformer_idx) {
+        station_id_t st_id =
+            tel.element_index_to_station_id(beamformer_idx, ElementOrder::CHIMEBeamformer);
+        reorder.at(beamformer_idx) =
+            tel.station_id_to_element_index(st_id, ElementOrder::CHIMECylinder);
+    }
 
     // Set up the UDP socket params and validate the the provided ID is valid
     dest_addr.sin_family = AF_INET;
@@ -242,7 +257,7 @@ void rfiBroadcast::main_thread() {
                 float* dst_bar_t = dst_bar + f * num_elements;
 
                 for (size_t e = 0; e < num_elements; ++e) {
-                    dst_bar_t[e] += src[e];
+                    dst_bar_t[reorder[e]] += src[e];
                 }
             }
         }

--- a/lib/stages/rfiBroadcast.hpp
+++ b/lib/stages/rfiBroadcast.hpp
@@ -13,7 +13,6 @@
 
 #include <netinet/in.h> // for sockaddr_in
 #include <stddef.h>     // for size_t
-#include <stdint.h>     // for uint16_t
 #include <string>       // for string, basic_string
 
 /*
@@ -103,6 +102,10 @@ private:
     size_t samples_per_data_set;           // base number of FPGA time samples
     size_t rfi_downsampling_factor;        // Downsampling rate to high-cadence SK
     size_t rfi_second_downsampling_factor; // Additional downsampling factor for low-cadence SK
+
+    // The table to reorder from beamformer to cylinder order.
+    // reorder[beamformer_idx] = cylinder_idx;
+    std::vector<size_t> reorder;
 
     // Derived buffer shapes
     size_t _downsampled_samples_per_data_set;

--- a/lib/utils/ICETelescope.cpp
+++ b/lib/utils/ICETelescope.cpp
@@ -399,7 +399,7 @@ std::tuple<uint32_t, uint32_t, std::string> ICETelescope::parse_reorder_single(n
 }
 
 std::tuple<std::vector<uint32_t>, std::vector<input_ctype>>
-ICETelescope::parse_reorder(nlohmann::json& j) {
+ICETelescope::parse_reorder(nlohmann::json& j) const {
 
     uint32_t adc_id, chan_id;
     std::string serial;
@@ -408,7 +408,7 @@ ICETelescope::parse_reorder(nlohmann::json& j) {
     std::vector<input_ctype> inputmap;
 
     if (!j.is_array()) {
-        throw std::runtime_error("Was expecting list of input orders.");
+        FATAL_ERROR("Was expecting list of input orders but received {:s}.", j.dump());
     }
 
     for (auto& element : j) {
@@ -416,6 +416,28 @@ ICETelescope::parse_reorder(nlohmann::json& j) {
 
         adc_ids.push_back(adc_id);
         inputmap.emplace_back(chan_id, serial);
+    }
+
+    // check that the orderings are permutations (no lost elements, no
+    // duplications)
+    {
+        std::vector<uint32_t> ordered(adc_ids.size());
+        std::iota(ordered.begin(), ordered.end(), 0);
+
+        std::vector<uint32_t> ordered_adc_ids(adc_ids);
+        std::sort(ordered_adc_ids.begin(), ordered_adc_ids.end());
+        if (ordered_adc_ids != ordered) {
+            FATAL_ERROR("Input mapping {:s} is not a permutation wrt to adc ids", j.dump());
+        }
+
+        std::vector<uint32_t> ordered_chan_ids;
+        for (const input_ctype& i : inputmap) {
+            ordered_chan_ids.emplace_back(i.chan_id);
+        }
+        std::sort(ordered_chan_ids.begin(), ordered_chan_ids.end());
+        if (ordered_chan_ids != ordered) {
+            FATAL_ERROR("Input mapping {:s} is not a permutation wrt to channel ids", j.dump());
+        }
     }
 
     return std::make_tuple(adc_ids, inputmap);
@@ -437,7 +459,7 @@ ICETelescope::default_reorder(size_t num_elements) {
 
 std::tuple<std::vector<uint32_t>, std::vector<input_ctype>>
 ICETelescope::parse_reorder_default(const kotekan::Config& config, const std::string& path,
-                                    uint64_t num_elements) {
+                                    uint64_t num_elements) const {
 
     try {
         nlohmann::json reorder_config =

--- a/lib/utils/ICETelescope.hpp
+++ b/lib/utils/ICETelescope.hpp
@@ -108,9 +108,9 @@ protected:
      * @return          Tuple containing a vector of the input reorder map, and a
      *                  vector of the input labels for the index map.
      */
-    static std::tuple<std::vector<uint32_t>, std::vector<input_ctype>>
+    std::tuple<std::vector<uint32_t>, std::vector<input_ctype>>
     parse_reorder_default(const kotekan::Config& config, const std::string& path,
-                          uint64_t num_elements);
+                          uint64_t num_elements) const;
 
     static std::vector<station_id_t>
     invert_reorder_table(const std::vector<uint32_t>& input_reorder);
@@ -174,8 +174,8 @@ protected:
 
 private:
     static std::tuple<uint32_t, uint32_t, std::string> parse_reorder_single(nlohmann::json j);
-    static std::tuple<std::vector<uint32_t>, std::vector<input_ctype>>
-    parse_reorder(nlohmann::json& j);
+    std::tuple<std::vector<uint32_t>, std::vector<input_ctype>>
+    parse_reorder(nlohmann::json& j) const;
     static std::tuple<std::vector<uint32_t>, std::vector<input_ctype>>
     default_reorder(size_t num_elements);
 };


### PR DESCRIPTION
*  5f134a6f4 - hdf5FileWrite: check frame size against array description
* 56f2256cc -  testQuantizeKernel8Chime: sort sub-frequencies in descending order
* 78873d741 - cudaQuantize8Chime: update metadata with revesed upchan freq idx
* 15ea14d4c - cudaQuantizeKernel8Chime: store sub-frequencies in descending order
* a38452aa0 - fix(bufferBadInputs): fix inversed cyl -> beamformer order mapping
* 170bf28a3 - fix(rfiBroadcast): ensure that output packets can be transposed to cylinder order
* fdfbbb4ea - feat(processFeedGains): optionally take the complex conjugate of gains while upchannelizing
* 53d0bcd79 - ICETelescope: check that user specified input reorder is a permutation

the changes in 15ea14d4c, 78873d741, 56f2256cc could be done in a number of places, but reversing the order last, when quantizing to CHIME's FRB beamformer format means all previous stages are the same for CHIME / CHORD / others (but CHIME and CHORD still label their frequency channels in reverse order).