### PR TITLE
Recalculate the baseband phase matrix periodically

### DIFF
--- a/config/fengine/include/bb_charts.j2
+++ b/config/fengine/include/bb_charts.j2
@@ -16,13 +16,17 @@ bb_beam_separation_y: 90.0 / 4  # 90 degrees
 #     log2(sqrt(num_dishes)) + 7
 bb_scale: 12
 
+# The phase matrix is valid for this many input samples. It must be a multiple of num_times,
+# the number of input samples the beamformer processes per kernel invocation.
+bb_phase_lifetime_in_samples: 20 * num_times # 1 second
+
 ################################################################################
 
 # Buffers
 
 host_bb_beam_positions_buffer:
     kotekan_buffer: ndarray
-    num_frames: 1
+    num_frames: buffer_depth
     value_type: float32
     extents: [bb_num_beams, 2]
     quantity_name: "bb_beam_positions"
@@ -32,7 +36,7 @@ host_bb_beam_positions_buffer:
 
 host_bb_beam_ids_buffer:
     kotekan_buffer: ndarray
-    num_frames: 1
+    num_frames: buffer_depth
     value_type: uint64
     extents: [bb_num_beams]
     quantity_name: "bb_beam_ids"
@@ -40,14 +44,19 @@ host_bb_beam_ids_buffer:
     dimscalings: [1]
     metadata_pool: main_pool
 
+# One frame is one phase matrix, covering bb_phase_lifetime_in_samples input samples.
 host_bb_phase_buffer:
     kotekan_buffer: ndarray
-    num_frames: 1
+    num_frames: buffer_depth
     value_type: int8
-    extents: [num_frequencies, num_polarizations, bb_num_beams, num_dishes, num_components]
+    extents: [1, num_frequencies, num_polarizations, bb_num_beams, num_dishes, num_components]
     quantity_name: "A"
-    dimnames: ["F", "P", "B", "D", "C"]
-    dimscalings: [1, 1, 1, 1, 1]
+    dimnames: ["Tbb", "F", "P", "B", "D", "C"]
+    dimscalings: [bb_phase_lifetime_in_samples, 1, 1, 1, 1, 1]
+    metadata_pool: main_pool
+host_bb_phase_ringbuffer:
+    kotekan_buffer: ring
+    ring_buffer_size: buffer_depth * num_frequencies * num_polarizations * bb_num_beams * num_dishes * num_components
     metadata_pool: main_pool
 
 host_bb_shift_buffer:
@@ -81,7 +90,7 @@ run_set_bb_beams:
     out_pos_buf: host_bb_beam_positions_buffer
     out_id_buf: host_bb_beam_ids_buffer
     fixed_mode: grid_degrees
-    time_downsampling_fpga: 1
+    time_downsampling_fpga: bb_phase_lifetime_in_samples
     num_x: bb_num_beams_x
     num_y: bb_num_beams_y
     x_min: -bb_beam_separation_x * (bb_num_beams_x - 1) / 2.0
@@ -97,21 +106,35 @@ run_calc_bb_phase:
     bb_phase: host_bb_phase_buffer
     bb_shift: host_bb_shift_buffer
 
+# Send the phase matrix to its GPU ringbuffer. One matrix covers
+# bb_phase_lifetime_in_samples input samples, so this runs far less often than run_bb.
+run_send_bb_phase:
+    gpu_0:
+        kotekan_stage: cudaProcess
+        gpu_id: 0
+        in_buffers:
+            host_bb_phase_buffer: host_bb_phase_buffer
+        out_buffers:
+            host_bb_phase_ringbuffer: host_bb_phase_ringbuffer
+        commands:
+        - name: cudaCopyToRingbuffer
+          input_size: num_frequencies * num_polarizations * bb_num_beams * num_dishes * num_components
+          ring_buffer_size: buffer_depth * input_size
+          in_buf: host_bb_phase_buffer
+          signal_buf: host_bb_phase_ringbuffer
+          gpu_mem_output: bb_phase_buffer
+
 run_bb:
     gpu_0:
         kotekan_stage: cudaProcess
         gpu_id: 0
         in_buffers:
             host_voltage_ringbuffer: host_voltage_ringbuffer
-            host_bb_phase_buffer: host_bb_phase_buffer
+            host_bb_phase_ringbuffer: host_bb_phase_ringbuffer
             host_bb_shift_buffer: host_bb_shift_buffer
         out_buffers:
             host_bb_beams_buffer: host_bb_beams_buffer
         commands:
-        - name: cudaInputData
-          do_once: true
-          in_buf: host_bb_phase_buffer
-          gpu_mem: bb_phase_buffer
         - name: cudaInputData
           do_once: true
           in_buf: host_bb_shift_buffer

--- a/config/fengine/include/bb_chime.j2
+++ b/config/fengine/include/bb_chime.j2
@@ -16,13 +16,17 @@ bb_beam_separation_y: 90.0 / 32 # 90 degrees
 #     log2(sqrt(num_dishes)) + 7
 bb_scale: 12
 
+# The phase matrix is valid for this many input samples. It must be a multiple of num_times,
+# the number of input samples the beamformer processes per kernel invocation.
+bb_phase_lifetime_in_samples: 25 * num_times # 1 second
+
 ################################################################################
 
 # Buffers
 
 host_bb_beam_positions_buffer:
     kotekan_buffer: ndarray
-    num_frames: 1
+    num_frames: buffer_depth
     value_type: float32
     extents: [bb_num_beams, 2]
     quantity_name: "bb_beam_positions"
@@ -32,7 +36,7 @@ host_bb_beam_positions_buffer:
 
 host_bb_beam_ids_buffer:
     kotekan_buffer: ndarray
-    num_frames: 1
+    num_frames: buffer_depth
     value_type: uint64
     extents: [bb_num_beams]
     quantity_name: "bb_beam_ids"
@@ -40,14 +44,19 @@ host_bb_beam_ids_buffer:
     dimscalings: [1]
     metadata_pool: main_pool
 
+# One frame is one phase matrix, covering bb_phase_lifetime_in_samples input samples.
 host_bb_phase_buffer:
     kotekan_buffer: ndarray
-    num_frames: 1
+    num_frames: buffer_depth
     value_type: int8
-    extents: [num_frequencies, num_polarizations, bb_num_beams, num_dishes, num_components]
+    extents: [1, num_frequencies, num_polarizations, bb_num_beams, num_dishes, num_components]
     quantity_name: "A"
-    dimnames: ["F", "P", "B", "D", "C"]
-    dimscalings: [1, 1, 1, 1, 1]
+    dimnames: ["Tbb", "F", "P", "B", "D", "C"]
+    dimscalings: [bb_phase_lifetime_in_samples, 1, 1, 1, 1, 1]
+    metadata_pool: main_pool
+host_bb_phase_ringbuffer:
+    kotekan_buffer: ring
+    ring_buffer_size: buffer_depth * num_frequencies * num_polarizations * bb_num_beams * num_dishes * num_components
     metadata_pool: main_pool
 
 host_bb_shift_buffer:
@@ -81,7 +90,7 @@ run_set_bb_beams:
     out_pos_buf: host_bb_beam_positions_buffer
     out_id_buf: host_bb_beam_ids_buffer
     fixed_mode: grid_degrees
-    time_downsampling_fpga: 1
+    time_downsampling_fpga: bb_phase_lifetime_in_samples
     num_x: bb_num_beams_x
     num_y: bb_num_beams_y
     x_min: -bb_beam_separation_x * (bb_num_beams_x - 1) / 2.0
@@ -97,21 +106,35 @@ run_calc_bb_phase:
     bb_phase: host_bb_phase_buffer
     bb_shift: host_bb_shift_buffer
 
+# Send the phase matrix to its GPU ringbuffer. One matrix covers
+# bb_phase_lifetime_in_samples input samples, so this runs far less often than run_bb.
+run_send_bb_phase:
+    gpu_0:
+        kotekan_stage: cudaProcess
+        gpu_id: 0
+        in_buffers:
+            host_bb_phase_buffer: host_bb_phase_buffer
+        out_buffers:
+            host_bb_phase_ringbuffer: host_bb_phase_ringbuffer
+        commands:
+        - name: cudaCopyToRingbuffer
+          input_size: num_frequencies * num_polarizations * bb_num_beams * num_dishes * num_components
+          ring_buffer_size: buffer_depth * input_size
+          in_buf: host_bb_phase_buffer
+          signal_buf: host_bb_phase_ringbuffer
+          gpu_mem_output: bb_phase_buffer
+
 run_bb:
     gpu_0:
         kotekan_stage: cudaProcess
         gpu_id: 0
         in_buffers:
             host_xposed_voltage_ringbuffer: host_xposed_voltage_ringbuffer
-            host_bb_phase_buffer: host_bb_phase_buffer
+            host_bb_phase_ringbuffer: host_bb_phase_ringbuffer
             host_bb_shift_buffer: host_bb_shift_buffer
         out_buffers:
             host_bb_beams_buffer: host_bb_beams_buffer
         commands:
-        - name: cudaInputData
-          do_once: true
-          in_buf: host_bb_phase_buffer
-          gpu_mem: bb_phase_buffer
         - name: cudaInputData
           do_once: true
           in_buf: host_bb_shift_buffer

--- a/config/fengine/include/bb_chord.j2
+++ b/config/fengine/include/bb_chord.j2
@@ -16,13 +16,17 @@ bb_beam_separation_y: 5.0 / 8   # 5 degrees
 #     log2(sqrt(num_dishes)) + 7
 bb_scale: 12
 
+# The phase matrix is valid for this many input samples. It must be a multiple of num_times,
+# the number of input samples the beamformer processes per kernel invocation.
+bb_phase_lifetime_in_samples: 25 * num_times # 1 second
+
 ################################################################################
 
 # Buffers
 
 host_bb_beam_positions_buffer:
     kotekan_buffer: ndarray
-    num_frames: 1
+    num_frames: buffer_depth
     value_type: float32
     extents: [bb_num_beams, 2]
     quantity_name: "bb_beam_positions"
@@ -32,7 +36,7 @@ host_bb_beam_positions_buffer:
 
 host_bb_beam_ids_buffer:
     kotekan_buffer: ndarray
-    num_frames: 1
+    num_frames: buffer_depth
     value_type: uint64
     extents: [bb_num_beams]
     quantity_name: "bb_beam_ids"
@@ -40,14 +44,19 @@ host_bb_beam_ids_buffer:
     dimscalings: [1]
     metadata_pool: main_pool
 
+# One frame is one phase matrix, covering bb_phase_lifetime_in_samples input samples.
 host_bb_phase_buffer:
     kotekan_buffer: ndarray
-    num_frames: 1
+    num_frames: buffer_depth
     value_type: int8
-    extents: [num_frequencies, num_polarizations, bb_num_beams, num_dishes, num_components]
+    extents: [1, num_frequencies, num_polarizations, bb_num_beams, num_dishes, num_components]
     quantity_name: "A"
-    dimnames: ["F", "P", "B", "D", "C"]
-    dimscalings: [1, 1, 1, 1, 1]
+    dimnames: ["Tbb", "F", "P", "B", "D", "C"]
+    dimscalings: [bb_phase_lifetime_in_samples, 1, 1, 1, 1, 1]
+    metadata_pool: main_pool
+host_bb_phase_ringbuffer:
+    kotekan_buffer: ring
+    ring_buffer_size: buffer_depth * num_frequencies * num_polarizations * bb_num_beams * num_dishes * num_components
     metadata_pool: main_pool
 
 host_bb_shift_buffer:
@@ -81,7 +90,7 @@ run_set_bb_beams:
     out_pos_buf: host_bb_beam_positions_buffer
     out_id_buf: host_bb_beam_ids_buffer
     fixed_mode: grid_degrees
-    time_downsampling_fpga: 1
+    time_downsampling_fpga: bb_phase_lifetime_in_samples
     num_x: bb_num_beams_x
     num_y: bb_num_beams_y
     x_min: -bb_beam_separation_x * (bb_num_beams_x - 1) / 2.0
@@ -97,21 +106,35 @@ run_calc_bb_phase:
     bb_phase: host_bb_phase_buffer
     bb_shift: host_bb_shift_buffer
 
+# Send the phase matrix to its GPU ringbuffer. One matrix covers
+# bb_phase_lifetime_in_samples input samples, so this runs far less often than run_bb.
+run_send_bb_phase:
+    gpu_0:
+        kotekan_stage: cudaProcess
+        gpu_id: 0
+        in_buffers:
+            host_bb_phase_buffer: host_bb_phase_buffer
+        out_buffers:
+            host_bb_phase_ringbuffer: host_bb_phase_ringbuffer
+        commands:
+        - name: cudaCopyToRingbuffer
+          input_size: num_frequencies * num_polarizations * bb_num_beams * num_dishes * num_components
+          ring_buffer_size: buffer_depth * input_size
+          in_buf: host_bb_phase_buffer
+          signal_buf: host_bb_phase_ringbuffer
+          gpu_mem_output: bb_phase_buffer
+
 run_bb:
     gpu_0:
         kotekan_stage: cudaProcess
         gpu_id: 0
         in_buffers:
             host_voltage_ringbuffer: host_voltage_ringbuffer
