### PR TITLE
Upstream chord #1592 and #1640: REST shutdown quiesce, config validation modes, frameID fix

### DIFF
--- a/docs/sphinx/user/user_introduction.rst
+++ b/docs/sphinx/user/user_introduction.rst
@@ -27,6 +27,19 @@ Use ``-b <ipv4:port>`` to change the REST bind address/port (IPv4 only), ``-s`` 
 and ``-e '{"foo": "bar"}'`` to provide Jinja variables for ``.j2`` configs. Running with no ``-c``
 starts the REST server only and waits for a POST to ``/start`` with the config.
 
+Two flags validate a config instead of running it, and both exit non-zero if it is bad.
+``--check-config`` is a static check: it parses the config and inspects it, constructing no
+stages, allocating no buffers, opening no devices and binding no port, so it is safe to run on
+a node with a live pipeline. ``--dry-run`` is the authoritative one: it builds the whole
+pipeline and tears it down without running it, which catches everything the static check
+cannot (buffer wiring, per-stage required keys) but needs the node's hardware to itself,
+because stage constructors open DPDK and CUDA devices and buffers claim hugepages.
+
+.. code:: bash
+
+    ./kotekan -c <config_file>.yaml --check-config   # safe anywhere, catches the cheap errors
+    sudo ./kotekan -c <config_file>.yaml --dry-run   # authoritative, needs a free node
+
 
 
 .. _user_pipeline_example:

--- a/kotekan/CMakeLists.txt
+++ b/kotekan/CMakeLists.txt
@@ -26,6 +26,17 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
                 -Wl,--no-whole-archive)
     if(ASDF_CXX_FOUND)
         target_link_libraries(kotekan PRIVATE blosc)
+        # asdf-cxx's pkg-config declares -lblosc (c-blosc 1.x), but an install built against
+        # c-blosc2 references blosc2_* from its static archive as well, and the .pc file does not
+        # say which. Link blosc2 too where it exists: --no-as-needed because the reference comes
+        # from an archive the linker has not seen yet at this point in the line (the .so would be
+        # dropped as unused); push/pop-state so the flag does not stick to the libraries that
+        # follow; the resolved path rather than -lblosc2 so CMake's prefixes are searched.
+        find_library(BLOSC2_LIB blosc2)
+        if(BLOSC2_LIB)
+            target_link_libraries(kotekan PRIVATE "-Wl,--push-state,--no-as-needed" ${BLOSC2_LIB}
+                                                  "-Wl,--pop-state")
+        endif()
     endif()
 elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     target_link_libraries(kotekan PRIVATE -Wl,-all_load kotekan_libs)

