### PR TITLE
Shutdown and GPU memory safety fixes from chord

### DIFF
--- a/lib/core/basebandApiManager.cpp
+++ b/lib/core/basebandApiManager.cpp
@@ -51,15 +51,17 @@ basebandApiManager::basebandReadoutRegistry::operator[](const uint32_t& key) { /
     return readout_map[key];
 }
 
+std::unique_lock<std::mutex> basebandApiManager::basebandReadoutRegistry::lock() {
+    return std::unique_lock<std::mutex>(map_lock);
+}
+
 basebandApiManager::basebandReadoutRegistry::iterator
 basebandApiManager::basebandReadoutRegistry::begin() noexcept {
-    std::lock_guard<std::mutex> lock(map_lock);
     return readout_map.begin();
 }
 
 basebandApiManager::basebandReadoutRegistry::iterator
 basebandApiManager::basebandReadoutRegistry::end() noexcept {
-    std::lock_guard<std::mutex> lock(map_lock);
     return readout_map.end();
 }
 
@@ -138,6 +140,7 @@ void basebandApiManager::status_callback_all(connectionInstance& conn) {
     }
 
     // If there isn't an event_id given, then return all the events
+    auto registry_lock = readout_registry.lock();
     for (auto& element : readout_registry) {
         uint32_t freq_id = element.first;
         auto& readout_manager = element.second;
@@ -156,6 +159,7 @@ void basebandApiManager::status_callback_single_event(const uint64_t event_id,
                                                       connectionInstance& conn) {
     std::vector<json> event_status;
 
+    auto registry_lock = readout_registry.lock();
     for (auto& element : readout_registry) {
         uint32_t freq_id = element.first;
         auto& readout_manager = element.second;
@@ -225,6 +229,7 @@ void basebandApiManager::handle_request_callback(connectionInstance& conn, json&
         const double dm_error = request["dm_error"];
 
         json response = json::object({});
+        auto registry_lock = readout_registry.lock();
         for (auto& element : readout_registry) {
             const uint32_t freq_id = element.first;
             auto& readout_entry = element.second;

--- a/lib/core/basebandApiManager.hpp
+++ b/lib/core/basebandApiManager.hpp
@@ -214,6 +214,9 @@ private:
     class basebandReadoutRegistry {
     public:
         using iterator = std::map<uint32_t, basebandReadoutManager>::iterator;
+        /// Hold the returned lock while iterating with `begin`/`end`, so that
+        /// stages registering concurrently cannot modify the map mid-traversal.
+        std::unique_lock<std::mutex> lock();
         iterator begin() noexcept;
         iterator end() noexcept;
         basebandReadoutManager& operator[](const uint32_t& key);

--- a/lib/core/buffer.cpp
+++ b/lib/core/buffer.cpp
@@ -595,10 +595,12 @@ void Buffer::json_description(nlohmann::json& buf_json) {
     // As above: snapshot under the lock, serialize after releasing it.
     std::vector<bool> local_is_full;
     double arrival_time;
+    bool hold_enabled;
     {
         buffer_lock lock(mutex);
         local_is_full = is_full;
         arrival_time = last_arrival_time;
+        hold_enabled = peek_hold_enabled;
     }
     buf_json["frames"];
     int num_full = 0;
@@ -612,7 +614,7 @@ void Buffer::json_description(nlohmann::json& buf_json) {
     buf_json["last_frame_arrival_time"] = arrival_time;
     // Lets /buffers consumers see which buffers keep their newest frame
     // peekable (and that one "full" frame at idle is the hold, not backlog).
-    buf_json["peek_hold"] = peek_hold_enabled;
+    buf_json["peek_hold"] = hold_enabled;
 }
 
 std::vector<std::string> Buffer::dot_label_lines(const kotekan::GraphOptions& options) {

--- a/lib/gpu/gpuDeviceInterface.cpp
+++ b/lib/gpu/gpuDeviceInterface.cpp
@@ -38,16 +38,14 @@ void* gpuDeviceInterface::get_gpu_memory(const std::string& name, const size_t l
         gpu_memory[name].metadata_pointers.push_back(nullptr);
     }
     // The size must match what has already been allocated.
-    if (len != gpu_memory[name].len) {
-        ERROR("GPU[{:d}] memory: {:s}, requested len: {:d}, have len: {:d}", gpu_id, name, len,
-              gpu_memory[name].len);
-    }
-    assert(len == gpu_memory[name].len);
-    if (gpu_memory[name].gpu_pointers.size() != 1) {
-        ERROR("GPU[{:d}] memory: {:s}, implicitly requested 1 frame, have {:d}", gpu_id, name,
-              gpu_memory[name].gpu_pointers.size());
-    }
-    assert(gpu_memory[name].gpu_pointers.size() == 1);
+    if (len != gpu_memory[name].len)
+        FATAL_ERROR("GPU[{:d}] memory: {:s}, requested len: {:d}, have len: {:d}", gpu_id, name,
+                    len, gpu_memory[name].len);
+    // Another user allocated this name as an array; returning frame 0 would
+    // silently alias whatever its instance 0 reads.
+    if (gpu_memory[name].gpu_pointers.size() != 1)
+        FATAL_ERROR("GPU[{:d}] memory: {:s}, implicitly requested 1 frame, have {:d}", gpu_id, name,
+                    gpu_memory[name].gpu_pointers.size());
 
     // Return the requested memory.
     return gpu_memory[name].gpu_pointers[0];
@@ -73,14 +71,16 @@ void* gpuDeviceInterface::get_gpu_memory_array(const std::string& name, const ui
         }
     }
     // The size must match what has already been allocated.
-    if (len != gpu_memory[name].len) {
-        ERROR("get_gpu_memory_array failed: requested name \"{:s}\" size {:d} index {:d}, but "
-              "existing memory is size {:d}",
-              name, len, index, gpu_memory[name].len);
-    }
-    assert(len == gpu_memory[name].len);
-    // Make sure we aren't asking for an index past the end of the array.
-    assert(index < gpu_memory[name].gpu_pointers.size());
+    if (len != gpu_memory[name].len)
+        FATAL_ERROR("get_gpu_memory_array failed: requested name \"{:s}\" size {:d} index {:d}, "
+                    "but existing memory is size {:d}",
+                    name, len, index, gpu_memory[name].len);
+    // Make sure we aren't asking for an index past the end of the array. This
+    // also catches another user having allocated the name as a single frame.
+    if (index >= gpu_memory[name].gpu_pointers.size())
+        FATAL_ERROR("get_gpu_memory_array failed: requested name \"{:s}\" index {:d}, but only "
+                    "{:d} frame(s) are allocated",
+                    name, index, gpu_memory[name].gpu_pointers.size());
     // Return the requested memory.
     return gpu_memory[name].gpu_pointers[index];
 }

--- a/lib/stages/BasebandWriter.cpp
+++ b/lib/stages/BasebandWriter.cpp
@@ -103,6 +103,10 @@ void BasebandWriter::main_thread() {
         in_buf->mark_frame_empty(unique_name, frame_id++);
     }
 
+    {
+        std::lock_guard<std::mutex> lk(mtx);
+        closing_stop = true;
+    }
     stop_closing.notify_one();
     closing_thread.join();
 }
@@ -170,14 +174,10 @@ void BasebandWriter::close_old_events() {
         double now = current_time();
         DEBUG("Run file-closing thread {:.1f}", now);
         std::unique_lock lk(mtx);
-        if (stop_closing.wait_for(lk, std::chrono::seconds(sweep_cadence_s))
-            != std::cv_status::timeout) {
-            // is it a notification to exit or a spurious interrupt?
-            if (stop_thread) {
-                return;
-            } else {
-                continue;
-            }
+        if (stop_closing.wait_for(lk, std::chrono::seconds(sweep_cadence_s),
+                                  [this]() { return closing_stop; })) {
+            // notified to exit (the predicate also filters spurious wakeups)
+            return;
         }
 
         // Otherwise, we've waited long enough and can do the sweep

--- a/lib/stages/BasebandWriter.hpp
+++ b/lib/stages/BasebandWriter.hpp
@@ -105,6 +105,9 @@ private:
     /// notifies the file-closing thread (i.e., running `close_old_events`)
     std::condition_variable stop_closing;
 
+    /// tells the file-closing thread to exit; guarded by `mtx`
+    bool closing_stop = false;
+
     /// Keep track of the average write time
     movingAverage write_time;
 

--- a/lib/stages/basebandReadout.cpp
+++ b/lib/stages/basebandReadout.cpp
@@ -298,6 +298,7 @@ basebandDumpData basebandReadout::wait_for_data(const uint64_t event_id, const u
     double max_wait_time = 1.;
     double min_wait_time = _samples_per_data_set * fpga_period_s;
     bool advance_info = false;
+    bool data_ready = false;
 
     while (!stop_thread) {
         int64_t frame_fpga_seq = -1;
@@ -352,11 +353,14 @@ basebandDumpData basebandReadout::wait_for_data(const uint64_t event_id, const u
             if (advance_info) {
                 INFO("Done waiting for dump data for {:d}.", event_id);
             }
+            data_ready = true;
             break;
         }
         unlock_range(dump_start_frame, dump_end_frame);
     }
-    if (stop_thread) {
+    // Once the frame range is locked for the dump, hand it to `extract_data`
+    // even if a shutdown just started: it releases the locks on all paths.
+    if (!data_ready) {
         return basebandDumpData::Status::Cancelled;
     } else if (dump_start_frame >= dump_end_frame) {
         // Trigger was too late and missed the data. Return an empty dataset.
@@ -425,8 +429,8 @@ basebandDumpData::Status basebandReadout::extract_data(basebandDumpData data) {
     // simple stop extracting data and release all the input frames.
     bool stop_extract = false;
 
-    for (int frame_index = data.dump_start_frame; !stop_thread && frame_index < data.dump_end_frame;
-         frame_index++) {
+    int frame_index = data.dump_start_frame;
+    for (; !stop_thread && frame_index < data.dump_end_frame; frame_index++) {
 
         if (stop_extract) {
             frame_dropped_counter.inc();
@@ -531,7 +535,9 @@ basebandDumpData::Status basebandReadout::extract_data(basebandDumpData data) {
         frame_sent_counter.inc();
     }
 
-    unlock_range(data.dump_start_frame, data.dump_end_frame);
+    // Frames the loop got to were already unlocked there; release the rest if
+    // the loop was cut short by a shutdown.
+    unlock_range(frame_index, data.dump_end_frame);
 
     if (stop_thread) {
         return basebandDumpData::Status::Cancelled;


### PR DESCRIPTION
Four small shutdown and safety fixes from the chord branch (July and August) that no other PR carried, plus one lock-discipline nit.

## Summary

- **gpuDeviceInterface**: stop with FATAL_ERROR when a second user of a named GPU memory block asks for a different length, or asks for a single frame of a block another user allocated as an array. Both were `ERROR` plus an `assert`, so a Release build silently aliased frame 0.
- **basebandApiManager**: hold the readout registry lock across iteration instead of per lookup, so a readout registering or unregistering while a request walks the registry cannot invalidate the iterator.
- **basebandReadout**: on shutdown, hand a frame range that is already locked to `extract_data`, which releases the locks on every path, and only unlock the frames the loop did not reach; previously a shutdown mid-dump double-unlocked some frames and leaked the rest.
- **BasebandWriter**: the file-closing thread waited on a condition variable with no predicate, so a shutdown notification that arrived before the wait began was lost and the thread slept out a full sweep cadence. Wait on a `closing_stop` flag.
- **Buffer::json_description** reads `peek_hold_enabled` under the buffer lock like the other fields it snapshots.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