-            host_bb_phase_buffer: host_bb_phase_buffer
+            host_bb_phase_ringbuffer: host_bb_phase_ringbuffer
             host_bb_shift_buffer: host_bb_shift_buffer
         out_buffers:
             host_bb_beams_buffer: host_bb_beams_buffer
         commands:
-        - name: cudaInputData
-          do_once: true
-          in_buf: host_bb_phase_buffer
-          gpu_mem: bb_phase_buffer
         - name: cudaInputData
           do_once: true
           in_buf: host_bb_shift_buffer

--- a/config/fengine/include/bb_hirax.j2
+++ b/config/fengine/include/bb_hirax.j2
@@ -16,13 +16,17 @@ bb_beam_separation_y: 5.0 / 4   # 5 degrees
 #     log2(sqrt(num_dishes)) + 7
 bb_scale: 12
 
+# The phase matrix is valid for this many input samples. It must be a multiple of num_times,
+# the number of input samples the beamformer processes per kernel invocation.
+bb_phase_lifetime_in_samples: 25 * num_times # 1 second
+
 ################################################################################
 
 # Buffers
 
 host_bb_beam_positions_buffer:
     kotekan_buffer: ndarray
-    num_frames: 1
+    num_frames: buffer_depth
     value_type: float32
     extents: [bb_num_beams, 2]
     quantity_name: "bb_beam_positions"
@@ -32,7 +36,7 @@ host_bb_beam_positions_buffer:
 
 host_bb_beam_ids_buffer:
     kotekan_buffer: ndarray
-    num_frames: 1
+    num_frames: buffer_depth
     value_type: uint64
     extents: [bb_num_beams]
     quantity_name: "bb_beam_ids"
@@ -40,14 +44,19 @@ host_bb_beam_ids_buffer:
     dimscalings: [1]
     metadata_pool: main_pool
 
+# One frame is one phase matrix, covering bb_phase_lifetime_in_samples input samples.
 host_bb_phase_buffer:
     kotekan_buffer: ndarray
-    num_frames: 1
+    num_frames: buffer_depth
     value_type: int8
-    extents: [num_frequencies, num_polarizations, bb_num_beams, num_dishes, num_components]
+    extents: [1, num_frequencies, num_polarizations, bb_num_beams, num_dishes, num_components]
     quantity_name: "A"
-    dimnames: ["F", "P", "B", "D", "C"]
-    dimscalings: [1, 1, 1, 1, 1]
+    dimnames: ["Tbb", "F", "P", "B", "D", "C"]
+    dimscalings: [bb_phase_lifetime_in_samples, 1, 1, 1, 1, 1]
+    metadata_pool: main_pool
+host_bb_phase_ringbuffer:
+    kotekan_buffer: ring
+    ring_buffer_size: buffer_depth * num_frequencies * num_polarizations * bb_num_beams * num_dishes * num_components
     metadata_pool: main_pool
 
 host_bb_shift_buffer:
@@ -81,7 +90,7 @@ run_set_bb_beams:
     out_pos_buf: host_bb_beam_positions_buffer
     out_id_buf: host_bb_beam_ids_buffer
     fixed_mode: grid_degrees
-    time_downsampling_fpga: 1
+    time_downsampling_fpga: bb_phase_lifetime_in_samples
     num_x: bb_num_beams_x
     num_y: bb_num_beams_y
     x_min: -bb_beam_separation_x * (bb_num_beams_x - 1) / 2.0
@@ -97,21 +106,35 @@ run_calc_bb_phase:
     bb_phase: host_bb_phase_buffer
     bb_shift: host_bb_shift_buffer
 
+# Send the phase matrix to its GPU ringbuffer. One matrix covers
+# bb_phase_lifetime_in_samples input samples, so this runs far less often than run_bb.
+run_send_bb_phase:
+    gpu_0:
+        kotekan_stage: cudaProcess
+        gpu_id: 0
+        in_buffers:
+            host_bb_phase_buffer: host_bb_phase_buffer
+        out_buffers:
+            host_bb_phase_ringbuffer: host_bb_phase_ringbuffer
+        commands:
+        - name: cudaCopyToRingbuffer
+          input_size: num_frequencies * num_polarizations * bb_num_beams * num_dishes * num_components
+          ring_buffer_size: buffer_depth * input_size
+          in_buf: host_bb_phase_buffer
+          signal_buf: host_bb_phase_ringbuffer
+          gpu_mem_output: bb_phase_buffer
+
 run_bb:
     gpu_0:
         kotekan_stage: cudaProcess
         gpu_id: 0
         in_buffers:
             host_voltage_ringbuffer: host_voltage_ringbuffer
-            host_bb_phase_buffer: host_bb_phase_buffer
+            host_bb_phase_ringbuffer: host_bb_phase_ringbuffer
             host_bb_shift_buffer: host_bb_shift_buffer
         out_buffers:
             host_bb_beams_buffer: host_bb_beams_buffer
         commands:
-        - name: cudaInputData
-          do_once: true
-          in_buf: host_bb_phase_buffer
-          gpu_mem: bb_phase_buffer
         - name: cudaInputData
           do_once: true
           in_buf: host_bb_shift_buffer

--- a/config/fengine/include/bb_pathfinder.j2
+++ b/config/fengine/include/bb_pathfinder.j2
@@ -16,13 +16,17 @@ bb_beam_separation_y: 5.0 / 4   # 5 degrees
 #     log2(sqrt(num_dishes)) + 7
 bb_scale: 12
 
+# The phase matrix is valid for this many input samples. It must be a multiple of num_times,
+# the number of input samples the beamformer processes per kernel invocation.
+bb_phase_lifetime_in_samples: 25 * num_times # 1 second
+
 ################################################################################
 
 # Buffers
 
 host_bb_beam_positions_buffer:
     kotekan_buffer: ndarray
-    num_frames: 1
+    num_frames: buffer_depth
     value_type: float32
     extents: [bb_num_beams, 2]
     quantity_name: "bb_beam_positions"
@@ -32,7 +36,7 @@ host_bb_beam_positions_buffer:
 
 host_bb_beam_ids_buffer:
     kotekan_buffer: ndarray
-    num_frames: 1
+    num_frames: buffer_depth
     value_type: uint64
     extents: [bb_num_beams]
     quantity_name: "bb_beam_ids"
@@ -40,14 +44,19 @@ host_bb_beam_ids_buffer:
     dimscalings: [1]
     metadata_pool: main_pool
 
+# One frame is one phase matrix, covering bb_phase_lifetime_in_samples input samples.
 host_bb_phase_buffer:
     kotekan_buffer: ndarray
-    num_frames: 1
+    num_frames: buffer_depth
     value_type: int8
-    extents: [num_frequencies, num_polarizations, bb_num_beams, num_dishes, num_components]
+    extents: [1, num_frequencies, num_polarizations, bb_num_beams, num_dishes, num_components]
     quantity_name: "A"
-    dimnames: ["F", "P", "B", "D", "C"]
-    dimscalings: [1, 1, 1, 1, 1]
+    dimnames: ["Tbb", "F", "P", "B", "D", "C"]
+    dimscalings: [bb_phase_lifetime_in_samples, 1, 1, 1, 1, 1]
+    metadata_pool: main_pool
+host_bb_phase_ringbuffer:
+    kotekan_buffer: ring
+    ring_buffer_size: buffer_depth * num_frequencies * num_polarizations * bb_num_beams * num_dishes * num_components
     metadata_pool: main_pool
 
 host_bb_shift_buffer:
@@ -81,7 +90,7 @@ run_set_bb_beams:
     out_pos_buf: host_bb_beam_positions_buffer
     out_id_buf: host_bb_beam_ids_buffer
     fixed_mode: grid_degrees
-    time_downsampling_fpga: 1
+    time_downsampling_fpga: bb_phase_lifetime_in_samples
     num_x: bb_num_beams_x
     num_y: bb_num_beams_y
     x_min: -bb_beam_separation_x * (bb_num_beams_x - 1) / 2.0
@@ -97,21 +106,35 @@ run_calc_bb_phase:
     bb_phase: host_bb_phase_buffer
     bb_shift: host_bb_shift_buffer
 
+# Send the phase matrix to its GPU ringbuffer. One matrix covers
+# bb_phase_lifetime_in_samples input samples, so this runs far less often than run_bb.
+run_send_bb_phase:
+    gpu_0:
+        kotekan_stage: cudaProcess
+        gpu_id: 0
+        in_buffers:
+            host_bb_phase_buffer: host_bb_phase_buffer
+        out_buffers:
+            host_bb_phase_ringbuffer: host_bb_phase_ringbuffer
+        commands:
+        - name: cudaCopyToRingbuffer
+          input_size: num_frequencies * num_polarizations * bb_num_beams * num_dishes * num_components
+          ring_buffer_size: buffer_depth * input_size
+          in_buf: host_bb_phase_buffer
+          signal_buf: host_bb_phase_ringbuffer
+          gpu_mem_output: bb_phase_buffer
+
 run_bb:
     gpu_0:
         kotekan_stage: cudaProcess
         gpu_id: 0
         in_buffers:
             host_voltage_ringbuffer: host_voltage_ringbuffer
-            host_bb_phase_buffer: host_bb_phase_buffer
+            host_bb_phase_ringbuffer: host_bb_phase_ringbuffer
             host_bb_shift_buffer: host_bb_shift_buffer
         out_buffers:
             host_bb_beams_buffer: host_bb_beams_buffer
         commands:
-        - name: cudaInputData
-          do_once: true
-          in_buf: host_bb_phase_buffer
-          gpu_mem: bb_phase_buffer
         - name: cudaInputData
           do_once: true
           in_buf: host_bb_shift_buffer

--- a/config/fengine/include/output_charts.j2
+++ b/config/fengine/include/output_charts.j2
@@ -238,7 +238,7 @@ write_data:
         kotekan_stage: hdf5FileWrite
         in_buf: host_bb_phase_buffer
         file_name: bb_phase
-        create_single_file: false  # not time-major
+        create_single_file: true
     write_bb_shift:
         kotekan_stage: hdf5FileWrite
         in_buf: host_bb_shift_buffer

--- a/config/fengine/include/output_chime.j2
+++ b/config/fengine/include/output_chime.j2
@@ -329,7 +329,7 @@ write_data:
         kotekan_stage: hdf5FileWrite
         in_buf: host_bb_phase_buffer
         file_name: bb_phase
-        create_single_file: false  # not time-major
+        create_single_file: true
     write_bb_shift:
         kotekan_stage: hdf5FileWrite
         in_buf: host_bb_shift_buffer

--- a/config/fengine/include/output_chord.j2
+++ b/config/fengine/include/output_chord.j2
@@ -397,7 +397,7 @@ write_data:
         kotekan_stage: hdf5FileWrite
         in_buf: host_bb_phase_buffer
         file_name: bb_phase
-        create_single_file: false  # not time-major
+        create_single_file: true
     write_bb_shift:
         kotekan_stage: hdf5FileWrite
         in_buf: host_bb_shift_buffer

--- a/config/fengine/include/output_hirax.j2
+++ b/config/fengine/include/output_hirax.j2
@@ -301,7 +301,7 @@ write_data:
         kotekan_stage: hdf5FileWrite
         in_buf: host_bb_phase_buffer
         file_name: bb_phase
-        create_single_file: false  # not time-major
+        create_single_file: true
     write_bb_shift:
         kotekan_stage: hdf5FileWrite
         in_buf: host_bb_shift_buffer

--- a/config/fengine/include/output_pathfinder.j2
+++ b/config/fengine/include/output_pathfinder.j2
@@ -397,7 +397,7 @@ write_data:
         kotekan_stage: hdf5FileWrite
         in_buf: host_bb_phase_buffer
         file_name: bb_phase
-        create_single_file: false  # not time-major
+        create_single_file: true
     write_bb_shift:
         kotekan_stage: hdf5FileWrite
         in_buf: host_bb_shift_buffer

--- a/julia/kernels/bb.jl
+++ b/julia/kernels/bb.jl
@@ -119,6 +119,11 @@ end
 
 const Tout = idiv(T, 4)         # always process 1/4 of the ringbuffer at a time
 
+# The phase matrix is recalculated periodically, and the matrices are handed to the GPU through a
+# ring buffer holding this many of them (the Kotekan buffer depth). How many FPGA samples one
+# matrix covers is a run-time setting, `bb_phase_lifetime_in_samples`.
+const Tbb = idiv(T, Tout)
+
 # Since we introduced Tmin and Tmax, we don't support Bt != 1 any more
 # const Bt = 16                   # distribute time samples over that many blocks
 const Bt = 1
