### PR TITLE
Clarify meaning of time_downsampling_fpga, and apply it everywhere

### DIFF
--- a/config/chime_upgrade_frb.j2
+++ b/config/chime_upgrade_frb.j2
@@ -1886,7 +1886,7 @@ write_frb:
     base_dir: frb_beams
     in_buf: host_frb3_beams_buffer_post
     file_name: host_frb3_beams_buffer
-    create_single_file: false  # split time axis: dim_scaling[0] != time_downsampling_fpga
+    create_single_file: false  # dim 0 has extent 1; single file needs a gap-free stream
     input_order: CHIMEBeamformer
 
 # enable to dump sk statistics data

--- a/config/fengine/include/output_benchmark.j2
+++ b/config/fengine/include/output_benchmark.j2
@@ -22,18 +22,18 @@ write_data:
         kotekan_stage: hdf5FileWrite
         in_buf: host_bb_beams_buffer
         file_name: bb_beams
-        create_single_file: false  # split time axis: dim_scaling[0] != time_downsampling_fpga
+        create_single_file: false  # dim 0 has extent 1; single file needs a gap-free stream
     write_frb3_beams:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb3_beams_buffer
         file_name: frb3_beams
-        create_single_file: false  # split time axis: dim_scaling[0] != time_downsampling_fpga
+        create_single_file: false  # dim 0 has extent 1; single file needs a gap-free stream
     write_frb3_beams_offsetscale:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb3_beams_offsetscale_buffer
         file_name: frb3_beams_offsetscale
         max_frames: 32          # each frame has 335.54432 ms
-        create_single_file: false  # split time axis: dim_scaling[0] != time_downsampling_fpga
+        create_single_file: false  # dim 0 has extent 1; single file needs a gap-free stream
     # this is chime only
     write_hfb2_beams:
         kotekan_stage: hdf5FileWrite

--- a/config/fengine/include/output_charts.j2
+++ b/config/fengine/include/output_charts.j2
@@ -248,7 +248,7 @@ write_data:
         kotekan_stage: hdf5FileWrite
         in_buf: host_bb_beams_buffer
         file_name: bb_beams
-        create_single_file: false  # split time axis: dim_scaling[0] != time_downsampling_fpga
+        create_single_file: false  # dim 0 has extent 1; single file needs a gap-free stream
     write_upchan_U32_gain:
         kotekan_stage: hdf5FileWrite
         in_buf: host_upchan_U32_gain_buffer
@@ -286,7 +286,7 @@ write_data:
         in_buf: host_frb2_beams_buffer
         file_name: frb2_beams
         max_frames: 3
-        create_single_file: false  # split time axis: dim_scaling[0] != time_downsampling_fpga
+        create_single_file: false  # dim 0 has extent 1; single file needs a gap-free stream
 #TODO     write_frb3_beams:
 #TODO         kotekan_stage: hdf5FileWrite
 #TODO         in_buf: host_frb3_beams_buffer

--- a/config/fengine/include/output_chime.j2
+++ b/config/fengine/include/output_chime.j2
@@ -339,7 +339,7 @@ write_data:
         kotekan_stage: hdf5FileWrite
         in_buf: host_bb_beams_buffer
         file_name: bb_beams
-        create_single_file: false  # split time axis: dim_scaling[0] != time_downsampling_fpga
+        create_single_file: false  # dim 0 has extent 1; single file needs a gap-free stream
     write_upchan_U16_gain:
         kotekan_stage: hdf5FileWrite
         in_buf: host_upchan_U16_gain_buffer
@@ -394,18 +394,18 @@ write_data:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb2_beams_buffer
         file_name: frb2_beams
-        create_single_file: false  # split time axis: dim_scaling[0] != time_downsampling_fpga
+        create_single_file: false  # dim 0 has extent 1; single file needs a gap-free stream
     write_frb3_beams:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb3_beams_buffer
         file_name: frb3_beams
