### PR TITLE
CI: request review of auto-lint PRs from the source branch's owner

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -419,3 +419,6 @@ jobs:
           branch: auto-lint-fix/${{ env.SOURCE_BRANCH }}
           base: ${{ env.SOURCE_BRANCH }}
           delete-branch: true
+          # The PR is authored by the workflow token, so the owner of the source
+          # branch hears about it only if asked to review it.
+          reviewers: ${{ github.event.pull_request.user.login || github.actor }}


### PR DESCRIPTION
The `auto-lint-fix` job opens its pull request through the workflow token, so the PR's author is the GitHub Actions app and the owner of the branch being fixed is not notified. Request a review from that owner: the author of the source pull request, or the pusher when the run came from a branch push. Requesting a review from someone other than the PR's author is allowed, so the token can do this with the `pull-requests: write` permission the job already has.

Note: the request would fail for a source PR opened by a bot account, since bots cannot be reviewers; the job only runs for pull requests from this repository, so that case should not arise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