@@ -1216,6 +1221,7 @@ function main(; compile_only::Bool=false, output_kernel::Bool=false, run_selftes
                         "hasbuffer" => false,
                         "hasringbuffer" => false,
                         "do_once" => false,
+                        "haslifetime" => false,
                     ),
                     Dict(
                         "name" => "T_max",
@@ -1226,23 +1232,32 @@ function main(; compile_only::Bool=false, output_kernel::Bool=false, run_selftes
                         "hasbuffer" => false,
                         "hasringbuffer" => false,
                         "do_once" => false,
+                        "haslifetime" => false,
                     ),
                     Dict(
                         "name" => "A",
                         "kotekan_name" => "bb_phase_name",
                         "type" => "int8",
+                        # The slowest axis is the ring buffer direction. Its `dimscaling` is a
+                        # placeholder; it is overwritten at run time with the configured
+                        # `bb_phase_lifetime_in_samples`. The kernel itself still sees a single
+                        # phase matrix: the wrapper passes it the element covering the voltage
+                        # samples being processed.
                         "axes" => [
                             Dict("label" => "C", "length" => C, "dimscaling" => 1),
                             Dict("label" => "D", "length" => D, "dimscaling" => 1),
                             Dict("label" => "B", "length" => B, "dimscaling" => 1),
                             Dict("label" => "P", "length" => P, "dimscaling" => 1),
                             Dict("label" => "F", "length" => F, "dimscaling" => 1),
+                            Dict("label" => "Tbb", "length" => Tbb, "dimscaling" => 1),
                         ],
                         "isoutput" => false,
                         "isscalar" => false,
                         "hasbuffer" => true,
-                        "hasringbuffer" => false,
-                        "do_once" => true,
+                        "hasringbuffer" => true,
+                        "do_once" => false,
+                        "haslifetime" => true,
+                        "lifetime_config" => "bb_phase_lifetime_in_samples",
                     ),
                     Dict(
                         "name" => "E",
@@ -1259,6 +1274,7 @@ function main(; compile_only::Bool=false, output_kernel::Bool=false, run_selftes
                         "hasbuffer" => true,
                         "hasringbuffer" => true,
                         "do_once" => false,
+                        "haslifetime" => false,
                     ),
                     Dict(
                         "name" => "s",
@@ -1274,6 +1290,7 @@ function main(; compile_only::Bool=false, output_kernel::Bool=false, run_selftes
                         "hasbuffer" => true,
                         "hasringbuffer" => false,
                         "do_once" => true,
+                        "haslifetime" => false,
                     ),
                     Dict(
                         "name" => "J",
@@ -1291,6 +1308,7 @@ function main(; compile_only::Bool=false, output_kernel::Bool=false, run_selftes
                         "hasbuffer" => true,
                         "hasringbuffer" => false,
                         "do_once" => false,
+                        "haslifetime" => false,
                     ),
                     Dict(
                         "name" => "info",
@@ -1306,6 +1324,7 @@ function main(; compile_only::Bool=false, output_kernel::Bool=false, run_selftes
                         "hasbuffer" => false,
                         "hasringbuffer" => false,
                         "do_once" => false,
+                        "haslifetime" => false,
                     ),
                     Dict(
                         "name" => "log",
@@ -1319,6 +1338,7 @@ function main(; compile_only::Bool=false, output_kernel::Bool=false, run_selftes
                         "hasbuffer" => false,
                         "hasringbuffer" => false,
                         "do_once" => false,
+                        "haslifetime" => false,
                     ),
                 ],
             ),

--- a/julia/kernels/bb_template.cxx
+++ b/julia/kernels/bb_template.cxx
@@ -39,6 +39,16 @@ std::array<T, D> reverse(const std::array<T, D>& values) {
         result[d] = values[D - 1 - d];
     return result;
 }
+
+// Override the leading (slowest) dimension's scaling with a run-time value. Used for inputs
+// that are valid for a configurable number of FPGA samples, such as the phase matrix.
+template<std::size_t D>
+std::array<std::ptrdiff_t, D> with_leading_dimscaling(std::array<std::ptrdiff_t, D> dimscalings,
+                                                      const std::ptrdiff_t dimscaling) {
+    static_assert(D > 0);
+    dimscalings[0] = dimscaling;
+    return dimscalings;
+}
 }
 
 /**
@@ -151,6 +161,13 @@ private:
         {{/isscalar}}
     {{/kernel_arguments}}
 
+    // Lifetimes of slowly varying inputs, in FPGA samples
+    {{#kernel_arguments}}
+        {{#haslifetime}}
+            const std::ptrdiff_t {{{name}}}_lifetime_in_samples;
+        {{/haslifetime}}
+    {{/kernel_arguments}}
+
     // Buffers
     {{#kernel_arguments}}
         {{^isscalar}}
@@ -197,6 +214,12 @@ cuda{{{kernel_name}}}::cuda{{{kernel_name}}}(Config& config,
     {{/kernel_arguments}}
 
     {{#kernel_arguments}}
+        {{#haslifetime}}
+            {{{name}}}_lifetime_in_samples(config.get<std::int64_t>(unique_name, "{{{lifetime_config}}}")),
+        {{/haslifetime}}
+    {{/kernel_arguments}}
+
+    {{#kernel_arguments}}
         {{^isscalar}}
             {{#hasbuffer}}
                 {{#hasringbuffer}}
@@ -205,7 +228,12 @@ cuda{{{kernel_name}}}::cuda{{{kernel_name}}}(Config& config,
                         {{{name}}}_quantity,
                         reverse({{{name}}}_lengths),
                         reverse({{{name}}}_labels),
-                        reverse({{{name}}}_dimscalings),
+                        {{#haslifetime}}
+                            with_leading_dimscaling(reverse({{{name}}}_dimscalings), {{{name}}}_lifetime_in_samples),
+                        {{/haslifetime}}
+                        {{^haslifetime}}
+                            reverse({{{name}}}_dimscalings),
+                        {{/haslifetime}}
                         *this
                     ),
                 {{/hasringbuffer}}
@@ -269,6 +297,23 @@ cuda{{{kernel_name}}}::cuda{{{kernel_name}}}(Config& config,
         {{/isscalar}}
     {{/kernel_arguments}}
 
+    // Slowly varying inputs are held in a ring buffer and read without claiming, one element
+    // per lifetime. The output `J` is a regular buffer, so the number of time samples per
+    // kernel invocation is fixed by the output frame size and cannot be shrunk to fit a
+    // lifetime -- hence the lifetime has to be a whole number of invocations instead.
+    {{#kernel_arguments}}
+        {{#haslifetime}}
+            {
+                const std::ptrdiff_t T_read_max = E_buffer.get_ndarray().extent(0) / 4;
+                if ({{{name}}}_lifetime_in_samples <= 0
+                    || {{{name}}}_lifetime_in_samples % T_read_max != 0)
+                    FATAL_ERROR("{{{lifetime_config}}} {:d} must be a positive multiple of the "
+                                "processing cadence of {:d} time samples",
+                                {{{name}}}_lifetime_in_samples, T_read_max);
+            }
+        {{/haslifetime}}
+    {{/kernel_arguments}}
+
     set_command_type(gpuCommandType::KERNEL);
 
     // Build the PTX once per device: the kernels live in this device's `runtime_kernels`, shared
@@ -304,6 +349,42 @@ int cuda{{{kernel_name}}}::wait_on_precondition() {
         if (errcode < 0)
             return errcode;
     }
+
+    // Slowly varying inputs: locate the element covering the voltage samples we just claimed,
+    // then read it. We read the same element on every invocation within its lifetime, and claim
+    // it only on the last one, so that the producer can recycle it afterwards.
+    {{#kernel_arguments}}
+        {{#haslifetime}}
+            {
+                const std::ptrdiff_t T_begin = E_buffer.get_read_valid().begin();
+                const std::ptrdiff_t T_end = E_buffer.get_read_valid().end();
+                const std::ptrdiff_t element = kotekan::div(T_begin, {{{name}}}_lifetime_in_samples);
+                const std::ptrdiff_t lifetime_end = (element + 1) * {{{name}}}_lifetime_in_samples;
+                // The constructor checks the cadences against each other; a short read (a starved
+                // voltage ring buffer) can still push a window across a boundary.
+                if (T_end > lifetime_end)
+                    FATAL_ERROR("voltage samples [{:d},{:d}) straddle the end {:d} of {{{name}}} "
+                                "element {:d}; {{{lifetime_config}}} {:d} and the voltage stream "
+                                "are not aligned",
+                                T_begin, T_end, lifetime_end, element,
+                                {{{name}}}_lifetime_in_samples);
+                const bool last_use = T_end == lifetime_end;
+                DEBUG("Waiting for {{{name}}} input ringbuffer data for frame {:d}...", gpu_frame_id);
+                const int errcode = {{{name}}}_buffer.wait_and_claim_readable(
+                    [&](const std::ptrdiff_t available_elements) {
+                        if (available_elements < 1)
+                            return read_descriptor_t{.claimed = 0, .read = 0};
+                        return read_descriptor_t{.claimed = last_use ? 1 : 0, .read = 1};
+                    });
+                if (errcode < 0)
+                    return errcode;
+                DEBUG("Done waiting for {{{name}}} input ringbuffer data for frame {:d}; "
+                      "using element {:d}{:s}",
+                      gpu_frame_id, element, last_use ? " (last use)" : "");
+                assert({{{name}}}_buffer.get_read_valid().begin() == element);
+            }
+        {{/haslifetime}}
+    {{/kernel_arguments}}
 
     return 0;
 }
@@ -348,6 +429,20 @@ cudaEvent_t cuda{{{kernel_name}}}::execute(cudaPipelineState& /*pipestate*/, con
     // Set E_memory to beginning of input ring buffer
     E_arg = array_desc(E_memory, E_length_in_bytes);
 
+    // Slowly varying inputs: the kernel wants a single element, not the whole ring buffer.
+    {{#kernel_arguments}}
+        {{#haslifetime}}
+            {
+                const std::ptrdiff_t ring_length = {{{name}}}_buffer.get_ndarray().extent(0);
+                const std::ptrdiff_t element = {{{name}}}_buffer.get_read_valid().begin();
+                {{{name}}}_arg = array_desc({{{name}}}_buffer.get_ndarray().data()
+                                                + {{{name}}}_buffer.get_ndarray().stride(0)
+                                                      * (element % ring_length),
+                                            {{{name}}}_length_in_bytes / ring_length);
+            }
+        {{/haslifetime}}
+    {{/kernel_arguments}}
+
     // Ringbuffer size
     const std::ptrdiff_t T_ringbuf = E_buffer.get_ndarray().extent(0);
 
@@ -372,6 +467,16 @@ cudaEvent_t cuda{{{kernel_name}}}::execute(cudaPipelineState& /*pipestate*/, con
         J_meta->set_fpga_seq_num(E_meta->get_fpga_seq_num()
                                  + T_min * E_meta->get_time_downsampling_fpga());
         assert(J_meta->get_time_downsampling_fpga() == 1);
+
+        // Element `k` of a slowly varying input covers the samples `k * lifetime` onwards,
+        // counted from the voltage ring buffer's logical beginning -- so the two streams have
+        // to start at the same sequence number.
+        {{#kernel_arguments}}
+            {{#haslifetime}}
+                assert({{{name}}}_buffer.get_metadata()->get_fpga_seq_num()
+                       == E_meta->get_fpga_seq_num());
+            {{/haslifetime}}
+        {{/kernel_arguments}}
     }
 
     // Copy inputs to device memory
@@ -491,8 +596,13 @@ cudaEvent_t cuda{{{kernel_name}}}::execute(cudaPipelineState& /*pipestate*/, con
 }
 
 void cuda{{{kernel_name}}}::finalize_frame() {
-    // Advance the input ring buffer
+    // Advance the input ring buffers
     E_buffer.finish_read();
+    {{#kernel_arguments}}
+        {{#haslifetime}}
+            {{{name}}}_buffer.finish_read();
+        {{/haslifetime}}
+    {{/kernel_arguments}}
 
     cudaCommand::finalize_frame();
 }

--- a/lib/cuda/generated/cudaBasebandBeamformer_charts.cpp
+++ b/lib/cuda/generated/cudaBasebandBeamformer_charts.cpp
@@ -39,6 +39,16 @@ std::array<T, D> reverse(const std::array<T, D>& values) {
         result[d] = values[D - 1 - d];
     return result;
 }
+
+// Override the leading (slowest) dimension's scaling with a run-time value. Used for inputs
+// that are valid for a configurable number of FPGA samples, such as the phase matrix.
+template<std::size_t D>
+std::array<std::ptrdiff_t, D> with_leading_dimscaling(std::array<std::ptrdiff_t, D> dimscalings,
+                                                      const std::ptrdiff_t dimscaling) {
+    static_assert(D > 0);
+    dimscalings[0] = dimscaling;
+    return dimscalings;
+}
 }
 
 /**
@@ -115,16 +125,17 @@ private:
         A_index_B,
         A_index_P,
         A_index_F,
+        A_index_Tbb,
         A_rank,
     };
     static constexpr std::array<const char*, A_rank> A_labels = {
-        "C", "D", "B", "P", "F",
+        "C", "D", "B", "P", "F", "Tbb",
     };
     static constexpr std::array<std::ptrdiff_t, A_rank> A_lengths = {
-        2, 64, 16, 2, 336,
+        2, 64, 16, 2, 336, 4,
     };
     static constexpr std::array<std::ptrdiff_t, A_rank> A_dimscalings = {
-        1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1,
     };
     static constexpr auto A_calc_stride = [](int dim) {
         std::ptrdiff_t str = 1;
@@ -134,7 +145,8 @@ private:
     };
     static constexpr std::array<std::ptrdiff_t, A_rank + 1> A_strides = {
         A_calc_stride(A_index_C), A_calc_stride(A_index_D), A_calc_stride(A_index_B),
-        A_calc_stride(A_index_P), A_calc_stride(A_index_F), A_calc_stride(A_rank),
+        A_calc_stride(A_index_P), A_calc_stride(A_index_F), A_calc_stride(A_index_Tbb),
+        A_calc_stride(A_rank),
     };
     static constexpr std::ptrdiff_t A_length = A_strides[A_rank];
     static constexpr std::ptrdiff_t A_length_in_bytes = type_total_bytes(A_type) * A_length;
@@ -332,8 +344,11 @@ private:
     const std::string info_name;
     const std::string log_name;
 
+    // Lifetimes of slowly varying inputs, in FPGA samples
+    const std::ptrdiff_t A_lifetime_in_samples;
+
     // Buffers
-    NDArrayBuffer<kotekan::GetType_t<A_type>, A_rank> A_buffer;
+    NDArrayRingBuffer<kotekan::GetType_t<A_type>, A_rank> A_buffer;
     NDArrayRingBuffer<kotekan::GetType_t<E_type>, E_rank> E_buffer;
     NDArrayBuffer<kotekan::GetType_t<s_type>, s_rank> s_buffer;
     NDArrayBuffer<kotekan::GetType_t<J_type>, J_rank> J_buffer;
@@ -364,8 +379,10 @@ cudaBasebandBeamformer_charts::cudaBasebandBeamformer_charts(Config& config,
     J_name(config.get<std::string>(unique_name, "bb_beams_name")),
     info_name(unique_name + "/gpu_mem_info"), log_name(unique_name + "/gpu_mem_log"),
 
-    A_buffer(A_name, A_quantity, reverse(A_lengths), reverse(A_labels), reverse(A_dimscalings),
-             *this, buffer_type_t::do_once),
+    A_lifetime_in_samples(config.get<std::int64_t>(unique_name, "bb_phase_lifetime_in_samples")),
+
+    A_buffer(A_name, A_quantity, reverse(A_lengths), reverse(A_labels),
+             with_leading_dimscaling(reverse(A_dimscalings), A_lifetime_in_samples), *this),
     E_buffer(E_name, E_quantity, reverse(E_lengths), reverse(E_labels), reverse(E_dimscalings),
              *this),
     s_buffer(s_name, s_quantity, reverse(s_lengths), reverse(s_labels), reverse(s_dimscalings),
@@ -400,6 +417,18 @@ cudaBasebandBeamformer_charts::cudaBasebandBeamformer_charts(Config& config,
         {.name = info_name, .is_array = true, .does_read = true, .does_write = true});
     register_gpu_buffer_user(
         {.name = log_name, .is_array = true, .does_read = true, .does_write = true});
+
+    // Slowly varying inputs are held in a ring buffer and read without claiming, one element
+    // per lifetime. The output `J` is a regular buffer, so the number of time samples per
+    // kernel invocation is fixed by the output frame size and cannot be shrunk to fit a
+    // lifetime -- hence the lifetime has to be a whole number of invocations instead.
+    {
+        const std::ptrdiff_t T_read_max = E_buffer.get_ndarray().extent(0) / 4;
+        if (A_lifetime_in_samples <= 0 || A_lifetime_in_samples % T_read_max != 0)
+            FATAL_ERROR("bb_phase_lifetime_in_samples {:d} must be a positive multiple of the "
+                        "processing cadence of {:d} time samples",
+                        A_lifetime_in_samples, T_read_max);
+    }
 
     set_command_type(gpuCommandType::KERNEL);
 
@@ -439,6 +468,37 @@ int cudaBasebandBeamformer_charts::wait_on_precondition() {
             return errcode;
     }
 
+    // Slowly varying inputs: locate the element covering the voltage samples we just claimed,
+    // then read it. We read the same element on every invocation within its lifetime, and claim
+    // it only on the last one, so that the producer can recycle it afterwards.
+    {
+        const std::ptrdiff_t T_begin = E_buffer.get_read_valid().begin();
+        const std::ptrdiff_t T_end = E_buffer.get_read_valid().end();
+        const std::ptrdiff_t element = kotekan::div(T_begin, A_lifetime_in_samples);
+        const std::ptrdiff_t lifetime_end = (element + 1) * A_lifetime_in_samples;
+        // The constructor checks the cadences against each other; a short read (a starved
+        // voltage ring buffer) can still push a window across a boundary.
+        if (T_end > lifetime_end)
+            FATAL_ERROR("voltage samples [{:d},{:d}) straddle the end {:d} of A "
+                        "element {:d}; bb_phase_lifetime_in_samples {:d} and the voltage stream "
+                        "are not aligned",
+                        T_begin, T_end, lifetime_end, element, A_lifetime_in_samples);
+        const bool last_use = T_end == lifetime_end;
+        DEBUG("Waiting for A input ringbuffer data for frame {:d}...", gpu_frame_id);
+        const int errcode =
+            A_buffer.wait_and_claim_readable([&](const std::ptrdiff_t available_elements) {
+                if (available_elements < 1)
+                    return read_descriptor_t{.claimed = 0, .read = 0};
+                return read_descriptor_t{.claimed = last_use ? 1 : 0, .read = 1};
+            });
+        if (errcode < 0)
+            return errcode;
+        DEBUG("Done waiting for A input ringbuffer data for frame {:d}; "
+              "using element {:d}{:s}",
+              gpu_frame_id, element, last_use ? " (last use)" : "");
+        assert(A_buffer.get_read_valid().begin() == element);
+    }
+
     return 0;
 }
 
@@ -475,6 +535,15 @@ cudaEvent_t cudaBasebandBeamformer_charts::execute(cudaPipelineState& /*pipestat
     // Set E_memory to beginning of input ring buffer
     E_arg = array_desc(E_memory, E_length_in_bytes);
 
+    // Slowly varying inputs: the kernel wants a single element, not the whole ring buffer.
+    {
+        const std::ptrdiff_t ring_length = A_buffer.get_ndarray().extent(0);
+        const std::ptrdiff_t element = A_buffer.get_read_valid().begin();
+        A_arg = array_desc(A_buffer.get_ndarray().data()
+                               + A_buffer.get_ndarray().stride(0) * (element % ring_length),
+                           A_length_in_bytes / ring_length);
+    }
+
     // Ringbuffer size
     const std::ptrdiff_t T_ringbuf = E_buffer.get_ndarray().extent(0);
 
@@ -499,6 +568,11 @@ cudaEvent_t cudaBasebandBeamformer_charts::execute(cudaPipelineState& /*pipestat
         J_meta->set_fpga_seq_num(E_meta->get_fpga_seq_num()
                                  + T_min * E_meta->get_time_downsampling_fpga());
         assert(J_meta->get_time_downsampling_fpga() == 1);
+
+        // Element `k` of a slowly varying input covers the samples `k * lifetime` onwards,
+        // counted from the voltage ring buffer's logical beginning -- so the two streams have
+        // to start at the same sequence number.
+        assert(A_buffer.get_metadata()->get_fpga_seq_num() == E_meta->get_fpga_seq_num());
     }
 
     // Copy inputs to device memory
@@ -589,8 +663,9 @@ cudaEvent_t cudaBasebandBeamformer_charts::execute(cudaPipelineState& /*pipestat
 }
 
 void cudaBasebandBeamformer_charts::finalize_frame() {
-    // Advance the input ring buffer
+    // Advance the input ring buffers
     E_buffer.finish_read();
+    A_buffer.finish_read();
 
     cudaCommand::finalize_frame();
 }

--- a/lib/cuda/generated/cudaBasebandBeamformer_chime.cpp
+++ b/lib/cuda/generated/cudaBasebandBeamformer_chime.cpp
@@ -39,6 +39,16 @@ std::array<T, D> reverse(const std::array<T, D>& values) {
         result[d] = values[D - 1 - d];
     return result;
 }
+
+// Override the leading (slowest) dimension's scaling with a run-time value. Used for inputs
+// that are valid for a configurable number of FPGA samples, such as the phase matrix.
+template<std::size_t D>
+std::array<std::ptrdiff_t, D> with_leading_dimscaling(std::array<std::ptrdiff_t, D> dimscalings,
+                                                      const std::ptrdiff_t dimscaling) {
+    static_assert(D > 0);
+    dimscalings[0] = dimscaling;
+    return dimscalings;
+}
 }
 
 /**
@@ -115,16 +125,17 @@ private:
         A_index_B,
         A_index_P,
         A_index_F,
+        A_index_Tbb,
         A_rank,
     };
     static constexpr std::array<const char*, A_rank> A_labels = {
-        "C", "D", "B", "P", "F",
+        "C", "D", "B", "P", "F", "Tbb",
     };
     static constexpr std::array<std::ptrdiff_t, A_rank> A_lengths = {
-        2, 1024, 32, 2, 16,
+        2, 1024, 32, 2, 16, 4,
     };
     static constexpr std::array<std::ptrdiff_t, A_rank> A_dimscalings = {
-        1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1,
     };
     static constexpr auto A_calc_stride = [](int dim) {
         std::ptrdiff_t str = 1;
@@ -134,7 +145,8 @@ private:
     };
     static constexpr std::array<std::ptrdiff_t, A_rank + 1> A_strides = {
         A_calc_stride(A_index_C), A_calc_stride(A_index_D), A_calc_stride(A_index_B),
-        A_calc_stride(A_index_P), A_calc_stride(A_index_F), A_calc_stride(A_rank),
+        A_calc_stride(A_index_P), A_calc_stride(A_index_F), A_calc_stride(A_index_Tbb),
+        A_calc_stride(A_rank),
     };
     static constexpr std::ptrdiff_t A_length = A_strides[A_rank];
     static constexpr std::ptrdiff_t A_length_in_bytes = type_total_bytes(A_type) * A_length;
@@ -332,8 +344,11 @@ private:
     const std::string info_name;
     const std::string log_name;
 
+    // Lifetimes of slowly varying inputs, in FPGA samples
+    const std::ptrdiff_t A_lifetime_in_samples;
+
     // Buffers
-    NDArrayBuffer<kotekan::GetType_t<A_type>, A_rank> A_buffer;
+    NDArrayRingBuffer<kotekan::GetType_t<A_type>, A_rank> A_buffer;
     NDArrayRingBuffer<kotekan::GetType_t<E_type>, E_rank> E_buffer;
     NDArrayBuffer<kotekan::GetType_t<s_type>, s_rank> s_buffer;
     NDArrayBuffer<kotekan::GetType_t<J_type>, J_rank> J_buffer;
@@ -364,8 +379,10 @@ cudaBasebandBeamformer_chime::cudaBasebandBeamformer_chime(Config& config,
     J_name(config.get<std::string>(unique_name, "bb_beams_name")),
     info_name(unique_name + "/gpu_mem_info"), log_name(unique_name + "/gpu_mem_log"),
 
-    A_buffer(A_name, A_quantity, reverse(A_lengths), reverse(A_labels), reverse(A_dimscalings),
-             *this, buffer_type_t::do_once),
+    A_lifetime_in_samples(config.get<std::int64_t>(unique_name, "bb_phase_lifetime_in_samples")),
+
+    A_buffer(A_name, A_quantity, reverse(A_lengths), reverse(A_labels),
+             with_leading_dimscaling(reverse(A_dimscalings), A_lifetime_in_samples), *this),
     E_buffer(E_name, E_quantity, reverse(E_lengths), reverse(E_labels), reverse(E_dimscalings),
              *this),
     s_buffer(s_name, s_quantity, reverse(s_lengths), reverse(s_labels), reverse(s_dimscalings),
@@ -400,6 +417,18 @@ cudaBasebandBeamformer_chime::cudaBasebandBeamformer_chime(Config& config,
         {.name = info_name, .is_array = true, .does_read = true, .does_write = true});
     register_gpu_buffer_user(
         {.name = log_name, .is_array = true, .does_read = true, .does_write = true});
+
+    // Slowly varying inputs are held in a ring buffer and read without claiming, one element
+    // per lifetime. The output `J` is a regular buffer, so the number of time samples per
+    // kernel invocation is fixed by the output frame size and cannot be shrunk to fit a
+    // lifetime -- hence the lifetime has to be a whole number of invocations instead.
+    {
+        const std::ptrdiff_t T_read_max = E_buffer.get_ndarray().extent(0) / 4;
+        if (A_lifetime_in_samples <= 0 || A_lifetime_in_samples % T_read_max != 0)
+            FATAL_ERROR("bb_phase_lifetime_in_samples {:d} must be a positive multiple of the "
+                        "processing cadence of {:d} time samples",
+                        A_lifetime_in_samples, T_read_max);
+    }
 
     set_command_type(gpuCommandType::KERNEL);
 
@@ -439,6 +468,37 @@ int cudaBasebandBeamformer_chime::wait_on_precondition() {
             return errcode;
     }
 
+    // Slowly varying inputs: locate the element covering the voltage samples we just claimed,
+    // then read it. We read the same element on every invocation within its lifetime, and claim
+    // it only on the last one, so that the producer can recycle it afterwards.
+    {
+        const std::ptrdiff_t T_begin = E_buffer.get_read_valid().begin();
+        const std::ptrdiff_t T_end = E_buffer.get_read_valid().end();
+        const std::ptrdiff_t element = kotekan::div(T_begin, A_lifetime_in_samples);
+        const std::ptrdiff_t lifetime_end = (element + 1) * A_lifetime_in_samples;
+        // The constructor checks the cadences against each other; a short read (a starved
+        // voltage ring buffer) can still push a window across a boundary.
+        if (T_end > lifetime_end)
+            FATAL_ERROR("voltage samples [{:d},{:d}) straddle the end {:d} of A "
+                        "element {:d}; bb_phase_lifetime_in_samples {:d} and the voltage stream "
+                        "are not aligned",
+                        T_begin, T_end, lifetime_end, element, A_lifetime_in_samples);
+        const bool last_use = T_end == lifetime_end;
+        DEBUG("Waiting for A input ringbuffer data for frame {:d}...", gpu_frame_id);
+        const int errcode =
+            A_buffer.wait_and_claim_readable([&](const std::ptrdiff_t available_elements) {
+                if (available_elements < 1)
+                    return read_descriptor_t{.claimed = 0, .read = 0};
+                return read_descriptor_t{.claimed = last_use ? 1 : 0, .read = 1};
+            });
+        if (errcode < 0)
+            return errcode;
+        DEBUG("Done waiting for A input ringbuffer data for frame {:d}; "
+              "using element {:d}{:s}",
+              gpu_frame_id, element, last_use ? " (last use)" : "");
+        assert(A_buffer.get_read_valid().begin() == element);
+    }
+
     return 0;
 }
 
@@ -475,6 +535,15 @@ cudaEvent_t cudaBasebandBeamformer_chime::execute(cudaPipelineState& /*pipestate
     // Set E_memory to beginning of input ring buffer
     E_arg = array_desc(E_memory, E_length_in_bytes);
 
+    // Slowly varying inputs: the kernel wants a single element, not the whole ring buffer.
+    {
+        const std::ptrdiff_t ring_length = A_buffer.get_ndarray().extent(0);
+        const std::ptrdiff_t element = A_buffer.get_read_valid().begin();
+        A_arg = array_desc(A_buffer.get_ndarray().data()
+                               + A_buffer.get_ndarray().stride(0) * (element % ring_length),
+                           A_length_in_bytes / ring_length);
+    }
+
     // Ringbuffer size
     const std::ptrdiff_t T_ringbuf = E_buffer.get_ndarray().extent(0);
 
@@ -499,6 +568,11 @@ cudaEvent_t cudaBasebandBeamformer_chime::execute(cudaPipelineState& /*pipestate
         J_meta->set_fpga_seq_num(E_meta->get_fpga_seq_num()
                                  + T_min * E_meta->get_time_downsampling_fpga());
         assert(J_meta->get_time_downsampling_fpga() == 1);
+
+        // Element `k` of a slowly varying input covers the samples `k * lifetime` onwards,
+        // counted from the voltage ring buffer's logical beginning -- so the two streams have
+        // to start at the same sequence number.
+        assert(A_buffer.get_metadata()->get_fpga_seq_num() == E_meta->get_fpga_seq_num());
     }
 
     // Copy inputs to device memory
@@ -589,8 +663,9 @@ cudaEvent_t cudaBasebandBeamformer_chime::execute(cudaPipelineState& /*pipestate
 }
 
 void cudaBasebandBeamformer_chime::finalize_frame() {
-    // Advance the input ring buffer
+    // Advance the input ring buffers
     E_buffer.finish_read();
+    A_buffer.finish_read();
 
     cudaCommand::finalize_frame();
 }

--- a/lib/cuda/generated/cudaBasebandBeamformer_chord.cpp
+++ b/lib/cuda/generated/cudaBasebandBeamformer_chord.cpp
@@ -39,6 +39,16 @@ std::array<T, D> reverse(const std::array<T, D>& values) {
         result[d] = values[D - 1 - d];
     return result;
 }
+
+// Override the leading (slowest) dimension's scaling with a run-time value. Used for inputs
+// that are valid for a configurable number of FPGA samples, such as the phase matrix.
+template<std::size_t D>
+std::array<std::ptrdiff_t, D> with_leading_dimscaling(std::array<std::ptrdiff_t, D> dimscalings,
+                                                      const std::ptrdiff_t dimscaling) {
+    static_assert(D > 0);
+    dimscalings[0] = dimscaling;
+    return dimscalings;
+}
 }
 
 /**
@@ -115,16 +125,17 @@ private:
         A_index_B,
         A_index_P,
         A_index_F,
+        A_index_Tbb,
         A_rank,
     };
     static constexpr std::array<const char*, A_rank> A_labels = {
-        "C", "D", "B", "P", "F",
+        "C", "D", "B", "P", "F", "Tbb",
     };
     static constexpr std::array<std::ptrdiff_t, A_rank> A_lengths = {
-        2, 512, 96, 2, 48,
+        2, 512, 96, 2, 48, 4,
     };
     static constexpr std::array<std::ptrdiff_t, A_rank> A_dimscalings = {
-        1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1,
     };
     static constexpr auto A_calc_stride = [](int dim) {
         std::ptrdiff_t str = 1;
@@ -134,7 +145,8 @@ private:
     };
     static constexpr std::array<std::ptrdiff_t, A_rank + 1> A_strides = {
         A_calc_stride(A_index_C), A_calc_stride(A_index_D), A_calc_stride(A_index_B),
-        A_calc_stride(A_index_P), A_calc_stride(A_index_F), A_calc_stride(A_rank),
+        A_calc_stride(A_index_P), A_calc_stride(A_index_F), A_calc_stride(A_index_Tbb),
+        A_calc_stride(A_rank),
     };
     static constexpr std::ptrdiff_t A_length = A_strides[A_rank];
     static constexpr std::ptrdiff_t A_length_in_bytes = type_total_bytes(A_type) * A_length;
@@ -332,8 +344,11 @@ private:
     const std::string info_name;
     const std::string log_name;
 
+    // Lifetimes of slowly varying inputs, in FPGA samples
+    const std::ptrdiff_t A_lifetime_in_samples;
+
     // Buffers
-    NDArrayBuffer<kotekan::GetType_t<A_type>, A_rank> A_buffer;
+    NDArrayRingBuffer<kotekan::GetType_t<A_type>, A_rank> A_buffer;
     NDArrayRingBuffer<kotekan::GetType_t<E_type>, E_rank> E_buffer;
     NDArrayBuffer<kotekan::GetType_t<s_type>, s_rank> s_buffer;
     NDArrayBuffer<kotekan::GetType_t<J_type>, J_rank> J_buffer;
@@ -364,8 +379,10 @@ cudaBasebandBeamformer_chord::cudaBasebandBeamformer_chord(Config& config,
     J_name(config.get<std::string>(unique_name, "bb_beams_name")),
     info_name(unique_name + "/gpu_mem_info"), log_name(unique_name + "/gpu_mem_log"),
 
-    A_buffer(A_name, A_quantity, reverse(A_lengths), reverse(A_labels), reverse(A_dimscalings),
-             *this, buffer_type_t::do_once),
+    A_lifetime_in_samples(config.get<std::int64_t>(unique_name, "bb_phase_lifetime_in_samples")),
+
+    A_buffer(A_name, A_quantity, reverse(A_lengths), reverse(A_labels),
+             with_leading_dimscaling(reverse(A_dimscalings), A_lifetime_in_samples), *this),
     E_buffer(E_name, E_quantity, reverse(E_lengths), reverse(E_labels), reverse(E_dimscalings),
              *this),
     s_buffer(s_name, s_quantity, reverse(s_lengths), reverse(s_labels), reverse(s_dimscalings),
@@ -400,6 +417,18 @@ cudaBasebandBeamformer_chord::cudaBasebandBeamformer_chord(Config& config,
         {.name = info_name, .is_array = true, .does_read = true, .does_write = true});
     register_gpu_buffer_user(
         {.name = log_name, .is_array = true, .does_read = true, .does_write = true});
+
+    // Slowly varying inputs are held in a ring buffer and read without claiming, one element
+    // per lifetime. The output `J` is a regular buffer, so the number of time samples per
+    // kernel invocation is fixed by the output frame size and cannot be shrunk to fit a
+    // lifetime -- hence the lifetime has to be a whole number of invocations instead.
+    {
+        const std::ptrdiff_t T_read_max = E_buffer.get_ndarray().extent(0) / 4;
+        if (A_lifetime_in_samples <= 0 || A_lifetime_in_samples % T_read_max != 0)
+            FATAL_ERROR("bb_phase_lifetime_in_samples {:d} must be a positive multiple of the "
+                        "processing cadence of {:d} time samples",
+                        A_lifetime_in_samples, T_read_max);
+    }
 
     set_command_type(gpuCommandType::KERNEL);
 
@@ -439,6 +468,37 @@ int cudaBasebandBeamformer_chord::wait_on_precondition() {
             return errcode;
     }
 
+    // Slowly varying inputs: locate the element covering the voltage samples we just claimed,
+    // then read it. We read the same element on every invocation within its lifetime, and claim
+    // it only on the last one, so that the producer can recycle it afterwards.
+    {
+        const std::ptrdiff_t T_begin = E_buffer.get_read_valid().begin();
+        const std::ptrdiff_t T_end = E_buffer.get_read_valid().end();
+        const std::ptrdiff_t element = kotekan::div(T_begin, A_lifetime_in_samples);
+        const std::ptrdiff_t lifetime_end = (element + 1) * A_lifetime_in_samples;
+        // The constructor checks the cadences against each other; a short read (a starved
+        // voltage ring buffer) can still push a window across a boundary.
+        if (T_end > lifetime_end)
+            FATAL_ERROR("voltage samples [{:d},{:d}) straddle the end {:d} of A "
+                        "element {:d}; bb_phase_lifetime_in_samples {:d} and the voltage stream "
+                        "are not aligned",
+                        T_begin, T_end, lifetime_end, element, A_lifetime_in_samples);
+        const bool last_use = T_end == lifetime_end;
+        DEBUG("Waiting for A input ringbuffer data for frame {:d}...", gpu_frame_id);
+        const int errcode =
+            A_buffer.wait_and_claim_readable([&](const std::ptrdiff_t available_elements) {
+                if (available_elements < 1)
+                    return read_descriptor_t{.claimed = 0, .read = 0};
+                return read_descriptor_t{.claimed = last_use ? 1 : 0, .read = 1};
+            });
+        if (errcode < 0)
+            return errcode;
+        DEBUG("Done waiting for A input ringbuffer data for frame {:d}; "
+              "using element {:d}{:s}",
+              gpu_frame_id, element, last_use ? " (last use)" : "");
+        assert(A_buffer.get_read_valid().begin() == element);
+    }
+
     return 0;
 }
 
@@ -475,6 +535,15 @@ cudaEvent_t cudaBasebandBeamformer_chord::execute(cudaPipelineState& /*pipestate
     // Set E_memory to beginning of input ring buffer
     E_arg = array_desc(E_memory, E_length_in_bytes);
 
+    // Slowly varying inputs: the kernel wants a single element, not the whole ring buffer.
+    {
+        const std::ptrdiff_t ring_length = A_buffer.get_ndarray().extent(0);
+        const std::ptrdiff_t element = A_buffer.get_read_valid().begin();
+        A_arg = array_desc(A_buffer.get_ndarray().data()
+                               + A_buffer.get_ndarray().stride(0) * (element % ring_length),
+                           A_length_in_bytes / ring_length);
+    }
+
     // Ringbuffer size
     const std::ptrdiff_t T_ringbuf = E_buffer.get_ndarray().extent(0);
 
@@ -499,6 +568,11 @@ cudaEvent_t cudaBasebandBeamformer_chord::execute(cudaPipelineState& /*pipestate
         J_meta->set_fpga_seq_num(E_meta->get_fpga_seq_num()
                                  + T_min * E_meta->get_time_downsampling_fpga());
         assert(J_meta->get_time_downsampling_fpga() == 1);
+
+        // Element `k` of a slowly varying input covers the samples `k * lifetime` onwards,
+        // counted from the voltage ring buffer's logical beginning -- so the two streams have
+        // to start at the same sequence number.
+        assert(A_buffer.get_metadata()->get_fpga_seq_num() == E_meta->get_fpga_seq_num());
     }
 
     // Copy inputs to device memory
@@ -589,8 +663,9 @@ cudaEvent_t cudaBasebandBeamformer_chord::execute(cudaPipelineState& /*pipestate
 }
 
 void cudaBasebandBeamformer_chord::finalize_frame() {
-    // Advance the input ring buffer
+    // Advance the input ring buffers
     E_buffer.finish_read();
+    A_buffer.finish_read();
 
     cudaCommand::finalize_frame();
 }

--- a/lib/cuda/generated/cudaBasebandBeamformer_hirax.cpp
+++ b/lib/cuda/generated/cudaBasebandBeamformer_hirax.cpp
@@ -39,6 +39,16 @@ std::array<T, D> reverse(const std::array<T, D>& values) {
         result[d] = values[D - 1 - d];
     return result;
 }
+
+// Override the leading (slowest) dimension's scaling with a run-time value. Used for inputs
+// that are valid for a configurable number of FPGA samples, such as the phase matrix.
+template<std::size_t D>
+std::array<std::ptrdiff_t, D> with_leading_dimscaling(std::array<std::ptrdiff_t, D> dimscalings,
+                                                      const std::ptrdiff_t dimscaling) {
+    static_assert(D > 0);
+    dimscalings[0] = dimscaling;
+    return dimscalings;
+}
 }
 
 /**
@@ -115,16 +125,17 @@ private:
         A_index_B,
         A_index_P,
         A_index_F,
+        A_index_Tbb,
         A_rank,
     };
     static constexpr std::array<const char*, A_rank> A_labels = {
-        "C", "D", "B", "P", "F",
+        "C", "D", "B", "P", "F", "Tbb",
     };
     static constexpr std::array<std::ptrdiff_t, A_rank> A_lengths = {
-        2, 256, 16, 2, 64,
+        2, 256, 16, 2, 64, 4,
     };
     static constexpr std::array<std::ptrdiff_t, A_rank> A_dimscalings = {
-        1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1,
     };
     static constexpr auto A_calc_stride = [](int dim) {
         std::ptrdiff_t str = 1;
@@ -134,7 +145,8 @@ private:
     };
     static constexpr std::array<std::ptrdiff_t, A_rank + 1> A_strides = {
         A_calc_stride(A_index_C), A_calc_stride(A_index_D), A_calc_stride(A_index_B),
-        A_calc_stride(A_index_P), A_calc_stride(A_index_F), A_calc_stride(A_rank),
+        A_calc_stride(A_index_P), A_calc_stride(A_index_F), A_calc_stride(A_index_Tbb),
+        A_calc_stride(A_rank),
     };
     static constexpr std::ptrdiff_t A_length = A_strides[A_rank];
     static constexpr std::ptrdiff_t A_length_in_bytes = type_total_bytes(A_type) * A_length;
@@ -332,8 +344,11 @@ private:
     const std::string info_name;
     const std::string log_name;
 
+    // Lifetimes of slowly varying inputs, in FPGA samples
+    const std::ptrdiff_t A_lifetime_in_samples;
+
     // Buffers
-    NDArrayBuffer<kotekan::GetType_t<A_type>, A_rank> A_buffer;
+    NDArrayRingBuffer<kotekan::GetType_t<A_type>, A_rank> A_buffer;
     NDArrayRingBuffer<kotekan::GetType_t<E_type>, E_rank> E_buffer;
     NDArrayBuffer<kotekan::GetType_t<s_type>, s_rank> s_buffer;
     NDArrayBuffer<kotekan::GetType_t<J_type>, J_rank> J_buffer;
@@ -364,8 +379,10 @@ cudaBasebandBeamformer_hirax::cudaBasebandBeamformer_hirax(Config& config,
     J_name(config.get<std::string>(unique_name, "bb_beams_name")),
     info_name(unique_name + "/gpu_mem_info"), log_name(unique_name + "/gpu_mem_log"),
 
-    A_buffer(A_name, A_quantity, reverse(A_lengths), reverse(A_labels), reverse(A_dimscalings),
-             *this, buffer_type_t::do_once),
+    A_lifetime_in_samples(config.get<std::int64_t>(unique_name, "bb_phase_lifetime_in_samples")),
+
+    A_buffer(A_name, A_quantity, reverse(A_lengths), reverse(A_labels),
+             with_leading_dimscaling(reverse(A_dimscalings), A_lifetime_in_samples), *this),
     E_buffer(E_name, E_quantity, reverse(E_lengths), reverse(E_labels), reverse(E_dimscalings),
              *this),
     s_buffer(s_name, s_quantity, reverse(s_lengths), reverse(s_labels), reverse(s_dimscalings),
@@ -400,6 +417,18 @@ cudaBasebandBeamformer_hirax::cudaBasebandBeamformer_hirax(Config& config,
         {.name = info_name, .is_array = true, .does_read = true, .does_write = true});
     register_gpu_buffer_user(
         {.name = log_name, .is_array = true, .does_read = true, .does_write = true});
+
+    // Slowly varying inputs are held in a ring buffer and read without claiming, one element
+    // per lifetime. The output `J` is a regular buffer, so the number of time samples per
+    // kernel invocation is fixed by the output frame size and cannot be shrunk to fit a
+    // lifetime -- hence the lifetime has to be a whole number of invocations instead.
+    {
+        const std::ptrdiff_t T_read_max = E_buffer.get_ndarray().extent(0) / 4;
+        if (A_lifetime_in_samples <= 0 || A_lifetime_in_samples % T_read_max != 0)
+            FATAL_ERROR("bb_phase_lifetime_in_samples {:d} must be a positive multiple of the "
+                        "processing cadence of {:d} time samples",
+                        A_lifetime_in_samples, T_read_max);
+    }
 
     set_command_type(gpuCommandType::KERNEL);
 
@@ -439,6 +468,37 @@ int cudaBasebandBeamformer_hirax::wait_on_precondition() {
             return errcode;
     }
 
+    // Slowly varying inputs: locate the element covering the voltage samples we just claimed,
+    // then read it. We read the same element on every invocation within its lifetime, and claim
+    // it only on the last one, so that the producer can recycle it afterwards.
+    {
+        const std::ptrdiff_t T_begin = E_buffer.get_read_valid().begin();
+        const std::ptrdiff_t T_end = E_buffer.get_read_valid().end();
+        const std::ptrdiff_t element = kotekan::div(T_begin, A_lifetime_in_samples);
+        const std::ptrdiff_t lifetime_end = (element + 1) * A_lifetime_in_samples;
+        // The constructor checks the cadences against each other; a short read (a starved
+        // voltage ring buffer) can still push a window across a boundary.
+        if (T_end > lifetime_end)
+            FATAL_ERROR("voltage samples [{:d},{:d}) straddle the end {:d} of A "
+                        "element {:d}; bb_phase_lifetime_in_samples {:d} and the voltage stream "
+                        "are not aligned",
+                        T_begin, T_end, lifetime_end, element, A_lifetime_in_samples);
+        const bool last_use = T_end == lifetime_end;
+        DEBUG("Waiting for A input ringbuffer data for frame {:d}...", gpu_frame_id);
+        const int errcode =
+            A_buffer.wait_and_claim_readable([&](const std::ptrdiff_t available_elements) {
+                if (available_elements < 1)
+                    return read_descriptor_t{.claimed = 0, .read = 0};
+                return read_descriptor_t{.claimed = last_use ? 1 : 0, .read = 1};
+            });
+        if (errcode < 0)
+            return errcode;
+        DEBUG("Done waiting for A input ringbuffer data for frame {:d}; "
+              "using element {:d}{:s}",
+              gpu_frame_id, element, last_use ? " (last use)" : "");
+        assert(A_buffer.get_read_valid().begin() == element);
+    }
+
     return 0;
 }
 
@@ -475,6 +535,15 @@ cudaEvent_t cudaBasebandBeamformer_hirax::execute(cudaPipelineState& /*pipestate
     // Set E_memory to beginning of input ring buffer
     E_arg = array_desc(E_memory, E_length_in_bytes);
 
+    // Slowly varying inputs: the kernel wants a single element, not the whole ring buffer.
+    {
+        const std::ptrdiff_t ring_length = A_buffer.get_ndarray().extent(0);
+        const std::ptrdiff_t element = A_buffer.get_read_valid().begin();
+        A_arg = array_desc(A_buffer.get_ndarray().data()
+                               + A_buffer.get_ndarray().stride(0) * (element % ring_length),
+                           A_length_in_bytes / ring_length);
+    }
+
     // Ringbuffer size
     const std::ptrdiff_t T_ringbuf = E_buffer.get_ndarray().extent(0);
 
@@ -499,6 +568,11 @@ cudaEvent_t cudaBasebandBeamformer_hirax::execute(cudaPipelineState& /*pipestate
         J_meta->set_fpga_seq_num(E_meta->get_fpga_seq_num()
                                  + T_min * E_meta->get_time_downsampling_fpga());
         assert(J_meta->get_time_downsampling_fpga() == 1);
+
+        // Element `k` of a slowly varying input covers the samples `k * lifetime` onwards,
+        // counted from the voltage ring buffer's logical beginning -- so the two streams have
+        // to start at the same sequence number.
+        assert(A_buffer.get_metadata()->get_fpga_seq_num() == E_meta->get_fpga_seq_num());
     }
 
     // Copy inputs to device memory
@@ -589,8 +663,9 @@ cudaEvent_t cudaBasebandBeamformer_hirax::execute(cudaPipelineState& /*pipestate
 }
 
 void cudaBasebandBeamformer_hirax::finalize_frame() {
-    // Advance the input ring buffer
+    // Advance the input ring buffers
     E_buffer.finish_read();
+    A_buffer.finish_read();
 
     cudaCommand::finalize_frame();
 }

--- a/lib/cuda/generated/cudaBasebandBeamformer_pathfinder.cpp
+++ b/lib/cuda/generated/cudaBasebandBeamformer_pathfinder.cpp
@@ -39,6 +39,16 @@ std::array<T, D> reverse(const std::array<T, D>& values) {
         result[d] = values[D - 1 - d];
     return result;
 }
+
+// Override the leading (slowest) dimension's scaling with a run-time value. Used for inputs
+// that are valid for a configurable number of FPGA samples, such as the phase matrix.
+template<std::size_t D>
+std::array<std::ptrdiff_t, D> with_leading_dimscaling(std::array<std::ptrdiff_t, D> dimscalings,
+                                                      const std::ptrdiff_t dimscaling) {
+    static_assert(D > 0);
+    dimscalings[0] = dimscaling;
+    return dimscalings;
+}
 }
 
 /**
@@ -115,16 +125,17 @@ private:
         A_index_B,
         A_index_P,
         A_index_F,
+        A_index_Tbb,
         A_rank,
     };
     static constexpr std::array<const char*, A_rank> A_labels = {
-        "C", "D", "B", "P", "F",
+        "C", "D", "B", "P", "F", "Tbb",
     };
     static constexpr std::array<std::ptrdiff_t, A_rank> A_lengths = {
-        2, 64, 16, 2, 384,
+        2, 64, 16, 2, 384, 4,
     };
     static constexpr std::array<std::ptrdiff_t, A_rank> A_dimscalings = {
-        1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1,
     };
     static constexpr auto A_calc_stride = [](int dim) {
         std::ptrdiff_t str = 1;
@@ -134,7 +145,8 @@ private:
     };
     static constexpr std::array<std::ptrdiff_t, A_rank + 1> A_strides = {
         A_calc_stride(A_index_C), A_calc_stride(A_index_D), A_calc_stride(A_index_B),
-        A_calc_stride(A_index_P), A_calc_stride(A_index_F), A_calc_stride(A_rank),
+        A_calc_stride(A_index_P), A_calc_stride(A_index_F), A_calc_stride(A_index_Tbb),
+        A_calc_stride(A_rank),
     };
     static constexpr std::ptrdiff_t A_length = A_strides[A_rank];
     static constexpr std::ptrdiff_t A_length_in_bytes = type_total_bytes(A_type) * A_length;
@@ -332,8 +344,11 @@ private:
     const std::string info_name;
     const std::string log_name;
 
+    // Lifetimes of slowly varying inputs, in FPGA samples
+    const std::ptrdiff_t A_lifetime_in_samples;
+
     // Buffers
-    NDArrayBuffer<kotekan::GetType_t<A_type>, A_rank> A_buffer;
+    NDArrayRingBuffer<kotekan::GetType_t<A_type>, A_rank> A_buffer;
     NDArrayRingBuffer<kotekan::GetType_t<E_type>, E_rank> E_buffer;
     NDArrayBuffer<kotekan::GetType_t<s_type>, s_rank> s_buffer;
     NDArrayBuffer<kotekan::GetType_t<J_type>, J_rank> J_buffer;
@@ -364,8 +379,10 @@ cudaBasebandBeamformer_pathfinder::cudaBasebandBeamformer_pathfinder(Config& con
     J_name(config.get<std::string>(unique_name, "bb_beams_name")),
     info_name(unique_name + "/gpu_mem_info"), log_name(unique_name + "/gpu_mem_log"),
 
-    A_buffer(A_name, A_quantity, reverse(A_lengths), reverse(A_labels), reverse(A_dimscalings),
-             *this, buffer_type_t::do_once),
+    A_lifetime_in_samples(config.get<std::int64_t>(unique_name, "bb_phase_lifetime_in_samples")),
+
+    A_buffer(A_name, A_quantity, reverse(A_lengths), reverse(A_labels),
+             with_leading_dimscaling(reverse(A_dimscalings), A_lifetime_in_samples), *this),
     E_buffer(E_name, E_quantity, reverse(E_lengths), reverse(E_labels), reverse(E_dimscalings),
              *this),
     s_buffer(s_name, s_quantity, reverse(s_lengths), reverse(s_labels), reverse(s_dimscalings),
@@ -400,6 +417,18 @@ cudaBasebandBeamformer_pathfinder::cudaBasebandBeamformer_pathfinder(Config& con
         {.name = info_name, .is_array = true, .does_read = true, .does_write = true});
     register_gpu_buffer_user(
         {.name = log_name, .is_array = true, .does_read = true, .does_write = true});
+
+    // Slowly varying inputs are held in a ring buffer and read without claiming, one element
+    // per lifetime. The output `J` is a regular buffer, so the number of time samples per
+    // kernel invocation is fixed by the output frame size and cannot be shrunk to fit a
+    // lifetime -- hence the lifetime has to be a whole number of invocations instead.
+    {
+        const std::ptrdiff_t T_read_max = E_buffer.get_ndarray().extent(0) / 4;
+        if (A_lifetime_in_samples <= 0 || A_lifetime_in_samples % T_read_max != 0)
+            FATAL_ERROR("bb_phase_lifetime_in_samples {:d} must be a positive multiple of the "
+                        "processing cadence of {:d} time samples",
+                        A_lifetime_in_samples, T_read_max);
+    }
 
     set_command_type(gpuCommandType::KERNEL);
 
@@ -440,6 +469,37 @@ int cudaBasebandBeamformer_pathfinder::wait_on_precondition() {
             return errcode;
     }
 
+    // Slowly varying inputs: locate the element covering the voltage samples we just claimed,
+    // then read it. We read the same element on every invocation within its lifetime, and claim
+    // it only on the last one, so that the producer can recycle it afterwards.
+    {
+        const std::ptrdiff_t T_begin = E_buffer.get_read_valid().begin();
+        const std::ptrdiff_t T_end = E_buffer.get_read_valid().end();
+        const std::ptrdiff_t element = kotekan::div(T_begin, A_lifetime_in_samples);
+        const std::ptrdiff_t lifetime_end = (element + 1) * A_lifetime_in_samples;
+        // The constructor checks the cadences against each other; a short read (a starved
+        // voltage ring buffer) can still push a window across a boundary.
+        if (T_end > lifetime_end)
+            FATAL_ERROR("voltage samples [{:d},{:d}) straddle the end {:d} of A "
+                        "element {:d}; bb_phase_lifetime_in_samples {:d} and the voltage stream "
+                        "are not aligned",
+                        T_begin, T_end, lifetime_end, element, A_lifetime_in_samples);
+        const bool last_use = T_end == lifetime_end;
+        DEBUG("Waiting for A input ringbuffer data for frame {:d}...", gpu_frame_id);
+        const int errcode =
+            A_buffer.wait_and_claim_readable([&](const std::ptrdiff_t available_elements) {
+                if (available_elements < 1)
+                    return read_descriptor_t{.claimed = 0, .read = 0};
+                return read_descriptor_t{.claimed = last_use ? 1 : 0, .read = 1};
+            });
+        if (errcode < 0)
+            return errcode;
+        DEBUG("Done waiting for A input ringbuffer data for frame {:d}; "
+              "using element {:d}{:s}",
+              gpu_frame_id, element, last_use ? " (last use)" : "");
+        assert(A_buffer.get_read_valid().begin() == element);
+    }
+
     return 0;
 }
 
@@ -477,6 +537,15 @@ cudaBasebandBeamformer_pathfinder::execute(cudaPipelineState& /*pipestate*/,
     // Set E_memory to beginning of input ring buffer
     E_arg = array_desc(E_memory, E_length_in_bytes);
 
+    // Slowly varying inputs: the kernel wants a single element, not the whole ring buffer.
+    {
+        const std::ptrdiff_t ring_length = A_buffer.get_ndarray().extent(0);
+        const std::ptrdiff_t element = A_buffer.get_read_valid().begin();
+        A_arg = array_desc(A_buffer.get_ndarray().data()
+                               + A_buffer.get_ndarray().stride(0) * (element % ring_length),
+                           A_length_in_bytes / ring_length);
+    }
+
     // Ringbuffer size
     const std::ptrdiff_t T_ringbuf = E_buffer.get_ndarray().extent(0);
 
@@ -501,6 +570,11 @@ cudaBasebandBeamformer_pathfinder::execute(cudaPipelineState& /*pipestate*/,
         J_meta->set_fpga_seq_num(E_meta->get_fpga_seq_num()
                                  + T_min * E_meta->get_time_downsampling_fpga());
         assert(J_meta->get_time_downsampling_fpga() == 1);
+
+        // Element `k` of a slowly varying input covers the samples `k * lifetime` onwards,
+        // counted from the voltage ring buffer's logical beginning -- so the two streams have
+        // to start at the same sequence number.
+        assert(A_buffer.get_metadata()->get_fpga_seq_num() == E_meta->get_fpga_seq_num());
     }
 
     // Copy inputs to device memory
@@ -592,8 +666,9 @@ cudaBasebandBeamformer_pathfinder::execute(cudaPipelineState& /*pipestate*/,
 }
 
 void cudaBasebandBeamformer_pathfinder::finalize_frame() {
-    // Advance the input ring buffer
+    // Advance the input ring buffers
     E_buffer.finish_read();
+    A_buffer.finish_read();
 
     cudaCommand::finalize_frame();
 }

--- a/lib/stages/calcBBPhase.cpp
+++ b/lib/stages/calcBBPhase.cpp
@@ -5,7 +5,7 @@
 #include "buffer.hpp"          // for Buffer
 #include "bufferContainer.hpp" // for bufferContainer
 #include "chordMetadata.hpp"   // for chordMetadata, get_chord_metadata
-#include "kotekanLogging.hpp"  // for DEBUG
+#include "kotekanLogging.hpp"  // for DEBUG, FATAL_ERROR
 
 #include "fmt.hpp" // for compile_string_to_view, format
 
@@ -19,7 +19,6 @@
 #include <functional> // for function
 #include <memory>     // for allocator, __shared_ptr_access, shared_ptr
 #include <string>     // for basic_string, string
-#include <unistd.h>   // for sleep
 #include <vector>     // for vector
 
 
@@ -38,6 +37,11 @@ class calcBBPhase : public kotekan::Stage {
     // Baseband beamformer setup
     const int bb_num_beams = config.get<int>(unique_name, "bb_num_beams");
     const int bb_scale = config.get<int>(unique_name, "bb_scale");
+
+    // Each phase matrix is valid for this many FPGA samples. It is the cadence at which this
+    // stage produces frames, and the `dimscaling` of the phase matrix's leading time axis.
+    const std::int64_t bb_phase_lifetime_in_samples =
+        config.get<std::int64_t>(unique_name, "bb_phase_lifetime_in_samples");
 
     const std::ptrdiff_t bb_beam_positions_frame_size [[maybe_unused]] =
         sizeof(float) * 2 * bb_num_beams;
@@ -73,9 +77,12 @@ public:
         bb_beam_positions_buffer->require_frame_desc(kotekan::NDArray<float, 2>::describe(
             "bb_beam_positions", {bb_num_beams, 2}, {"B", "X/Y"}, {1, 1}));
 
-        A_buffer->require_frame_desc(kotekan::NDArray<std::int8_t, 5>::describe(
-            "A", {num_frequencies, num_polarizations, bb_num_beams, num_dishes, num_components},
-            {"F", "P", "B", "D", "C"}, {1, 1, 1, 1, 1}));
+        // The leading axis has length 1 and carries the lifetime as its `dimscaling`; that is how
+        // the GPU ring buffer learns how many FPGA samples one phase matrix covers. Same shape as
+        // the bad feed mask's "Tbf" axis.
+        A_buffer->require_frame_desc(kotekan::NDArray<std::int8_t, 6>::describe(
+            "A", {1, num_frequencies, num_polarizations, bb_num_beams, num_dishes, num_components},
+            {"Tbb", "F", "P", "B", "D", "C"}, {bb_phase_lifetime_in_samples, 1, 1, 1, 1, 1}));
 
         s_buffer->require_frame_desc(kotekan::NDArray<std::int32_t, 3>::describe(
             "s", {num_frequencies, num_polarizations, bb_num_beams}, {"F", "P", "B"}, {1, 1, 1}));
@@ -84,10 +91,6 @@ public:
     virtual ~calcBBPhase() {}
 
     void main_thread() override {
-        // Only calculate a single frame
-        const int frame_index = 0;
-        const int frame_id = frame_index;
-
         if (stop_thread)
             return;
 
@@ -95,7 +98,7 @@ public:
         const Telescope& telescope = Telescope::instance();
 
         // Get dish positions (in the Telescope's GRID frame in meters).
-        std::vector<vec3d_t> feed_pos_m =
+        const std::vector<vec3d_t> feed_pos_m =
             telescope.get_feed_positions_m(num_elements, telescope.fiducial_element_order());
         assert(std::ptrdiff_t(feed_pos_m.size()) == num_elements);
 
@@ -108,133 +111,155 @@ public:
         const std::vector<int> freq_upchan_factor(frequency_channels.size(), 1);
         const std::vector<int> freq_upchan_index(frequency_channels.size(), 0);
 
-        // Wait for buffers
-        DEBUG("[{:s}/{:d}] Waiting for buffer...", bb_beam_positions_buffer->buffer_name,
-              frame_index);
-        float* const bb_beam_positions_frame = static_cast<float*>(static_cast<void*>(
-            bb_beam_positions_buffer->wait_for_full_frame(unique_name, frame_id)));
-        if (!bb_beam_positions_frame)
-            return;
-
-        DEBUG("[{:s}/{:d}] Waiting for buffer...", A_buffer->buffer_name, frame_index);
-        std::complex<std::int8_t>* const A_frame = static_cast<std::complex<std::int8_t>*>(
-            static_cast<void*>(A_buffer->wait_for_empty_frame(unique_name, frame_id)));
-        if (!A_frame)
-            return;
-
-        DEBUG("[{:s}/{:d}] Waiting for buffer...", s_buffer->buffer_name, frame_index);
-        std::int32_t* const s_frame = static_cast<std::int32_t*>(
-            static_cast<void*>(s_buffer->wait_for_empty_frame(unique_name, frame_id)));
-        if (!s_frame)
-            return;
-
         // Check buffer sizes
         assert(std::ptrdiff_t(bb_beam_positions_buffer->frame_size)
                == bb_beam_positions_frame_size);
         assert(std::ptrdiff_t(A_buffer->frame_size) == A_frame_size);
         assert(std::ptrdiff_t(s_buffer->frame_size) == s_frame_size);
 
+        // `frame_index` counts all frames produced, not just the current slot: it must keep
+        // increasing so that the phase matrices form one continuous stream.
+        for (std::int64_t frame_index = 0; !stop_thread; ++frame_index) {
+            const int bb_beam_positions_frame_id =
+                frame_index % bb_beam_positions_buffer->num_frames;
+            const int A_frame_id = frame_index % A_buffer->num_frames;
 
-        // Get timing info from beam positions buffer.
-        const auto& bb_beam_positions_meta =
-            get_chord_metadata(bb_beam_positions_buffer->get_metadata(frame_id));
-        uint64_t seq_num = bb_beam_positions_meta->get_fpga_seq_num();
-        uint64_t time_downsampling = bb_beam_positions_meta->get_time_downsampling_fpga();
+            // Wait for buffers. Blocking here paces production to the consumers.
+            DEBUG("[{:s}/{:d}] Waiting for buffer...", bb_beam_positions_buffer->buffer_name,
+                  frame_index);
+            const float* const bb_beam_positions_frame = static_cast<const float*>(
+                static_cast<const void*>(bb_beam_positions_buffer->wait_for_full_frame(
+                    unique_name, bb_beam_positions_frame_id)));
+            if (!bb_beam_positions_frame)
+                return;
 
-        // Set metadata
-        A_buffer->allocate_new_metadata_object(frame_id);
-        const auto& A_meta = get_chord_metadata(A_buffer->get_metadata(frame_id));
-        A_meta->set_from_frame_desc(A_buffer->get_frame_desc<kotekan::GenericNDArray>());
-        A_meta->set_fpga_seq_num(seq_num);
-        A_meta->set_time_downsampling_fpga(time_downsampling);
-        A_meta->set_coarse_freq(frequency_channels);
-        A_meta->set_freq_upchan_factor(freq_upchan_factor);
-        A_meta->set_freq_upchan_index(freq_upchan_index);
+            DEBUG("[{:s}/{:d}] Waiting for buffer...", A_buffer->buffer_name, frame_index);
+            std::complex<std::int8_t>* const A_frame = static_cast<std::complex<std::int8_t>*>(
+                static_cast<void*>(A_buffer->wait_for_empty_frame(unique_name, A_frame_id)));
+            if (!A_frame)
+                return;
 
-        s_buffer->allocate_new_metadata_object(frame_id);
-        const auto& s_meta = get_chord_metadata(s_buffer->get_metadata(frame_id));
-        s_meta->set_from_frame_desc(s_buffer->get_frame_desc<kotekan::GenericNDArray>());
-        s_meta->set_fpga_seq_num(seq_num);
-        s_meta->set_time_downsampling_fpga(time_downsampling);
-        s_meta->set_coarse_freq(frequency_channels);
-        s_meta->set_freq_upchan_factor(freq_upchan_factor);
-        s_meta->set_freq_upchan_index(freq_upchan_index);
+            // Get timing info from beam positions buffer.
+            const auto& bb_beam_positions_meta = get_chord_metadata(
+                bb_beam_positions_buffer->get_metadata(bb_beam_positions_frame_id));
+            const std::uint64_t seq_num = bb_beam_positions_meta->get_fpga_seq_num();
+            // One phase matrix per beam position frame, so the two cadences must agree;
+            // otherwise the sequence numbers would advance at a different rate than the GPU
+            // consumers assume.
+            if (std::int64_t(bb_beam_positions_meta->get_time_downsampling_fpga())
+                != bb_phase_lifetime_in_samples)
+                FATAL_ERROR("{:s} advances by {:d} FPGA samples per frame, but "
+                            "bb_phase_lifetime_in_samples is {:d}; they must be equal",
+                            bb_beam_positions_buffer->buffer_name,
+                            bb_beam_positions_meta->get_time_downsampling_fpga(),
+                            bb_phase_lifetime_in_samples);
 
-        // Set A
-        {
-            const float c0 = 299792458.0f; // speed of light in vacuum [m/s]
-            const std::ptrdiff_t str_dish = 1;
-            const std::ptrdiff_t str_beam = str_dish * num_dishes;
-            const std::ptrdiff_t str_polr = str_beam * bb_num_beams;
-            const std::ptrdiff_t str_freq = str_polr * num_polarizations;
-            for (int freq = 0; freq < num_frequencies; ++freq) {
-                for (int polr = 0; polr < num_polarizations; ++polr) {
-                    for (int beam = 0; beam < bb_num_beams; ++beam) {
-                        for (int dish = 0; dish < num_dishes; ++dish) {
-                            const std::ptrdiff_t idx = str_dish * dish + str_beam * beam
-                                                       + str_polr * polr + str_freq * freq;
-                            // We choose A independent of polarization
-                            using std::clamp, std::lrint, std::polar, std::sqrt;
-                            const auto pow2 = [](auto x) { return x * x; };
-                            const int element = dish + polr * num_dishes;
-                            // Dish positions are cartesian components in GRID frame in meters.
-                            const float dish_x = feed_pos_m.at(element)[0];
-                            const float dish_y = feed_pos_m.at(element)[1];
-                            const float dish_z = feed_pos_m.at(element)[2];
-                            // Buffered beam positions are nx & ny cartesian components in GRID
-                            // frame. |n| = 1.0
-                            const float n_x = bb_beam_positions_frame[2 * beam + 0];
-                            const float n_y = bb_beam_positions_frame[2 * beam + 1];
-                            const float n_z = sqrt(1 - (pow2(n_x) + pow2(n_y)));
-                            const float deltat =
-                                n_x * dish_x / c0 + n_y * dish_y / c0 + n_z * dish_z / c0;
-                            const float f = frequencies.at(freq);
-                            const float phi = 2 * float(M_PI) * f * deltat;
-                            const std::complex<float> A = polar(127.5f, phi);
-                            const std::complex<std::int8_t> iA(
-                                clamp(int(lrint(real(A))), -127, +127),
-                                clamp(int(lrint(imag(A))), -127, +127));
-                            assert(idx >= 0
-                                   && idx < std::ptrdiff_t(A_buffer->frame_size / sizeof *A_frame));
-                            A_frame[idx] = iA;
+            // Set A metadata
+            A_buffer->allocate_new_metadata_object(A_frame_id);
+            const auto& A_meta = get_chord_metadata(A_buffer->get_metadata(A_frame_id));
+            A_meta->set_from_frame_desc(A_buffer->get_frame_desc<kotekan::GenericNDArray>());
+            A_meta->set_fpga_seq_num(seq_num);
+            A_meta->set_time_downsampling_fpga(bb_phase_lifetime_in_samples);
+            A_meta->set_coarse_freq(frequency_channels);
+            A_meta->set_freq_upchan_factor(freq_upchan_factor);
+            A_meta->set_freq_upchan_index(freq_upchan_index);
+            A_meta->check_frame_desc(A_buffer->get_frame_desc<kotekan::GenericNDArray>());
+
+            // Set A
+            {
+                const float c0 = 299792458.0f; // speed of light in vacuum [m/s]
+                const std::ptrdiff_t str_dish = 1;
+                const std::ptrdiff_t str_beam = str_dish * num_dishes;
+                const std::ptrdiff_t str_polr = str_beam * bb_num_beams;
+                const std::ptrdiff_t str_freq = str_polr * num_polarizations;
+                for (int freq = 0; freq < num_frequencies; ++freq) {
+                    for (int polr = 0; polr < num_polarizations; ++polr) {
+                        for (int beam = 0; beam < bb_num_beams; ++beam) {
+                            for (int dish = 0; dish < num_dishes; ++dish) {
+                                const std::ptrdiff_t idx = str_dish * dish + str_beam * beam
+                                                           + str_polr * polr + str_freq * freq;
+                                // We choose A independent of polarization
+                                using std::clamp, std::lrint, std::polar, std::sqrt;
+                                const auto pow2 = [](auto x) { return x * x; };
+                                const int element = dish + polr * num_dishes;
+                                // Dish positions are cartesian components in GRID frame in meters.
+                                const float dish_x = feed_pos_m.at(element)[0];
+                                const float dish_y = feed_pos_m.at(element)[1];
+                                const float dish_z = feed_pos_m.at(element)[2];
+                                // Buffered beam positions are nx & ny cartesian components in GRID
+                                // frame. |n| = 1.0
+                                const float n_x = bb_beam_positions_frame[2 * beam + 0];
+                                const float n_y = bb_beam_positions_frame[2 * beam + 1];
+                                const float n_z = sqrt(1 - (pow2(n_x) + pow2(n_y)));
+                                const float deltat =
+                                    n_x * dish_x / c0 + n_y * dish_y / c0 + n_z * dish_z / c0;
+                                const float f = frequencies.at(freq);
+                                const float phi = 2 * float(M_PI) * f * deltat;
+                                const std::complex<float> A = polar(127.5f, phi);
+                                const std::complex<std::int8_t> iA(
+                                    clamp(int(lrint(real(A))), -127, +127),
+                                    clamp(int(lrint(imag(A))), -127, +127));
+                                assert(idx >= 0
+                                       && idx < std::ptrdiff_t(A_buffer->frame_size
+                                                               / sizeof *A_frame));
+                                A_frame[idx] = iA;
+                            }
                         }
                     }
                 }
             }
-        }
 
-        // Set s
-        {
-            const std::ptrdiff_t str_beam = 1;
-            const std::ptrdiff_t str_polr = str_beam * bb_num_beams;
-            const std::ptrdiff_t str_freq = str_polr * num_polarizations;
-            for (int freq = 0; freq < num_frequencies; ++freq) {
-                for (int polr = 0; polr < num_polarizations; ++polr) {
-                    for (int beam = 0; beam < bb_num_beams; ++beam) {
-                        const std::ptrdiff_t idx =
-                            str_beam * beam + str_polr * polr + str_freq * freq;
-                        assert(idx >= 0
-                               && idx < std::ptrdiff_t(s_buffer->frame_size / sizeof *s_frame));
-                        s_frame[idx] = bb_scale;
+            // The shift vector does not change, so it is written once and then held by the GPU
+            // (its `cudaInputData` is configured `do_once`).
+            if (frame_index == 0) {
+                DEBUG("[{:s}/{:d}] Waiting for buffer...", s_buffer->buffer_name, frame_index);
+                std::int32_t* const s_frame = static_cast<std::int32_t*>(
+                    static_cast<void*>(s_buffer->wait_for_empty_frame(unique_name, 0)));
+                if (!s_frame)
+                    return;
+
+                s_buffer->allocate_new_metadata_object(0);
+                const auto& s_meta = get_chord_metadata(s_buffer->get_metadata(0));
+                s_meta->set_from_frame_desc(s_buffer->get_frame_desc<kotekan::GenericNDArray>());
+                s_meta->set_fpga_seq_num(seq_num);
+                s_meta->set_time_downsampling_fpga(
+                    bb_beam_positions_meta->get_time_downsampling_fpga());
+                s_meta->set_coarse_freq(frequency_channels);
+                s_meta->set_freq_upchan_factor(freq_upchan_factor);
+                s_meta->set_freq_upchan_index(freq_upchan_index);
+                s_meta->check_frame_desc(s_buffer->get_frame_desc<kotekan::GenericNDArray>());
+
+                // Set s
+                {
+                    const std::ptrdiff_t str_beam = 1;
+                    const std::ptrdiff_t str_polr = str_beam * bb_num_beams;
+                    const std::ptrdiff_t str_freq = str_polr * num_polarizations;
+                    for (int freq = 0; freq < num_frequencies; ++freq) {
+                        for (int polr = 0; polr < num_polarizations; ++polr) {
+                            for (int beam = 0; beam < bb_num_beams; ++beam) {
+                                const std::ptrdiff_t idx =
+                                    str_beam * beam + str_polr * polr + str_freq * freq;
+                                assert(idx >= 0
+                                       && idx < std::ptrdiff_t(s_buffer->frame_size
+                                                               / sizeof *s_frame));
+                                s_frame[idx] = bb_scale;
+                            }
+                        }
                     }
                 }
+
+                DEBUG("[{:s}/{:d}] Marking buffer as full...", s_buffer->buffer_name, frame_index);
+                s_buffer->mark_frame_full(unique_name, 0);
             }
+
+            // Mark buffers as full
+            DEBUG("[{:s}/{:d}] Marking buffer as empty...", bb_beam_positions_buffer->buffer_name,
+                  frame_index);
+            bb_beam_positions_buffer->mark_frame_empty(unique_name, bb_beam_positions_frame_id);
+
+            DEBUG("[{:s}/{:d}] Marking buffer as full...", A_buffer->buffer_name, frame_index);
+            A_buffer->mark_frame_full(unique_name, A_frame_id);
         }
-
-        // Mark buffers as full
-        DEBUG("[{:s}/{:d}] Marking buffer as empty...", bb_beam_positions_buffer->buffer_name,
-              frame_index);
-        bb_beam_positions_buffer->mark_frame_empty(unique_name, frame_id);
-
-        DEBUG("[{:s}/{:d}] Marking buffer as full...", A_buffer->buffer_name, frame_index);
-        A_buffer->mark_frame_full(unique_name, frame_id);
-
-        DEBUG("[{:s}/{:d}] Marking buffer as full...", s_buffer->buffer_name, frame_index);
-        s_buffer->mark_frame_full(unique_name, frame_id);
-
-        // Wait for shutdown (don't trigger a shutdown)
-        while (!stop_thread)
-            sleep(1);
     }
 };
 

--- a/lib/stages/setBBBeams.cpp
+++ b/lib/stages/setBBBeams.cpp
@@ -46,10 +46,9 @@ constexpr double deg2rad = M_PI / 180.0;
  *
  * Beam IDs are u64 values used to identify beams in post.
  *
- * NOTE: This stage is intended to be run continuously, so as to produce the time-dependent
- * tracking beams. However, this will require modification of the calcBBPhases stage and the
- * cudaBBBeamformer wrapper. It was written to demonstrate how beams should be produced and
- * how to use the Telescope for Tracking beams.
+ * This stage runs continuously, emitting one frame every `time_downsampling_fpga` FPGA samples,
+ * so that tracking beams can be time-dependent. The positions are consumed by calcBBPhase, which
+ * turns them into a phase matrix at the same cadence.
  *
  * NOTE: This stage is likely a placeholder, or will require (possibly telescope-specific) upgrades
  * to be used in production (e.g. updating beams via REST).
@@ -255,19 +254,15 @@ void setBBBeams::main_thread() {
     // in)
     in_buf->unregister_consumer(unique_name);
 
-    // Set the seq_num of the first output to be on our output cadence and <= the seq_num
-    // of the first frame we saw. This means these beams will already be considered valid.
-    uint64_t num_frames = 0; // Total number of frame output
-    uint64_t seq0 = time_downsampling_fpga
-                    * (input_seq / time_downsampling_fpga); // seq number of 1st output frame
+    // Start this stream at the voltage stream's first sequence number, without rounding to our
+    // own cadence: the GPU-side consumers locate phase-matrix element `k` at
+    // `k * time_downsampling_fpga` FPGA samples after the logical beginning of the voltage ring
+    // buffer, so both streams have to share an origin. (Same reasoning as PR #1644 for the bad
+    // feed mask.)
+    uint64_t num_frames = 0;         // Total number of frame output
+    const uint64_t seq0 = input_seq; // seq number of 1st output frame
 
     while (!stop_thread) {
-        // TODO: remove this (and update the cuda wrappers) to make the beam positions time
-        // dependent.  Have to keep this stage spinning on the input buffer to not stall the
-        // pipeline.
-        if (num_frames > 0)
-            break;
-
         // Grab output buffer frames
         float* beam_pos = (float*)out_pos_buf->wait_for_empty_frame(unique_name, pos_frame_id);
         if (beam_pos == nullptr)


### PR DESCRIPTION
In anticipation of tracking baseband beams:

Recalculate the baseband beam phase matrix periodically (e.g. every second) instead of only once at startup.

This does not yet introduce a mechanism to actually update the beam pointings dynamically.