-        create_single_file: false  # split time axis: dim_scaling[0] != time_downsampling_fpga
+        create_single_file: false  # dim 0 has extent 1; single file needs a gap-free stream
     write_frb3_beams_offsetscale:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb3_beams_offsetscale_buffer
         file_name: frb3_beams_offsetscale
         max_frames: 4
-        create_single_file: false  # split time axis: dim_scaling[0] != time_downsampling_fpga
+        create_single_file: false  # dim 0 has extent 1; single file needs a gap-free stream
     write_hfb1_U128_phase:
         kotekan_stage: hdf5FileWrite
         in_buf: host_hfb1_U128_phase_buffer
@@ -434,7 +434,7 @@ write_data:
         in_buf: host_hfb2_beams_buffer
         file_name: hfb2_beams
         max_frames: 1
-        create_single_file: false  # split time axis: dim_scaling[0] != time_downsampling_fpga
+        create_single_file: false  # dim 0 has extent 1; single file needs a gap-free stream
     # write_hfb3_beams:
     #     kotekan_stage: hdf5FileWrite
     #     in_buf: host_hfb3_beams_buffer

--- a/config/fengine/include/output_chord.j2
+++ b/config/fengine/include/output_chord.j2
@@ -407,7 +407,7 @@ write_data:
         kotekan_stage: hdf5FileWrite
         in_buf: host_bb_beams_buffer
         file_name: bb_beams
-        create_single_file: false  # split time axis: dim_scaling[0] != time_downsampling_fpga
+        create_single_file: false  # dim 0 has extent 1; single file needs a gap-free stream
     write_upchan_U2_gain:
         kotekan_stage: hdf5FileWrite
         in_buf: host_upchan_U2_gain_buffer
@@ -544,15 +544,15 @@ write_data:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb2_beams_buffer
         file_name: frb2_beams
-        create_single_file: false  # split time axis: dim_scaling[0] != time_downsampling_fpga
+        create_single_file: false  # dim 0 has extent 1; single file needs a gap-free stream
     write_frb3_beams:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb3_beams_buffer
         file_name: frb3_beams
-        create_single_file: false  # split time axis: dim_scaling[0] != time_downsampling_fpga
+        create_single_file: false  # dim 0 has extent 1; single file needs a gap-free stream
     write_frb3_beams_offsetscale:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb3_beams_offsetscale_buffer
         file_name: frb3_beams_offsetscale
         max_frames: 4
-        create_single_file: false  # split time axis: dim_scaling[0] != time_downsampling_fpga
+        create_single_file: false  # dim 0 has extent 1; single file needs a gap-free stream

--- a/config/fengine/include/output_hirax.j2
+++ b/config/fengine/include/output_hirax.j2
@@ -311,7 +311,7 @@ write_data:
         kotekan_stage: hdf5FileWrite
         in_buf: host_bb_beams_buffer
         file_name: bb_beams
-        create_single_file: false  # split time axis: dim_scaling[0] != time_downsampling_fpga
+        create_single_file: false  # dim 0 has extent 1; single file needs a gap-free stream
     write_upchan_U8_gain:
         kotekan_stage: hdf5FileWrite
         in_buf: host_upchan_U8_gain_buffer
@@ -389,15 +389,15 @@ write_data:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb2_beams_buffer
         file_name: frb2_beams
-        create_single_file: false  # split time axis: dim_scaling[0] != time_downsampling_fpga
+        create_single_file: false  # dim 0 has extent 1; single file needs a gap-free stream
     write_frb3_beams:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb3_beams_buffer
         file_name: frb3_beams
-        create_single_file: false  # split time axis: dim_scaling[0] != time_downsampling_fpga
+        create_single_file: false  # dim 0 has extent 1; single file needs a gap-free stream
     write_frb3_beams_offsetscale:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb3_beams_offsetscale_buffer
         file_name: frb3_beams_offsetscale
         max_frames: 4
-        create_single_file: false  # split time axis: dim_scaling[0] != time_downsampling_fpga
+        create_single_file: false  # dim 0 has extent 1; single file needs a gap-free stream