--- a/kotekan/kotekan.cpp
+++ b/kotekan/kotekan.cpp
@@ -707,6 +707,15 @@ int main(int argc, char** argv) {
 
         if (sig_value == SIGINT || sig_value == SIGTERM) {
             INFO_NON_OO("Got SIGINT or SIGTERM, shutting down kotekan...");
+            // Quiesce the REST server before destructing the stages: this
+            // teardown runs on the main thread while the server thread may
+            // still be handling a request that captured a stage's `this`
+            // (e.g. a monitor polling a stage's get_status endpoint), which
+            // would use-after-free once the stage is deleted below. Must
+            // happen before kotekan_state_lock is taken: the /start, /stop
+            // and /status handlers block on that lock, so draining while
+            // holding it would deadlock against any such handler in flight.
+            rest_server.stop_processing();
             std::lock_guard<std::mutex> lock(kotekan_state_lock);
             if (kotekan_mode != nullptr) {
                 INFO_NON_OO("Attempting to stop and join kotekan_stages...");

--- a/kotekan/kotekan.cpp
+++ b/kotekan/kotekan.cpp
@@ -27,6 +27,7 @@
 #include <locale>      // for locale
 #include <map>         // for map, operator!=, _Rb_tree_iterator
 #include <mutex>       // for mutex, lock_guard
+#include <set>         // for set
 #include <stdexcept>   // for runtime_error, out_of_range
 #include <stdio.h>     // for printf, fprintf, fclose, stderr, fdopen, feof, fgets
 #include <stdlib.h>    // for exit, free, WEXITSTATUS, WIFEXITED
@@ -195,6 +196,12 @@ else:
     sys.stdout.write(json.dumps(config_yaml))
 )";
 
+// Long-only option values, past the range of any short option character.
+enum : int {
+    OPT_CHECK = 1000,
+    OPT_DRY_RUN,
+};
+
 kotekanMode* kotekan_mode = nullptr;
 bool running = false;
 std::mutex kotekan_state_lock;
@@ -218,6 +225,19 @@ void print_help() {
 
     printf("    --print-json (-p)              Prints the json version of the config.\n");
     printf("    --print-yaml (-y)              Prints the yaml version of the config.\n\n");
+    printf("Validation modes (require --config; neither binds the REST port nor runs\n");
+    printf("the pipeline, and both exit non-zero if the config does not pass):\n");
+    printf("    --check-config                 Static checks only: unknown stage types,\n");
+    printf("                                   duplicate names, dangling metadata pools.\n");
+    printf("                                   Constructs nothing -- safe to run next to a\n");
+    printf("                                   live pipeline.\n");
+    printf("    --dry-run                      Builds the full pipeline (every constructor,\n");
+    printf("                                   every config key), fails on any buffer with\n");
+    printf("                                   consumers but no producer, then tears down\n");
+    printf("                                   without starting. Authoritative, but stage\n");
+    printf("                                   constructors open devices (DPDK/CUDA) and\n");
+    printf("                                   buffers claim hugepages -- only run this where\n");
+    printf("                                   the node is free.\n\n");
     printf("If no options are given then kotekan runs in daemon mode and\n");
     printf("expects to get it configuration via the REST endpoint '/start'.\n");
     printf("In daemon mode output is only sent to syslog.\n\n");
@@ -379,9 +399,14 @@ std::string exec(std::vector<std::string>& cmd) {
     return result;
 }
 
-void update_log_levels(Config& config) {
-    // Adjust the log level
-    string s_log_level = config.get<std::string>("/", "log_level");
+/**
+ * @brief Maps a `log_level` string to its level, throwing on anything else.
+ *
+ * Split out so the static config check tests exactly what the runtime accepts: a second copy
+ * of this list would be free to drift, and a validator that passes a config the runtime then
+ * rejects is worse than no validator.
+ */
+logLevel parse_log_level(const std::string& s_log_level) {
     logLevel log_level;
 
     if (strcasecmp(s_log_level.c_str(), "off") == 0) {
@@ -403,6 +428,12 @@ void update_log_levels(Config& config) {
                         s_log_level));
     }
 
+    return log_level;
+}
+
+void update_log_levels(Config& config) {
+    // Adjust the log level
+    const logLevel log_level = parse_log_level(config.get<std::string>("/", "log_level"));
     _global_log_level = static_cast<std::underlying_type<logLevel>::type>(log_level);
 }
 
@@ -437,6 +468,189 @@ void start_new_kotekan_mode(Config& config, bool dump_config) {
     running = true;
 }
 
+/// A stage/buffer/metadata-pool block found in the config tree.
+struct config_block {
+    std::string name; ///< The key the factories use to identify it.
+    std::string type; ///< The `kotekan_stage`/`kotekan_buffer`/... type string.
+    std::string path; ///< Full config path, for hierarchical lookups.
+};
+
+/**
+ * @brief Recursively collects the stage, buffer and metadata-pool blocks.
+ *
+ * Mirrors the traversal in StageFactory/bufferFactory/metadataFactory: a block
+ * is identified by its `kotekan_stage`, `kotekan_buffer` or
+ * `kotekan_metadata_pool` key; any other object is a scope to descend into.
+ * Note the factories key buffers and pools by their bare name but stages by
+ * their full path, and that is reproduced here so duplicate detection matches
+ * what the factories themselves would reject.
+ */
+void collect_config_blocks(const json& tree, const std::string& path,
+                           std::vector<config_block>& stages, std::vector<config_block>& buffers,
+                           std::vector<config_block>& pools) {
+    for (json::const_iterator it = tree.begin(); it != tree.end(); ++it) {
+        if (!it.value().is_object())
+            continue;
+
+        const std::string block_path = fmt::format(fmt("{:s}/{:s}"), path, it.key());
+
+        const std::string stage_type = it.value().value("kotekan_stage", "none");
+        if (stage_type != "none") {
+            stages.push_back({block_path, stage_type, block_path});
+            continue;
+        }
+        const std::string buffer_type = it.value().value("kotekan_buffer", "none");
+        if (buffer_type != "none") {
+            buffers.push_back({it.key(), buffer_type, block_path});
+            continue;
+        }
+        const std::string pool_type = it.value().value("kotekan_metadata_pool", "none");
+        if (pool_type != "none") {
+            pools.push_back({it.key(), pool_type, block_path});
+            continue;
+        }
+
+        collect_config_blocks(it.value(), block_path, stages, buffers, pools);
+    }
+}
+
+/**
+ * @brief Static config checks that construct nothing and touch no hardware.
+ *
+ * Safe to run alongside a live pipeline: nothing is allocated, no device is
+ * opened, and the REST port is never bound. Catches the errors that are cheap
+ * to catch statically -- unknown stage types, duplicate names, and dangling
+ * metadata-pool references. Everything else (buffer wiring, per-stage required
+ * config keys) is left to `--dry-run`, which finds them authoritatively by
+ * actually building the pipeline.
+ *
+ * @param config The parsed config to check.
+ * @return The number of problems found; 0 means the config passed.
+ */
+int validate_config_static(Config& config) {
+    std::vector<config_block> stages, buffers, pools;
+    collect_config_blocks(config.get_full_config_json(), "", stages, buffers, pools);
+
+    int problems = 0;
+    auto report = [&problems](const std::string& msg) {
+        ERROR_NON_OO("config check: {:s}", msg);
+        problems++;
+    };
+
+    // Every stage type must be one the binary actually knows how to build.
+    const std::map<std::string, StageMaker*> known_stages =
+        StageFactoryRegistry::get_registered_stages();
+    for (const auto& stage : stages) {
+        if (known_stages.find(stage.type) == known_stages.end())
+            report(fmt::format(fmt("stage {:s} has unknown type '{:s}'"), stage.path, stage.type));
+    }
+
+    // Duplicate names are fatal in the factories; find them before they are. Buffers and
+    // pools are keyed by bare name, so the same name in two scopes collides; stages are
+    // keyed by full path, which a JSON tree cannot duplicate, so they are not checked.
+    auto find_duplicates = [&report](const std::vector<config_block>& blocks, const char* what) {
+        std::map<std::string, int> counts;
+        for (const auto& block : blocks)
+            counts[block.name]++;
+        for (const auto& count : counts) {
+            if (count.second > 1)
+                report(fmt::format(fmt("{:s} '{:s}' is defined {:d} times"), what, count.first,
+                                   count.second));
+        }
+    };
+    find_duplicates(buffers, "buffer");
+    find_duplicates(pools, "metadata pool");
+
+    // A buffer's metadata_pool may be inherited from an enclosing scope, so ask
+    // the config for it by path rather than reading the block's own json.
+    std::set<std::string> pool_names;
+    for (const auto& pool : pools)
+        pool_names.insert(pool.name);
+    for (const auto& buffer : buffers) {
+        const std::string pool =
+            config.get_default<std::string>(buffer.path, "metadata_pool", "none");
+        if (pool != "none" && pool_names.count(pool) == 0)
+            report(fmt::format(fmt("buffer '{:s}' requests metadata pool '{:s}', which is not "
+                                   "defined"),
+                               buffer.name, pool));
+    }
+
+    // The runtime and --dry-run both call update_log_levels() before anything else, so a
+    // config without a usable root `log_level` fails there however well-formed the rest is.
+    // Checked through the same parser rather than a second copy of the accepted values.
+    try {
+        parse_log_level(config.get<std::string>("/", "log_level"));
+    } catch (const std::exception& ex) {
+        report(fmt::format(fmt("root 'log_level': {:s}"), ex.what()));
+    }
+
+    INFO_NON_OO("config check: {:d} stages, {:d} buffers, {:d} metadata pools", stages.size(),
+                buffers.size(), pools.size());
+    return problems;
+}
+
+/**
+ * @brief Builds the whole pipeline, then tears it down without running it.
+ *
+ * This is the authoritative check -- it exercises every stage constructor and
+ * allocates every buffer -- and that is exactly why it is NOT safe alongside a
+ * live pipeline: stage constructors open devices (DPDK, CUDA) and buffers claim
+ * hugepages. Run it only where the node is free.
+ *
+ * @param config The parsed config to build from.
+ * @return 0 if the pipeline built and tore down cleanly, 1 otherwise.
+ */
+int run_dry_run(Config& config) {
+    kotekanMode* mode = nullptr;
+    try {
+        // Inside the try: a config with no root `log_level` throws here, and a
+        // validator must report that rather than terminate on it.
+        update_log_levels(config);
+        mode = new kotekanMode(config);
+        mode->initalize_stages();
+    } catch (const std::exception& ex) {
+        ERROR_NON_OO("dry run: pipeline construction FAILED: {:s}", ex.what());
+        delete mode;
+        return 1;
+    }
+
+    // A stage blocks until its inputs arrive, so a buffer with consumers and no producer is
+    // not an error at construction -- it is a pipeline that starts, looks healthy, and wedges
+    // silently (e.g. a config that pruned the only producer of a mask another stage needs).
+    // The graph is fully known here, so check it. The reverse case (a producer with no
+    // consumer) is NOT an error: it is the normal way to disable an output leg.
+    int stalled = 0;
+    const json bufs = mode->get_buffer_json();
+    for (auto it = bufs.begin(); it != bufs.end(); ++it) {
+        const json& b = it.value();
+        if (!b.is_object())
+            continue;
+        const bool has_prod =
+            b.contains("producers") && b["producers"].is_object() && !b["producers"].empty();
+        const bool has_cons =
+            b.contains("consumers") && b["consumers"].is_object() && !b["consumers"].empty();
+        if (has_prod || !has_cons)
+            continue;
+        std::string who;
+        for (auto c = b["consumers"].begin(); c != b["consumers"].end(); ++c)
+            who += (who.empty() ? "" : ", ") + c.key();
+        ERROR_NON_OO("dry run: buffer '{:s}' has consumers ({:s}) but NO producer -- those "
+                     "stages would block forever.",
+                     it.key(), who);
+        stalled++;
+    }
+    if (stalled > 0) {
+        ERROR_NON_OO("dry run: {:d} buffer(s) would stall the pipeline.", stalled);
+        delete mode;
+        return 1;
+    }
+
+    INFO_NON_OO("dry run: pipeline constructed; tearing down without starting stages.");
+    delete mode;
+    INFO_NON_OO("dry run: teardown complete.");
+    return 0;
+}
+
 int main(int argc, char** argv) {
 
     std::signal(SIGINT, signal_handler);
@@ -459,6 +673,8 @@ int main(int argc, char** argv) {
     bool enable_stderr = true;
     bool dump_config = false;
     bool dump_yaml = false;
+    bool check_config = false;
+    bool dry_run = false;
     std::string bind_address = "0.0.0.0:12048";
     std::string jinja_variables = "";
     // We disable syslog to start.
@@ -479,6 +695,8 @@ int main(int argc, char** argv) {
                                                {"version-json", no_argument, nullptr, 'j'},
                                                {"print-json", no_argument, nullptr, 'p'},
                                                {"print-yaml", no_argument, nullptr, 'y'},
+                                               {"check-config", no_argument, nullptr, OPT_CHECK},
+                                               {"dry-run", no_argument, nullptr, OPT_DRY_RUN},
                                                {nullptr, 0, nullptr, 0}};
 
         int option_index = 0;
@@ -524,11 +742,25 @@ int main(int argc, char** argv) {
             case 'p':
                 dump_config = true;
                 break;
+            case OPT_CHECK:
+                check_config = true;
+                break;
+            case OPT_DRY_RUN:
+                dry_run = true;
+                break;
             default:
                 printf("Invalid option, run with -h to see options");
                 return -1;
                 break;
         }
+    }
+
+    // The validation modes need a config file, and they have to say so on
+    // stderr: the daemon-mode block right below switches logging to syslog
+    // only, which would swallow the message and leave a bare exit status.
+    if ((check_config || dry_run) && string(config_file_name) == "none") {
+        fprintf(stderr, "--check-config/--dry-run require a config file (-c/--config).\n");
+        return 1;
     }
 
     if (string(config_file_name) == "none") {
@@ -559,7 +791,11 @@ int main(int argc, char** argv) {
                      bind_address.c_str());
         exit(-1);
     }
-    rest_server.start(address_parts.at(0), std::stoi(address_parts.at(1)));
+    // The validation modes must never bind the REST port: the whole point is to
+    // be runnable on a node that already has a kotekan instance on it.
+    const bool validate_only = check_config || dry_run;
+    if (!validate_only)
+        rest_server.start(address_parts.at(0), std::stoi(address_parts.at(1)));
 
     if (string(config_file_name) != "none") {
         std::lock_guard<std::mutex> lock(kotekan_state_lock);
@@ -594,6 +830,42 @@ int main(int argc, char** argv) {
             exit(-1);
         }
         config.update_config(config_json);
+
+        if (validate_only) {
+            if (dump_config)
+                config.dump_config();
+
+            const char* what = dry_run ? "dry run" : "config check";
+            int problems = 0;
+            // A malformed config throws out of the checks themselves -- a
+            // non-string `kotekan_stage`, a missing root `log_level`. A
+            // validator has to report that as a failed config, not abort: the
+            // half-written config is exactly the case it exists for.
+            try {
+                problems = validate_config_static(config);
+                // Only attempt the build if the static checks passed -- building
+                // on a config with an unknown stage type just reports the same
+                // fault again, more expensively and with hardware side effects.
+                if (dry_run && problems == 0)
+                    problems += run_dry_run(config);
+            } catch (const std::exception& ex) {
+                fprintf(stderr, "%s: %s FAILED: %s\n", what, config_file_name, ex.what());
+                free(config_file_name);
+                return 1;
+            }
+
+            // The verdict goes to stdout/stderr directly, not through the log
+            // level: `log_level: off` in the config under test must not be able
+            // to suppress the answer the caller asked for.
+            if (problems == 0)
+                fprintf(stdout, "%s: %s PASSED.\n", what, config_file_name);
+            else
+                fprintf(stderr, "%s: %s FAILED with %d problem(s).\n", what, config_file_name,
+                        problems);
+            free(config_file_name);
+            return problems == 0 ? 0 : 1;
+        }
+
         try {
             start_new_kotekan_mode(config, dump_config);
         } catch (const std::exception& ex) {

--- a/lib/core/restServer.cpp
+++ b/lib/core/restServer.cpp
@@ -71,6 +71,13 @@ restServer::restServer() : main_thread() {
 restServer::~restServer() {
     _restServer_alive.store(false, std::memory_order_release);
     stop_thread = true;
+    // A server that was never started has no thread to join, and join() on a
+    // non-joinable thread throws. That is an ordinary path (--check-config and
+    // --dry-run build the REST endpoints without starting the server), so it is
+    // not a warning; the warning below is for a join that fails on a thread that
+    // really was running.
+    if (!main_thread.joinable())
+        return;
     try {
         main_thread.join();
     } catch (std::exception& e) {
@@ -723,6 +730,15 @@ static void maybe_add_cors_headers(struct evhttp_request* request) {
 }
 
 void restServer::set_server_affinity(Config& config) {
+    // If the server was never started there is no thread to pin, and
+    // main_thread.native_handle() is 0 -- passing that to pthread_setaffinity_np
+    // segfaults. This is the case when a pipeline is built without being run
+    // (see kotekan --dry-run).
+    if (!main_thread.joinable()) {
+        DEBUG_NON_OO("restServer: not started, skipping affinity.");
+        return;
+    }
+
     vector<int32_t> cpu_affinity = config.get<std::vector<int32_t>>("/rest_server", "cpu_affinity");
 
     cpu_set_t cpuset;

--- a/lib/core/restServer.cpp
+++ b/lib/core/restServer.cpp
@@ -235,9 +235,45 @@ void restServer::start(const std::string& bind_address, u_short port) {
 #endif
 }
 
+void restServer::stop_processing() {
+    // Refuse further dispatch first, so any request that has not yet taken the
+    // shared lock will see this and 503 instead of invoking a callback.
+    accepting_requests = false;
+
+    // If we are already on the server thread, the single-threaded event loop
+    // guarantees no other handler is in flight, and taking the lock
+    // exclusively here would dead-lock against our own shared hold. The flag
+    // above is enough; skip the drain.
+    if (std::this_thread::get_id() == main_thread.get_id())
+        return;
+
+    // Otherwise (main-thread signal shutdown) wait out any handler currently
+    // running on the server thread. Once we hold the lock exclusively, no
+    // handler is executing and none can start, so the caller may destruct the
+    // stages those handlers reach into. Bound the wait: a handler stuck past
+    // it means shutdown would hang forever, and proceeding with a loud error
+    // at least leaves a restartable process (kotekan runs under a daemon).
+    std::unique_lock<std::shared_timed_mutex> drain(request_lock, std::chrono::seconds(30));
+    if (!drain.owns_lock())
+        ERROR_NON_OO("restServer: a request handler is still running 30s into shutdown; "
+                     "proceeding with teardown anyway.");
+}
+
 void restServer::handle_request(struct evhttp_request* request, void* cb_data) {
 
     restServer* server = (restServer*)(cb_data);
+
+    // Hold the request lock (shared) for the whole handler, including the
+    // callback invocation below. stop_processing() takes it exclusively during
+    // teardown, so it cannot free a stage while one of that stage's callbacks
+    // is running. Distinct from callback_map_lock, which is dropped before the
+    // callback runs (callbacks may re-register endpoints).
+    std::shared_lock<std::shared_timed_mutex> request_guard(server->request_lock);
+    if (!server->accepting_requests) {
+        connectionInstance conn(request);
+        conn.send_error("Server shutting down", HTTP_RESPONSE::SERVICE_UNAVAILABLE);
+        return;
+    }
 
     string url = string(evhttp_uri_get_path(evhttp_request_get_evhttp_uri(request)));
 
@@ -708,6 +744,8 @@ string restServer::get_http_responce_code_text(const HTTP_RESPONSE& status) {
             return "BAD_REQUEST";
         case HTTP_RESPONSE::REQUEST_FAILED:
             return "REQUEST_FAILED";
+        case HTTP_RESPONSE::SERVICE_UNAVAILABLE:
+            return "SERVICE_UNAVAILABLE";
         default:
             return "";
     }

--- a/lib/core/restServer.hpp
+++ b/lib/core/restServer.hpp
@@ -29,7 +29,8 @@ enum class HTTP_RESPONSE {
     BAD_REQUEST = 400,
     REQUEST_FAILED = 402,
     NOT_FOUND = 404,
-    INTERNAL_ERROR = 500
+    INTERNAL_ERROR = 500,
+    SERVICE_UNAVAILABLE = 503
 };
 
 #define PORT_REST_SERVER 12048
@@ -195,6 +196,39 @@ public:
      * @param port The port to bind.  Default: PORT_REST_SERVER
      */
     void start(const std::string& bind_address = "0.0.0.0", u_short port = PORT_REST_SERVER);
+
+    /**
+     * @brief Quiesce request handling ahead of process teardown.
+     *
+     * Stop dispatching to registered endpoint callbacks and block until any
+     * handler already running on the server thread has returned. After this
+     * call every incoming request is answered with 503 (Service Unavailable)
+     * without touching a callback, so it is safe for the caller to destruct
+     * the stages that own those callbacks.
+     *
+     * This closes a use-after-free on shutdown: an external signal (SIGINT /
+     * SIGTERM) tears the pipeline down on the main thread while the server
+     * thread may be part-way through a handler that captured a stage's @c
+     * this. handle_request looks a callback up under a lock but invokes a
+     * copy after releasing it (so callbacks may re-register endpoints), so the
+     * map lock alone does not keep the stage alive across the call; this
+     * barrier does.
+     *
+     * One-way: requests are refused permanently, so this is only for process
+     * teardown -- not for the @c /stop path, which must leave the server
+     * usable for a later @c /start. The caller must not hold any lock that
+     * request handlers also take (e.g. the kotekan state lock in kotekan.cpp)
+     * while this drains, or drain and handler deadlock against each other.
+     * The drain is bounded: after 30 seconds an error is logged and teardown
+     * proceeds anyway. When called from the server thread itself the drain is
+     * skipped, since the single-threaded event loop guarantees no other
+     * handler is in flight.
+     *
+     * The server thread is left running (endpoints stay resolvable, just
+     * refused) so this composes with the framework's normal singleton
+     * teardown. Idempotent.
+     */
+    void stop_processing();
 
     /**
      * @brief Set the server thread CPU affinity
@@ -473,6 +507,17 @@ private:
 
     /// Flag set to true when exit condition is reached
     std::atomic<bool> stop_thread;
+
+    /// Held shared for the whole duration of a request handler and exclusively
+    /// by @c stop_processing, so shutdown can wait out any in-flight handler
+    /// before the stages those handlers reach into are destructed. Distinct
+    /// from @c callback_map_lock (which only guards the map structure and is
+    /// released before a callback is invoked).
+    std::shared_timed_mutex request_lock;
+
+    /// Cleared by @c stop_processing to refuse further callback dispatch. Once
+    /// false, handle_request answers 503 without invoking any endpoint.
+    std::atomic<bool> accepting_requests{true};
 
     /// Cached value of /rest_server/enable_cors (legacy "*" mode); see
     /// @c set_cors_from_config.

--- a/lib/stages/bufferRecv.cpp
+++ b/lib/stages/bufferRecv.cpp
@@ -301,10 +301,10 @@ void bufferRecv::main_thread() {
     listener = socket(AF_INET, SOCK_STREAM, 0);
     evutil_make_socket_nonblocking(listener);
 
-    // Bind even when connections from a previous run are still in TIME_WAIT.
-    // Without this, a restart within the TIME_WAIT window (a couple of minutes)
-    // fails with EADDRINUSE on a port nothing is listening on any more, which
-    // is exactly the window a supervisor restarts kotekan in.
+    // Bind even when connections from a previous run are still in TIME_WAIT;
+    // otherwise a restart within that window fails with EADDRINUSE on a port
+    // nothing is listening on. SO_REUSEADDR on a listener only permits rebinding
+    // over TIME_WAIT -- two live listeners sharing a port would need SO_REUSEPORT.
     {
         int reuse = 1;
         if (setsockopt(listener, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(int)) < 0) {

--- a/lib/stages/rawFileRead.cpp
+++ b/lib/stages/rawFileRead.cpp
@@ -11,6 +11,7 @@
 #include "fmt.hpp" // for compile_string_to_view
 
 #include <assert.h>   // for assert
+#include <chrono>     // for microseconds
 #include <cstdio>     // for fread, snprintf, fclose, fopen, fseek, ftell, rewind, FILE
 #include <errno.h>    // for errno
 #include <functional> // for bind, function
@@ -18,6 +19,7 @@
 #include <stdint.h>   // for uint32_t, uint8_t
 #include <string.h>   // for strerror
 #include <sys/stat.h> // for stat
+#include <thread>     // for sleep_for
 #include <unistd.h>   // for gethostname, sleep
 
 
@@ -46,6 +48,13 @@ rawFileRead::rawFileRead(Config& config, const std::string& unique_name,
 
     // Interrupt Kotekan if run out of files to read.
     end_interrupt = config.get_default<bool>(unique_name, "end_interrupt", false);
+
+    // Optional replay pacing: sleep this many microseconds after publishing each frame,
+    // so a captured file replays at roughly the rate it was acquired at. 0 (the default)
+    // reads as fast as the downstream pipeline drains, which is what you want unless
+    // something downstream is tied to the wall clock. See the class doc: this is a floor
+    // on the frame period, not a rate lock.
+    frame_period_us = config.get_default<uint64_t>(unique_name, "frame_period_us", 0);
 }
 
 rawFileRead::~rawFileRead() {}
@@ -137,6 +146,11 @@ void rawFileRead::main_thread() {
                  buf->buffer_name, frame_id);
             buf->mark_frame_full(unique_name, frame_id);
             frame_id = (frame_id + 1) % buf->num_frames;
+
+            // sleep_for, not usleep: useconds_t is 32-bit, so a period past
+            // ~4.29 s would silently truncate (and POSIX.1-2008 dropped usleep).
+            if (frame_period_us > 0)
+                std::this_thread::sleep_for(std::chrono::microseconds(frame_period_us));
         }
 
         fclose(fp);

--- a/lib/stages/rawFileRead.hpp
+++ b/lib/stages/rawFileRead.hpp
@@ -12,7 +12,8 @@
 #include "buffer.hpp"          // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
 
-#include <string> // for string, basic_string
+#include <stdint.h> // for uint64_t
+#include <string>   // for string, basic_string
 
 /**
  * @class rawFileRead
@@ -26,7 +27,25 @@
  * @conf   base_dir         String. Directory to read from.
  * @conf   file_name        String. Base filename to read.
  * @conf   file_ext         String. File extension.
- * @conf   end_interrupt    Bool. Interrupt Kotekan if run out of files to read
+ * @conf   end_interrupt    Bool. Interrupt Kotekan if run out of files to read.
+ *                          Default false.
+ * @conf   prefix_hostname  Bool. Expect the local hostname in the filename, as written
+ *                          by rawFileWrite. Default false -- note rawFileWrite defaults
+ *                          the same key to TRUE, so a capture written with defaults
+ *                          needs prefix_hostname: true here to be found.
+ * @conf   frame_period_us  Uint64. Sleep this long after publishing each frame, so a
+ *                          capture replays at roughly the rate it was acquired at.
+ *                          Set it to one frame's worth of acquisition time: e.g. a frame
+ *                          of 199680 samples taken at 20 MS/s is 9984 us.
+ *                          Default 0 = unthrottled: frames are read as fast as the
+ *                          downstream pipeline drains them, which is the behaviour you
+ *                          want unless something in the pipeline is tied to the wall
+ *                          clock. Note this is a floor on the frame period, not a rate
+ *                          lock -- the read and per-file open overhead add to it, so a
+ *                          paced replay runs somewhat slower than 1/frame_period_us.
+ *                          A consumer that needs to know where in the file it is
+ *                          should derive that from the frame metadata, not from
+ *                          elapsed wall time.
  */
 class rawFileRead : public kotekan::Stage {
 public:
@@ -44,6 +63,8 @@ private:
     bool prefix_hostname;
     // Interrupt Kotekan if run out of files to read
     bool end_interrupt;
+    // Realtime replay pacing: microseconds to sleep per frame (0 = unthrottled)
+    uint64_t frame_period_us;
 };
 
 #endif

--- a/lib/stages/rawFileWrite.cpp
+++ b/lib/stages/rawFileWrite.cpp
@@ -45,6 +45,12 @@ rawFileWrite::rawFileWrite(Config& config, const std::string& unique_name,
     _num_frames_per_file = config.get_default<uint32_t>(unique_name, "num_frames_per_file", 1);
     _prefix_hostname = config.get_default<bool>(unique_name, "prefix_hostname", true);
     _exit_after_n_files = config.get_default<uint32_t>(unique_name, "exit_after_n_files", 0);
+    // Opt-in escape from the NDArray refusal below. The refusal exists because the frame
+    // descriptor is set dynamically and is not written to the file, so a reader cannot
+    // recover the shape from the file alone. That is no hazard when the shape is fixed and
+    // known out of band (a flat sample stream whose only "shape" is samples_per_data_set,
+    // pinned in both the capture and the replay config). Default false: you must say you know.
+    _allow_ndarray = config.get_default<bool>(unique_name, "allow_ndarray", false);
 
     if (_exit_after_n_files > 0)
         waiting_for_max_frames++;
@@ -76,10 +82,12 @@ void rawFileWrite::main_thread() {
             break;
 
         // Check for NDArray on first frame (after producer may have set the descriptor)
-        if (buf->get_frame_desc<kotekan::GenericNDArray>()) {
+        if (buf->get_frame_desc<kotekan::GenericNDArray>() && !_allow_ndarray) {
             FATAL_ERROR(
                 "rawFileWrite does not support NDArray buffers. The NDArray frame descriptor "
-                "is set dynamically and will not be written to the file.");
+                "is set dynamically and will not be written to the file. Set "
+                "allow_ndarray: true to write the raw bytes anyway (the descriptor is then "
+                "the READER's responsibility -- see the note on the option).");
         }
 
         // Start timing the write time

--- a/lib/stages/rawFileWrite.hpp
+++ b/lib/stages/rawFileWrite.hpp
@@ -23,6 +23,10 @@
  * @conf file_ext  String. File extension.
  * @conf num_frames_per_file Int. No of frames to write into a single file.
  * @conf exit_after_n_files  Int. Stop writing after this many files, Default 0 = unlimited files.
+ * @conf prefix_hostname    Bool. Prefix the filename with the hostname. Default true.
+ * @conf allow_ndarray      Bool. Write an NDArray buffer's raw bytes instead of failing.
+ *                          Default false. The frame descriptor is NOT written, so the
+ *                          reader has to know the shape out of band.
  *
  * @par Metrics
  * @metric kotekan_rawfilewrite_write_time_seconds
@@ -48,6 +52,8 @@ private:
     std::string _file_ext;
     uint32_t _num_frames_per_file;
     uint32_t _exit_after_n_files;
+    /// Write NDArray-descriptor buffers anyway (shape known out of band; see the .cpp note).
+    bool _allow_ndarray = false;
     // Prefix file name with hostname or not
     bool _prefix_hostname;
 };

--- a/lib/stages/valve.cpp
+++ b/lib/stages/valve.cpp
@@ -12,6 +12,7 @@
 
 #include "fmt.hpp" // for compile_string_to_view, format, fmt
 
+#include <chrono>     // for steady_clock, seconds
 #include <cstring>    // for memcpy
 #include <exception>  // for exception
 #include <functional> // for bind, function
@@ -45,6 +46,13 @@ void Valve::main_thread() {
     /// Metric to track the number of dropped frames.
     auto& dropped_total =
         Metrics::instance().add_counter("kotekan_valve_dropped_frames_total", unique_name);
+    // ...and the denominator: a drop count alone cannot be read (the same number is
+    // catastrophic on a short run and negligible on a long one). With both counters a
+    // consumer gets the lost fraction without knowing the frame period.
+    auto& passed_total =
+        Metrics::instance().add_counter("kotekan_valve_passed_frames_total", unique_name);
+    uint64_t n_dropped = 0;
+    auto last_warn = std::chrono::steady_clock::now();
 
     while (!stop_thread) {
         // Fetch a new frame and get its sequence id
@@ -65,8 +73,20 @@ void Valve::main_thread() {
                 break;
             }
             _buf_out->mark_frame_full(unique_name, frame_id_out++);
+            passed_total.inc();
         } else {
-            WARN("Output buffer full. Dropping incoming frame {:d}.", frame_id_in);
+            // Rate-limited BY TIME, carrying the running total. A valve in front of a
+            // newest-is-best consumer drops most of its input by design -- at 1e5 frames/s
+            // even one line per hundred drops is gigabytes of log per hour -- while a valve
+            // that should never drop wants its first loss reported at once.
+            ++n_dropped;
+            auto now = std::chrono::steady_clock::now();
+            if (n_dropped == 1 || now - last_warn >= std::chrono::seconds(60)) {
+                WARN("Output buffer full, dropping frames: {:d} lost so far (downstream "
+                     "cannot keep up).",
+                     n_dropped);
+                last_warn = now;
+            }
             dropped_total.inc();
         }
         _buf_in->mark_frame_empty(unique_name, frame_id_in++);

--- a/lib/stages/valve.hpp
+++ b/lib/stages/valve.hpp
@@ -34,6 +34,11 @@
  * @metric kotekan_valve_dropped_frames_total
  *        The number of frames dropped.
  *
+ * @metric kotekan_valve_passed_frames_total
+ *         The number of frames this stage has passed through, labelled by
+ *         `unique_name`. The denominator for the dropped count: a drop total
+ *         on its own does not say whether the valve is shedding a trickle or
+ *         nearly everything.
  *
  * @author  Rick Nitsche
  *

--- a/lib/utils/N2Util.hpp
+++ b/lib/utils/N2Util.hpp
@@ -155,16 +155,17 @@ public:
     /// Assignment of a number into the modular number.
     modulo<T>& operator=(const T& i) {
         _i = i;
+        reduce();
         return *this;
     }
 
     // Increment and decrement
     modulo<T>& operator++() {
-        _i++;
+        shift(1);
         return *this;
     }
     modulo<T>& operator--() {
-        _i--;
+        shift(-1);
         return *this;
     }
     modulo<T> operator++(int) {
@@ -180,13 +181,13 @@ public:
 
     template<typename V, typename std::enable_if_t<std::is_integral<V>::value>* = nullptr>
     modulo<T>& operator+=(const V& rhs) {
-        _i += rhs;
+        shift(static_cast<std::int64_t>(rhs));
         return *this;
     }
 
     template<typename V, typename std::enable_if_t<std::is_integral<V>::value>* = nullptr>
     modulo<T>& operator-=(const V& rhs) {
-        _i -= rhs;
+        shift(-static_cast<std::int64_t>(rhs));
         return *this;
     }
 
@@ -230,7 +231,7 @@ public:
      * @returns The modular number.
      **/
     T norm() const {
-        return _i % _n;
+        return _i;
     }
 
     /// Conversion back to type T
@@ -239,8 +240,45 @@ public:
     }
 
 private:
-    // Internally we don't actually keep bother mod'ing the number when
-    // we do arithmetic, only at output time.
+    // Keep _i in [0, _n) after every mutation. Counting unreduced and taking
+    // `_i % _n` only on read is not equivalent: a signed T overflows after 2^k
+    // increments and the (unsigned) `% _n` is then discontinuous by (2^k mod _n)
+    // unless _n divides 2^k (e.g. int over a base of 24: 2^32 mod 24 == 16, so
+    // the sequence jumps from 15 to 0 and skips 8 values). Reducing on write also
+    // makes a decrement below zero land on _n-1 instead of on the unsigned wrap of -1.
+    //
+    // A base of 0 means "not set" (default-constructed): the value is left
+    // unreduced rather than divided by zero, and norm() returns it as stored.
+    void reduce() {
+        if (_n == 0)
+            return;
+        const T n = static_cast<T>(_n);
+        _i %= n;
+        // Only a signed T can land below zero here; the test is not merely
+        // redundant for an unsigned one, it is unreachable, which is why every
+        // step that could go below zero goes through shift() instead.
+        if constexpr (std::is_signed<T>::value) {
+            if (_i < 0)
+                _i += n;
+        }
+    }
+
+    // Apply a delta to the stored value. The delta is reduced BEFORE it is
+    // combined, in int64 arithmetic, so no argument can overflow T on the way
+    // in and an unsigned T never sees the wrap of a negative intermediate
+    // (a decrement at 0 lands on _n-1 for every T, not on (max % _n)).
+    // The base is assumed to fit in an int64; every Buffer cursor's does,
+    // since Buffer::num_frames is an int.
+    void shift(std::int64_t delta) {
+        if (_n == 0)
+            return;
+        const std::int64_t n = static_cast<std::int64_t>(_n);
+        std::int64_t v = (static_cast<std::int64_t>(_i) % n + delta % n) % n;
+        if (v < 0)
+            v += n;
+        _i = static_cast<T>(v);
+    }
+
     T _i = 0;
 
     // The modular base.

--- a/lib/utils/visUtil.hpp
+++ b/lib/utils/visUtil.hpp
@@ -820,16 +820,17 @@ public:
     /// Assignment of a number into the modular number.
     modulo<T>& operator=(const T& i) {
         _i = i;
+        reduce();
         return *this;
     }
 
     // Increment and decrement
     modulo<T>& operator++() {
-        _i++;
+        shift(1);
         return *this;
     }
     modulo<T>& operator--() {
-        _i--;
+        shift(-1);
         return *this;
     }
     modulo<T> operator++(int) {
@@ -845,13 +846,13 @@ public:
 
     template<typename V, typename std::enable_if_t<std::is_integral<V>::value>* = nullptr>
     modulo<T>& operator+=(const V& rhs) {
-        _i += rhs;
+        shift(static_cast<std::int64_t>(rhs));
         return *this;
     }
 
     template<typename V, typename std::enable_if_t<std::is_integral<V>::value>* = nullptr>
     modulo<T>& operator-=(const V& rhs) {
-        _i -= rhs;
+        shift(-static_cast<std::int64_t>(rhs));
         return *this;
     }
 
@@ -895,7 +896,7 @@ public:
      * @returns The modular number.
      **/
     T norm() const {
-        return _i % _n;
+        return _i;
     }
 
     /// Conversion back to type T
@@ -904,8 +905,45 @@ public:
     }
 
 private:
-    // Internally we don't actually keep bother mod'ing the number when
-    // we do arithmetic, only at output time.
+    // Keep _i in [0, _n) after every mutation. Counting unreduced and taking
+    // `_i % _n` only on read is not equivalent: a signed T overflows after 2^k
+    // increments and the (unsigned) `% _n` is then discontinuous by (2^k mod _n)
+    // unless _n divides 2^k (e.g. int over a base of 24: 2^32 mod 24 == 16, so
+    // the sequence jumps from 15 to 0 and skips 8 values). Reducing on write also
+    // makes a decrement below zero land on _n-1 instead of on the unsigned wrap of -1.
+    //
+    // A base of 0 means "not set" (default-constructed): the value is left
+    // unreduced rather than divided by zero, and norm() returns it as stored.
+    void reduce() {
+        if (_n == 0)
+            return;
+        const T n = static_cast<T>(_n);
+        _i %= n;
+        // Only a signed T can land below zero here; the test is not merely
+        // redundant for an unsigned one, it is unreachable, which is why every
+        // step that could go below zero goes through shift() instead.
+        if constexpr (std::is_signed<T>::value) {
+            if (_i < 0)
+                _i += n;
+        }
+    }
+
+    // Apply a delta to the stored value. The delta is reduced BEFORE it is
+    // combined, in int64 arithmetic, so no argument can overflow T on the way
+    // in and an unsigned T never sees the wrap of a negative intermediate
+    // (a decrement at 0 lands on _n-1 for every T, not on (max % _n)).
+    // The base is assumed to fit in an int64; every Buffer cursor's does,
+    // since Buffer::num_frames is an int.
+    void shift(std::int64_t delta) {
+        if (_n == 0)
+            return;
+        const std::int64_t n = static_cast<std::int64_t>(_n);
+        std::int64_t v = (static_cast<std::int64_t>(_i) % n + delta % n) % n;
+        if (v < 0)
+            v += n;
+        _i = static_cast<T>(v);
+    }
+
     T _i = 0;
 
     // The modular base.

--- a/tests/boost/CMakeLists.txt
+++ b/tests/boost/CMakeLists.txt
@@ -11,6 +11,10 @@ target_link_libraries(test_truncate PRIVATE kotekan_libs kotekan_utils)
 add_executable(test_synchronized_queue test_synchronized_queue.cpp)
 target_link_libraries(test_synchronized_queue PRIVATE pthread kotekan_libs kotekan_utils)
 
+# frameID / modulo<int>: reduce-on-write, the 2^32 wrap that skips buffer slots
+add_executable(test_modulo test_modulo.cpp)
+target_link_libraries(test_modulo PRIVATE libexternal kotekan_libs kotekan_utils kotekan_core)
+
 add_executable(test_stat_tracker test_stat_tracker.cpp)
 target_link_libraries(test_stat_tracker PRIVATE libexternal kotekan_libs kotekan_utils kotekan_core)
 

--- a/tests/boost/test_modulo.cpp
+++ b/tests/boost/test_modulo.cpp
@@ -1,0 +1,141 @@
+#define BOOST_TEST_MODULE "test_modulo"
+
+#include "N2Util.hpp"  // for N2::modulo
+#include "visUtil.hpp" // for modulo, frameID
+
+#include <boost/test/included/unit_test.hpp>
+#include <cstdint>
+
+// frameID is modulo<int> over a buffer's num_frames. These tests pin the
+// reduce-on-write semantics for both copies of the class: the value stays in
+// [0, n) through 2^32 increments (the point at which an unreduced int count
+// wraps and `% n` becomes discontinuous unless n divides 2^32), a decrement
+// below zero lands on n-1, and deltas larger than the type are reduced first.
+
+template<typename M>
+static void check_sequence_survives_2_32(unsigned n) {
+    // Nine chunks of 1e9 pass through both 2^31 and 2^32.
+    M x(n);
+    int64_t total = 0;
+    // BOOST_REQUIRE, not BOOST_CHECK: an implementation that counts unreduced
+    // makes this loop signed-overflow UB, and at -O2 a soft check failure
+    // becomes a non-terminating loop emitting unbounded output.
+    for (int chunk = 0; chunk < 9; ++chunk) {
+        x += 1000000000;
+        total += 1000000000;
+        BOOST_REQUIRE_EQUAL((int)x, (int)(total % n));
+        BOOST_REQUIRE((int)x >= 0 && (int)x < (int)n);
+    }
+    // ...and keeps counting in step after the wrap.
+    for (int k = 0; k < 100; ++k) {
+        ++x;
+        ++total;
+        BOOST_REQUIRE_EQUAL((int)x, (int)(total % n));
+    }
+}
+
+template<typename M>
+static void check_basic_semantics(unsigned n) {
+    M x(n);
+    BOOST_CHECK_EQUAL((int)x, 0);
+
+    // Post-increment returns the old value and advances the counter.
+    M old = x++;
+    BOOST_CHECK_EQUAL((int)old, 0);
+    BOOST_CHECK_EQUAL((int)x, 1);
+
+    // Stepping forward through a full lap lands back on 0.
+    for (unsigned k = 1; k < n; ++k)
+        ++x;
+    BOOST_CHECK_EQUAL((int)x, 0);
+
+    // Decrementing below zero wraps to n-1, not to the unsigned wrap of -1 mod n.
+    --x;
+    BOOST_CHECK_EQUAL((int)x, (int)n - 1);
+    x -= 1;
+    BOOST_CHECK_EQUAL((int)x, (int)n - 2);
+    BOOST_CHECK_EQUAL((int)(x - 1), (int)n - 3);
+    BOOST_CHECK_EQUAL((int)(x + 3), 1);
+
+    // Assignment reduces too, negatives included.
+    x = 2 * (int)n + 5;
+    BOOST_CHECK_EQUAL((int)x, (int)(5 % n));
+    x = -1;
+    BOOST_CHECK_EQUAL((int)x, (int)n - 1);
+
+    // Comparisons work on the reduced value.
+    M y(n);
+    y = 5;
+    x = 5;
+    BOOST_CHECK(x == y);
+    ++y;
+    BOOST_CHECK(x != y);
+    BOOST_CHECK(x < y);
+}
+
+// An unsigned T has no negative intermediate to reduce, so the decrement path
+// has to be right in the arithmetic rather than in a sign fixup: at 0 a
+// decrement must land on n-1, not on ((max value) % n).
+template<typename M>
+static void check_unsigned_semantics(unsigned n) {
+    M x(n);
+    BOOST_CHECK_EQUAL((uint64_t)x, 0u);
+    --x;
+    BOOST_CHECK_EQUAL((uint64_t)x, (uint64_t)n - 1);
+    x -= 1;
+    BOOST_CHECK_EQUAL((uint64_t)x, (uint64_t)n - 2);
+    ++x;
+    ++x;
+    BOOST_CHECK_EQUAL((uint64_t)x, 0u);
+    // A delta far larger than the base, and larger than a 32-bit type.
+    x += 5000000000LL;
+    BOOST_CHECK_EQUAL((uint64_t)x, (uint64_t)(5000000000LL % n));
+}
+
+BOOST_AUTO_TEST_CASE(_modulo_basic) {
+    check_basic_semantics<modulo<int>>(24);
+    check_basic_semantics<N2::modulo<int>>(24);
+    check_basic_semantics<modulo<int>>(4);
+    check_basic_semantics<modulo<int>>(7);
+}
+
+BOOST_AUTO_TEST_CASE(_modulo_unsigned_base) {
+    check_unsigned_semantics<modulo<size_t>>(24);
+    check_unsigned_semantics<N2::modulo<size_t>>(24);
+    check_unsigned_semantics<modulo<unsigned>>(7);
+}
+
+// A delta whose magnitude exceeds T: the increment is reduced before it is
+// combined, so it cannot overflow the stored value on the way in.
+BOOST_AUTO_TEST_CASE(_modulo_delta_larger_than_type) {
+    modulo<int> x(24);
+    x += int64_t(5000000000LL);
+    BOOST_CHECK_EQUAL((int)x, (int)(5000000000LL % 24));
+    modulo<int> y(24);
+    y -= int64_t(5000000000LL);
+    BOOST_CHECK_EQUAL((int)y, (int)((24 - 5000000000LL % 24) % 24));
+}
+
+BOOST_AUTO_TEST_CASE(_modulo_survives_int_wrap) {
+    // 24 does not divide 2^32 (2^32 mod 24 == 16), so an unreduced count skips here.
+    check_sequence_survives_2_32<modulo<int>>(24);
+    check_sequence_survives_2_32<N2::modulo<int>>(24);
+    // 4 does divide 2^32: continuous either way, and must stay so.
+    check_sequence_survives_2_32<modulo<int>>(4);
+    // An odd base, for good measure.
+    check_sequence_survives_2_32<modulo<int>>(7);
+}
+
+BOOST_AUTO_TEST_CASE(_modulo_incremental_lap_count) {
+    // The incremental path the pipelines actually take: one ++ per frame, checked
+    // against the true count over many laps.
+    modulo<int> x(24);
+    for (int64_t k = 1; k <= 5000000; ++k) {
+        ++x;
+        if ((int)x != (int)(k % 24)) {
+            BOOST_FAIL("modulo<int>(24) diverged from k % 24 at k=" << k);
+            break;
+        }
+    }
+    BOOST_CHECK_EQUAL((int)x, (int)(5000000 % 24));
+}


### PR DESCRIPTION
Upstreams two of kvand's chord PRs whose content never reached develop: #1592 and the develop-relevant part of #1640. Commits keep kvand's authorship; the #1640 squash is reworded to say what it contains, since the GNSS parts of that PR are already on develop.

## Summary

- **restServer::stop_processing()** (#1592): before pipeline teardown, stop dispatching to endpoint callbacks and wait out any handler already running on the server thread; further requests get 503. Closes a use-after-free where a SIGINT/SIGTERM teardown on the main thread destructed a stage while the server thread was still inside one of its handlers. Called from kotekan.cpp's shutdown path. restServer::stop() also no longer joins a server thread that was never started.
- **`kotekan --check-config` and `--dry-run`** (#1640): validation modes that exit non-zero on a bad config without binding the REST port or running the pipeline. `--check-config` is static (unknown stage types, duplicate names, dangling metadata pools) and constructs nothing, so it is safe next to a live pipeline; `--dry-run` builds the whole pipeline and tears it down without starting it. log_level parsing is shared with the runtime so the check accepts exactly what the runtime accepts. Documented in user_introduction.rst.
- **modulo<T> / frameID reduce-on-write** (#1640), in both N2Util.hpp and visUtil.hpp: the value is kept in [0, n) after every mutation. Counting unreduced and taking `% n` on read is discontinuous once a signed counter overflows (2^32 mod n is nonzero unless n divides 2^32), and a decrement below zero now lands on n-1 for unsigned T as well. test_modulo pins both copies through 2^32 increments.
- **rawFileRead `frame_period_us`** replay pacing, **rawFileWrite `allow_ndarray`**, and **valve** `kotekan_valve_passed_frames_total` plus a time-rate-limited drop warning (#1640).
- kotekan/CMakeLists.txt links blosc2 where asdf-cxx was built against c-blosc2 (#1640).