--- a/config/fengine/include/output_pathfinder.j2
+++ b/config/fengine/include/output_pathfinder.j2
@@ -407,7 +407,7 @@ write_data:
         kotekan_stage: hdf5FileWrite
         in_buf: host_bb_beams_buffer
         file_name: bb_beams
-        create_single_file: false  # split time axis: dim_scaling[0] != time_downsampling_fpga
+        create_single_file: false  # dim 0 has extent 1; single file needs a gap-free stream
     write_upchan_U2_gain:
         kotekan_stage: hdf5FileWrite
         in_buf: host_upchan_U2_gain_buffer
@@ -544,15 +544,15 @@ write_data:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb2_beams_buffer
         file_name: frb2_beams
-        create_single_file: false  # split time axis: dim_scaling[0] != time_downsampling_fpga
+        create_single_file: false  # dim 0 has extent 1; single file needs a gap-free stream
     write_frb3_beams:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb3_beams_buffer
         file_name: frb3_beams
-        create_single_file: false  # split time axis: dim_scaling[0] != time_downsampling_fpga
+        create_single_file: false  # dim 0 has extent 1; single file needs a gap-free stream
     write_frb3_beams_offsetscale:
         kotekan_stage: hdf5FileWrite
         in_buf: host_frb3_beams_offsetscale_buffer
         file_name: frb3_beams_offsetscale
         max_frames: 4
-        create_single_file: false  # split time axis: dim_scaling[0] != time_downsampling_fpga
+        create_single_file: false  # dim 0 has extent 1; single file needs a gap-free stream

--- a/docs/sphinx/user/file_formats/hdf5_frames.rst
+++ b/docs/sphinx/user/file_formats/hdf5_frames.rst
@@ -83,7 +83,11 @@ Dataset attributes:
      - First FPGA sequence number of the frame and its instrument time in
        ns (only if the metadata carries a sequence number).
    * - ``time_downsampling_fpga``
-     - Total FPGA-tick downsampling factor of the time axis (if present).
+     - FPGA ticks spanned by one step along dimension 0, i.e.
+       ``dim_scalings[0]`` (if present). For a buffer whose time direction is
+       split across a slow dimension 0 and a fast trailing dimension this
+       includes the trailing axis' factor; it is not the spacing of
+       individual time samples.
    * - ``coarse_freq``, ``freq_upchan_factor``, ``freq_upchan_index``
      - Per-channel coarse frequency ids, upchannelization factors and
        indices (if present).
@@ -118,9 +122,11 @@ stream. ``hdf5FileWrite`` enforces that and aborts otherwise:
   time axis iff its name starts with ``T`` (``T``, ``Tc``, ``Tbar``,
   ``Ttilde``, ``Thi64``, ``T8hi128``, ...);
 * ``dim_scaling[0]`` must equal ``time_downsampling_fpga`` (1 when the
-  metadata does not carry that field), so a *split* time axis --- one whose
-  high and low halves are separate dimensions, e.g. ``Thi``/``T`` or
-  ``Ttildehi256`` --- does not qualify;
+  metadata does not carry that field). This is the general kotekan
+  convention, so a *split* time axis --- one whose slow and fast halves are
+  separate dimensions, e.g. ``Thi``/``T`` or ``Ttildehi256``/``Ttildelo256``
+  --- satisfies it as well, as long as ``time_downsampling_fpga`` describes
+  the slow half and hence includes the fast half's factor;
 * consecutive frames must advance ``fpga_seq_num`` by exactly ``dim[0] *
   time_downsampling_fpga``, and must not change the frame shape or the
   downsampling factor;
@@ -135,8 +141,9 @@ That is why a number of writers in the F-engine configurations
 (``config/fengine/include/output_*.j2``, ``config/chime_upgrade_frb.j2``)
 override the group-wide ``create_single_file: true`` with
 ``create_single_file: false`` --- the beamformer phases, gains, weights and
-beam positions are not time-major, and the packed beam outputs have a split
-time axis.
+beam positions are not time-major, and the packed beam outputs carry a single
+dimension-0 slice per frame, so per-frame files spare them the requirement of
+a gap-free frame stream.
 
 The checks run per frame, so a single-file writer that aborts part-way leaves
 a truncated (but still readable) file behind; a dump that ended in a ``FATAL``

--- a/julia/kernels/bb_template.cxx
+++ b/julia/kernels/bb_template.cxx
@@ -371,7 +371,12 @@ cudaEvent_t cuda{{{kernel_name}}}::execute(cudaPipelineState& /*pipestate*/, con
         // and `T_min` counts samples from there.
         J_meta->set_fpga_seq_num(E_meta->get_fpga_seq_num()
                                  + T_min * E_meta->get_time_downsampling_fpga());
-        assert(J_meta->get_time_downsampling_fpga() == 1);
+        // The kernel's generated dim scalings assume the input is sampled at the FPGA rate
+        assert(E_meta->get_time_downsampling_fpga() == 1);
+        // `J` splits the time direction into a slow `Thi` (dimension 0, extent 1) and a fast
+        // `T`. `time_downsampling_fpga` describes dimension 0, i.e. the whole frame, so it is
+        // that dimension's scaling, not the input's value that `set_metadata` copied over.
+        J_meta->set_time_downsampling_fpga(static_cast<int>(J_buffer.get_ndarray().dimscaling(0)));
     }
 
     // Copy inputs to device memory

--- a/lib/cuda/cudaFRBBeamReformer.cpp
+++ b/lib/cuda/cudaFRBBeamReformer.cpp
@@ -206,9 +206,21 @@ cudaEvent_t cudaFRBBeamReformer::execute(cudaPipelineState& /*pipestate*/,
         std::dynamic_pointer_cast<chordMetadata>(frb1_beams_buffer.get_metadata());
     assert(frb1_beams_meta);
     const std::shared_ptr<chordMetadata> frb2_beams_meta = frb2_beams_buffer.get_metadata();
+    // `frb1_beams_offset` counts elements of the input's dimension 0 (`Ttilde`), so it has to be
+    // scaled by the *input's* `time_downsampling_fpga`, which by convention is that dimension's
+    // scaling.
+    assert(frb1_beams_meta->get_time_downsampling_fpga()
+           == frb1_beams_buffer.get_ndarray().dimscaling(0));
     frb2_beams_meta->set_fpga_seq_num(frb1_beams_meta->get_fpga_seq_num()
                                       + frb1_beams_offset
-                                            * frb2_beams_meta->get_time_downsampling_fpga());
+                                            * frb1_beams_meta->get_time_downsampling_fpga());
+    // The output splits the time direction into a slow `Ttildehi256` (dimension 0, extent 1) and
+    // a fast `Ttildelo256`. `time_downsampling_fpga` describes dimension 0, i.e. the whole frame,
+    // so it is that dimension's scaling and not the one inherited from the input. (`set_metadata`
+    // copies `time_downsampling_fpga` verbatim; only the array description is taken from the
+    // output's own ndarray.)
+    frb2_beams_meta->set_time_downsampling_fpga(
+        static_cast<int>(frb2_beams_buffer.get_ndarray().dimscaling(0)));
 
     if (poison_buffers)
         frb2_beams_buffer.set_to_poison(0xff); // 0xffff is a NaN16

--- a/lib/cuda/generated/cudaBasebandBeamformer_charts.cpp
+++ b/lib/cuda/generated/cudaBasebandBeamformer_charts.cpp
@@ -498,7 +498,12 @@ cudaEvent_t cudaBasebandBeamformer_charts::execute(cudaPipelineState& /*pipestat
         // and `T_min` counts samples from there.
         J_meta->set_fpga_seq_num(E_meta->get_fpga_seq_num()
                                  + T_min * E_meta->get_time_downsampling_fpga());
-        assert(J_meta->get_time_downsampling_fpga() == 1);
+        // The kernel's generated dim scalings assume the input is sampled at the FPGA rate
+        assert(E_meta->get_time_downsampling_fpga() == 1);
+        // `J` splits the time direction into a slow `Thi` (dimension 0, extent 1) and a fast
+        // `T`. `time_downsampling_fpga` describes dimension 0, i.e. the whole frame, so it is
+        // that dimension's scaling, not the input's value that `set_metadata` copied over.
+        J_meta->set_time_downsampling_fpga(static_cast<int>(J_buffer.get_ndarray().dimscaling(0)));
     }
 
     // Copy inputs to device memory

--- a/lib/cuda/generated/cudaBasebandBeamformer_chime.cpp
+++ b/lib/cuda/generated/cudaBasebandBeamformer_chime.cpp
@@ -498,7 +498,12 @@ cudaEvent_t cudaBasebandBeamformer_chime::execute(cudaPipelineState& /*pipestate
         // and `T_min` counts samples from there.
         J_meta->set_fpga_seq_num(E_meta->get_fpga_seq_num()
                                  + T_min * E_meta->get_time_downsampling_fpga());
-        assert(J_meta->get_time_downsampling_fpga() == 1);
+        // The kernel's generated dim scalings assume the input is sampled at the FPGA rate
+        assert(E_meta->get_time_downsampling_fpga() == 1);
+        // `J` splits the time direction into a slow `Thi` (dimension 0, extent 1) and a fast
+        // `T`. `time_downsampling_fpga` describes dimension 0, i.e. the whole frame, so it is
+        // that dimension's scaling, not the input's value that `set_metadata` copied over.
+        J_meta->set_time_downsampling_fpga(static_cast<int>(J_buffer.get_ndarray().dimscaling(0)));
     }
 
     // Copy inputs to device memory

--- a/lib/cuda/generated/cudaBasebandBeamformer_chord.cpp
+++ b/lib/cuda/generated/cudaBasebandBeamformer_chord.cpp
@@ -498,7 +498,12 @@ cudaEvent_t cudaBasebandBeamformer_chord::execute(cudaPipelineState& /*pipestate
         // and `T_min` counts samples from there.
         J_meta->set_fpga_seq_num(E_meta->get_fpga_seq_num()
                                  + T_min * E_meta->get_time_downsampling_fpga());
-        assert(J_meta->get_time_downsampling_fpga() == 1);
+        // The kernel's generated dim scalings assume the input is sampled at the FPGA rate
+        assert(E_meta->get_time_downsampling_fpga() == 1);
+        // `J` splits the time direction into a slow `Thi` (dimension 0, extent 1) and a fast
+        // `T`. `time_downsampling_fpga` describes dimension 0, i.e. the whole frame, so it is
+        // that dimension's scaling, not the input's value that `set_metadata` copied over.
+        J_meta->set_time_downsampling_fpga(static_cast<int>(J_buffer.get_ndarray().dimscaling(0)));
     }
 
     // Copy inputs to device memory

--- a/lib/cuda/generated/cudaBasebandBeamformer_hirax.cpp
+++ b/lib/cuda/generated/cudaBasebandBeamformer_hirax.cpp
@@ -498,7 +498,12 @@ cudaEvent_t cudaBasebandBeamformer_hirax::execute(cudaPipelineState& /*pipestate
         // and `T_min` counts samples from there.
         J_meta->set_fpga_seq_num(E_meta->get_fpga_seq_num()
                                  + T_min * E_meta->get_time_downsampling_fpga());
-        assert(J_meta->get_time_downsampling_fpga() == 1);
+        // The kernel's generated dim scalings assume the input is sampled at the FPGA rate
+        assert(E_meta->get_time_downsampling_fpga() == 1);
+        // `J` splits the time direction into a slow `Thi` (dimension 0, extent 1) and a fast
+        // `T`. `time_downsampling_fpga` describes dimension 0, i.e. the whole frame, so it is
+        // that dimension's scaling, not the input's value that `set_metadata` copied over.
+        J_meta->set_time_downsampling_fpga(static_cast<int>(J_buffer.get_ndarray().dimscaling(0)));
     }
 
     // Copy inputs to device memory

--- a/lib/cuda/generated/cudaBasebandBeamformer_pathfinder.cpp
+++ b/lib/cuda/generated/cudaBasebandBeamformer_pathfinder.cpp
@@ -500,7 +500,12 @@ cudaBasebandBeamformer_pathfinder::execute(cudaPipelineState& /*pipestate*/,
         // and `T_min` counts samples from there.
         J_meta->set_fpga_seq_num(E_meta->get_fpga_seq_num()
                                  + T_min * E_meta->get_time_downsampling_fpga());
-        assert(J_meta->get_time_downsampling_fpga() == 1);
+        // The kernel's generated dim scalings assume the input is sampled at the FPGA rate
+        assert(E_meta->get_time_downsampling_fpga() == 1);
+        // `J` splits the time direction into a slow `Thi` (dimension 0, extent 1) and a fast
+        // `T`. `time_downsampling_fpga` describes dimension 0, i.e. the whole frame, so it is
+        // that dimension's scaling, not the input's value that `set_metadata` copied over.
+        J_meta->set_time_downsampling_fpga(static_cast<int>(J_buffer.get_ndarray().dimscaling(0)));
     }
 
     // Copy inputs to device memory

--- a/lib/metadata/chordMetadata.hpp
+++ b/lib/metadata/chordMetadata.hpp
@@ -220,8 +220,33 @@ public:
         return metadata.at(jsonMetadata::FPGA_SEQ_NUM).template get<int64_t>();
     }
 
-    // Time downsampling -- the factor by which the time samples have
-    // been downsampled relative to FPGA samples.
+    // Time downsampling -- the number of FPGA samples spanned by one
+    // step along dimension 0, i.e. `dim_scaling[0]`.
+    //
+    // Dimension 0 is the buffer's slowest (outermost) axis, and for a
+    // buffer that carries time it is a time axis. Together with
+    // `fpga_seq_num` this defines the time of every slice of the
+    // buffer:
+    //
+    //     fpga_seq_num(i) = fpga_seq_num + i * time_downsampling_fpga
+    //
+    // where `i` indexes dimension 0. A frame therefore spans
+    // `dim[0] * time_downsampling_fpga` FPGA samples. Ring buffer
+    // cursors also count dimension-0 elements, so the same expression
+    // converts a cursor into an FPGA sequence number.
+    //
+    // Some buffers split the time direction into two axes, a slow
+    // outer one (dimension 0, e.g. "Thi64", "T8hi128", "Ttildehi256")
+    // and a fast inner one (the last dimension, e.g. "Tlo64",
+    // "T8lo128", "Ttildelo256"). This happens either because the
+    // samples are bit-packed (the packet loss and RFI masks) or
+    // because a whole chunk of samples is produced per frame and
+    // dimension 0 is a placeholder of extent 1 (the baseband and
+    // FRB2 beams). `time_downsampling_fpga` always refers to the
+    // *outer* axis and hence includes the inner axis' factor; it is
+    // not the spacing of individual time samples. The spacing of
+    // individual samples is `dim_scaling` of the innermost time axis,
+    // and the two are equal only when the time axis is not split.
     void set_time_downsampling_fpga(const int time_downsampling_fpga) {
         std::lock_guard<std::mutex> lock(this->lock);
         metadata[jsonMetadata::TIME_DOWNSAMPLING_FPGA] = time_downsampling_fpga;


### PR DESCRIPTION
`time_downsampling_fpga` had become ambiguous for buffers whose time direction is split across two axes: does it describe the slow outer axis or the fast inner one? The majority of the code means the outer axis, i.e. `dim_scaling[0]`. This meaning is now added to its definition, and the two beamformers which assumed a different meaning are updated.
